### PR TITLE
support js rule

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/actions/ApiExportAction.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/actions/ApiExportAction.kt
@@ -7,10 +7,10 @@ import com.itangcent.idea.plugin.api.cache.FileApiCacheRepository
 import com.itangcent.idea.plugin.api.cache.ProjectCacheRepository
 import com.itangcent.idea.plugin.api.export.CommonRules
 import com.itangcent.idea.plugin.api.export.SpringClassExporter
+import com.itangcent.idea.plugin.rule.JsRuleParser
 import com.itangcent.idea.utils.CustomizedPsiClassHelper
 import com.itangcent.idea.utils.ModuleHelper
 import com.itangcent.intellij.config.rule.RuleParser
-import com.itangcent.intellij.config.rule.SimpleRuleParser
 import com.itangcent.intellij.context.ActionContext
 import com.itangcent.intellij.extend.guice.singleton
 import com.itangcent.intellij.extend.guice.with
@@ -23,7 +23,7 @@ abstract class ApiExportAction(text: String) : BasicAnAction(text) {
     override fun onBuildActionContext(builder: ActionContext.ActionContextBuilder) {
         super.onBuildActionContext(builder)
 
-        builder.bind(RuleParser::class) { it.with(SimpleRuleParser::class) }
+        builder.bind(RuleParser::class) { it.with(JsRuleParser::class) }
         builder.bind(CommonRules::class) { it.singleton() }
         builder.bind(PsiClassHelper::class) { it.with(CustomizedPsiClassHelper::class).singleton() }
         builder.bind(DuckTypeHelper::class) { it.singleton() }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/actions/ApiExportAction.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/actions/ApiExportAction.kt
@@ -7,7 +7,7 @@ import com.itangcent.idea.plugin.api.cache.FileApiCacheRepository
 import com.itangcent.idea.plugin.api.cache.ProjectCacheRepository
 import com.itangcent.idea.plugin.api.export.CommonRules
 import com.itangcent.idea.plugin.api.export.SpringClassExporter
-import com.itangcent.idea.plugin.rule.JsRuleParser
+import com.itangcent.idea.plugin.rule.SuvRuleParser
 import com.itangcent.idea.utils.CustomizedPsiClassHelper
 import com.itangcent.idea.utils.ModuleHelper
 import com.itangcent.intellij.config.rule.RuleParser
@@ -23,7 +23,7 @@ abstract class ApiExportAction(text: String) : BasicAnAction(text) {
     override fun onBuildActionContext(builder: ActionContext.ActionContextBuilder) {
         super.onBuildActionContext(builder)
 
-        builder.bind(RuleParser::class) { it.with(JsRuleParser::class) }
+        builder.bind(RuleParser::class) { it.with(SuvRuleParser::class) }
         builder.bind(CommonRules::class) { it.singleton() }
         builder.bind(PsiClassHelper::class) { it.with(CustomizedPsiClassHelper::class).singleton() }
         builder.bind(DuckTypeHelper::class) { it.singleton() }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/actions/FieldsToJsonAction.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/actions/FieldsToJsonAction.kt
@@ -5,10 +5,10 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.project.Project
 import com.itangcent.idea.plugin.fields.FieldJsonGenerator
+import com.itangcent.idea.plugin.rule.SuvRuleParser
 import com.itangcent.idea.utils.CustomizedPsiClassHelper
 import com.itangcent.idea.utils.traceError
 import com.itangcent.intellij.config.rule.RuleParser
-import com.itangcent.intellij.config.rule.SimpleRuleParser
 import com.itangcent.intellij.context.ActionContext
 import com.itangcent.intellij.extend.guice.singleton
 import com.itangcent.intellij.extend.guice.with
@@ -28,7 +28,7 @@ class FieldsToJsonAction : BasicAnAction("To Json") {
     override fun onBuildActionContext(builder: ActionContext.ActionContextBuilder) {
         super.onBuildActionContext(builder)
 
-        builder.bind(RuleParser::class) { it.with(SimpleRuleParser::class) }
+        builder.bind(RuleParser::class) { it.with(SuvRuleParser::class) }
         builder.bind(PsiClassHelper::class) { it.with(CustomizedPsiClassHelper::class).singleton() }
         builder.bind(DuckTypeHelper::class) { it.singleton() }
     }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/CommonRules.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/CommonRules.kt
@@ -1,6 +1,7 @@
 package com.itangcent.idea.plugin.api.export
 
 import com.google.inject.Inject
+import com.itangcent.idea.utils.traceError
 import com.itangcent.intellij.config.ConfigReader
 import com.itangcent.intellij.config.rule.BooleanRule
 import com.itangcent.intellij.config.rule.RuleParser
@@ -28,13 +29,14 @@ class CommonRules {
 
         configReader!!.foreach({ key ->
             key.startsWith("module")
-        }, { key, value ->
+        }) { key, value ->
             try {
                 moduleRules!!.addAll(ruleParser!!.parseStringRule(value))
             } catch (e: Exception) {
                 logger!!.error("error to parse module rule:$key=$value")
+                logger.traceError(e)
             }
-        })
+        }
 
         return moduleRules!!
     }
@@ -50,16 +52,42 @@ class CommonRules {
 
         configReader!!.foreach({ key ->
             key.startsWith("ignore")
-        }, { key, value ->
+        }) { key, value ->
             try {
                 ignoreRules!!.addAll(ruleParser!!.parseBooleanRule(value))
             } catch (e: Exception) {
                 logger!!.error("error to parse module rule:$key=$value")
+                logger.traceError(e)
             }
-        })
+        }
 
         return ignoreRules!!
     }
 
     //endregion ignoreRules--------------------------------------------------------
+
+
+    //region moduleRules--------------------------------------------------------
+    var methodDocRules: ArrayList<StringRule>? = null
+
+    fun readMethodReadRules(): List<StringRule> {
+        if (methodDocRules != null) return methodDocRules!!
+        methodDocRules = ArrayList()
+
+        configReader!!.foreach({ key ->
+            key.startsWith("doc.method")
+        }) { key, value ->
+            try {
+                methodDocRules!!.addAll(ruleParser!!.parseStringRule(value))
+            } catch (e: Exception) {
+                logger!!.error("error to parse doc.method rule:$key=$value")
+                logger.traceError(e)
+            }
+        }
+
+        return methodDocRules!!
+    }
+
+    //endregion moduleRules--------------------------------------------------------
+
 }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/JsRuleParser.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/JsRuleParser.kt
