### PR TITLE
fix: resolve export silent failure and threading issues

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
@@ -16,6 +16,7 @@ import com.intellij.util.ui.UIUtil
 import com.itangcent.easyapi.cache.ApiIndex
 import com.itangcent.easyapi.cache.ApiIndexManager
 import com.itangcent.easyapi.core.context.ActionContext
+import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.exporter.ApiExporterRegistry
@@ -358,7 +359,9 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
     private fun navigateToSource(endpoint: ApiEndpoint) {
         val method = endpoint.sourceMethod ?: return
         if (method.canNavigate()) {
-            method.navigate(true)
+            IdeDispatchers.readSync {
+                method.navigate(true)
+            }
         }
     }
 
@@ -419,9 +422,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
                     orchestrator.exportEndpoints(endpoints, exportFormat, outputConfig, indicator)
                 }
 
-                swing {
-                    handleExportResult(result, format)
-                }
+                handleExportResult(result, format)
             } catch (e: Exception) {
                 LOG.warn("Export failed", e)
                 swing {
@@ -448,7 +449,12 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
                 val exporterRegistry = ApiExporterRegistry.getInstance(project)
                 val exporter = format?.let { exporterRegistry.getExporter(it) }
 
-                val handled = exporter?.handleExportResult(project, result) ?: false
+                val handled = try {
+                    exporter?.handleExportResult(project, result) ?: false
+                } catch (e: Exception) {
+                    LOG.warn("Failed to handle export result", e)
+                    false
+                }
 
                 if (!handled) {
                     showExportSuccessNotification(result)

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
@@ -94,16 +94,28 @@ class ApiScanner(private val project: Project) {
      * Use this when you have a specific set of classes to scan,
      * such as when exporting selected files from the project view.
      *
+     * If [indicator] is provided (e.g. from an outer [runWithProgress]),
+     * it is reused directly to avoid nested progress dialogs.
+     * Otherwise a new progress dialog is shown automatically.
+     *
      * @param classes The classes to scan
+     * @param indicator Optional progress indicator from the caller
      * @return Sequence of discovered API endpoints
      */
-    suspend fun scanClasses(classes: List<PsiClass>): Sequence<ApiEndpoint> {
-        LOG.debug("scanClasses called with ${classes.size} classes")
+    suspend fun scanClasses(
+        classes: List<PsiClass>,
+        indicator: ProgressIndicator? = null
+    ): Sequence<ApiEndpoint> {
+        LOG.info("scanClasses called with ${classes.size} classes")
         DumbModeHelper.waitForSmartMode(project)
 
         LOG.info("Starting API scan for selected classes...")
-        val endpoints = runWithProgress(project, "Scanning ${classes.size} classes...") { indicator ->
+        val endpoints = if (indicator != null) {
             exportClassesSequence(classes, indicator)
+        } else {
+            runWithProgress(project, "Scanning ${classes.size} classes...") { newIndicator ->
+                exportClassesSequence(classes, newIndicator)
+            }
         }
         return endpoints.asSequence()
     }
@@ -252,7 +264,7 @@ class ApiScanner(private val project: Project) {
         classes: List<PsiClass>,
         indicator: ProgressIndicator
     ): List<ApiEndpoint> {
-        LOG.debug("Building ActionContext for sequence scan...")
+        LOG.info("Building ActionContext for sequence scan...")
         val context = ActionContext.forProject(project)
 
         return try {
@@ -261,7 +273,7 @@ class ApiScanner(private val project: Project) {
                 LOG.warn("No exporters enabled")
                 return emptyList()
             }
-            LOG.debug("Enabled exporters: ${exporters.map { it::class.simpleName }}")
+            LOG.info("Enabled exporters: ${exporters.map { it::class.simpleName }}")
 
             indicator.isIndeterminate = false
             indicator.fraction = 0.0
@@ -290,16 +302,16 @@ class ApiScanner(private val project: Project) {
         psiClasses: List<PsiClass>,
         exporters: List<ClassExporter>,
         context: ActionContext,
-        indicator: ProgressIndicator
+        indicator: ProgressIndicator?
     ): List<ApiEndpoint> {
         val endpoints = mutableListOf<ApiEndpoint>()
         val total = psiClasses.size
 
         for ((index, psiClass) in psiClasses.withIndex()) {
-            indicator.checkCanceled()
+            indicator?.checkCanceled()
             val className = psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
-            indicator.text = className
-            indicator.fraction = index.toDouble() / total
+            indicator?.text = className
+            indicator?.fraction = index.toDouble() / total
             LOG.info("search api from: $className")
 
             for (exporter in exporters) {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/ExportOrchestrator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/ExportOrchestrator.kt
@@ -68,7 +68,7 @@ class ExportOrchestrator(private val project: Project) {
     ): ExportResult {
         indicator?.text = "Scanning for API endpoints..."
         indicator?.isIndeterminate = true
-        val endpoints = scanEndpoints(selection)
+        val endpoints = scanEndpoints(selection, indicator)
         
         if (endpoints.isEmpty()) {
             return ExportResult.Error("No API endpoints found")
@@ -116,19 +116,19 @@ class ExportOrchestrator(private val project: Project) {
     /**
      * Scans for API endpoints from the given selection or index.
      */
-    private suspend fun scanEndpoints(selection: SelectionScope?): List<ApiEndpoint> {
-        return withContext(IdeDispatchers.ReadAction) {
-            if (selection != null) {
-                val classes = selection.classes().toList()
-                if (classes.isNotEmpty()) {
-                    apiScanner.scanClasses(classes).toList()
-                } else {
-                    apiIndex.endpoints()
-                }
-            } else {
-                apiIndex.endpoints()
+    private suspend fun scanEndpoints(
+        selection: SelectionScope?,
+        indicator: ProgressIndicator? = null
+    ): List<ApiEndpoint> {
+        if (selection != null) {
+            val classes = withContext(IdeDispatchers.ReadAction) {
+                selection.classes().toList()
+            }
+            if (classes.isNotEmpty()) {
+                return apiScanner.scanClasses(classes, indicator).toList()
             }
         }
+        return apiIndex.endpoints()
     }
     
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/curl/CurlExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/curl/CurlExporter.kt
@@ -7,14 +7,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileWrapper
 import com.itangcent.easyapi.cache.DefaultHttpContextCacheHelper
-import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.background
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.exporter.ApiExporter
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportFormat
 import com.itangcent.easyapi.exporter.model.ExportResult
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -80,11 +78,13 @@ class CurlExporter(private val project: Project) : ApiExporter {
 
         val targetFile = selectTargetFile(project) ?: return false
 
-        withContext(Dispatchers.IO) {
+        background {
             targetFile.writeText(metadata.content)
         }
 
-        showSuccessMessage(project, result, targetFile.absolutePath)
+        swing {
+            showSuccessMessage(project, result, targetFile.absolutePath)
+        }
         return true
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/httpclient/HttpClientExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/httpclient/HttpClientExporter.kt
@@ -60,7 +60,9 @@ class HttpClientExporter(private val project: Project) : ApiExporter {
             FileEditorManager.getInstance(project).openFile(scratchFile, true)
         }
 
-        showSuccessMessage(project, result, scratchFile.path)
+        swing {
+            showSuccessMessage(project, result, scratchFile.path)
+        }
         return true
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/MarkdownExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/MarkdownExporter.kt
@@ -6,14 +6,13 @@ import com.intellij.openapi.fileChooser.FileSaverDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileWrapper
-import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.background
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.exporter.ApiExporter
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportFormat
 import com.itangcent.easyapi.exporter.model.ExportResult
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import com.itangcent.easyapi.logging.IdeaLog
 import java.io.File
 
 /**
@@ -24,7 +23,7 @@ import java.io.File
  * structured documentation with tables for parameters and request/response bodies.
  */
 @Service(Service.Level.PROJECT)
-class MarkdownExporter(private val project: Project) : ApiExporter {
+class MarkdownExporter(private val project: Project) : ApiExporter, IdeaLog {
 
     /** The export format this exporter handles */
     override val format: ExportFormat = ExportFormat.MARKDOWN
@@ -70,11 +69,14 @@ class MarkdownExporter(private val project: Project) : ApiExporter {
 
         val targetFile = selectTargetFile(project) ?: return false
 
-        withContext(Dispatchers.IO) {
+        background {
             targetFile.writeText(metadata.content)
         }
+        LOG.info("Markdown exported to ${targetFile.absolutePath}")
 
-        showSuccessMessage(project, result, targetFile.absolutePath)
+        swing {
+            showSuccessMessage(project, result, targetFile.absolutePath)
+        }
         return true
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/postman/PostmanExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/postman/PostmanExporter.kt
@@ -21,7 +21,6 @@ import com.itangcent.easyapi.settings.PostmanExportMode
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.exporter.postman.model.postmanGson
 import com.itangcent.easyapi.util.ide.ModuleHelper
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 
@@ -361,11 +360,13 @@ class PostmanExporter(private val project: Project) : ApiExporter {
         val gson = postmanGson()
         val content = gson.toJson(metadata.collectionData)
 
-        withContext(Dispatchers.IO) {
+        withContext(IdeDispatchers.Background) {
             targetFile.writeText(content)
         }
 
-        showSuccessMessage(project, result, targetFile.absolutePath)
+        swing {
+            showSuccessMessage(project, result, targetFile.absolutePath)
+        }
         return true
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/BaseExportAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/BaseExportAction.kt
@@ -1,11 +1,9 @@
 package com.itangcent.easyapi.ide.action
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.core.context.ActionContext
-import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.exporter.ApiExporterRegistry
@@ -18,10 +16,7 @@ import com.itangcent.easyapi.ide.support.SelectionScope
 import com.itangcent.easyapi.ide.support.runWithProgress
 import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Base class for API export actions.
@@ -104,11 +99,12 @@ abstract class BaseExportAction : EasyApiAction(), IdeaLog {
             val orchestrator = ExportOrchestrator.getInstance(project)
             val result = orchestrator.orchestrateExport(selection, exportFormat, indicator = indicator)
 
-            swing {
-                handleExportResult(project, result)
-            }
+            handleExportResult(project, result)
+        } catch (ce: CancellationException) {
+            LOG.info("Export cancelled")
+            throw ce
         } catch (ex: Exception) {
-            LOG.error("Export failed", ex)
+            LOG.warn("Export failed", ex)
             IdeaConsoleProvider.getInstance(project).getConsole().error("Export failed", ex)
             swing {
                 showExportError(project, ex.message ?: "Unknown error")
@@ -124,10 +120,19 @@ abstract class BaseExportAction : EasyApiAction(), IdeaLog {
                 val exporterRegistry = ApiExporterRegistry.getInstance(project)
                 val exporter = exporterRegistry.getExporter(exportFormat)
 
-                val handled = exporter?.handleExportResult(project, result) ?: false
+                val handled = try {
+                    exporter?.handleExportResult(project, result) ?: false
+                } catch (e: Exception) {
+                    LOG.warn("Failed to handle export result", e)
+                    IdeaConsoleProvider.getInstance(project).getConsole()
+                        .error("Failed to save export result", e)
+                    false
+                }
 
                 if (!handled) {
-                    showSuccessMessage(project, result)
+                    swing {
+                        showSuccessMessage(project, result)
+                    }
                 }
             }
 
@@ -135,7 +140,9 @@ abstract class BaseExportAction : EasyApiAction(), IdeaLog {
             }
 
             is ExportResult.Error -> {
-                showExportError(project, result.message)
+                swing {
+                    showExportError(project, result.message)
+                }
             }
         }
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
@@ -12,16 +12,11 @@ import com.itangcent.easyapi.ide.dialog.ExportDialogResult
 import com.itangcent.easyapi.ide.support.SelectedHelper
 import com.itangcent.easyapi.ide.support.SelectionScope
 import com.itangcent.easyapi.ide.support.runWithProgress
-import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.cache.ApiIndex
 import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiScanner
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import com.itangcent.easyapi.logging.IdeaLog
 
 /**
  * Action for exporting APIs with a format selection dialog.
@@ -37,26 +32,24 @@ import kotlinx.coroutines.withContext
  * @see ExportDialog for the configuration dialog
  * @see ExportOrchestrator for the export process
  */
-class ExportApiAction : AnAction() {
+class ExportApiAction : AnAction(), IdeaLog {
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val selection = SelectedHelper.resolveSelection(e)
 
         backgroundAsync {
-            val endpoints = withContext(IdeDispatchers.ReadAction) {
-                val apiIndex = ApiIndex.getInstance(project)
-                val scanner = ApiScanner.getInstance(project)
-                if (selection != null) {
-                    val classes = selection.classes().toList()
-                    if (classes.isNotEmpty()) {
-                        scanner.scanClasses(classes).toList()
-                    } else {
-                        apiIndex.endpoints()
-                    }
+            val apiIndex = ApiIndex.getInstance(project)
+            val scanner = ApiScanner.getInstance(project)
+            val endpoints = if (selection != null) {
+                val classes = selection.classes().toList()
+                if (classes.isNotEmpty()) {
+                    scanner.scanClasses(classes).toList()
                 } else {
                     apiIndex.endpoints()
                 }
+            } else {
+                apiIndex.endpoints()
             }
 
             swing {
@@ -80,9 +73,7 @@ class ExportApiAction : AnAction() {
                     selection, dialogResult.format, dialogResult.outputConfig, indicator
                 )
 
-                swing {
-                    handleExportResult(project, exportResult, dialogResult)
-                }
+                handleExportResult(project, exportResult, dialogResult)
             }
         }
     }
@@ -96,15 +87,24 @@ class ExportApiAction : AnAction() {
             is ExportResult.Success -> {
                 val exporter = ApiExporterRegistry.getInstance(project)
                     .getExporter(dialogResult.format)
-                val handled = exporter?.handleExportResult(project, result) ?: false
+                val handled = try {
+                    exporter?.handleExportResult(project, result) ?: false
+                } catch (e: Exception) {
+                    LOG.warn("Failed to handle export result", e)
+                    false
+                }
                 if (!handled) {
-                    val message = "Successfully exported ${result.count} endpoints to ${result.target}"
-                    Messages.showInfoMessage(project, message, "Export Successful")
+                    swing {
+                        val message = "Successfully exported ${result.count} endpoints to ${result.target}"
+                        Messages.showInfoMessage(project, message, "Export Successful")
+                    }
                 }
             }
 
             is ExportResult.Error -> {
-                Messages.showErrorDialog(project, result.message, "Export Failed")
+                swing {
+                    Messages.showErrorDialog(project, result.message, "Export Failed")
+                }
             }
 
             is ExportResult.Cancelled -> {}


### PR DESCRIPTION
## Problem

Markdown export (and other exports) can silently fail — the progress bar shows but nothing is produced. Reported in tangcent/easy-yapi#1298.

## Root Causes

1. **Nested `runWithProgress`** — `BaseExportAction` wraps in `runWithProgress`, then `ExportOrchestrator` calls `ApiScanner.scanClasses` which called `runWithProgress` again internally. The nested `ProgressManager.run(Task.Backgroundable)` inside `runBlocking` caused deadlocks or silent failures on newer IDEA versions.

2. **`Dispatchers.IO` instead of `IdeDispatchers.Background`** — File writes in `MarkdownExporter`, `PostmanExporter`, and `CurlExporter` used `Dispatchers.IO` which inherits EDT context markers from IntelliJ managed executors, causing threading violations.

3. **Silent exception swallowing** — `exporter.handleExportResult()` was called without try-catch in `BaseExportAction`, `ExportApiAction`, and `ApiDashboardPanel`. Any exception during file save would vanish.

4. **`handleExportResult` wrapped in outer `swing {}`** — The exporters already manage their own `swing {}` calls internally for dialogs. Wrapping the call in `swing {}` from the caller caused nested EDT dispatch issues.

5. **`CancellationException` caught as `Exception`** — In `BaseExportAction.performExport`, catching `Exception` swallowed coroutine cancellation.

6. **`LOG.error` usage** — Violated project logging guidelines (should use `LOG.warn`).

## Changes

- `ApiScanner.scanClasses`: Reuses caller indicator when provided, creates own `runWithProgress` only when called standalone
- `ExportOrchestrator.scanEndpoints`: Passes indicator through to `scanClasses`; resolves selection classes in `ReadAction` separately from `scanClasses` (which handles its own threading)
- `BaseExportAction`: Catches `CancellationException` properly; wraps `exporter.handleExportResult` in try-catch; uses `LOG.warn`; removes outer `swing {}` around `handleExportResult`
- `ExportApiAction`: Same fixes for `handleExportResult` call
- `ApiDashboardPanel`: Same fixes for `handleExportResult` call
- `MarkdownExporter`, `CurlExporter`: Replace `Dispatchers.IO` with `IdeDispatchers.Background`; wrap `showSuccessMessage` in `swing {}`
- `PostmanExporter`: Replace `Dispatchers.IO` with `IdeDispatchers.Background`; wrap `showSuccessMessage` in `swing {}`
- `HttpClientExporter`: Wrap `showSuccessMessage` in `swing {}`

Fixes tangcent/easy-yapi#1298