### PR TITLE
release 2.3.3

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,13 @@
+* 2.3.3
+	* feat: support Jackson JsonView  [(#556)](https://github.com/tangcent/easy-api/pull/556)
+
+	* feat: omit content-type header when no parameters are present  [(#555)](https://github.com/tangcent/easy-api/pull/555)
+
+	* build: update IntelliJ plugin version from 1.14.2 to 1.17.1  [(#554)](https://github.com/tangcent/easy-api/pull/554)
+
+	* feat(script): add support for 'mavenId()' in 'class'  [(#553)](https://github.com/tangcent/easy-api/pull/553)
+
+	* chore: add missing space in log message for setting Postman privateToken  [(#551)](https://github.com/tangcent/easy-api/pull/551)
 * 2.3.2
 	* fix: remove Non-extendable interface usage  [(#548)](https://github.com/tangcent/easy-api/pull/548)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 plugin_name=EasyApi
-plugin_version=2.3.2.212.0
+plugin_version=2.3.3.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2
-itangcent_intellij_version=1.6.6
+itangcent_intellij_version=1.7.0

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,12 +1,14 @@
-<a href="https://github.com/tangcent/easy-api/releases/tag/v2.3.2">v2.3.2(2024-06-30)</a><br>
+<a href="https://github.com/tangcent/easy-api/releases/tag/v2.3.3">v2.3.3(2024-11-06)</a><br>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
 
-<h3>Fixes:</h3>
-
 <ul>
-  <li>fix: remove Non-extendable interface usage (<a href="https://github.com/tangcent/easy-api/pull/548">#548</a>)</li>
+  <li>feat: support Jackson JsonView (<a href="https://github.com/tangcent/easy-api/pull/556">#556</a>)</li>
 
-  <li>fix: correct content-type for Postman API export (<a href="https://github.com/tangcent/easy-api/pull/546">#546</a>)</li>
+  <li>feat: omit content-type header when no parameters are present (<a href="https://github.com/tangcent/easy-api/pull/555">#555</a>)</li>
+
+  <li>feat(script): add support for 'mavenId()' in 'class' (<a href="https://github.com/tangcent/easy-api/pull/553">#553</a>)</li>
 </ul>
+
+<h3>Fixes:</h3>


### PR DESCRIPTION
* feat: support Jackson JsonView  [(#556)](https://github.com/tangcent/easy-api/pull/556)

* feat: omit content-type header when no parameters are present  [(#555)](https://github.com/tangcent/easy-api/pull/555)

* build: update IntelliJ plugin version from 1.14.2 to 1.17.1  [(#554)](https://github.com/tangcent/easy-api/pull/554)

* feat(script): add support for 'mavenId()' in 'class'  [(#553)](https://github.com/tangcent/easy-api/pull/553)

* chore: add missing space in log message for setting Postman privateToken  [(#551)](https://github.com/tangcent/easy-api/pull/551)