### PR TITLE
release v2.1.4

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,7 @@
+* 2.1.4
+
+	* fix: use `asKV` instead of `as KV<>` [(#386)](https://github.com/tangcent/easy-api/pull/386)
+
 * 2.1.0~
 
     * fix: resolve on-demand import [(#84)](https://github.com/Earth-1610/intellij-kotlin/pull/84)

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.nio.charset.StandardCharsets
 
 group 'com.itangcent'
-version '2.1.3.183.0'
+version '2.1.4.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyApi
-plugin_version=2.1.3.183.0
+plugin_version=2.1.4.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,29 +1,8 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.3">v2.1.3.183.0(2021-03-03)</a>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.4">v2.1.4.183.0(2021-03-07)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
-<ul>enhancement:
-    <li> opti: support built-in config <a
-            href="https://github.com/tangcent/easy-api/pull/375">(#375)</a>
-    </li>
-    <li> opti: `properties.additional` support url <a
-            href="https://github.com/tangcent/easy-api/pull/377">(#377)</a>
-    </li>
-    <li> opti: support `param.doc` for export methodDoc <a
-            href="https://github.com/tangcent/easy-api/pull/378">(#378)</a>
-    </li>
-    <li> opti: support `url.cache.expire` <a
-            href="https://github.com/tangcent/easy-api/pull/379">(#379)</a>
-    </li>
-    <li> opti: add recommend third config <a
-            href="https://github.com/tangcent/easy-api/pull/381">(#381)</a>
-    </li>
-    <li> opti: show default built-in config in setting <a
-            href="https://github.com/tangcent/easy-api/pull/382">(#382)</a>
-    </li>
-</ul>
 <ul>fix:
-    <li> fix: bind `settings.builtInConfig` as nullable <a
-            href="https://github.com/tangcent/easy-api/pull/382">(#384)</a>
+    <li> fix: use `asKV` instead of `as KV<>` <a
+            href="https://github.com/tangcent/easy-api/pull/386">(#386)</a>
     </li>
 </ul>
-

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-api</id>
     <name>EasyApi</name>
-    <version>2.1.3.183.0</version>
+    <version>2.1.4.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: use `asKV` instead of `as KV<>` [(#386)](https://github.com/tangcent/easy-api/pull/386)