### PR TITLE
fix: prevent OOM from circular ObjectModel references in markdown formatter

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
@@ -423,7 +423,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
                 }
 
                 handleExportResult(result, format)
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 LOG.warn("Export failed", e)
                 swing {
                     NotificationUtils.notifyError(

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatter.kt
@@ -36,7 +36,8 @@ import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
  * @param outputDemo Whether to include JSON demo examples in the output
  */
 class DefaultMarkdownFormatter(
-    private val outputDemo: Boolean = true
+    private val outputDemo: Boolean = true,
+    private val maxVisits: Int = 2
 ) : MarkdownFormatter {
     
     /**
@@ -354,14 +355,28 @@ class DefaultMarkdownFormatter(
      * @param depth The current nesting depth for indentation
      */
     private fun formatObjectModelRecursive(sb: StringBuilder, model: ObjectModel, depth: Int) {
+        val visitCounts = HashMap<Int, Int>()
+        formatObjectModelRecursive(sb, model, depth, visitCounts)
+    }
+
+    private fun formatObjectModelRecursive(
+        sb: StringBuilder,
+        model: ObjectModel,
+        depth: Int,
+        visitCounts: HashMap<Int, Int>
+    ) {
         when (model) {
             is ObjectModel.Object -> {
+                val count = visitCounts.getOrDefault(model.id, 0)
+                if (count >= maxVisits) return
+                visitCounts[model.id] = count + 1
                 for ((fieldName, fieldModel) in model.fields) {
-                    formatFieldRow(sb, fieldName, fieldModel, depth)
+                    formatFieldRow(sb, fieldName, fieldModel, depth, visitCounts)
                 }
+                visitCounts[model.id] = count
             }
             is ObjectModel.Array -> {
-                formatArrayItemRecursive(sb, model.item, "[0]", depth)
+                formatArrayItemRecursive(sb, model.item, "[0]", depth, visitCounts)
             }
             is ObjectModel.Single -> {
                 sb.append("| | ").append(escape(model.type)).append(" | |").append('\n')
@@ -381,15 +396,25 @@ class DefaultMarkdownFormatter(
      * @param prefix The prefix for field names (e.g., "[0]")
      * @param depth The current nesting depth
      */
-    private fun formatArrayItemRecursive(sb: StringBuilder, item: ObjectModel, prefix: String, depth: Int) {
+    private fun formatArrayItemRecursive(
+        sb: StringBuilder,
+        item: ObjectModel,
+        prefix: String,
+        depth: Int,
+        visitCounts: HashMap<Int, Int>
+    ) {
         when (item) {
             is ObjectModel.Object -> {
+                val count = visitCounts.getOrDefault(item.id, 0)
+                if (count >= maxVisits) return
+                visitCounts[item.id] = count + 1
                 for ((fieldName, fieldModel) in item.fields) {
-                    formatFieldRow(sb, "$prefix.$fieldName", fieldModel, depth)
+                    formatFieldRow(sb, "$prefix.$fieldName", fieldModel, depth, visitCounts)
                 }
+                visitCounts[item.id] = count
             }
             is ObjectModel.Array -> {
-                formatArrayItemRecursive(sb, item.item, "$prefix[0]", depth)
+                formatArrayItemRecursive(sb, item.item, "$prefix[0]", depth, visitCounts)
             }
             is ObjectModel.Single -> {
                 sb.append("| ").append(escape(prefix)).append(" | ")
@@ -416,7 +441,13 @@ class DefaultMarkdownFormatter(
      * @param fieldModel The field model containing type and description
      * @param depth The current nesting depth
      */
-    private fun formatFieldRow(sb: StringBuilder, fieldName: String, fieldModel: FieldModel, depth: Int) {
+    private fun formatFieldRow(
+        sb: StringBuilder,
+        fieldName: String,
+        fieldModel: FieldModel,
+        depth: Int,
+        visitCounts: HashMap<Int, Int>
+    ) {
         val indent = if (depth > 0) {
             "&ensp;&ensp;".repeat(depth) + "&#124;─"
         } else {
@@ -434,16 +465,24 @@ class DefaultMarkdownFormatter(
         
         when (val nestedModel = fieldModel.model) {
             is ObjectModel.Object -> {
+                val count = visitCounts.getOrDefault(nestedModel.id, 0)
+                if (count >= maxVisits) return
+                visitCounts[nestedModel.id] = count + 1
                 for ((nestedFieldName, nestedFieldModel) in nestedModel.fields) {
-                    formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1)
+                    formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1, visitCounts)
                 }
+                visitCounts[nestedModel.id] = count
             }
             is ObjectModel.Array -> {
                 when (val item = nestedModel.item) {
                     is ObjectModel.Object -> {
+                        val count = visitCounts.getOrDefault(item.id, 0)
+                        if (count >= maxVisits) return
+                        visitCounts[item.id] = count + 1
                         for ((nestedFieldName, nestedFieldModel) in item.fields) {
-                            formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1)
+                            formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1, visitCounts)
                         }
+                        visitCounts[item.id] = count
                     }
                     else -> {
                         // For simple array types, no nested rows needed

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/BaseExportAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/BaseExportAction.kt
@@ -103,7 +103,7 @@ abstract class BaseExportAction : EasyApiAction(), IdeaLog {
         } catch (ce: CancellationException) {
             LOG.info("Export cancelled")
             throw ce
-        } catch (ex: Exception) {
+        } catch (ex: Throwable) {
             LOG.warn("Export failed", ex)
             IdeaConsoleProvider.getInstance(project).getConsole().error("Export failed", ex)
             swing {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatterTest.kt
@@ -288,4 +288,113 @@ class DefaultMarkdownFormatterTest {
         assertTrue(markdown.contains("file"))
         assertTrue(markdown.contains("description"))
     }
+
+    @Test
+    fun testFormatCircularReferenceDoesNotStackOverflow() = runBlocking {
+        // Simulate a self-referencing type like TreeNode { name: String, children: List<TreeNode> }
+        val fields = mutableMapOf<String, FieldModel>()
+        val treeNode = ObjectModel.Object(fields)
+        fields["name"] = FieldModel(ObjectModel.single(JsonType.STRING), comment = "node name")
+        fields["children"] = FieldModel(ObjectModel.array(treeNode), comment = "child nodes")
+
+        val endpoint = ApiEndpoint(
+            name = "Get Tree",
+            metadata = HttpMetadata(
+                path = "/api/tree",
+                method = HttpMethod.GET,
+                responseBody = treeNode
+            )
+        )
+
+        // Should complete without OOM or StackOverflow
+        val markdown = formatter.format(listOf(endpoint), "Tree API")
+
+        assertTrue(markdown.contains("name"))
+        assertTrue(markdown.contains("children"))
+        // Should contain nested fields (maxVisits=2 allows one level of recursion)
+        assertTrue("Should contain nested name field", markdown.contains("&#124;─name"))
+    }
+
+    @Test
+    fun testFormatDirectCircularObjectReference() = runBlocking {
+        // Object A has a field of type Object A (direct self-reference)
+        val fields = mutableMapOf<String, FieldModel>()
+        val selfRef = ObjectModel.Object(fields)
+        fields["id"] = FieldModel(ObjectModel.single(JsonType.INT), comment = "id")
+        fields["parent"] = FieldModel(selfRef, comment = "parent reference")
+
+        val endpoint = ApiEndpoint(
+            name = "Get Node",
+            metadata = HttpMetadata(
+                path = "/api/node",
+                method = HttpMethod.GET,
+                responseBody = selfRef
+            )
+        )
+
+        val markdown = formatter.format(listOf(endpoint), "Node API")
+
+        assertTrue(markdown.contains("| id |"))
+        assertTrue(markdown.contains("| parent |"))
+        // The nested parent.id should appear (first recursion allowed by maxVisits=2)
+        assertTrue("Should contain nested id", markdown.contains("&#124;─id"))
+    }
+
+    @Test
+    fun testFormatMutualCircularReference() = runBlocking {
+        // Object A references Object B, Object B references Object A
+        val fieldsA = mutableMapOf<String, FieldModel>()
+        val fieldsB = mutableMapOf<String, FieldModel>()
+        val objectA = ObjectModel.Object(fieldsA)
+        val objectB = ObjectModel.Object(fieldsB)
+        fieldsA["name"] = FieldModel(ObjectModel.single(JsonType.STRING))
+        fieldsA["refB"] = FieldModel(objectB, comment = "reference to B")
+        fieldsB["value"] = FieldModel(ObjectModel.single(JsonType.INT))
+        fieldsB["refA"] = FieldModel(objectA, comment = "reference to A")
+
+        val endpoint = ApiEndpoint(
+            name = "Get Mutual",
+            metadata = HttpMetadata(
+                path = "/api/mutual",
+                method = HttpMethod.GET,
+                responseBody = objectA
+            )
+        )
+
+        val markdown = formatter.format(listOf(endpoint), "Mutual API")
+
+        assertTrue(markdown.contains("name"))
+        assertTrue(markdown.contains("refB"))
+        assertTrue(markdown.contains("value"))
+        assertTrue(markdown.contains("refA"))
+    }
+
+    @Test
+    fun testFormatNonCircularDeepNesting() = runBlocking {
+        // Non-circular deep nesting should render all levels
+        val inner = ObjectModel.Object(
+            mapOf("value" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "inner value"))
+        )
+        val middle = ObjectModel.Object(
+            mapOf("inner" to FieldModel(inner, comment = "inner object"))
+        )
+        val outer = ObjectModel.Object(
+            mapOf("middle" to FieldModel(middle, comment = "middle object"))
+        )
+
+        val endpoint = ApiEndpoint(
+            name = "Get Nested",
+            metadata = HttpMetadata(
+                path = "/api/nested",
+                method = HttpMethod.GET,
+                responseBody = outer
+            )
+        )
+
+        val markdown = formatter.format(listOf(endpoint), "Nested API")
+
+        assertTrue(markdown.contains("middle"))
+        assertTrue(markdown.contains("inner"))
+        assertTrue(markdown.contains("value"))
+    }
 }


### PR DESCRIPTION
DefaultMarkdownFormatter.formatFieldRow recursed infinitely on circular ObjectModel references (e.g. TreeNode with children: List<TreeNode>), causing OOM. Uses visitCounts with maxVisits=2 (consistent with ObjectModelJsonBuilder/PropertiesFormatter). Also catches Throwable instead of Exception in BaseExportAction/ApiDashboardPanel so OOM is reported to user. Adds 4 circular reference tests. Depends on #636. Fixes tangcent/easy-yapi#1298