### PR TITLE
chore: fix compatibility issues in compatibility verification

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/DefaultMethodInferHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/DefaultMethodInferHelper.kt
@@ -723,7 +723,7 @@ class DefaultMethodInferHelper : MethodInferHelper {
     private fun getSimpleFields(psiType: PsiType?, context: PsiElement): Any? {
         actionContext!!.checkStatus()
         when {
-            psiType == null || psiType == PsiType.VOID -> return null
+            psiType == null -> return null
             psiType is PsiPrimitiveType -> return PsiTypesUtil.getDefaultValue(psiType)
             psiClassHelper!!.isNormalType(psiType) -> return psiClassHelper.getDefaultValue(psiType)
             psiType is PsiArrayType -> {
@@ -764,7 +764,7 @@ class DefaultMethodInferHelper : MethodInferHelper {
         }
         actionContext!!.checkStatus()
         when {
-            psiType == null || psiType == PsiType.VOID -> return null
+            psiType == null -> return null
             psiType is PsiPrimitiveType -> return PsiTypesUtil.getDefaultValue(psiType)
             psiClassHelper!!.isNormalType(psiType) -> return psiClassHelper.getDefaultValue(psiType)
             psiType is PsiArrayType -> {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/feign/FeignRequestClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/feign/FeignRequestClassExporter.kt
@@ -15,7 +15,6 @@ import com.itangcent.idea.plugin.api.export.condition.ConditionOnSimple
 import com.itangcent.idea.plugin.api.export.core.*
 import com.itangcent.idea.plugin.api.export.spring.SpringRequestClassExporter
 import com.itangcent.idea.plugin.condition.ConditionOnSetting
-import org.apache.commons.lang.StringUtils.lowerCase
 
 /**
  * Support export apis from client that annotated with @FeignClient
@@ -104,7 +103,7 @@ open class FeignRequestClassExporter : SpringRequestClassExporter() {
                 val name = it.first
                 val value = it.second.trim()
                 if (name.equalIgnoreCase("content-type")) {
-                    if (lowerCase(value).contains("application/json")) {
+                    if (value.lowercase().contains("application/json")) {
                         methodExportContext.setExt("paramType", "body")
                     }
                 }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/http/HttpClientFileSaver.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/http/HttpClientFileSaver.kt
@@ -11,9 +11,11 @@ import com.intellij.util.io.createDirectories
 import com.intellij.util.io.readText
 import com.itangcent.intellij.context.ActionContext
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
 /**
@@ -67,7 +69,7 @@ class HttpClientFileSaver {
         val file = scratchesPath.resolve(module).resolve(fileName).apply {
             parent.createDirectories()
         }
-        file.writeText(content(file.takeIf { Files.exists(it) }?.readText()))
+        file.writeText(content(file.takeIf { Files.exists(it) }?.readText(StandardCharsets.UTF_8)))
 
         return (localFileSystem.refreshAndFindFileByPath(file.toString())
             ?: throw IOException("Unable to find file: $file"))

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/GsonExUtils.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/GsonExUtils.kt
@@ -1,15 +1,13 @@
 package com.itangcent.idea.utils
 
-import com.google.gson.JsonParser
 import com.itangcent.common.utils.GsonUtils
 
 @Deprecated(replaceWith = ReplaceWith("GsonUtils"), message = "use GsonUtils")
 typealias GsonExUtils = GsonUtils
 
 fun GsonUtils.prettyJsonStr(json: String): String {
-    val jsonParser = JsonParser()
-    val jsonObject = jsonParser.parse(json).asJsonObject
-    return GsonUtils.prettyJson(jsonObject)
+    val jsonObject = parseToJsonTree(json)
+    return prettyJson(jsonObject)
 }
 
 fun String.resolveGsonLazily(): String {

--- a/idea-plugin/src/main/kotlin/com/itangcent/utils/ExtensibleKit.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/utils/ExtensibleKit.kt
@@ -2,17 +2,16 @@ package com.itangcent.utils
 
 import com.itangcent.common.constant.Attrs
 import com.itangcent.common.utils.Extensible
-import com.itangcent.common.utils.mapToTypedArray
+import com.itangcent.common.utils.GsonUtils
 import com.itangcent.intellij.extend.unbox
 import kotlin.reflect.KClass
 
 object ExtensibleKit {
 
-    private val JSON_PARSER = com.google.gson.JsonParser()
     private val GSON = com.google.gson.Gson()
 
     fun <T : Extensible> KClass<T>.fromJson(json: String): T {
-        val jsonElement = JSON_PARSER.parse(json)
+        val jsonElement = GsonUtils.parseToJsonTree(json)!!
         val t = GSON.fromJson(jsonElement, this.java)
         jsonElement.asJsonObject.entrySet()
             .filter { it.key.startsWith(Attrs.PREFIX) }
@@ -24,7 +23,7 @@ object ExtensibleKit {
         val extNames = exts.toSet() +
                 exts.map { it.removePrefix(Attrs.PREFIX) } +
                 exts.map { it.addPrefix(Attrs.PREFIX) }
-        val jsonElement = JSON_PARSER.parse(json)
+        val jsonElement = GsonUtils.parseToJsonTree(json)!!
         val t = GSON.fromJson(jsonElement, this.java)
         jsonElement.asJsonObject.entrySet()
             .filter { extNames.contains(it.key) }


### PR DESCRIPTION
IntelliJ IDEA Ultimate (241.14494.127) Compatible. 

- 3 usages of scheduled for removal API
    - EasyApi 2.2.9.212.0 uses API scheduled for removal in future releases
    - Scheduled for removal fields usages (2)
        - PsiType.VOID (2) (scheduled for removal in a future release)
            - Deprecated field PsiType.VOID is accessed in DefaultMethodInferHelper.getSimpleFields(...). This field will be removed in a future release
            - Deprecated field PsiType.VOID is accessed in DefaultMethodInferHelper.getSimpleFields(...). This field will be removed in a future release
        - Scheduled for removal class usage (1)
            - StringUtils (1) (scheduled for removal in a future release)
            - Deprecated class StringUtils is referenced in FeignRequestClassExporter.resolveHeader(...). This class will be removed in a future release

- 6 deprecated API usages
    - EasyApi 2.2.9.212.0 uses deprecated API, which may be removed in future releases leading to binary and source code incompatibilities
    - Deprecated methods usages (4)
        - JsonParser.parse(String) (3)
            - Deprecated method JsonParser.parse(String) is invoked in GsonExUtilsKt.prettyJsonStr(GsonUtils, String)
            - Deprecated method JsonParser.parse(String) is invoked in ExtensibleKit.fromJson(KClass, String)
            - Deprecated method JsonParser.parse(String) is invoked in ExtensibleKit.fromJson(KClass, String, String[])
        - PathKt.readText(Path) (1)
            - Deprecated method PathKt.readText(Path) is invoked in HttpClientFileSaver.saveHttpFile(...)
    - Deprecated constructors usages (2)
        - JsonParser.<init>() (2)
            - Deprecated constructor JsonParser.<init>() is invoked in ExtensibleKit.<clinit>()
            - Deprecated constructor JsonParser.<init>() is invoked in GsonExUtilsKt.prettyJsonStr(GsonUtils, String)