### PR TITLE
feat: support rule `param.http.type` for `RequestParam `

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/ClassExportRuleKeys.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/ClassExportRuleKeys.kt
@@ -106,11 +106,12 @@ object ClassExportRuleKeys {
     )
 
     /**
-     * The type of the param without annotations(@RequestBody/@ModelAttribute/...).
+     * The type of the param in http request.
+     * Param with annotation like @RequestBody/@ModelAttribute/... do not compute this rule.
      * should return body/form/query
      */
-    val PARAM_WITHOUT_ANN_TYPE: RuleKey<String> = SimpleRuleKey(
-            "param.without.ann.type", StringRule::class,
+    val PARAM_HTTP_TYPE: RuleKey<String> = SimpleRuleKey(
+            "param.http.type", StringRule::class,
             StringRuleMode.SINGLE
     )
 


### PR DESCRIPTION
new rule `param.http.type`
Supported for params in Spring MVC and Spring WebFlux as follows:
- param without none of annotations like 
  * `@org.springframework.web.bind.annotation.RequestHeader`
  * `@org.springframework.web.bind.annotation.PathVariable`
  * `org.springframework.web.bind.annotation.ModelAttribute`
  * `org.springframework.web.bind.annotation.RequestBody`
- param annotated with `org.springframework.web.bind.annotation.RequestParam` and the handle method has not explicate the http method as `GET`