### PR TITLE
fix: respect ExportDialog output path and handle user cancellation properly

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
@@ -431,7 +431,9 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
                     }
                 }
 
-                handleExportResult(result, format)
+                handleExportResult(result, format, outputConfig)
+            } catch (_: kotlin.coroutines.cancellation.CancellationException) {
+                LOG.info("Export cancelled by user")
             } catch (e: Throwable) {
                 LOG.warn("Export failed", e)
                 swing {
@@ -452,14 +454,20 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
      * @param result The export result (success, cancelled, or error)
      * @param format The export format used
      */
-    private suspend fun handleExportResult(result: ExportResult, format: ExportFormat?) {
+    private suspend fun handleExportResult(
+        result: ExportResult,
+        format: ExportFormat?,
+        outputConfig: com.itangcent.easyapi.exporter.model.OutputConfig
+    ) {
         when (result) {
             is ExportResult.Success -> {
                 val exporterRegistry = ApiExporterRegistry.getInstance(project)
                 val exporter = format?.let { exporterRegistry.getExporter(it) }
 
                 val handled = try {
-                    exporter?.handleExportResult(project, result) ?: false
+                    exporter?.handleExportResult(project, result, outputConfig) ?: false
+                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     LOG.warn("Failed to handle export result", e)
                     false

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/ApiExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/ApiExporter.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportFormat
 import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.exporter.model.OutputConfig
 
 /**
  * Interface for API exporters that convert API endpoints to various formats.
@@ -47,7 +48,11 @@ interface ApiExporter {
      * @param result The successful export result
      * @return true if the result was handled, false otherwise
      */
-    suspend fun handleExportResult(project: Project, result: ExportResult.Success): Boolean {
+    suspend fun handleExportResult(
+        project: Project,
+        result: ExportResult.Success,
+        outputConfig: OutputConfig = OutputConfig.DEFAULT
+    ): Boolean {
         return false
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/curl/CurlExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/curl/CurlExporter.kt
@@ -13,6 +13,8 @@ import com.itangcent.easyapi.exporter.ApiExporter
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportFormat
 import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.exporter.model.OutputConfig
+import kotlinx.coroutines.CancellationException
 import java.io.File
 
 /**
@@ -73,10 +75,15 @@ class CurlExporter(private val project: Project) : ApiExporter {
      * @param result The successful export result
      * @return true if the file was saved successfully, false otherwise
      */
-    override suspend fun handleExportResult(project: Project, result: ExportResult.Success): Boolean {
+    override suspend fun handleExportResult(
+        project: Project,
+        result: ExportResult.Success,
+        outputConfig: OutputConfig
+    ): Boolean {
         val metadata = result.metadata as? CurlExportMetadata ?: return false
 
-        val targetFile = selectTargetFile(project) ?: return false
+        val targetFile = resolveTargetFile(project, outputConfig, "curl_commands.sh")
+            ?: throw CancellationException("User cancelled file selection")
 
         background {
             targetFile.writeText(metadata.content)
@@ -88,13 +95,25 @@ class CurlExporter(private val project: Project) : ApiExporter {
         return true
     }
 
-    /**
-     * Shows a file save dialog for selecting the output location.
-     * 
-     * @param project The IntelliJ project
-     * @return The selected file, or null if cancelled
-     */
-    private suspend fun selectTargetFile(project: Project): File? {
+    private suspend fun resolveTargetFile(
+        project: Project,
+        outputConfig: OutputConfig,
+        defaultFileName: String
+    ): File? {
+        val outputDir = outputConfig.outputDir
+        val fileName = outputConfig.fileName
+        if (!outputDir.isNullOrBlank()) {
+            val dir = File(outputDir)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            val name = if (!fileName.isNullOrBlank()) "$fileName.sh" else defaultFileName
+            return File(dir, name)
+        }
+        return selectTargetFile(project, defaultFileName)
+    }
+
+    private suspend fun selectTargetFile(project: Project, defaultFileName: String): File? {
         return swing {
             val descriptor = FileSaverDescriptor(
                 "Save cURL Commands",
@@ -102,7 +121,7 @@ class CurlExporter(private val project: Project) : ApiExporter {
             )
             val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
 
-            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, "curl_commands.sh")
+            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, defaultFileName)
             wrapper?.file
         }
     }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/httpclient/HttpClientExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/httpclient/HttpClientExporter.kt
@@ -13,6 +13,7 @@ import com.itangcent.easyapi.exporter.formatter.HttpClientFileFormatter
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportFormat
 import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.exporter.model.OutputConfig
 
 @Service(Service.Level.PROJECT)
 class HttpClientExporter(private val project: Project) : ApiExporter {
@@ -33,7 +34,8 @@ class HttpClientExporter(private val project: Project) : ApiExporter {
             }
         }
 
-        val content = HttpClientFileFormatter.formatAll(context.endpointsToExport, host, context.outputConfig.fileName ?: "api")
+        val content =
+            HttpClientFileFormatter.formatAll(context.endpointsToExport, host, context.outputConfig.fileName ?: "api")
 
         return ExportResult.Success(
             count = context.endpointsToExport.size,
@@ -42,7 +44,11 @@ class HttpClientExporter(private val project: Project) : ApiExporter {
         )
     }
 
-    override suspend fun handleExportResult(project: Project, result: ExportResult.Success): Boolean {
+    override suspend fun handleExportResult(
+        project: Project,
+        result: ExportResult.Success,
+        outputConfig: OutputConfig
+    ): Boolean {
         val metadata = result.metadata as? HttpClientExportMetadata ?: return false
 
         val fileName = generateFileName()

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/MarkdownExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/MarkdownExporter.kt
@@ -12,7 +12,9 @@ import com.itangcent.easyapi.exporter.ApiExporter
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportFormat
 import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.exporter.model.OutputConfig
 import com.itangcent.easyapi.logging.IdeaLog
+import kotlinx.coroutines.CancellationException
 import java.io.File
 
 /**
@@ -64,10 +66,15 @@ class MarkdownExporter(private val project: Project) : ApiExporter, IdeaLog {
      * @param result The successful export result
      * @return true if the file was saved successfully, false otherwise
      */
-    override suspend fun handleExportResult(project: Project, result: ExportResult.Success): Boolean {
+    override suspend fun handleExportResult(
+        project: Project,
+        result: ExportResult.Success,
+        outputConfig: OutputConfig
+    ): Boolean {
         val metadata = result.metadata as? MarkdownExportMetadata ?: return false
 
-        val targetFile = selectTargetFile(project) ?: return false
+        val targetFile = resolveTargetFile(project, outputConfig, "api_documentation.md")
+            ?: throw CancellationException("User cancelled file selection")
 
         background {
             targetFile.writeText(metadata.content)
@@ -80,13 +87,25 @@ class MarkdownExporter(private val project: Project) : ApiExporter, IdeaLog {
         return true
     }
 
-    /**
-     * Shows a file save dialog for selecting the output location.
-     * 
-     * @param project The IntelliJ project
-     * @return The selected file, or null if cancelled
-     */
-    private suspend fun selectTargetFile(project: Project): File? {
+    private suspend fun resolveTargetFile(
+        project: Project,
+        outputConfig: OutputConfig,
+        defaultFileName: String
+    ): File? {
+        val outputDir = outputConfig.outputDir
+        val fileName = outputConfig.fileName
+        if (!outputDir.isNullOrBlank()) {
+            val dir = File(outputDir)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            val name = if (!fileName.isNullOrBlank()) "$fileName.md" else defaultFileName
+            return File(dir, name)
+        }
+        return selectTargetFile(project, defaultFileName)
+    }
+
+    private suspend fun selectTargetFile(project: Project, defaultFileName: String): File? {
         return swing {
             val descriptor = FileSaverDescriptor(
                 "Save Markdown Documentation",
@@ -94,7 +113,7 @@ class MarkdownExporter(private val project: Project) : ApiExporter, IdeaLog {
             )
             val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
 
-            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, "api_documentation.md")
+            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, defaultFileName)
             wrapper?.file
         }
     }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/postman/PostmanExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/postman/PostmanExporter.kt
@@ -14,6 +14,7 @@ import com.itangcent.easyapi.exporter.ApiExporter
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportFormat
 import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.exporter.model.OutputConfig
 import com.itangcent.easyapi.exporter.postman.model.PostmanCollection
 import com.itangcent.easyapi.exporter.postman.model.PostmanItem
 import com.itangcent.easyapi.http.HttpClientProvider
@@ -21,6 +22,7 @@ import com.itangcent.easyapi.settings.PostmanExportMode
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.exporter.postman.model.postmanGson
 import com.itangcent.easyapi.util.ide.ModuleHelper
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import java.io.File
 
@@ -332,11 +334,15 @@ class PostmanExporter(private val project: Project) : ApiExporter {
         return formatter.format(endpoints, baseName)
     }
 
-    override suspend fun handleExportResult(project: Project, result: ExportResult.Success): Boolean {
+    override suspend fun handleExportResult(
+        project: Project,
+        result: ExportResult.Success,
+        outputConfig: OutputConfig
+    ): Boolean {
         val metadata = result.metadata as? PostmanExportMetadata ?: return false
 
         if (metadata.collectionData != null) {
-            return handleFileExport(project, result, metadata)
+            return handleFileExport(project, result, metadata, outputConfig)
         }
 
         val details = metadata.formatDisplay()
@@ -353,9 +359,11 @@ class PostmanExporter(private val project: Project) : ApiExporter {
     private suspend fun handleFileExport(
         project: Project,
         result: ExportResult.Success,
-        metadata: PostmanExportMetadata
+        metadata: PostmanExportMetadata,
+        outputConfig: OutputConfig
     ): Boolean {
-        val targetFile = selectTargetFile(project) ?: return false
+        val targetFile = resolveTargetFile(project, outputConfig, "postman_collection.json")
+            ?: throw CancellationException("User cancelled file selection")
 
         val gson = postmanGson()
         val content = gson.toJson(metadata.collectionData)
@@ -370,7 +378,25 @@ class PostmanExporter(private val project: Project) : ApiExporter {
         return true
     }
 
-    private suspend fun selectTargetFile(project: Project): File? {
+    private suspend fun resolveTargetFile(
+        project: Project,
+        outputConfig: OutputConfig,
+        defaultFileName: String
+    ): File? {
+        val outputDir = outputConfig.outputDir
+        val fileName = outputConfig.fileName
+        if (!outputDir.isNullOrBlank()) {
+            val dir = File(outputDir)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            val name = if (!fileName.isNullOrBlank()) "$fileName.json" else defaultFileName
+            return File(dir, name)
+        }
+        return selectTargetFile(project, defaultFileName)
+    }
+
+    private suspend fun selectTargetFile(project: Project, defaultFileName: String): File? {
         return swing {
             val descriptor = FileSaverDescriptor(
                 "Save Postman Collection",
@@ -378,7 +404,7 @@ class PostmanExporter(private val project: Project) : ApiExporter {
             )
             val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
 
-            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, "postman_collection.json")
+            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, defaultFileName)
             wrapper?.file
         }
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/BaseExportAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/BaseExportAction.kt
@@ -121,7 +121,9 @@ abstract class BaseExportAction : EasyApiAction(), IdeaLog {
                 val exporter = exporterRegistry.getExporter(exportFormat)
 
                 val handled = try {
-                    exporter?.handleExportResult(project, result) ?: false
+                    exporter?.handleExportResult(project, result, com.itangcent.easyapi.exporter.model.OutputConfig.DEFAULT) ?: false
+                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     LOG.warn("Failed to handle export result", e)
                     IdeaConsoleProvider.getInstance(project).getConsole()

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
@@ -17,6 +17,7 @@ import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiScanner
 import com.itangcent.easyapi.logging.IdeaLog
+import kotlinx.coroutines.CancellationException
 
 /**
  * Action for exporting APIs with a format selection dialog.
@@ -96,7 +97,9 @@ class ExportApiAction : AnAction(), IdeaLog {
                 val exporter = ApiExporterRegistry.getInstance(project)
                     .getExporter(dialogResult.format)
                 val handled = try {
-                    exporter?.handleExportResult(project, result) ?: false
+                    exporter?.handleExportResult(project, result, dialogResult.outputConfig) ?: false
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     LOG.warn("Failed to handle export result", e)
                     false

--- a/src/main/kotlin/com/itangcent/easyapi/ide/support/SelectedHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/support/SelectedHelper.kt
@@ -172,12 +172,12 @@ class SelectionScope(private val elements: List<Any>) {
         stack.addLast(directory)
         while (stack.isNotEmpty()) {
             val dir = stack.removeFirst()
-            for (file in dir.files) {
+            for (file in readSync { dir.files }) {
                 if (FileType.acceptable(file.name)) {
                     yield(file)
                 }
             }
-            dir.subdirectories.forEach { stack.addLast(it) }
+            readSync { dir.subdirectories }.forEach { stack.addLast(it) }
         }
     }
 


### PR DESCRIPTION
## Summary

Two bugs fixed in the export flow:

### Bug 1: File folder selector shown after selecting output path in ExportDialog
The ExportDialog collects outputDir and fileName from the user, but the exporters completely ignored these values and always showed a FileSaverDialog. Fix: Added OutputConfig parameter to ApiExporter.handleExportResult(). Exporters now use outputDir/fileName when available, falling back to the file save dialog only when not provided.

### Bug 2: Export success notification shown after user cancels
When handleExportResult() returned false (user cancelled file dialog), callers showed a success notification. Fix: Exporters now throw CancellationException when user cancels. Callers catch it silently.