### PR TITLE
release 2.1.2

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -20,6 +20,10 @@
     
     * opti: support `url.cache.expire` [(#379)](https://github.com/tangcent/easy-api/pull/379)
     
+    * opti: add recommend third config [(#381)](https://github.com/tangcent/easy-api/pull/381)
+    
+    * opti: show default built-in config in setting [(#382)](https://github.com/tangcent/easy-api/pull/382)
+    
 * 2.0.0~
     * feat: new rules `class.postman.prerequest`&`class.postman.test` [(#312)](https://github.com/tangcent/easy-api/pull/312)
     

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.1.2.183.0-rc'
+version '2.1.2.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyApi
-plugin_version=2.1.2.183.0-rc
+plugin_version=2.1.2.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.2-rc">v2.1.2.183.0-rc(2021-02-25)</a>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.2">v2.1.2.183.0(2021-02-28)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
@@ -14,5 +14,12 @@
     <li> opti: support `url.cache.expire` <a
             href="https://github.com/tangcent/easy-api/pull/379">(#379)</a>
     </li>
+    <li> opti: add recommend third config <a
+            href="https://github.com/tangcent/easy-api/pull/381">(#381)</a>
+    </li>
+    <li> opti: show default built-in config in setting <a
+            href="https://github.com/tangcent/easy-api/pull/382">(#382)</a>
+    </li>
+
 </ul>
 

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-api</id>
     <name>EasyApi</name>
-    <version>2.1.2.183.0-rc</version>
+    <version>2.1.2.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* opti: support built-in config [(#375)](https://github.com/tangcent/easy-api/pull/375)

* opti: `properties.additional` support url [(#377)](https://github.com/tangcent/easy-api/pull/377)

* opti: support `param.doc` for export methodDoc [(#378)](https://github.com/tangcent/easy-api/pull/378)

* opti: support `url.cache.expire` [(#379)](https://github.com/tangcent/easy-api/pull/379)

* opti: add recommend third config [(#381)](https://github.com/tangcent/easy-api/pull/381)

* opti: show default built-in config in setting [(#382)](https://github.com/tangcent/easy-api/pull/382)
