### PR TITLE
perf: use fine-grained ReadAction scoping in API exporters

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
@@ -9,8 +9,9 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import com.itangcent.easyapi.core.context.ActionContext
-import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.read
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.core.CompositeApiClassRecognizer
 import com.itangcent.easyapi.exporter.feign.FeignClassExporter
@@ -23,9 +24,6 @@ import com.itangcent.easyapi.ide.DumbModeHelper
 import com.itangcent.easyapi.ide.support.runWithProgress
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.settings.SettingBinder
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -253,9 +251,7 @@ class ApiScanner(private val project: Project) {
             indicator.isIndeterminate = false
             indicator.fraction = 0.0
 
-            val endpoints = withContext(IdeDispatchers.ReadAction) {
-                scanClassesWithExporters(classes, exporters, context, indicator)
-            }
+            val endpoints = scanClassesWithExporters(classes, exporters, context, indicator)
 
             indicator.fraction = 1.0
             LOG.info("Total endpoints found: ${endpoints.size}")
@@ -283,9 +279,7 @@ class ApiScanner(private val project: Project) {
             indicator.isIndeterminate = false
             indicator.fraction = 0.0
 
-            val endpoints = withContext(IdeDispatchers.ReadAction) {
-                scanClassesWithExporters(classes, exporters, context, indicator)
-            }
+            val endpoints = scanClassesWithExporters(classes, exporters, context, indicator)
 
             indicator.fraction = 1.0
             endpoints
@@ -314,7 +308,9 @@ class ApiScanner(private val project: Project) {
 
         for ((index, psiClass) in psiClasses.withIndex()) {
             indicator?.checkCanceled()
-            val className = psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+            val className = read {
+                psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+            }
             indicator?.text = className
             indicator?.fraction = index.toDouble() / total
             LOG.info("search api from: $className")

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -6,6 +6,8 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.util.PsiTypesUtil
 import com.itangcent.easyapi.core.context.ActionContext
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ApiHeader
@@ -25,6 +27,7 @@ import com.itangcent.easyapi.psi.type.ResolvedType
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.util.PathVariablePattern
+import kotlinx.coroutines.withContext
 
 /**
  * Exports API endpoints from Feign client interfaces.
@@ -69,18 +72,23 @@ class FeignClassExporter(
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!recognizer.isFeignClient(psiClass)) return emptyList()
 
-        val className = psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        val className = read {
+            psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        }
         LOG.info("before parse class:$className")
 
-        engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
+        withContext(IdeDispatchers.Background) {
+            engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
+        }
 
         val info = pathResolver.resolve(psiClass)
         val basePath = normalizePath(info.path ?: "")
 
         val classType = ResolvedType.ClassType(psiClass, emptyList())
+        val resolvedMethods = read { classType.methods() }
         val endpoints = ArrayList<ApiEndpoint>()
         try {
-            for (resolvedMethod in classType.methods()) {
+            for (resolvedMethod in resolvedMethods) {
                 if (resolvedMethod.psiMethod.isConstructor) continue
                 endpoints.addAll(exportMethod(basePath, psiClass, resolvedMethod))
             }
@@ -97,7 +105,9 @@ class FeignClassExporter(
         resolvedMethod: com.itangcent.easyapi.psi.type.ResolvedMethod
     ): List<ApiEndpoint> {
         val method = resolvedMethod.psiMethod
-        val methodKey = "${psiClass.qualifiedName ?: psiClass.name}#${method.name}"
+        val methodKey = read {
+            "${psiClass.qualifiedName ?: psiClass.name}#${method.name}"
+        }
         LOG.info("before parse method:$methodKey")
 
         engine.evaluate(RuleKeys.API_METHOD_PARSE_BEFORE, method)
@@ -119,77 +129,85 @@ class FeignClassExporter(
                 return emptyList()
             }
 
-            val name = metadataResolver.resolveApiName(method)
-            val folder = metadataResolver.resolveFolderName(method, psiClass)
-            val description = metadataResolver.resolveMethodDoc(method)
-            val classDesc = metadataResolver.resolveClassDoc(psiClass)
+            val endpoints: List<ApiEndpoint>
 
-            val params = buildSpringParams(method)
-            val body = buildSpringRequestBody(method)
-            val responseBody = buildResponseBody(method)
+            withContext(IdeDispatchers.ReadAction) {
+                val name = metadataResolver.resolveApiName(method)
+                val folder = metadataResolver.resolveFolderName(method, psiClass)
+                val description = metadataResolver.resolveMethodDoc(method)
+                val classDesc = metadataResolver.resolveClassDoc(psiClass)
 
-            LOG.info("after parse method:$methodKey")
+                val params = buildSpringParams(method)
+                val body = buildSpringRequestBody(method)
+                val responseBody = buildResponseBody(method)
 
-            val endpoints = mappings.map { m ->
-                val contentType = m.consumes.firstOrNull()
-                val headers = buildList {
-                    if (!contentType.isNullOrBlank()) {
-                        add(ApiHeader(name = "Content-Type", value = contentType))
-                    }
-                    for ((name, value) in m.headers) {
-                        if (!name.equals("Content-Type", ignoreCase = true)) {
-                            add(ApiHeader(name = name, value = value))
+                LOG.info("after parse method:$methodKey")
+
+                endpoints = mappings.map { m ->
+                    val contentType = m.consumes.firstOrNull()
+                    val headers = buildList {
+                        if (!contentType.isNullOrBlank()) {
+                            add(ApiHeader(name = "Content-Type", value = contentType))
+                        }
+                        for ((name, value) in m.headers) {
+                            if (!name.equals("Content-Type", ignoreCase = true)) {
+                                add(ApiHeader(name = name, value = value))
+                            }
                         }
                     }
-                }
 
-                val rawPath = normalizePath(join(basePath, m.path))
-                val pathVariablePatterns = PathVariablePattern.extractPathVariablesFromPath(rawPath)
-                val normalizedPath = PathVariablePattern.normalizePath(rawPath)
+                    val rawPath = normalizePath(join(basePath, m.path))
+                    val pathVariablePatterns = PathVariablePattern.extractPathVariablesFromPath(rawPath)
+                    val normalizedPath = PathVariablePattern.normalizePath(rawPath)
 
-                val pathParamsFromPath = pathVariablePatterns.map { pattern ->
-                    ApiParameter(
-                        name = pattern.name,
-                        type = ParameterType.TEXT,
-                        required = true,
-                        binding = ParameterBinding.Path,
-                        defaultValue = pattern.defaultValue,
-                        description = "Path variable with possible values: ${pattern.possibleValues.joinToString(", ")}",
-                        enumValues = pattern.possibleValues
+                    val pathParamsFromPath = pathVariablePatterns.map { pattern ->
+                        ApiParameter(
+                            name = pattern.name,
+                            type = ParameterType.TEXT,
+                            required = true,
+                            binding = ParameterBinding.Path,
+                            defaultValue = pattern.defaultValue,
+                            description = "Path variable with possible values: ${pattern.possibleValues.joinToString(", ")}",
+                            enumValues = pattern.possibleValues
+                        )
+                    }
+
+                    val mergedParams = mergePathParameters(params, pathParamsFromPath)
+
+                    ApiEndpoint(
+                        name = name,
+                        folder = folder,
+                        description = description,
+                        sourceClass = psiClass,
+                        sourceMethod = method,
+                        className = read { psiClass.qualifiedName ?: psiClass.name },
+                        classDescription = classDesc,
+                        metadata = HttpMetadata(
+                            path = normalizedPath,
+                            method = m.method,
+                            parameters = mergedParams,
+                            headers = headers,
+                            contentType = contentType,
+                            body = body,
+                            responseBody = responseBody
+                        )
                     )
                 }
-
-                val mergedParams = mergePathParameters(params, pathParamsFromPath)
-
-                ApiEndpoint(
-                    name = name,
-                    folder = folder,
-                    description = description,
-                    sourceClass = psiClass,
-                    sourceMethod = method,
-                    className = psiClass.qualifiedName ?: psiClass.name,
-                    classDescription = classDesc,
-                    metadata = HttpMetadata(
-                        path = normalizedPath,
-                        method = m.method,
-                        parameters = mergedParams,
-                        headers = headers,
-                        contentType = contentType,
-                        body = body,
-                        responseBody = responseBody
-                    )
-                )
             }
 
-            for (endpoint in endpoints) {
-                engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
-                    ctx.setExt("api", endpoint)
+            withContext(IdeDispatchers.Background) {
+                for (endpoint in endpoints) {
+                    engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
+                        ctx.setExt("api", endpoint)
+                    }
                 }
             }
 
             return endpoints
         } finally {
-            engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, method)
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, method)
+            }
         }
     }
 
@@ -241,7 +259,7 @@ class FeignClassExporter(
             folder = null,
             sourceClass = psiClass,
             sourceMethod = method,
-            className = psiClass.qualifiedName ?: psiClass.name,
+            className = read { psiClass.qualifiedName ?: psiClass.name },
             classDescription = classDesc,
             metadata = HttpMetadata(
                 path = normalizedPathTemplate,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignPathResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignPathResolver.kt
@@ -1,6 +1,7 @@
 package com.itangcent.easyapi.exporter.feign
 
 import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.psi.helper.AnnotationHelper
 
 /**
@@ -40,10 +41,13 @@ class FeignPathResolver(
     private val annotationHelper: AnnotationHelper
 ) {
     suspend fun resolve(psiClass: PsiClass): FeignClientInfo {
-        if (!annotationHelper.hasAnn(psiClass, "org.springframework.cloud.openfeign.FeignClient")) {
+        val ann = read {
+            annotationHelper.findAnnMap(psiClass, "org.springframework.cloud.openfeign.FeignClient")
+        }.orEmpty()
+
+        if (ann.isEmpty()) {
             return FeignClientInfo()
         }
-        val ann = annotationHelper.findAnnMap(psiClass, "org.springframework.cloud.openfeign.FeignClient").orEmpty()
         val path = (ann["path"] ?: ann["value"])?.toString()?.takeIf { it.isNotBlank() }
         val url = ann["url"]?.toString()?.takeIf { it.isNotBlank() }
         val name = (ann["name"] ?: ann["value"])?.toString()?.takeIf { it.isNotBlank() }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/NativeFeignAnnotationParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/NativeFeignAnnotationParser.kt
@@ -40,7 +40,7 @@ class NativeFeignAnnotationParser(
         val http = parts.firstOrNull().orEmpty()
         val path = parts.getOrNull(1).orEmpty()
         val httpMethod = runCatching { HttpMethod.valueOf(http.uppercase()) }.getOrNull() ?: HttpMethod.GET
-        return RequestLine(httpMethod, if (path.isBlank()) "/" else path)
+        return RequestLine(httpMethod, path.ifBlank { "/" })
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.itangcent.easyapi.core.context.ActionContext
 import com.itangcent.easyapi.core.context.project
+import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
@@ -45,14 +46,16 @@ class GrpcClassExporter(
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!recognizer.isGrpcService(psiClass)) return emptyList()
 
-        val className = psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        val className = read {
+            psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        }
         LOG.info("before parse gRPC class:$className")
 
         engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
 
         val classDescription = resolveClassDescription(psiClass)
         val folder = classDescription?.lines()?.firstOrNull { it.isNotBlank() }
-            ?: psiClass.name
+            ?: read { psiClass.name }
             ?: "Unknown"
 
         val rpcMethods = methodResolver.resolveRpcMethods(psiClass)
@@ -62,6 +65,7 @@ class GrpcClassExporter(
                 try {
                     val requestBody = buildRequestBody(methodInfo.requestType)
                     val responseBody = buildResponseBody(methodInfo.responseType)
+                    val responseTypeName = read { methodInfo.responseType?.qualifiedName }
 
                     ApiEndpoint(
                         name = methodInfo.description
@@ -71,7 +75,7 @@ class GrpcClassExporter(
                         tags = listOf("gRPC"),
                         sourceClass = psiClass,
                         sourceMethod = methodInfo.psiMethod,
-                        className = psiClass.qualifiedName ?: psiClass.name,
+                        className = className,
                         classDescription = classDescription,
                         metadata = GrpcMetadata(
                             path = methodInfo.fullPath,
@@ -81,7 +85,7 @@ class GrpcClassExporter(
                             streamingType = methodInfo.streamingType,
                             body = requestBody,
                             responseBody = responseBody,
-                            responseType = methodInfo.responseType?.qualifiedName
+                            responseType = responseTypeName
                         )
                     )
                 } catch (e: Exception) {
@@ -111,19 +115,19 @@ class GrpcClassExporter(
         }
     }
 
-    private fun buildRequestBody(requestType: PsiClass?): ObjectModel? {
+    private suspend fun buildRequestBody(requestType: PsiClass?): ObjectModel? {
         if (requestType == null) return null
         return try {
-            typeParser.parseMessageType(requestType)
+            read { typeParser.parseMessageType(requestType) }
         } catch (_: Exception) {
             null
         }
     }
 
-    private fun buildResponseBody(responseType: PsiClass?): ObjectModel? {
+    private suspend fun buildResponseBody(responseType: PsiClass?): ObjectModel? {
         if (responseType == null) return null
         return try {
-            typeParser.parseMessageType(responseType)
+            read { typeParser.parseMessageType(responseType) }
         } catch (_: Exception) {
             null
         }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcServiceRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcServiceRecognizer.kt
@@ -1,6 +1,7 @@
 package com.itangcent.easyapi.exporter.grpc
 
 import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.exporter.core.ApiClassRecognizer
 import com.itangcent.easyapi.exporter.core.MetaAnnotationResolver
 import com.itangcent.easyapi.rule.RuleKeys
@@ -57,7 +58,7 @@ class GrpcServiceRecognizer(
          * We walk the full supertype hierarchy to find it.
          */
         fun extendsBindableService(psiClass: PsiClass): Boolean {
-            return walkSupers(psiClass, mutableSetOf())
+            return readSync { walkSupers(psiClass, mutableSetOf()) }
         }
 
         private fun walkSupers(cls: PsiClass, visited: MutableSet<String>): Boolean {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiParameter
 import com.intellij.psi.util.PsiTypesUtil
 import com.itangcent.easyapi.core.context.ActionContext
 import com.itangcent.easyapi.core.context.project
+import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.exporter.ClassExporter
@@ -21,6 +22,7 @@ import com.itangcent.easyapi.psi.type.ResolvedType
 import com.itangcent.easyapi.psi.type.searchAnnotation
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
+import kotlinx.coroutines.withContext
 
 /**
  * Exports API endpoints from JAX-RS resource classes.
@@ -65,22 +67,29 @@ class JaxRsClassExporter(
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!recognizer.isResource(psiClass)) return emptyList()
 
-        val className = psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        val className = read {
+            psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        }
         LOG.info("before parse class:$className")
 
-        engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
+        withContext(IdeDispatchers.Background) {
+            engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
+        }
 
         val resolvedType = ResolvedType.ClassType(psiClass, emptyList())
+        val resolvedMethods = read { resolvedType.methods() }
         val endpoints = ArrayList<ApiEndpoint>()
         try {
-            for (resolvedMethod in resolvedType.methods()) {
-                val httpMethodAnn = resolvedMethod.searchAnnotation(JAXRS_HTTP_METHOD_ANNOTATIONS)
+            for (resolvedMethod in resolvedMethods) {
+                val httpMethodAnn = read { resolvedMethod.searchAnnotation(JAXRS_HTTP_METHOD_ANNOTATIONS) }
                     ?: continue
                 val annotatedMethod = (httpMethodAnn.owner as? PsiMethod) ?: resolvedMethod.psiMethod
                 endpoints.addAll(exportMethod(psiClass, resolvedMethod.psiMethod, annotatedMethod))
             }
         } finally {
-            engine.evaluate(RuleKeys.API_CLASS_PARSE_AFTER, psiClass)
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_CLASS_PARSE_AFTER, psiClass)
+            }
         }
         LOG.info("after parse class:$className")
         return endpoints
@@ -91,10 +100,16 @@ class JaxRsClassExporter(
         method: PsiMethod,
         annotatedMethod: PsiMethod
     ): List<ApiEndpoint> {
-        val methodKey = "${psiClass.qualifiedName ?: psiClass.name}#${method.name}"
+        val methodKey = read {
+            "${psiClass.qualifiedName ?: psiClass.name}#${method.name}"
+        }
         LOG.info("before parse method:$methodKey")
 
-        engine.evaluate(RuleKeys.API_METHOD_PARSE_BEFORE, method)
+        withContext(IdeDispatchers.Background) {
+            engine.evaluate(RuleKeys.API_METHOD_PARSE_BEFORE, method)
+        }
+
+        val classQualifiedName = read { psiClass.qualifiedName ?: psiClass.name }
 
         try {
             val httpMethod = methodResolver.resolve(annotatedMethod)
@@ -102,54 +117,63 @@ class JaxRsClassExporter(
                 LOG.info("after parse method:$methodKey")
                 return emptyList()
             }
-            val path = pathResolver.resolve(psiClass, annotatedMethod)
-            val types = contentTypeResolver.resolve(psiClass, annotatedMethod)
+            val endpoints: List<ApiEndpoint>
 
-            val name = metadataResolver.resolveApiName(method)
-            val folder = metadataResolver.resolveFolderName(method, psiClass)
-            val description = metadataResolver.resolveMethodDoc(method)
-            val classDesc = metadataResolver.resolveClassDoc(psiClass)
+            withContext(IdeDispatchers.ReadAction) {
+                val path = pathResolver.resolve(psiClass, annotatedMethod)
+                val types = contentTypeResolver.resolve(psiClass, annotatedMethod)
 
-            val params = buildParameters(method)
-            val paramHeaders = extractParamHeaders(method)
-            val contentType = types.consumes.firstOrNull()
-            val headers = buildHeaders(contentType, paramHeaders)
-            val body = buildRequestBody(method)
-            val responseBody = buildResponseBody(method)
+                val name = metadataResolver.resolveApiName(method)
+                val folder = metadataResolver.resolveFolderName(method, psiClass)
+                val description = metadataResolver.resolveMethodDoc(method)
+                val classDesc = metadataResolver.resolveClassDoc(psiClass)
 
-            LOG.info("after parse method:$methodKey")
+                val params = buildParameters(method)
+                val paramHeaders = extractParamHeaders(method)
+                val contentType = types.consumes.firstOrNull()
+                val headers = buildHeaders(contentType, paramHeaders)
+                val body = buildRequestBody(method)
+                val responseBody = buildResponseBody(method)
+                val responseTypeName = read { method.returnType?.canonicalText }
 
-            val endpoints = listOf(
-                ApiEndpoint(
-                    name = name,
-                    folder = folder,
-                    description = description,
-                    sourceClass = psiClass,
-                    sourceMethod = method,
-                    className = psiClass.qualifiedName ?: psiClass.name,
-                    classDescription = classDesc,
-                    metadata = HttpMetadata(
-                        path = path,
-                        method = httpMethod,
-                        parameters = params,
-                        headers = headers,
-                        contentType = contentType,
-                        body = body,
-                        responseBody = responseBody,
-                        responseType = method.returnType?.canonicalText
+                LOG.info("after parse method:$methodKey")
+
+                endpoints = listOf(
+                    ApiEndpoint(
+                        name = name,
+                        folder = folder,
+                        description = description,
+                        sourceClass = psiClass,
+                        sourceMethod = method,
+                        className = classQualifiedName,
+                        classDescription = classDesc,
+                        metadata = HttpMetadata(
+                            path = path,
+                            method = httpMethod,
+                            parameters = params,
+                            headers = headers,
+                            contentType = contentType,
+                            body = body,
+                            responseBody = responseBody,
+                            responseType = responseTypeName
+                        )
                     )
                 )
-            )
+            }
 
-            for (endpoint in endpoints) {
-                engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
-                    ctx.setExt("api", endpoint)
+            withContext(IdeDispatchers.Background) {
+                for (endpoint in endpoints) {
+                    engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
+                        ctx.setExt("api", endpoint)
+                    }
                 }
             }
 
             return endpoints
         } finally {
-            engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, method)
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, method)
+            }
         }
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsHttpMethodResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsHttpMethodResolver.kt
@@ -2,8 +2,11 @@ package com.itangcent.easyapi.exporter.jaxrs
 
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifierListOwner
+import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.psi.helper.AnnotationHelper
+import kotlinx.coroutines.withContext
 
 /**
  * Resolves HTTP methods from JAX-RS method annotations.
@@ -20,30 +23,59 @@ import com.itangcent.easyapi.psi.helper.AnnotationHelper
 class JaxRsHttpMethodResolver(
     private val annotationHelper: AnnotationHelper
 ) {
-    suspend fun resolve(psiMethod: PsiMethod): HttpMethod? {
-        direct(psiMethod)?.let { return it }
+    suspend fun resolve(psiMethod: PsiMethod): HttpMethod? = withContext(IdeDispatchers.ReadAction) {
+        direct(psiMethod)?.let { return@withContext it }
         val anns = annotationHelper.findAnnMaps(psiMethod, "javax.ws.rs.HttpMethod").orEmpty() +
-            annotationHelper.findAnnMaps(psiMethod, "jakarta.ws.rs.HttpMethod").orEmpty()
-        if (anns.isNotEmpty()) return null
-        val allAnnotations = (psiMethod as? com.intellij.psi.PsiModifierListOwner)?.annotations.orEmpty()
-        return resolveFromMeta(allAnnotations)
+                annotationHelper.findAnnMaps(psiMethod, "jakarta.ws.rs.HttpMethod").orEmpty()
+        if (anns.isNotEmpty()) return@withContext null
+        val allAnnotations = (psiMethod as? PsiModifierListOwner)?.annotations.orEmpty()
+        return@withContext resolveFromMeta(allAnnotations)
     }
 
     private suspend fun direct(psiMethod: PsiMethod): HttpMethod? {
-        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.GET") || annotationHelper.hasAnn(psiMethod, "jakarta.ws.rs.GET")) return HttpMethod.GET
-        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.POST") || annotationHelper.hasAnn(psiMethod, "jakarta.ws.rs.POST")) return HttpMethod.POST
-        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.PUT") || annotationHelper.hasAnn(psiMethod, "jakarta.ws.rs.PUT")) return HttpMethod.PUT
-        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.DELETE") || annotationHelper.hasAnn(psiMethod, "jakarta.ws.rs.DELETE")) return HttpMethod.DELETE
-        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.PATCH") || annotationHelper.hasAnn(psiMethod, "jakarta.ws.rs.PATCH")) return HttpMethod.PATCH
-        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.HEAD") || annotationHelper.hasAnn(psiMethod, "jakarta.ws.rs.HEAD")) return HttpMethod.HEAD
-        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.OPTIONS") || annotationHelper.hasAnn(psiMethod, "jakarta.ws.rs.OPTIONS")) return HttpMethod.OPTIONS
+        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.GET") || annotationHelper.hasAnn(
+                psiMethod,
+                "jakarta.ws.rs.GET"
+            )
+        ) return HttpMethod.GET
+        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.POST") || annotationHelper.hasAnn(
+                psiMethod,
+                "jakarta.ws.rs.POST"
+            )
+        ) return HttpMethod.POST
+        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.PUT") || annotationHelper.hasAnn(
+                psiMethod,
+                "jakarta.ws.rs.PUT"
+            )
+        ) return HttpMethod.PUT
+        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.DELETE") || annotationHelper.hasAnn(
+                psiMethod,
+                "jakarta.ws.rs.DELETE"
+            )
+        ) return HttpMethod.DELETE
+        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.PATCH") || annotationHelper.hasAnn(
+                psiMethod,
+                "jakarta.ws.rs.PATCH"
+            )
+        ) return HttpMethod.PATCH
+        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.HEAD") || annotationHelper.hasAnn(
+                psiMethod,
+                "jakarta.ws.rs.HEAD"
+            )
+        ) return HttpMethod.HEAD
+        if (annotationHelper.hasAnn(psiMethod, "javax.ws.rs.OPTIONS") || annotationHelper.hasAnn(
+                psiMethod,
+                "jakarta.ws.rs.OPTIONS"
+            )
+        ) return HttpMethod.OPTIONS
         return null
     }
 
     private fun resolveFromMeta(annotations: Array<out PsiAnnotation>): HttpMethod? {
         for (ann in annotations) {
             val meta = ann.resolveAnnotationType() ?: continue
-            val hasHttpMethod = meta.annotations.any { it.qualifiedName == "javax.ws.rs.HttpMethod" || it.qualifiedName == "jakarta.ws.rs.HttpMethod" }
+            val hasHttpMethod =
+                meta.annotations.any { it.qualifiedName == "javax.ws.rs.HttpMethod" || it.qualifiedName == "jakarta.ws.rs.HttpMethod" }
             if (!hasHttpMethod) continue
             val name = meta.qualifiedName ?: meta.name ?: continue
             val last = name.substringAfterLast('.').uppercase()

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.exporter.springmvc
 
 import com.intellij.psi.PsiClass
 import com.itangcent.easyapi.core.context.ActionContext
+import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.logging.IdeaLog
@@ -19,14 +20,16 @@ class ActuatorEndpointExporter(
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!recognizer.isApiClass(psiClass)) return emptyList()
 
-        val className = psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        val className = read {
+            psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        }
         LOG.info("before parse actuator endpoint:$className")
 
         engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
 
         val endpoints: List<ApiEndpoint>
         try {
-            endpoints = scanner.scan(psiClass)
+            endpoints = read { scanner.scan(psiClass) }
 
             for (endpoint in endpoints) {
                 val method = endpoint.sourceMethod ?: continue

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -8,6 +8,8 @@ import com.intellij.psi.PsiTypes
 import com.intellij.psi.util.PsiTypesUtil
 import com.itangcent.easyapi.core.context.ActionContext
 import com.itangcent.easyapi.core.context.project
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
@@ -26,6 +28,7 @@ import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.util.PathVariablePattern
+import kotlinx.coroutines.withContext
 
 /**
  * Exports API endpoints from Spring MVC controller classes.
@@ -66,15 +69,18 @@ class SpringMvcClassExporter(
         if (!controllerRecognizer.isController(psiClass)) return emptyList()
         if (metadataResolver.isIgnored(psiClass)) return emptyList()
 
-        val className = psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        val className = read {
+            psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        }
         LOG.info("before parse class:$className")
 
         engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
 
         val resolvedType = ResolvedType.ClassType(psiClass, emptyList())
+        val resolvedMethods = read { resolvedType.methods() }
         val endpoints = ArrayList<ApiEndpoint>()
         try {
-            for (resolvedMethod in resolvedType.methods()) {
+            for (resolvedMethod in resolvedMethods) {
                 if (metadataResolver.isIgnored(resolvedMethod.psiMethod)) continue
                 endpoints.addAll(exportMethod(psiClass, resolvedMethod))
             }
@@ -90,104 +96,114 @@ class SpringMvcClassExporter(
         resolvedMethod: com.itangcent.easyapi.psi.type.ResolvedMethod
     ): List<ApiEndpoint> {
         val method = resolvedMethod.psiMethod
-        val methodKey = "${psiClass.qualifiedName ?: psiClass.name}#${method.name}"
+        val methodKey = read {
+            "${psiClass.qualifiedName ?: psiClass.name}#${method.name}"
+        }
         LOG.info("before parse method:$methodKey")
 
-        engine.evaluate(RuleKeys.API_METHOD_PARSE_BEFORE, method)
+        withContext(IdeDispatchers.Background) {
+            engine.evaluate(RuleKeys.API_METHOD_PARSE_BEFORE, method)
+        }
 
         try {
-            val mappings = mappingResolver.resolve(resolvedMethod)
+            val mappings = read { mappingResolver.resolve(resolvedMethod) }
             if (mappings.isEmpty()) {
                 LOG.info("after parse method:$methodKey")
                 return emptyList()
             }
 
-            // Build generic context from the class hierarchy.
-            val genericContext = GenericContext(TypeResolver.resolveGenericParams(psiClass, emptyList()))
+            val endpoints: List<ApiEndpoint>
 
-            // Use the concrete method for metadata resolution
-            val apiName = metadataResolver.resolveApiName(method)
-            val folder = metadataResolver.resolveFolderName(method, psiClass)
-            val description = metadataResolver.resolveMethodDoc(method)
-            val classDesc = metadataResolver.resolveClassDoc(psiClass)
-            val tags = metadataResolver.resolveApiTag(method)
-                ?.split("\n")?.map { it.trim() }?.filter { it.isNotBlank() }
-                ?: emptyList()
+            withContext(IdeDispatchers.ReadAction) {
+                val genericContext = GenericContext(TypeResolver.resolveGenericParams(psiClass, emptyList()))
 
-            val resolvedBindings = resolveParameterBindings(resolvedMethod)
-            val params = buildParameters(resolvedBindings)
-            val paramHeaders = extractParamHeaders(resolvedBindings)
-            val body = buildRequestBody(resolvedBindings, genericContext)
-            val response = ReturnTypeUnwrapper.unwrap(method.returnType)
-            val responseBody = buildResponseBody(method, genericContext)
+                val apiName = metadataResolver.resolveApiName(method)
+                val folder = metadataResolver.resolveFolderName(method, psiClass)
+                val description = metadataResolver.resolveMethodDoc(method)
+                val classDesc = metadataResolver.resolveClassDoc(psiClass)
+                val tags = metadataResolver.resolveApiTag(method)
+                    ?.split("\n")?.map { it.trim() }?.filter { it.isNotBlank() }
+                    ?: emptyList()
 
-            val additionalHeaders = metadataResolver.resolveAdditionalHeaders(method)
-            val additionalParams = metadataResolver.resolveAdditionalParams(method)
-            val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
+                val resolvedBindings = resolveParameterBindings(resolvedMethod)
+                val params = buildParameters(resolvedBindings)
+                val paramHeaders = extractParamHeaders(resolvedBindings)
+                val body = buildRequestBody(resolvedBindings, genericContext)
+                val response = read { ReturnTypeUnwrapper.unwrap(method.returnType) }
+                val responseBody = buildResponseBody(method, genericContext)
 
-            val defaultHttpMethod = metadataResolver.resolveDefaultHttpMethod(method)
-                ?.let { HttpMethod.fromSpring(it) }
+                val additionalHeaders = metadataResolver.resolveAdditionalHeaders(method)
+                val additionalParams = metadataResolver.resolveAdditionalParams(method)
+                val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
 
-            // Filter mappings by path.multi strategy before building endpoints
-            val pathSelector = metadataResolver.resolvePathMulti(method)
-            val selectedMappings = pathSelector.select(mappings) { it.path }
+                val defaultHttpMethod = metadataResolver.resolveDefaultHttpMethod(method)
+                    ?.let { HttpMethod.fromSpring(it) }
 
-            LOG.info("after parse method:$methodKey")
+                // Filter mappings by path.multi strategy before building endpoints
+                val pathSelector = metadataResolver.resolvePathMulti(method)
+                val selectedMappings = pathSelector.select(mappings) { it.path }
 
-            val endpoints = selectedMappings.map { mapping ->
-                val contentType = resolveContentType(method, mapping, body != null, params)
-                val headers = buildHeaders(contentType, mapping, paramHeaders, additionalHeaders)
-                val inferredMethod = inferHttpMethod(mapping.method, body != null, params, defaultHttpMethod)
+                LOG.info("after parse method:$methodKey")
 
-                val pathVariablePatterns = PathVariablePattern.extractPathVariablesFromPath(mapping.path)
-                val normalizedPath = PathVariablePattern.normalizePath(mapping.path)
+                endpoints = selectedMappings.map { mapping ->
+                    val contentType = resolveContentType(method, mapping, body != null, params)
+                    val headers = buildHeaders(contentType, mapping, paramHeaders, additionalHeaders)
+                    val inferredMethod = inferHttpMethod(mapping.method, body != null, params, defaultHttpMethod)
 
-                val pathParamsFromPath = pathVariablePatterns.map { pattern ->
-                    ApiParameter(
-                        name = pattern.name,
-                        type = ParameterType.TEXT,
-                        required = true,
-                        binding = ParameterBinding.Path,
-                        defaultValue = pattern.defaultValue,
-                        description = "Path variable with possible values: ${pattern.possibleValues.joinToString(", ")}",
-                        enumValues = pattern.possibleValues
+                    val pathVariablePatterns = PathVariablePattern.extractPathVariablesFromPath(mapping.path)
+                    val normalizedPath = PathVariablePattern.normalizePath(mapping.path)
+
+                    val pathParamsFromPath = pathVariablePatterns.map { pattern ->
+                        ApiParameter(
+                            name = pattern.name,
+                            type = ParameterType.TEXT,
+                            required = true,
+                            binding = ParameterBinding.Path,
+                            defaultValue = pattern.defaultValue,
+                            description = "Path variable with possible values: ${pattern.possibleValues.joinToString(", ")}",
+                            enumValues = pattern.possibleValues
+                        )
+                    }
+
+                    val mergedParams = mergePathParameters(params + additionalParams, pathParamsFromPath)
+
+                    ApiEndpoint(
+                        name = apiName,
+                        folder = folder,
+                        description = description,
+                        tags = tags,
+                        sourceClass = psiClass,
+                        sourceMethod = method,
+                        className = psiClass.qualifiedName ?: psiClass.name,
+                        classDescription = classDesc,
+                        metadata = HttpMetadata(
+                            path = normalizedPath,
+                            method = inferredMethod,
+                            parameters = mergedParams,
+                            headers = headers + additionalResponseHeaders,
+                            contentType = contentType,
+                            body = body,
+                            responseBody = responseBody,
+                            responseType = response.toString()
+                        )
                     )
                 }
-
-                val mergedParams = mergePathParameters(params + additionalParams, pathParamsFromPath)
-
-                ApiEndpoint(
-                    name = apiName,
-                    folder = folder,
-                    description = description,
-                    tags = tags,
-                    sourceClass = psiClass,
-                    sourceMethod = method,
-                    className = psiClass.qualifiedName ?: psiClass.name,
-                    classDescription = classDesc,
-                    metadata = HttpMetadata(
-                        path = normalizedPath,
-                        method = inferredMethod,
-                        parameters = mergedParams,
-                        headers = headers + additionalResponseHeaders,
-                        contentType = contentType,
-                        body = body,
-                        responseBody = responseBody,
-                        responseType = response.toString()
-                    )
-                )
             }
 
-            // Fire export.after for each endpoint
-            for (endpoint in endpoints) {
-                engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
-                    ctx.setExt("api", endpoint)
+            withContext(IdeDispatchers.Background) {
+                // Fire export.after for each endpoint
+                for (endpoint in endpoints) {
+                    engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
+                        ctx.setExt("api", endpoint)
+                    }
                 }
             }
 
             return endpoints
         } finally {
-            engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, method)
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, method)
+            }
         }
     }
 
@@ -247,7 +263,8 @@ class SpringMvcClassExporter(
      */
     private suspend fun resolveParameterBindings(resolvedMethod: com.itangcent.easyapi.psi.type.ResolvedMethod): List<ResolvedParamBinding> {
         val method = resolvedMethod.psiMethod
-        return method.parameterList.parameters.mapIndexedNotNull { index, p ->
+        val parameters = read { method.parameterList.parameters.toList() }
+        return parameters.mapIndexedNotNull { index, p ->
             val binding = bindingResolver.resolve(p, resolvedMethod, index) ?: ParameterBinding.Query
             if (binding == ParameterBinding.Ignored) return@mapIndexedNotNull null
             ResolvedParamBinding(p, binding)

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/UnifiedAnnotationHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/UnifiedAnnotationHelper.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiReferenceExpression
 import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.psi.adapter.GroovyPsiAdapter
 import com.itangcent.easyapi.psi.adapter.JavaPsiAdapter
@@ -49,34 +50,30 @@ class UnifiedAnnotationHelper(
     )
 ) : AnnotationHelper {
 
-    private suspend fun <T> readAction(block: () -> T): T {
-        return withContext(IdeDispatchers.ReadAction) { block() }
-    }
-
     override suspend fun hasAnn(element: PsiElement, annFqn: String): Boolean {
-        return readSync {
+        return read {
             findPsiAnnotations(element, annFqn).isNotEmpty()
         }
     }
 
     override suspend fun findAnnMap(element: PsiElement, annFqn: String): Map<String, Any?>? {
-        return readSync {
+        return read {
             findPsiAnnotations(element, annFqn).firstOrNull()?.let { normalizeAttributes(it, element.project) }
         }
     }
 
     override suspend fun findAnnMaps(element: PsiElement, annFqn: String): List<Map<String, Any?>>? {
-        return readSync {
+        return read {
             val anns = findPsiAnnotations(element, annFqn)
-            if (anns.isEmpty()) return@readSync null
+            if (anns.isEmpty()) return@read null
             anns.map { normalizeAttributes(it, element.project) }
         }
     }
 
     override suspend fun findAttr(element: PsiElement, annFqn: String, attr: String): Any? {
-        return readSync {
-            val ann = findPsiAnnotations(element, annFqn).firstOrNull() ?: return@readSync null
-            val value = ann.findAttributeValue(attr) ?: return@readSync null
+        return read {
+            val ann = findPsiAnnotations(element, annFqn).firstOrNull() ?: return@read null
+            val value = ann.findAttributeValue(attr) ?: return@read null
             normalizeValue(value, element.project)
         }
     }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/postman/CachedPostmanApiClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/postman/CachedPostmanApiClientTest.kt
@@ -2,27 +2,24 @@ package com.itangcent.easyapi.exporter.postman
 
 import com.itangcent.easyapi.cache.AppCacheRepository
 import com.itangcent.easyapi.http.UrlConnectionHttpClient
-import kotlinx.coroutines.runBlocking
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import org.junit.Assert.*
-import org.junit.Test
 
-class CachedPostmanApiClientTest {
+class CachedPostmanApiClientTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     private fun createClient(apiKey: String = ""): CachedPostmanApiClient {
         val postmanClient = PostmanApiClient(apiKey = apiKey, httpClient = UrlConnectionHttpClient)
         return CachedPostmanApiClient(postmanClient)
     }
 
-    @Test
-    fun testListWorkspacesWithEmptyApiKey() = runBlocking {
+    fun testListWorkspacesWithEmptyApiKey() = runTest {
         val client = createClient(apiKey = "")
 
         val workspaces = client.listWorkspaces()
         assertTrue("Workspaces should be empty for blank API key", workspaces.isEmpty())
     }
 
-    @Test
-    fun testListWorkspacesWithCache() = runBlocking {
+    fun testListWorkspacesWithCache() = runTest {
         AppCacheRepository.getInstance().clear()
 
         val client = createClient(apiKey = "test-api-key")
@@ -33,8 +30,7 @@ class CachedPostmanApiClientTest {
         assertNotNull("Workspaces list should not be null", workspacesWithCache)
     }
 
-    @Test
-    fun testClearWorkspacesCache() = runBlocking {
+    fun testClearWorkspacesCache() = runTest {
         AppCacheRepository.getInstance().clear()
 
         val client = createClient(apiKey = "test-api-key")
@@ -46,8 +42,7 @@ class CachedPostmanApiClientTest {
         assertNull("Cache should be cleared", cached)
     }
 
-    @Test
-    fun testWorkspaceCaching() = runBlocking {
+    fun testWorkspaceCaching() = runTest {
         AppCacheRepository.getInstance().clear()
 
         val client = createClient(apiKey = "test-api-key")
@@ -60,16 +55,14 @@ class CachedPostmanApiClientTest {
         }
     }
 
-    @Test
-    fun testListCollectionsWithEmptyApiKey() = runBlocking {
+    fun testListCollectionsWithEmptyApiKey() = runTest {
         val client = createClient(apiKey = "")
 
         val collections = client.listCollections("test-workspace-id")
         assertTrue("Collections should be empty for blank API key", collections.isEmpty())
     }
 
-    @Test
-    fun testListCollectionsWithCache() = runBlocking {
+    fun testListCollectionsWithCache() = runTest {
         AppCacheRepository.getInstance().clear()
 
         val client = createClient(apiKey = "test-api-key")
@@ -80,8 +73,7 @@ class CachedPostmanApiClientTest {
         assertNotNull("Collections list should not be null", collectionsWithCache)
     }
 
-    @Test
-    fun testCollectionCaching() = runBlocking {
+    fun testCollectionCaching() = runTest {
         AppCacheRepository.getInstance().clear()
 
         val client = createClient(apiKey = "test-api-key")
@@ -96,8 +88,7 @@ class CachedPostmanApiClientTest {
         }
     }
 
-    @Test
-    fun testUploadCollection() = runBlocking {
+    fun testUploadCollection() = runTest {
         val client = createClient(apiKey = "")
 
         val collection = com.itangcent.easyapi.exporter.postman.model.PostmanCollection(
@@ -110,8 +101,7 @@ class CachedPostmanApiClientTest {
         assertTrue("Upload should succeed with empty API key (mock mode)", result.success)
     }
 
-    @Test
-    fun testUpdateCollection() = runBlocking {
+    fun testUpdateCollection() = runTest {
         val client = createClient(apiKey = "")
 
         val collection = com.itangcent.easyapi.exporter.postman.model.PostmanCollection(


### PR DESCRIPTION
- Remove outer withContext(IdeDispatchers.ReadAction) from ApiScanner.scanClassesWithExporters
- Add fine-grained read { } blocks for individual PSI reads in each exporter
- Let rule engine evaluations run on Background without holding read lock
- Improves IDE responsiveness during long-running API scans by releasing read lock between operations
