### PR TITLE
release 2.3.2

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,9 @@
+* 2.3.2
+	* fix: remove Non-extendable interface usage  [(#548)](https://github.com/tangcent/easy-api/pull/548)
+
+	* chore: polish Postman API helper classes and cache management  [(#547)](https://github.com/tangcent/easy-api/pull/547)
+
+	* fix: correct content-type for Postman API export  [(#546)](https://github.com/tangcent/easy-api/pull/546)
 * 2.3.1
 	* fix: resolve 'module_path' property resolution issue  [(#544)](https://github.com/tangcent/easy-api/pull/544)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyApi
-plugin_version=2.3.1.212.0
+plugin_version=2.3.2.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,22 +1,12 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.3.1">v2.3.1(2024-05-17)</a><br>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.3.2">v2.3.2(2024-06-30)</a><br>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
 
-<ul>
-  <li>feat: added functionality to choose between apache and okHttp for sending HTTP requests via settings (<a href="https://github.com/tangcent/easy-api/pull/543">#543</a>)</li>
-
-  <li>feat: add rules `param.name`, `param.type` (<a href="https://github.com/tangcent/easy-api/pull/541">#541</a>)</li>
-
-  <li>feat: add support for io.swagger.v3.oas.annotations.media.Schema annotation (<a href="https://github.com/tangcent/easy-api/pull/540">#540</a>)</li>
-
-  <li>feat: Replace gson and jsoup with IntelliJ code style for JSON/XML/HTML formatting (<a href="https://github.com/tangcent/easy-api/pull/538">#538</a>)</li>
-</ul>
-
 <h3>Fixes:</h3>
 
 <ul>
-  <li>fix: resolve 'module_path' property resolution issue (<a href="https://github.com/tangcent/easy-api/pull/544">#544</a>)</li>
+  <li>fix: remove Non-extendable interface usage (<a href="https://github.com/tangcent/easy-api/pull/548">#548</a>)</li>
 
-  <li>fix: fix issue where the configuration was not being loaded before actions were performed (<a href="https://github.com/tangcent/easy-api/pull/539">#539</a>)</li>
+  <li>fix: correct content-type for Postman API export (<a href="https://github.com/tangcent/easy-api/pull/546">#546</a>)</li>
 </ul>


### PR DESCRIPTION
* fix: remove Non-extendable interface usage  [(#548)](https://github.com/tangcent/easy-api/pull/548)

* chore: polish Postman API helper classes and cache management  [(#547)](https://github.com/tangcent/easy-api/pull/547)

* fix: correct content-type for Postman API export  [(#546)](https://github.com/tangcent/easy-api/pull/546)
