### PR TITLE
release v2.2.1

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,41 @@
+* 2.2.1
+
+	* fix: fix the icons and buttons disappeared [(#466)](https://github.com/tangcent/easy-api/pull/466)
+
+	* fix: check group with `javax.validation.groups.Default` [(#468)](https://github.com/tangcent/easy-api/pull/468)
+
+	* amend: group actions in pop [(#467)](https://github.com/tangcent/easy-api/pull/467)
+
+	* fix: remove invalid attributes for create postman collections [(#465)](https://github.com/tangcent/easy-api/pull/465)
+
+	* fix: open FileChooser at AWT Thread [(#464)](https://github.com/tangcent/easy-api/pull/464)
+
+	* polish: remove usage of AutoComputer in ApiCallDialog [(#463)](https://github.com/tangcent/easy-api/pull/463)
+
+	* polish: update icons [(#462)](https://github.com/tangcent/easy-api/pull/462)
+
+	* feat: highlight new content in Settings->Recommend [(#461)](https://github.com/tangcent/easy-api/pull/461)
+
+	* feat: support remote config setting [(#460)](https://github.com/tangcent/easy-api/pull/460)
+
+	* feat: populate field from default value [(#458)](https://github.com/tangcent/easy-api/pull/458)
+
+	* amend: use :Log() instead of define [(#457)](https://github.com/tangcent/easy-api/pull/457)
+
+	* fix: parse FeignClient#path [(#456)](https://github.com/tangcent/easy-api/pull/456)
+
+	* feat: support export apis from actuator [(#454)](https://github.com/tangcent/easy-api/pull/454)
+
+	* amend: update config [(#453)](https://github.com/tangcent/easy-api/pull/453)
+
+	* feat: asks how to convert enum on the first use [(#452)](https://github.com/tangcent/easy-api/pull/452)
+
+	* fix: resolve desc of return type [(#451)](https://github.com/tangcent/easy-api/pull/451)
+
+	* fix: support parse apis in several modules to one collection [(#450)](https://github.com/tangcent/easy-api/pull/450)
+
+	* feat: new setting  `Postman > build example` [(#449)](https://github.com/tangcent/easy-api/pull/449)
+
 * 2.1.9
 
 	* feat: enum auto select field by type [(#447)](https://github.com/tangcent/easy-api/pull/447)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.1.9.183.0'
+version '2.2.1.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyApi
-plugin_version=2.1.9.183.0
+plugin_version=2.2.1.183.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,64 +1,46 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.1.9">v2.1.9.183.0(2022-07-17)</a>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.2.1">v2.2.1.183.0(2022-12-12)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: enum auto select field by type <a
-			href="https://github.com/tangcent/easy-api/pull/447">(#447)</a>
+	<li> feat: highlight new content in Settings->Recommend <a
+			href="https://github.com/tangcent/easy-api/pull/461">(#461)</a>
 	</li>
-	<li> feat: resolve suspend function in kotlin <a
-			href="https://github.com/tangcent/easy-api/pull/444">(#444)</a>
+	<li> feat: support remote config setting <a
+			href="https://github.com/tangcent/easy-api/pull/460">(#460)</a>
 	</li>
-	<li> feat: get resource with timeout <a
-			href="https://github.com/tangcent/easy-api/pull/443">(#443)</a>
+	<li> feat: populate field from default value <a
+			href="https://github.com/tangcent/easy-api/pull/458">(#458)</a>
 	</li>
-	<li> feat: support new setting 'export selected method only' <a
-			href="https://github.com/tangcent/easy-api/pull/441">(#441)</a>
+	<li> feat: support export apis from actuator <a
+			href="https://github.com/tangcent/easy-api/pull/454">(#454)</a>
 	</li>
-	<li> feat: not require confirmation to export apis from directory <a
-			href="https://github.com/tangcent/easy-api/pull/437">(#437)</a>
+	<li> feat: asks how to convert enum on the first use <a
+			href="https://github.com/tangcent/easy-api/pull/452">(#452)</a>
 	</li>
-	<li> feat: wrap script result <a
-			href="https://github.com/tangcent/easy-api/pull/436">(#436)</a>
-	</li>
-	<li> feat: rename module quarkus to jaxrs <a
-			href="https://github.com/tangcent/easy-api/pull/433">(#433)</a>
-	</li>
-	<li> feat: init recommend config even if no module be switched <a
-			href="https://github.com/tangcent/easy-api/pull/431">(#431)</a>
-	</li>
-	<li> feat: new method for rule context `class` <a
-			href="https://github.com/tangcent/easy-api/pull/429">(#429)</a>
-	</li>
-	<li> feat: resolve RequestMapping from interfaces <a
-			href="https://github.com/tangcent/easy-api/pull/428">(#428)</a>
-	</li>
-	<li> feat: provide rules to customize tables in markdown <a
-			href="https://github.com/tangcent/easy-api/pull/427">(#427)</a>
-	</li>
-	<li> feat: provide rules to customize markdown <a
-			href="https://github.com/tangcent/easy-api/pull/423">(#423)</a>
+	<li> feat: new setting  `Postman > build example` <a
+			href="https://github.com/tangcent/easy-api/pull/449">(#449)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: resolve doc of fields for param annotated with @BeanParam <a
-			href="https://github.com/tangcent/easy-api/pull/446">(#446)</a>
+	<li> fix: fix the icons and buttons disappeared <a
+			href="https://github.com/tangcent/easy-api/pull/466">(#466)</a>
 	</li>
-	<li> fix: not use '0' as example <a
-			href="https://github.com/tangcent/easy-api/pull/440">(#440)</a>
+	<li> fix: check group with `javax.validation.groups.Default` <a
+			href="https://github.com/tangcent/easy-api/pull/468">(#468)</a>
 	</li>
-	<li> fix: fix resize of ApiCallDialog <a
-			href="https://github.com/tangcent/easy-api/pull/439">(#439)</a>
+	<li> fix: remove invalid attributes for create postman collections <a
+			href="https://github.com/tangcent/easy-api/pull/465">(#465)</a>
 	</li>
-	<li> fix: fix  rule `field.default.value` <a
-			href="https://github.com/tangcent/easy-api/pull/438">(#438)</a>
+	<li> fix: open FileChooser at AWT Thread <a
+			href="https://github.com/tangcent/easy-api/pull/464">(#464)</a>
 	</li>
-	<li> fix: refactor the thread model <a
-			href="https://github.com/tangcent/easy-api/pull/435">(#435)</a>
+	<li> fix: parse FeignClient#path <a
+			href="https://github.com/tangcent/easy-api/pull/456">(#456)</a>
 	</li>
-	<li> fix: interval sleep during parsing <a
-			href="https://github.com/tangcent/easy-api/pull/434">(#434)</a>
+	<li> fix: resolve desc of return type <a
+			href="https://github.com/tangcent/easy-api/pull/451">(#451)</a>
 	</li>
-	<li> fix: set `readTimeout` for read resource by url <a
-			href="https://github.com/tangcent/easy-api/pull/430">(#430)</a>
+	<li> fix: support parse apis in several modules to one collection <a
+			href="https://github.com/tangcent/easy-api/pull/450">(#450)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-api</id>
     <name>EasyApi</name>
-    <version>2.1.9.183.0</version>
+    <version>2.2.1.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* fix: fix the icons and buttons disappeared [(#466)](https://github.com/tangcent/easy-api/pull/466)

* fix: check group with `javax.validation.groups.Default` [(#468)](https://github.com/tangcent/easy-api/pull/468)

* amend: group actions in pop [(#467)](https://github.com/tangcent/easy-api/pull/467)

* fix: remove invalid attributes for create postman collections [(#465)](https://github.com/tangcent/easy-api/pull/465)

* fix: open FileChooser at AWT Thread [(#464)](https://github.com/tangcent/easy-api/pull/464)

* polish: remove usage of AutoComputer in ApiCallDialog [(#463)](https://github.com/tangcent/easy-api/pull/463)

* polish: update icons [(#462)](https://github.com/tangcent/easy-api/pull/462)

* feat: highlight new content in Settings->Recommend [(#461)](https://github.com/tangcent/easy-api/pull/461)

* feat: support remote config setting [(#460)](https://github.com/tangcent/easy-api/pull/460)

* feat: populate field from default value [(#458)](https://github.com/tangcent/easy-api/pull/458)

* amend: use :Log() instead of define [(#457)](https://github.com/tangcent/easy-api/pull/457)

* fix: parse FeignClient#path [(#456)](https://github.com/tangcent/easy-api/pull/456)

* feat: support export apis from actuator [(#454)](https://github.com/tangcent/easy-api/pull/454)

* amend: update config [(#453)](https://github.com/tangcent/easy-api/pull/453)

* feat: asks how to convert enum on the first use [(#452)](https://github.com/tangcent/easy-api/pull/452)

* fix: resolve desc of return type [(#451)](https://github.com/tangcent/easy-api/pull/451)

* fix: support parse apis in several modules to one collection [(#450)](https://github.com/tangcent/easy-api/pull/450)

* feat: new setting  `Postman > build example` [(#449)](https://github.com/tangcent/easy-api/pull/449)
