### PR TITLE
release v2.1.8

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,15 @@
+* 2.1.8
+
+	* chore: update swagger.config [(#421)](https://github.com/tangcent/easy-api/pull/421)
+
+	* fix: resolve mapping annotation for feign client [(#420)](https://github.com/tangcent/easy-api/pull/420)
+
+	* feat: export apis from implements [(#419)](https://github.com/tangcent/easy-api/pull/419)
+
+	* feat:  support change log charset by settings [(#418)](https://github.com/tangcent/easy-api/pull/418)
+
+	* test: DefaultFileSaveHelperTest [(#417)](https://github.com/tangcent/easy-api/pull/417)
+
 * 2.1.7
 
 	* feat: pick features from easy-yapi [(#415)](https://github.com/tangcent/easy-api/pull/415)&[(#414)](https://github.com/tangcent/easy-api/pull/414)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.1.7.183.0'
+version '2.1.8.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyApi
-plugin_version=2.1.7.183.0
+plugin_version=2.1.8.183.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,19 +1,16 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.7">v2.1.7.183.0(2022-02-27)</a>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.8">v2.1.8.183.0(2022-03-13)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: [generic] auto fix http method <a
-			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
+	<li> feat: export apis from implements <a
+			href="https://github.com/tangcent/easy-api/pull/419">(#419)</a>
 	</li>
-	<li> feat: new Action FieldsToProperties <a
-			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
+	<li> feat:  support change log charset by settings <a
+			href="https://github.com/tangcent/easy-api/pull/418">(#418)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: use `any` instead of `forEach` to export api from superMethods <a
-			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
-	</li>
-	<li> fix: remove usage of  ObjectTypeAdapter.FACTORY <a
-			href="https://github.com/tangcent/easy-api/pull/414">(#414)</a>
+	<li> fix: resolve mapping annotation for feign client <a
+			href="https://github.com/tangcent/easy-api/pull/420">(#420)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-api</id>
     <name>EasyApi</name>
-    <version>2.1.7.183.0</version>
+    <version>2.1.8.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* chore: update swagger.config [(#421)](https://github.com/tangcent/easy-api/pull/421)

* fix: resolve mapping annotation for feign client [(#420)](https://github.com/tangcent/easy-api/pull/420)

* feat: export apis from implements [(#419)](https://github.com/tangcent/easy-api/pull/419)

* feat:  support change log charset by settings [(#418)](https://github.com/tangcent/easy-api/pull/418)

* test: DefaultFileSaveHelperTest [(#417)](https://github.com/tangcent/easy-api/pull/417)
