### PR TITLE
release v2.0.1.183.0

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -154,3 +154,9 @@
     
     * feat: new Setting [postman] wrapCollection & autoMergeScript [(#317)](https://github.com/tangcent/easy-api/pull/317)
     
+    * opti: parse param as query by default [(#320)](https://github.com/tangcent/easy-api/pull/320)
+    
+    * feat: [ScriptExecutor] support select field or method in the class. [(#321)](https://github.com/tangcent/easy-api/pull/321)
+    
+    * feat: add rule alias `param.doc`/`method.doc`/`class.doc` [(#323)](https://github.com/tangcent/easy-api/pull/323)
+    

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.0.0.183.0'
+version '2.0.1.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyApi
-plugin_version=2.0.0.183.0
+plugin_version=2.0.1.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,14 +1,14 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.0.0">v2.0.0.183.0(2020-08-02)</a>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.0.1">v2.0.1.183.0(2020-08-09)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li> feat: support new rules `class.postman.prerequest`&`class.postman.test` <a
-            href="https://github.com/tangcent/easy-api/pull/312">(#312)</a>
+    <li> opti: parse param as query by default <a
+            href="https://github.com/tangcent/easy-api/pull/320">(#320)</a>
     </li>
-    <li> feat: new rule `collection.postman.prerequest`&`collection.postman.test` <a
-            href="https://github.com/tangcent/easy-api/pull/314">(#314)</a>
+    <li> feat: [ScriptExecutor] support select field or method in the class. <a
+            href="https://github.com/tangcent/easy-api/pull/321">(#321)</a>
     </li>
-    <li> feat: new Setting [postman] wrapCollection & autoMergeScript <a
-            href="https://github.com/tangcent/easy-api/pull/317">(#317)</a>
+    <li> feat: add rule alias `param.doc`/`method.doc`/`class.doc` <a
+            href="https://github.com/tangcent/easy-api/pull/323">(#323)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-api</id>
     <name>EasyApi</name>
-    <version>2.0.0.183.0</version>
+    <version>2.0.1.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>
@@ -21,7 +21,7 @@
     <change-notes><![CDATA[	Change notes will be filled by gradle build ]]>
     </change-notes>
 
-    <!--This plugin will support IntelliJ IDEA Community and Ultimate Only before v2.0.0-->
+    <!--This plugin will support IntelliJ IDEA Community and Ultimate Only before v2.0.1-->
 
     <depends optional="true" config-file="easy-api-java.xml">com.intellij.modules.java</depends>
     <!--it will cause 【Optional dependency declaration on 'com.intellij.modules.idea' should specify "config-file"】-->


### PR DESCRIPTION
* opti: parse param as query by default [(#320)](https://github.com/tangcent/easy-api/pull/320)
    
* feat: [ScriptExecutor] support select field or method in the class. [(#321)](https://github.com/tangcent/easy-api/pull/321)
    
* feat: add rule alias `param.doc`/`method.doc`/`class.doc` [(#323)](https://github.com/tangcent/easy-api/pull/323)
    