### PR TITLE
some new rules

### DIFF
--- a/docs/2. Supported-custom-rules.md
+++ b/docs/2. Supported-custom-rules.md
@@ -10,6 +10,7 @@
 | doc.field | field | v0.7.2+ | the additional doc for field |
 | doc.method | method | v0.7.2+ | the additional doc for method |
 | param.required | arg | v0.7.3+ | the param is required(must not be null) |
+| param.ignore | arg | v1.3.0+ | ignore the param |
 | field.required | field | v0.7.3+ | the field is required(must not be null) |
 | mdoc.class.filter | class | v0.9.5+ | filter classes to export method documentation(rpc) |
 | mdoc.method.filter | method | v0.9.5+ | filter methods to export method documentation(rpc) |

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/ClassExportRuleKeys.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/ClassExportRuleKeys.kt
@@ -24,6 +24,15 @@ object ClassExportRuleKeys {
     val CLASS_DOC: RuleKey<String> = SimpleRuleKey("doc.class", StringRule::class,
             StringRuleMode.MERGE_DISTINCT)
 
+    val METHOD_ADDITIONAL_HEADER: RuleKey<String> = SimpleRuleKey("method.additional.header", StringRule::class,
+            StringRuleMode.MERGE_DISTINCT)
+
+    val METHOD_ADDITIONAL_PARAM: RuleKey<String> = SimpleRuleKey("method.additional.param", StringRule::class,
+            StringRuleMode.MERGE_DISTINCT)
+
+    val METHOD_ADDITIONAL_RESPONSE_HEADER: RuleKey<String> = SimpleRuleKey("method.additional.response.header", StringRule::class,
+            StringRuleMode.MERGE_DISTINCT)
+
     val PARAM_REQUIRED: RuleKey<Boolean> = SimpleRuleKey("param.required", BooleanRule::class,
             BooleanRuleMode.ANY)
 


### PR DESCRIPTION
- new rules:
  - [method.additional.header]:provide additional header for request
  - [method.additional.param]:provide additional param for request
  - [method.additional.response.header]:provide additional header for response
---
see [easy-yapi#78](https://github.com/tangcent/easy-yapi/issues/78)