### PR TITLE
opti: support rule `field.default.value`

### DIFF
--- a/common-api/src/main/kotlin/com/itangcent/common/constant/Attrs.kt
+++ b/common-api/src/main/kotlin/com/itangcent/common/constant/Attrs.kt
@@ -6,5 +6,7 @@ object Attrs {
 
     const val REQUIRED_ATTR = "@required"
 
-    val ALL = arrayOf(COMMENT_ATTR, REQUIRED_ATTR)
+    const val DEFAULT_VALUE_ATTR = "@default"
+
+    val ALL = arrayOf(COMMENT_ATTR, REQUIRED_ATTR, DEFAULT_VALUE_ATTR)
 }

--- a/common-api/src/main/kotlin/com/itangcent/common/kit/KVUtils.kt
+++ b/common-api/src/main/kotlin/com/itangcent/common/kit/KVUtils.kt
@@ -1,7 +1,9 @@
 package com.itangcent.common.kit
 
 import com.itangcent.common.constant.Attrs
-import com.itangcent.common.utils.*
+import com.itangcent.common.utils.KV
+import com.itangcent.common.utils.joinToString
+import com.itangcent.common.utils.notNullOrEmpty
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -165,7 +167,6 @@ object KVUtils {
         }
     }
 }
-
 
 @Suppress("UNCHECKED_CAST")
 fun <T> Map<*, *>.getAs(key: Any?): T? {

--- a/common-api/src/main/kotlin/com/itangcent/http/RequestUtils.kt
+++ b/common-api/src/main/kotlin/com/itangcent/http/RequestUtils.kt
@@ -21,10 +21,14 @@ object RequestUtils {
     fun toRawBody(body: Any?, copy: Boolean): Any? {
         if (body == null) return null
         if (body is Map<*, *>) {
-            val mutableBody = body.mutable(copy)
-            Attrs.ALL.forEach { mutableBody.remove(it) }
+            val mutableBody = body.filterKeys { !Attrs.ALL.contains(it) }.mutable(copy)
             for (mutableEntry in mutableBody) {
-                mutableEntry.value?.let { mutableEntry.setValue(toRawBody(it, copy)) }
+                mutableEntry.value?.let {
+                    val rawValue = toRawBody(it, copy)
+                    if (rawValue != it) {
+                        mutableEntry.setValue(rawValue)
+                    }
+                }
             }
             return mutableBody
         }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/ClassExportRuleKeys.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/ClassExportRuleKeys.kt
@@ -143,6 +143,11 @@ object ClassExportRuleKeys {
             StringRuleMode.SINGLE
     )
 
+    val FIELD_DEFAULT_VALUE: RuleKey<String> = SimpleRuleKey(
+            "field.default.value", StringRule::class,
+            StringRuleMode.SINGLE
+    )
+
     val POST_MAN_HOST: RuleKey<String> = SimpleRuleKey(
             "postman.host", StringRule::class,
             StringRuleMode.SINGLE

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/suv/SuvApiExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/suv/SuvApiExporter.kt
@@ -484,7 +484,7 @@ class SuvApiExporter {
                     return
                 }
                 logger!!.info("Start parse apis")
-                val apiInfo = markdownFormatter!!.parseRequests(docs.toMutableList())
+                val apiInfo = markdownFormatter!!.parseRequests(docs)
                 docs.clear()
                 actionContext!!.runAsync {
                     try {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.form
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.form
@@ -3,7 +3,7 @@
   <grid id="b08f8" binding="rootPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="504" height="763"/>
+      <xy x="20" y="20" width="504" height="802"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -289,11 +289,11 @@
                       </grid>
                     </children>
                   </grid>
-                  <grid id="a7de6" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="a7de6" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="0" right="0"/>
                     <constraints>
                       <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false">
-                        <maximum-size width="-1" height="60"/>
+                        <maximum-size width="-1" height="90"/>
                       </grid>
                     </constraints>
                     <properties/>
@@ -339,6 +339,34 @@
                                 <minimum-size width="80" height="-1"/>
                                 <preferred-size width="130" height="-1"/>
                                 <maximum-size width="200" height="-1"/>
+                              </grid>
+                            </constraints>
+                            <properties/>
+                          </component>
+                        </children>
+                      </grid>
+                      <grid id="55a49" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                        <margin top="0" left="0" bottom="0" right="0"/>
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                        <border type="none"/>
+                        <children>
+                          <component id="3eb40" class="javax.swing.JLabel">
+                            <constraints>
+                              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                            </constraints>
+                            <properties>
+                              <text value="format type:"/>
+                            </properties>
+                          </component>
+                          <component id="915c1" class="javax.swing.JComboBox" binding="markdownFormatTypeComboBox">
+                            <constraints>
+                              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                                <minimum-size width="70" height="-1"/>
+                                <preferred-size width="90" height="-1"/>
+                                <maximum-size width="120" height="-1"/>
                               </grid>
                             </constraints>
                             <properties/>
@@ -474,7 +502,7 @@
                               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                             </constraints>
                             <properties>
-                              <text value="inferEnable"/>
+                              <text value="enable infer"/>
                               <toolTipText value="try infer return generic type of api method"/>
                             </properties>
                           </component>
@@ -493,7 +521,7 @@
                               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                             </constraints>
                             <properties>
-                              <text value="maxDeep:"/>
+                              <text value="max deep:"/>
                             </properties>
                           </component>
                           <component id="9bab4" class="javax.swing.JTextField" binding="maxDeepTextField">

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.kt
@@ -13,13 +13,11 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.CheckBoxList
-import com.itangcent.common.utils.GsonUtils
-import com.itangcent.common.utils.SystemUtils
-import com.itangcent.common.utils.notNullOrEmpty
-import com.itangcent.common.utils.truncate
+import com.itangcent.common.utils.*
 import com.itangcent.idea.icons.EasyIcons
 import com.itangcent.idea.icons.iconOnly
 import com.itangcent.idea.plugin.config.RecommendConfigReader
+import com.itangcent.idea.plugin.settings.MarkdownFormatType
 import com.itangcent.idea.plugin.settings.Settings
 import com.itangcent.idea.utils.Charsets
 import com.itangcent.idea.utils.ConfigurableLogger
@@ -85,6 +83,8 @@ class EasyApiSettingGUI {
     private var outputDemoCheckBox: JCheckBox? = null
 
     private var outputCharsetComboBox: JComboBox<Charsets>? = null
+
+    private var markdownFormatTypeComboBox: JComboBox<String>? = null
 
     private var inferEnableCheckBox: JCheckBox? = null
 
@@ -213,10 +213,17 @@ class EasyApiSettingGUI {
 
         outputCharsetComboBox!!.model = DefaultComboBoxModel(Charsets.SUPPORTED_CHARSETS)
 
+        markdownFormatTypeComboBox!!.model = DefaultComboBoxModel(MarkdownFormatType.values().mapToTypedArray { it.name })
+
         autoComputer.bind<String?>(this, "settings.outputCharset")
                 .with(this.outputCharsetComboBox!!)
                 .filter { throttleHelper.acquire("settings.outputCharset", 300) }
                 .eval { (it ?: Charsets.UTF_8).displayName() }
+
+        autoComputer.bind<String?>(this, "settings.markdownFormatType")
+                .with(this.markdownFormatTypeComboBox!!)
+                .filter { throttleHelper.acquire("settings.markdownFormatType", 300) }
+                .eval { (it ?: MarkdownFormatType.SIMPLE.name) }
 
         autoComputer.bind(this.previewTextArea!!)
                 .with<String>(this, "settings.recommendConfigs")

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/settings/MarkdownFormatType.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/settings/MarkdownFormatType.kt
@@ -1,0 +1,6 @@
+package com.itangcent.idea.plugin.settings
+
+enum class MarkdownFormatType(var desc: String) {
+    SIMPLE("simple columns, include name、type、desc"),
+    ULTIMATE("more columns than simple, include name、type、required、default、desc")
+}

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/settings/Settings.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/settings/Settings.kt
@@ -38,9 +38,13 @@ class Settings {
 
     var logLevel: Int = ConfigurableLogger.CoarseLogLevel.LOW.getLevel()
 
+    // markdown
+
     var outputDemo: Boolean = true
 
     var outputCharset: String = Charsets.UTF_8.displayName()
+
+    var markdownFormatType: String = MarkdownFormatType.SIMPLE.name
 
     fun copy(): Settings {
         val newSetting = Settings()
@@ -59,6 +63,7 @@ class Settings {
         newSetting.logLevel = this.logLevel
         newSetting.outputDemo = this.outputDemo
         newSetting.outputCharset = this.outputCharset
+        newSetting.markdownFormatType = this.markdownFormatType
         return newSetting
     }
 
@@ -83,6 +88,7 @@ class Settings {
         if (logLevel != other.logLevel) return false
         if (outputDemo != other.outputDemo) return false
         if (outputCharset != other.outputCharset) return false
+        if (markdownFormatType != other.markdownFormatType) return false
 
         return true
     }
@@ -103,6 +109,7 @@ class Settings {
         result = 31 * result + logLevel
         result = 31 * result + outputDemo.hashCode()
         result = 31 * result + outputCharset.hashCode()
+        result = 31 * result + markdownFormatType.hashCode()
         return result
     }
 

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/CustomizedPsiClassHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/CustomizedPsiClassHelper.kt
@@ -1,24 +1,45 @@
 package com.itangcent.idea.utils
 
+import com.google.inject.Inject
 import com.itangcent.common.constant.Attrs
 import com.itangcent.common.kit.sub
 import com.itangcent.common.utils.KV
 import com.itangcent.idea.plugin.api.export.ClassExportRuleKeys
 import com.itangcent.intellij.config.rule.computer
+import com.itangcent.intellij.extend.toPrettyString
+import com.itangcent.intellij.jvm.PsiExpressionResolver
 import com.itangcent.intellij.jvm.duck.DuckType
 import com.itangcent.intellij.jvm.element.ExplicitClass
 import com.itangcent.intellij.jvm.element.ExplicitElement
+import com.itangcent.intellij.jvm.element.ExplicitField
 import com.itangcent.intellij.psi.DefaultPsiClassHelper
 
 /**
- * 1.support rule:["field.required"]
+ * support rules:
+ * 1. field.required
+ * 2. field.default.value
  */
 class CustomizedPsiClassHelper : DefaultPsiClassHelper() {
 
+    @Inject
+    private val psiExpressionResolver: PsiExpressionResolver? = null
+
     override fun afterParseFieldOrMethod(fieldName: String, fieldType: DuckType, fieldOrMethod: ExplicitElement<*>, resourcePsiClass: ExplicitClass, option: Int, kv: KV<String, Any?>) {
         super.afterParseFieldOrMethod(fieldName, fieldType, fieldOrMethod, resourcePsiClass, option, kv)
+
         ruleComputer!!.computer(ClassExportRuleKeys.FIELD_REQUIRED, fieldOrMethod)?.let { required ->
             kv.sub(Attrs.REQUIRED_ATTR)[fieldName] = required
+        }
+
+        //compute `field.default.value`
+        val defaultValue = ruleComputer.computer(ClassExportRuleKeys.FIELD_DEFAULT_VALUE, fieldOrMethod)
+        if (defaultValue.isNullOrEmpty()) {
+            if (fieldOrMethod is ExplicitField) {
+                fieldOrMethod.psi().initializer?.let { psiExpressionResolver!!.process(it) }?.toPrettyString()
+                        ?.let { kv.sub(Attrs.DEFAULT_VALUE_ATTR)[fieldName] = it }
+            }
+        } else {
+            kv.sub(Attrs.DEFAULT_VALUE_ATTR)[fieldName] = defaultValue
         }
     }
 


### PR DESCRIPTION
support tow markdown format type:

-   **SIMPLE**: simple columns, include name、type、desc
-   **ULTIMATE**: more columns than simple, include name、type、required、default、desc

![image](https://user-images.githubusercontent.com/17569144/96333050-367b7280-109a-11eb-84c0-6c2d7be00318.png)

--

close #337 