### PR TITLE
fix: export multipart and file-like params as FILE type

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -779,11 +779,15 @@ class DefaultPsiClassHelper : PsiClassHelper {
             "java.lang.Boolean" -> ObjectModel.single(JsonType.BOOLEAN)
             "java.lang.Short" -> ObjectModel.single(JsonType.SHORT)
             else -> {
-                val specialDefault = SpecialTypeHandler.getDefaultValueForSpecialType(qualifiedName)
-                if (specialDefault != null) {
-                    ObjectModel.single(JsonType.STRING)
+                if (SpecialTypeHandler.isFileType(qualifiedName)) {
+                    ObjectModel.single(JsonType.FILE)
                 } else {
-                    ObjectModel.single(JsonType.OBJECT)
+                    val specialDefault = SpecialTypeHandler.getDefaultValueForSpecialType(qualifiedName)
+                    if (specialDefault != null) {
+                        ObjectModel.single(JsonType.STRING)
+                    } else {
+                        ObjectModel.single(JsonType.OBJECT)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/type/JsonType.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/type/JsonType.kt
@@ -85,8 +85,14 @@ object JsonType {
             normalized == "localdatetime" || normalized == "java.time.localdatetime" ||
                     normalized == "timestamp" || normalized == "java.sql.timestamp" -> DATETIME
 
-            normalized == "file" || normalized == "multipartfile" ||
-                    normalized == "org.springframework.web.multipart.multipartfile" -> FILE
+            normalized == "file" || normalized == "__file__" || normalized == "multipartfile" ||
+                    normalized == "org.springframework.web.multipart.multipartfile" ||
+                    normalized == "org.springframework.web.multipart.commons.commonsmultipartfile" ||
+                    normalized == "javax.servlet.http.part" ||
+                    normalized == "jakarta.servlet.http.part" ||
+                    normalized == "java.io.file" ||
+                    normalized == "java.nio.file.path" ||
+                    normalized == "org.springframework.core.io.resource" -> FILE
 
             normalized.contains("multipartfile[]") ||
                     normalized.contains("multipartfile>") && normalized.contains("[]") ||

--- a/src/main/kotlin/com/itangcent/easyapi/psi/type/SpecialTypeHandler.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/type/SpecialTypeHandler.kt
@@ -105,7 +105,7 @@ object SpecialTypeHandler {
     fun isFileTypeName(typeName: String?): Boolean {
         if (typeName.isNullOrBlank()) return false
         val t = singleTypeName(typeName.trim())
-        return t == "file" || isFileTypeCanonical(t)
+        return t == "file" || t == "__file__" || isFileTypeCanonical(t)
     }
 
     fun isDateTimeAsString(qualifiedName: String?): Boolean {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/model/ApiParameterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/model/ApiParameterTest.kt
@@ -128,6 +128,7 @@ class ApiParameterTest {
     fun testFromTypeNameFile() {
         assertEquals(ParameterType.FILE, ParameterType.fromTypeName("file"))
         assertEquals(ParameterType.FILE, ParameterType.fromTypeName("file[]"))
+        assertEquals(ParameterType.FILE, ParameterType.fromTypeName("__file__"))
         assertEquals(ParameterType.FILE, ParameterType.fromTypeName("MultipartFile"))
         assertEquals(ParameterType.FILE, ParameterType.fromTypeName("org.springframework.web.multipart.MultipartFile"))
         assertEquals(ParameterType.FILE, ParameterType.fromTypeName("org.springframework.web.multipart.MultipartFile[]"))

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporterTest.kt
@@ -314,4 +314,121 @@ class SpringMvcClassExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
         // Just verify the endpoint was exported with a response body
         assertNotNull("data field should exist in response body", dataField)
     }
+
+    fun testMultipartFileFieldExportedAsFileParam() = runTest {
+        loadFile("api/FileUploadCtrl.java",
+            """
+            package com.itangcent.api;
+            import com.itangcent.model.Result;
+            import com.itangcent.model.UserDto;
+            import org.springframework.web.bind.annotation.PostMapping;
+            import org.springframework.web.bind.annotation.ModelAttribute;
+            import org.springframework.web.bind.annotation.RequestMapping;
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            @RequestMapping("/file")
+            public class FileUploadCtrl {
+                /**
+                 * Create new user and upload avatar
+                 * @param userDto user data with avatar
+                 * @return save result
+                 */
+                @PostMapping("/add")
+                public Result<String> add(@ModelAttribute UserDto userDto) {
+                    return Result.success("Save successful");
+                }
+            }
+            """.trimIndent()
+        )
+        loadFile("model/UserDto.java",
+            """
+            package com.itangcent.model;
+            import org.springframework.web.multipart.MultipartFile;
+
+            public class UserDto extends UserInfo {
+                /** User Profile Image File */
+                private MultipartFile profileImg;
+
+                public MultipartFile getProfileImg() {
+                    return profileImg;
+                }
+
+                public void setProfileImg(MultipartFile profileImg) {
+                    this.profileImg = profileImg;
+                }
+            }
+            """.trimIndent()
+        )
+
+        val psiClass = findClass("com.itangcent.api.FileUploadCtrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        val endpoint = endpoints.find { it.httpMetadata?.path == "/file/add" }
+        assertNotNull("Should find /file/add endpoint", endpoint)
+
+        val params = endpoint!!.httpMetadata?.parameters ?: emptyList()
+        val profileImgParam = params.find { it.name == "profileImg" }
+        assertNotNull("profileImg field should be expanded as a form parameter", profileImgParam)
+        assertEquals(
+            "profileImg (MultipartFile) should be FILE type, not TEXT",
+            com.itangcent.easyapi.exporter.model.ParameterType.FILE,
+            profileImgParam!!.type
+        )
+        assertEquals(
+            "profileImg should have Form binding",
+            com.itangcent.easyapi.exporter.model.ParameterBinding.Form,
+            profileImgParam.binding
+        )
+    }
+
+    fun testMultipartFileDirectParamExportedAsFileParam() = runTest {
+        loadFile("api/DirectFileUploadCtrl.java",
+            """
+            package com.itangcent.api;
+            import com.itangcent.model.Result;
+            import org.springframework.web.multipart.MultipartFile;
+            import org.springframework.web.bind.annotation.PostMapping;
+            import org.springframework.web.bind.annotation.RequestParam;
+            import org.springframework.web.bind.annotation.RequestMapping;
+            import org.springframework.web.bind.annotation.RestController;
+
+            @RestController
+            @RequestMapping("/file-direct")
+            public class DirectFileUploadCtrl {
+                /**
+                 * Upload a single file
+                 * @param file the file to upload
+                 * @return upload result
+                 */
+                @PostMapping("/upload")
+                public Result<String> upload(@RequestParam("file") MultipartFile file) {
+                    return Result.success("Upload successful");
+                }
+            }
+            """.trimIndent()
+        )
+
+        val psiClass = findClass("com.itangcent.api.DirectFileUploadCtrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        val endpoint = endpoints.find { it.httpMetadata?.path == "/file-direct/upload" }
+        assertNotNull("Should find /file-direct/upload endpoint", endpoint)
+
+        val params = endpoint!!.httpMetadata?.parameters ?: emptyList()
+        val fileParam = params.find { it.name == "file" }
+        assertNotNull("file parameter should be present", fileParam)
+        assertEquals(
+            "MultipartFile parameter should be FILE type",
+            com.itangcent.easyapi.exporter.model.ParameterType.FILE,
+            fileParam!!.type
+        )
+        assertEquals(
+            "MultipartFile parameter should have Form binding",
+            com.itangcent.easyapi.exporter.model.ParameterBinding.Form,
+            fileParam.binding
+        )
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelperUtilityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelperUtilityTest.kt
@@ -273,10 +273,9 @@ class DefaultPsiClassHelperUtilityTest : TestCase() {
         val threadValue = ObjectModelValueConverter.toSimpleValue(callGetDefaultValueForType("java.lang.Thread"))
         assertTrue(threadValue is Map<*, *>)
         assertTrue((threadValue as Map<*, *>).isEmpty())
-        
+
         val fileValue = ObjectModelValueConverter.toSimpleValue(callGetDefaultValueForType("java.io.File"))
-        assertTrue(fileValue is Map<*, *>)
-        assertTrue((fileValue as Map<*, *>).isEmpty())
+        assertEquals("java.io.File should be treated as file type", "(binary)", fileValue)
         
         assertEquals("", ObjectModelValueConverter.toSimpleValue(callGetDefaultValueForType("java.util.Date")))
         assertEquals("", ObjectModelValueConverter.toSimpleValue(callGetDefaultValueForType("java.time.LocalDate")))
@@ -436,5 +435,26 @@ class DefaultPsiClassHelperUtilityTest : TestCase() {
 
     private fun callGetDefaultValueForType(typeName: String): ObjectModel? {
         return ObjectModel.single(JsonType.fromJavaType(typeName))
+    }
+
+    fun testFromFileTypeMarkerResolvesToFile() {
+        val model = ObjectModel.single(JsonType.fromJavaType("__file__"))
+        val single = model.asSingle()
+        assertNotNull("ObjectModel.Single should be created from __file__", single)
+        assertEquals("__file__ should resolve to 'file' type", JsonType.FILE, single!!.type)
+    }
+
+    fun testFromFileTypeMarkerNotObject() {
+        val model = ObjectModel.single(JsonType.fromJavaType("__file__"))
+        val single = model.asSingle()
+        assertNotNull(single)
+        assertNotSame("__file__ should NOT resolve to 'object' type", JsonType.OBJECT, single!!.type)
+    }
+
+    fun testFromFileTypeCanonicalResolvesToFile() {
+        val model = ObjectModel.single(JsonType.fromJavaType("org.springframework.web.multipart.MultipartFile"))
+        val single = model.asSingle()
+        assertNotNull(single)
+        assertEquals("MultipartFile canonical name should resolve to 'file' type", JsonType.FILE, single!!.type)
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/JsonTypeTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/JsonTypeTest.kt
@@ -129,6 +129,13 @@ class JsonTypeTest {
     @Test
     fun testFromJavaType_fileTypes() {
         assertEquals(JsonType.FILE, JsonType.fromJavaType("org.springframework.web.multipart.MultipartFile"))
+        assertEquals(JsonType.FILE, JsonType.fromJavaType("__file__"))
+        assertEquals(JsonType.FILE, JsonType.fromJavaType("MultipartFile"))
+        assertEquals(JsonType.FILE, JsonType.fromJavaType("javax.servlet.http.Part"))
+        assertEquals(JsonType.FILE, JsonType.fromJavaType("jakarta.servlet.http.Part"))
+        assertEquals(JsonType.FILE, JsonType.fromJavaType("java.io.File"))
+        assertEquals(JsonType.FILE, JsonType.fromJavaType("java.nio.file.Path"))
+        assertEquals(JsonType.FILE, JsonType.fromJavaType("org.springframework.core.io.Resource"))
     }
     
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/SpecialTypeHandlerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/SpecialTypeHandlerTest.kt
@@ -179,6 +179,8 @@ class SpecialTypeHandlerTest : TestCase() {
         // json type strings
         assertTrue(SpecialTypeHandler.isFileTypeName("file"))
         assertTrue(SpecialTypeHandler.isFileTypeName("file[]"))
+        // internal file marker (produced by SpecialTypeHandler.resolveSpecialType)
+        assertTrue(SpecialTypeHandler.isFileTypeName("__file__"))
         // simple class names
         assertTrue(SpecialTypeHandler.isFileTypeName("MultipartFile"))
         assertTrue(SpecialTypeHandler.isFileTypeName("MultipartFile[]"))


### PR DESCRIPTION
## Summary
- map MultipartFile and additional file-like Java/Spring/Servlet types to FILE
- ensure special __file__ marker is treated as file type
- add/export tests for model attribute and direct MultipartFile parameters

## Testing
- not run locally