### PR TITLE
chore: fix recommend config for ignore serialVersionUID

### DIFF
--- a/idea-plugin/src/main/resources/.recommend.easy.api.config
+++ b/idea-plugin/src/main/resources/.recommend.easy.api.config
@@ -98,7 +98,7 @@ class.prefix.path=${server.servlet.context-path}
 
 #[ignore_serialVersionUID]
 #ignore serialVersionUID
-constant.field.ignore=serialVersionUID
+constant.field.ignore=groovy:it.name()=="serialVersionUID"
 
 #[private_protected_field_only]
 #only keep private/protected field


### PR DESCRIPTION
before:

```properties
#ignore serialVersionUID
constant.field.ignore=serialVersionUID
```

after:

```properties
#ignore serialVersionUID
constant.field.ignore=groovy:it.name()=="serialVersionUID"
```