### PR TITLE
release v2.0.4

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -170,3 +170,11 @@
     
     * fix: fix class/type #isExtend [(#334)](https://github.com/tangcent/easy-api/pull/334)
     
+    * fix: always use json settings. [(#336)](https://github.com/tangcent/easy-api/pull/336)
+    
+    * opti: new func: tool.traversal [(#338)](https://github.com/tangcent/easy-api/pull/338)
+    
+    * opti: support rule `field.default.value` [(#339)](https://github.com/tangcent/easy-api/pull/339)
+    
+    * fix: remove usage of Module.getModuleFilePath [(#340)](https://github.com/tangcent/easy-api/pull/340)
+    

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.0.3.183.0'
+version '2.0.4.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyApi
-plugin_version=2.0.3.183.0
+plugin_version=2.0.4.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,16 +1,19 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.0.3">v2.0.3.183.0(2020-09-22)</a>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.0.4">v2.0.4.183.0(2020-09-22)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li> feat: support DeferredResult by recommend <a
-            href="https://github.com/tangcent/easy-api/pull/332">(#332)</a>
+    <li> opti: new func: tool.traversal <a
+            href="https://github.com/tangcent/easy-api/pull/338">(#338)</a>
     </li>
-    <li> feat: new recommend config [support_enum_common] <a
-            href="https://github.com/tangcent/easy-api/pull/333">(#333)</a>
+    <li> opti: support rule `field.default.value` <a
+            href="https://github.com/tangcent/easy-api/pull/339">(#339)</a>
     </li>
 </ul>
 <ul>fix:
-    <li> fix: fix class/type #isExtend <a
-            href="https://github.com/tangcent/easy-api/pull/334">(#334)</a>
+    <li> fix: always use json settings. <a
+            href="https://github.com/tangcent/easy-api/pull/336">(#336)</a>
+    </li>
+    <li> fix: remove usage of Module.getModuleFilePath. <a
+            href="https://github.com/tangcent/easy-api/pull/340">(#340)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-api</id>
     <name>EasyApi</name>
-    <version>2.0.3.183.0</version>
+    <version>2.0.4.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>
@@ -21,7 +21,7 @@
     <change-notes><![CDATA[	Change notes will be filled by gradle build ]]>
     </change-notes>
 
-    <!--This plugin will support IntelliJ IDEA Community and Ultimate Only before v2.0.1-->
+    <!--This plugin will support IntelliJ IDEA Community and Ultimate only before v3.0.0-->
 
     <depends optional="true" config-file="easy-api-java.xml">com.intellij.modules.java</depends>
     <!--it will cause 【Optional dependency declaration on 'com.intellij.modules.idea' should specify "config-file"】-->


### PR DESCRIPTION

* fix: always use json settings. [(#336)](https://github.com/tangcent/easy-api/pull/336)

* opti: new func: tool.traversal [(#338)](https://github.com/tangcent/easy-api/pull/338)

* opti: support rule `field.default.value` [(#339)](https://github.com/tangcent/easy-api/pull/339)

* fix: remove usage of Module.getModuleFilePath [(#340)](https://github.com/tangcent/easy-api/pull/340)