@@ -1,0 +1,28 @@
+package com.itangcent.idea.plugin.rule
+
+import javax.script.ScriptEngine
+import javax.script.ScriptEngineManager
+
+/**
+ * see @{link jdk.nashorn.api.scripting.NashornScriptEngineFactory}
+ *
+ */
+class JsRuleParser : ScriptRuleParser() {
+    private var scriptEngine: ScriptEngine? = null
+
+    private fun buildScriptEngine(): ScriptEngine? {
+        val manager = ScriptEngineManager()
+        return manager.getEngineByName("JavaScript")
+    }
+
+    override fun getScriptEngine(): ScriptEngine {
+        if (scriptEngine != null) return scriptEngine!!
+        synchronized(this) {
+            if (scriptEngine != null) return scriptEngine!!
+            scriptEngine = buildScriptEngine()
+        }
+        return scriptEngine!!
+    }
+
+}
+

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/ScriptRuleParser.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/ScriptRuleParser.kt
@@ -1,0 +1,301 @@
+package com.itangcent.idea.plugin.rule
+
+import com.google.inject.Inject
+import com.intellij.psi.*
+import com.intellij.psi.util.PsiTypesUtil
+import com.itangcent.intellij.config.rule.*
+import com.itangcent.intellij.extend.getPropertyValue
+import com.itangcent.intellij.extend.toBoolean
+import com.itangcent.intellij.psi.*
+import com.itangcent.intellij.util.DocCommentUtils
+import javax.script.ScriptContext
+import javax.script.ScriptEngine
+import javax.script.SimpleScriptContext
+
+abstract class ScriptRuleParser : RuleParser {
+
+    @Inject
+    private val duckTypeHelper: DuckTypeHelper? = null
+
+    override fun parseBooleanRule(rule: String): List<BooleanRule> {
+        return listOf(BooleanRule.of { context ->
+            return@of eval(rule, context).toBoolean()
+        })
+    }
+
+    @Deprecated(message = "it will be removed at next version")
+    override fun parseBooleanRule(rule: String, delimiters: String, defaultValue: Boolean): List<BooleanRule> {
+        TODO("com.itangcent.idea.plugin.rule.JsRuleParser.parseBooleanRule(java.lang.String, java.lang.String, boolean) was not implemented")
+    }
+
+    override fun parseStringRule(rule: String): List<StringRule> {
+        return listOf(StringRule.of { context ->
+            return@of eval(rule, context).toString()
+        })
+    }
+
+    @Deprecated(message = "it will be removed at next version")
+    override fun parseStringRule(rule: String, delimiters: String): List<StringRule> {
+        TODO("com.itangcent.idea.plugin.rule.JsRuleParser.parseStringRule(java.lang.String, java.lang.String) was not implemented")
+    }
+
+    private fun eval(ruleScript: String, context: PsiElementContext): Any? {
+        val simpleScriptContext = SimpleScriptContext()
+        simpleScriptContext.setAttribute("it", context, ScriptContext.ENGINE_SCOPE)
+        return getScriptEngine().eval(ruleScript, simpleScriptContext)
+    }
+
+    protected abstract fun getScriptEngine(): ScriptEngine
+
+    override fun contextOf(psiElement: PsiElement): PsiElementContext {
+        return when (psiElement) {
+            is PsiClass -> JsPsiClassContext(psiElement)
+            is PsiField -> JsPsiFieldContext(psiElement)
+            is PsiMethod -> JsPsiMethodContext(psiElement)
+            else -> PsiUnknownContext(psiElement)
+        }
+    }
+
+    /**
+     * support is js:
+     * it.ann("annotation_name"):String?
+     * it.ann("annotation_name#value"):String?
+     * it.annotation("annotation_name"):String?
+     * it.annotation("annotation_name#value"):String?
+     * it.doc():String
+     * it.doc("tag"):String?
+     * it.doc("param","param"):String?
+     */
+    abstract class AbstractJsPsiElementContext : PsiElementContext {
+
+        protected var psiElement: PsiElement? = null
+
+        constructor(psiClass: PsiElement) {
+            this.psiElement = psiClass
+        }
+
+        constructor()
+
+        override fun getResource(): PsiElement? {
+            return psiElement
+        }
+
+        override fun getName(): String? {
+            return psiElement!!.getPropertyValue("name")?.toString()
+        }
+
+        override fun asPsiDocCommentOwner(): PsiDocCommentOwner {
+            if (psiElement is PsiDocCommentOwner) {
+                return psiElement as PsiDocCommentOwner
+            }
+            throw IllegalArgumentException("$psiElement has non comment")
+        }
+
+        fun name(): String {
+            return getName()!!
+        }
+
+        /**
+         * it.ann("annotation_name"):String?
+         */
+        fun ann(name: String): String? {
+            return annotation(name)
+        }
+
+        /**
+         * it.ann("annotation_name","value"):String?
+         */
+        fun ann(name: String, attr: String): String? {
+            return annotation(name, attr)
+        }
+
+        /**
+         * it.annotation("annotation_name"):String?
+         */
+        fun annotation(name: String): String? {
+            return annotation(name, "value")
+        }
+
+        /**
+         * it.annotation("annotation_name","attr"):String?
+         */
+        fun annotation(name: String, attr: String): String? {
+            return PsiAnnotationUtils.findAttr(asPsiDocCommentOwner(), name, attr)
+        }
+
+        /**
+         * it.doc():String
+         */
+        fun doc(): String? {
+            return DocCommentUtils.getAttrOfDocComment(asPsiDocCommentOwner().docComment)
+        }
+
+        /**
+         * it.doc("tag"):String?
+         */
+        fun doc(tag: String): String? {
+            return DocCommentUtils.findDocsByTag(asPsiDocCommentOwner().docComment, tag)
+        }
+
+        /**
+         * it.doc("param","param"):String?
+         */
+        fun doc(tag: String, subTag: String): String? {
+            return DocCommentUtils.findDocsByTagAndName(asPsiDocCommentOwner().docComment,
+                    tag, subTag)
+        }
+
+    }
+
+    /**
+     * it.methods():method[]
+     * it.isExtend(""):Boolean
+     * it.isSuper(""):Boolean
+     * it.isMap():Boolean
+     * it.isCollection():Boolean
+     * it.isArray():Boolean
+     * @see JsPsiTypeContext
+     */
+    inner class JsPsiClassContext(private val psiClass: PsiClass) : AbstractJsPsiElementContext(psiClass) {
+
+        fun methods(): Array<JsPsiMethodContext> {
+            return psiClass.allMethods.map { JsPsiMethodContext(it) }
+                    .toTypedArray()
+        }
+
+        fun fields(): Array<JsPsiFieldContext> {
+            return psiClass.allFields
+                    .map { JsPsiFieldContext(it) }
+                    .toTypedArray()
+        }
+
+        fun isExtend(superClass: String): Boolean {
+            var currClass: PsiClass? = psiClass
+            do {
+                if (superClass == currClass!!.qualifiedName) {
+                    return true
+                }
+                currClass = currClass.superClass
+            } while (currClass != null && currClass.name != "Object")
+            return false
+        }
+
+        fun isMap(): Boolean {
+            return PsiClassHelper.isMap(PsiTypesUtil.getClassType(psiClass))
+        }
+
+        fun isCollection(): Boolean {
+            return PsiClassHelper.isCollection(PsiTypesUtil.getClassType(psiClass))
+        }
+
+        fun isArray(): Boolean {
+            return false
+        }
+
+        override fun getName(): String? {
+            return psiClass.name
+        }
+    }
+
+    inner class JsPsiFieldContext(private val psiField: PsiField) : AbstractJsPsiElementContext(psiField) {
+
+        fun type(): JsPsiTypeContext {
+            return JsPsiTypeContext(psiField.type)
+        }
+
+        override fun getName(): String? {
+            return psiField.name
+        }
+    }
+
+    /**
+     * it.name:String
+     * it.return:class
+     * it.args:arg[]
+     */
+    inner class JsPsiMethodContext(val psiMethod: PsiMethod) : AbstractJsPsiElementContext(psiMethod) {
+
+        fun `return`(): JsPsiTypeContext {
+            return JsPsiTypeContext((psiElement as PsiMethod).returnType!!)
+        }
+
+        override fun getName(): String? {
+            return psiMethod.name
+        }
+    }
+
+    /**
+     * it.methods():method[]
+     * it.isExtend(""):Boolean
+     * it.isSuper(""):Boolean
+     * it.isMap():Boolean
+     * it.isCollection():Boolean
+     * it.isArray():Boolean
+     * @see JsPsiClassContext
+     */
+    inner class JsPsiTypeContext(private val psiType: PsiType) : AbstractJsPsiElementContext() {
+
+        private var duckType: DuckType? = null
+
+        override fun getName(): String? {
+            return duckType?.let { getDuckTypeName(it) }
+        }
+
+        private fun getDuckTypeName(duckType: DuckType): String? {
+            return when (duckType) {
+                is ArrayDuckType -> getDuckTypeName(duckType.componentType()) + "[]"
+                is SingleDuckType -> duckType.psiClass().name
+                else -> duckType.toString()
+            }
+        }
+
+        fun methods(): Array<JsPsiMethodContext> {
+            return getResource()?.let { psiElement ->
+                return@let (psiElement as PsiClass).allMethods.map { JsPsiMethodContext(it) }
+                        .toTypedArray()
+            } ?: emptyArray()
+        }
+
+        fun fields(): Array<JsPsiFieldContext> {
+            return getResource()?.let { psiElement ->
+                return@let (psiElement as PsiClass).allFields
+                        .map { JsPsiFieldContext(it) }
+                        .toTypedArray()
+            } ?: emptyArray()
+        }
+
+        fun isExtend(superClass: String): Boolean {
+            return getResource()?.let { psiClass ->
+                var currClass: PsiClass? = psiClass as PsiClass
+                do {
+                    if (superClass == currClass!!.qualifiedName) {
+                        return true
+                    }
+                    currClass = currClass.superClass
+                } while (currClass != null && currClass.name != "Object")
+                return false
+            } ?: false
+        }
+
+        fun isMap(): Boolean {
+            return PsiClassHelper.isMap(psiType)
+        }
+
+        fun isCollection(): Boolean {
+            return PsiClassHelper.isCollection(psiType)
+        }
+
+        fun isArray(): Boolean {
+            return duckType is ArrayDuckType
+        }
+
+        init {
+            duckType = duckTypeHelper!!.ensureType(psiType)
+            if (duckType != null && duckType is SingleDuckType) {
+                this.psiElement = (duckType as SingleDuckType).psiClass()
+            }
+        }
+    }
+
+}
+

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/ScriptRuleParser.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/ScriptRuleParser.kt
@@ -43,7 +43,11 @@ abstract class ScriptRuleParser : RuleParser {
 
     private fun eval(ruleScript: String, context: PsiElementContext): Any? {
         val simpleScriptContext = SimpleScriptContext()
-        simpleScriptContext.setAttribute("it", context, ScriptContext.ENGINE_SCOPE)
+        var contextForScript: PsiElementContext? = when (context) {
+            is AbstractJsPsiElementContext -> context
+            else -> contextOf(context.getResource()!!)
+        }
+        simpleScriptContext.setAttribute("it", contextForScript, ScriptContext.ENGINE_SCOPE)
         return getScriptEngine().eval(ruleScript, simpleScriptContext)
     }
 

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/SuvRuleParser.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/rule/SuvRuleParser.kt
@@ -1,0 +1,59 @@
+package com.itangcent.idea.plugin.rule
+
+import com.google.inject.Inject
+import com.intellij.psi.PsiElement
+import com.itangcent.intellij.config.rule.*
+import com.itangcent.intellij.context.ActionContext
+import com.itangcent.intellij.extend.guice.PostConstruct
+
+/**
+ * [js:] -> jsRule
+ * [@]|[#] ->  simpleRule
+ */
+class SuvRuleParser : RuleParser {
+
+    private val jsRuleParser: RuleParser = JsRuleParser()
+
+    private val simpleRuleParser: RuleParser = SimpleRuleParser()
+
+    @Inject
+    private val actionContext: ActionContext? = null
+
+    @PostConstruct
+    fun init() {
+        actionContext!!.init(jsRuleParser)
+        actionContext.init(simpleRuleParser)
+    }
+
+    override fun contextOf(psiElement: PsiElement): PsiElementContext {
+        return simpleRuleParser.contextOf(psiElement)
+    }
+
+    override fun parseBooleanRule(rule: String): List<BooleanRule> {
+        return when {
+            rule.isBlank() -> emptyList()
+            rule.startsWith(JS_PREFIX) -> jsRuleParser.parseBooleanRule(rule.removePrefix(JS_PREFIX))
+            else -> simpleRuleParser.parseBooleanRule(rule)
+        }
+    }
+
+    override fun parseBooleanRule(rule: String, delimiters: String, defaultValue: Boolean): List<BooleanRule> {
+        return simpleRuleParser.parseBooleanRule(rule, delimiters, defaultValue)
+    }
+
+    override fun parseStringRule(rule: String): List<StringRule> {
+        return when {
+            rule.isBlank() -> emptyList()
+            rule.startsWith(JS_PREFIX) -> jsRuleParser.parseStringRule(rule.removePrefix(JS_PREFIX))
+            else -> simpleRuleParser.parseStringRule(rule)
+        }
+    }
+
+    override fun parseStringRule(rule: String, delimiters: String): List<StringRule> {
+        return simpleRuleParser.parseStringRule(rule, delimiters)
+    }
+
+    companion object {
+        private const val JS_PREFIX = "js:"
+    }
+}

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/ConfigurableLogger.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/ConfigurableLogger.kt
@@ -25,6 +25,10 @@ class ConfigurableLogger : AbstractLogger() {
         currentLogLevel = logLevel?.let { CoarseLogLevel.toLevel(it, CoarseLogLevel.LOW) } ?: CoarseLogLevel.LOW
     }
 
+    override fun log(msg: String) {
+        super.log(CoarseLogLevel.EMPTY, msg)
+    }
+
     override fun currentLogLevel(): Level {
         return currentLogLevel!!
     }
@@ -39,6 +43,11 @@ class ConfigurableLogger : AbstractLogger() {
     }
 
     enum class CoarseLogLevel : Level {
+        EMPTY(1000) {
+            override fun getLevelStr(): String {
+                return ""
+            }
+        },
         LOW(50),
         MEDIUM(250),
         HIGH(450)

--- a/idea-plugin/src/main/kotlin/com/itangcent/intellij/extend/AnyKit.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/intellij/extend/AnyKit.kt
@@ -25,6 +25,14 @@ fun Any?.toInt(): Int? {
     return null
 }
 
+fun Any?.toBoolean(): Boolean? {
+    if (this == null) return null
+    if (this is Boolean) return this
+    if (this is Number) return this.toInt() == 1
+    if (this is String) return this == "true"
+    return null
+}
+
 @Suppress("UNCHECKED_CAST")
 fun Any.asHashMap(obj: Any?): HashMap<String, Any?> {
     if (obj is HashMap<*, *>) {

--- a/idea-plugin/src/main/kotlin/com/itangcent/intellij/util/CollectionExtend.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/intellij/util/CollectionExtend.kt
@@ -1,0 +1,14 @@
+package com.itangcent.intellij.util
+
+/**
+ * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ */
+public inline fun <S, T : S> Iterable<T>.reduceSafely(operation: (acc: S, T) -> S): S? {
+    val iterator = this.iterator()
+    if (!iterator.hasNext()) return null
+    var accumulator: S = iterator.next()
+    while (iterator.hasNext()) {
+        accumulator = operation(accumulator, iterator.next())
+    }
+    return accumulator
+}


### PR DESCRIPTION
close #65
- support js expression
- support context:it
- support method in it:
     * it.name():String
     * it.hasAnn("annotation_name"):Boolean
     * it.ann("annotation_name"):String?
     * it.ann("annotation_name","attr"):String?
     * it.doc():String
     * it.doc("tag"):String?
     * it.doc("tag","subTag"):String?
- additional
   - if it is class
     * it.methods():method[]
     * it.methodCnt():int
     * it.field():field[]
     * it.fieldCnt():int
     * it.isExtend("cls"):Boolean
     * it.isMap():Boolean
     * it.isCollection():Boolean
     * it.isArray():Boolean

  - if it is method
     * it.return:class
     * it.isVarArgs:Boolean
     * it.args:arg[]
     * it.argTypes:class[]
     * it.argCnt:int
     * it.containingClass:class

  - if it is field
     * it.type:class
     * it.containingClass:class
     * it.jsonName:String

  - if it is arg
     * it.name:String
     * it.type:class
     * it.isVarArgs:Boolean