### PR TITLE
feat: unify rule-based metadata resolution across frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@
 
 - [kotlin-doc](https://kotlinlang.org/docs/reference/kotlin-doc.html)
 
-## Version
-
-`$major.$minor.$min_support.$max_support.$fix`
 
 Installation
 ----
@@ -94,7 +91,7 @@ restart **IDE**.
 
 ```text
     Click [Preference -> Other Setting -> EasyApi]
-    set postman privatetoken
+    set postman privateToken
     If you do not have a privateToken of postman,
     you can easily generate one by heading over to the Postman Integrations Dashboard
     [https://go.postman.co/integrations/services/pm_pro_api]


### PR DESCRIPTION
## Summary
Ensure rules like method.return, method.return.main, method.additional.header, and method.additional.response.header work consistently across all framework exporters (SpringMVC, JAX-RS, Feign, gRPC).

## Changes
- Extract shared endpoint building logic (buildResponseBody, buildHeaders, expandBodyParam, mergePathParameters) into centralized EndpointBuilder
- Convert EndpointBuilder to IntelliJ project service for clean dependency injection
- Add comprehensive KDoc documentation to EndpointBuilder
- Add 24 test cases covering all EndpointBuilder methods
- Remove redundant settings caching from all ClassExporters (JAX-RS, Feign, gRPC, SpringMVC)
- Update ActuatorEndpointScanner to use EndpointBuilder service

## Motivation
Previously, the logic for applying rules (like method.return for response body override) was duplicated across ClassExporters, leading to inconsistent behavior. Now all exporters use the same EndpointBuilder implementation, ensuring rules work uniformly regardless of framework.

## Test Plan
- All 24 new EndpointBuilderTest cases pass
- All existing exporter tests pass