### PR TITLE
release v2.1.7

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,7 @@
+* 2.1.7
+
+	* feat: pick features from easy-yapi [(#415)](https://github.com/tangcent/easy-api/pull/415)&[(#414)](https://github.com/tangcent/easy-api/pull/414)
+
 * 2.1.6
 
 	* test: add test case of ApiCaller [(#412)](https://github.com/tangcent/easy-api/pull/412)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.1.6.183.0'
+version '2.1.7.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyApi
-plugin_version=2.1.6.183.0
+plugin_version=2.1.7.183.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,22 +1,19 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.6">v2.1.6.183.0(2021-11-06)</a>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.7">v2.1.7.183.0(2022-02-27)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: new event rules <a
-			href="https://github.com/tangcent/easy-api/pull/411">(#411)</a>
+	<li> feat: [generic] auto fix http method <a
+			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
 	</li>
-	<li> feat: [ScriptExecutor] explicit class <a
-			href="https://github.com/tangcent/easy-api/pull/410">(#410)</a>
-	</li>
-	<li> feat: change action groups <a
-			href="https://github.com/tangcent/easy-api/pull/408">(#408)</a>
-	</li>
-	<li> feat: recommend configs of Jackson JsonNaming(namingStrategy) <a
-			href="https://github.com/tangcent/easy-api/pull/407">(#407)</a>
+	<li> feat: new Action FieldsToProperties <a
+			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: resolve Object as {} <a
-			href="https://github.com/tangcent/easy-api/pull/409">(#409)</a>
+	<li> fix: use `any` instead of `forEach` to export api from superMethods <a
+			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
+	</li>
+	<li> fix: remove usage of  ObjectTypeAdapter.FACTORY <a
+			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-api</id>
     <name>EasyApi</name>
-    <version>2.1.6.183.0</version>
+    <version>2.1.7.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: [generic] auto fix http method [(#414)](https://github.com/tangcent/easy-api/pull/414)

* fix: use `any` instead of `forEach` to export api from superMethods [(#414)](https://github.com/tangcent/easy-api/pull/414)

* fix: remove usage of  ObjectTypeAdapter.FACTORY [(#414)](https://github.com/tangcent/easy-api/pull/414)

* feat: new Action FieldsToProperties [(#414)](https://github.com/tangcent/easy-api/pull/414)
