### PR TITLE
resolve RequestMapping#params

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/AbstractRequestClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/AbstractRequestClassExporter.kt
@@ -171,7 +171,7 @@ abstract class AbstractRequestClassExporter : ClassExporter, Worker {
 
         processResponse(method, request)
 
-        processCompleted(method, request)
+        processCompleted(method, kv, request)
 
         docHandle(request)
     }
@@ -192,7 +192,7 @@ abstract class AbstractRequestClassExporter : ClassExporter, Worker {
         return ruleComputer!!.computer(ClassExportRuleKeys.PARAM_DEFAULT_VALUE, param)
     }
 
-    protected open fun processCompleted(method: ExplicitMethod, request: Request) {
+    protected open fun processCompleted(method: ExplicitMethod, kv: KV<String, Any?>, request: Request) {
         //parse additionalHeader by config
         val additionalHeader = ruleComputer!!.computer(ClassExportRuleKeys.METHOD_ADDITIONAL_HEADER,
                 method)


### PR DESCRIPTION
* resolve org.springframework.web.bind.annotation.RequestMapping#params

---

**docs:**
```
The parameters of the mapped request, narrowing the primary mapping.
<p>Same format for any environment: a sequence of "myParam=myValue" style
expressions, with a request only mapped if each such parameter is found
to have the given value. Expressions can be negated by using the "!=" operator,
 as in "myParam!=myValue". "myParam" style expressions are also supported,
with such parameters having to be present in the request (allowed to have
any value). Finally, "!myParam" style expressions indicate that the
specified parameter is <i>not</i> supposed to be present in the request.
<p><b>Supported at the type level as well as at the method level!</b>
When used at the type level, all method-level mappings inherit
this parameter restriction (i.e. the type-level restriction
gets checked before the handler method is even resolved).
<p>Parameter mappings are considered as restrictions that are enforced at
the type level. The primary path mapping (i.e. the specified URI value)
still has to uniquely identify the target handler, with parameter mappings
simply expressing preconditions for invoking the handler.
```

---

**solution:**

- `!name ` : append desc "parameter $param should not be present") to the request.
- `name` : append a new param to the request or set existed param to required.
- `name!=value` : if param present. append desc "should not equal to [$value]" to the param,otherwise append desc "parameter $param should not equal to [$value]") to the request.
- `name=value` : append a new param to the request or set existed param to required & valued the given value.