### PR TITLE
fix: resolve generic types in API method params (#1302)

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -18,7 +18,9 @@ import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.type.GenericContext
 import com.itangcent.easyapi.psi.type.ResolvedType
+import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.psi.type.searchAnnotation
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
@@ -132,7 +134,8 @@ class JaxRsClassExporter(
                 val paramHeaders = extractParamHeaders(method)
                 val contentType = types.consumes.firstOrNull()
                 val headers = buildHeaders(contentType, paramHeaders)
-                val body = buildRequestBody(method)
+                val genericContext = GenericContext(TypeResolver.resolveGenericParams(psiClass, emptyList()))
+                val body = buildRequestBody(method, genericContext)
                 val responseBody = buildResponseBody(method)
                 val responseTypeName = read { method.returnType?.canonicalText }
 
@@ -212,23 +215,28 @@ class JaxRsClassExporter(
         return result
     }
 
-    private suspend fun buildRequestBody(method: PsiMethod): ObjectModel? = read {
+    private suspend fun buildRequestBody(method: PsiMethod, genericContext: GenericContext = GenericContext.EMPTY): ObjectModel? = read {
         for (p in method.parameterList.parameters) {
             val resolved = parameterResolver.resolve(p)
             if (resolved.any { it.binding == ParameterBinding.Body }) {
-                return@read expandBodyParam(p)
+                return@read expandBodyParam(p, genericContext)
             }
         }
         return@read null
     }
 
-    private suspend fun expandBodyParam(parameter: PsiParameter): ObjectModel? {
+    private suspend fun expandBodyParam(parameter: PsiParameter, genericContext: GenericContext = GenericContext.EMPTY): ObjectModel? {
         val psiClass = PsiTypesUtil.getPsiClass(parameter.type) ?: return null
         val qualifiedName = psiClass.qualifiedName ?: return null
         if (qualifiedName.startsWith("java.lang.") || qualifiedName == "java.lang.String") return null
         return runCatching {
             val helper = PsiClassHelper.getInstance(project)
-            helper.buildObjectModel(psiClass, actionContext)
+            helper.buildObjectModelFromType(
+                psiType = parameter.type,
+                actionContext = actionContext,
+                genericContext = genericContext,
+                contextElement = parameter
+            )
         }.getOrNull()
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -126,7 +126,7 @@ class SpringMvcClassExporter(
                     ?: emptyList()
 
                 val resolvedBindings = resolveParameterBindings(resolvedMethod)
-                val params = buildParameters(resolvedBindings)
+                val params = buildParameters(resolvedBindings, genericContext)
                 val paramHeaders = extractParamHeaders(resolvedBindings)
                 val body = buildRequestBody(resolvedBindings, genericContext)
                 val response = read { ReturnTypeUnwrapper.unwrap(method.returnType) }
@@ -272,7 +272,8 @@ class SpringMvcClassExporter(
     }
 
     private suspend fun buildParameters(
-        bindings: List<ResolvedParamBinding>
+        bindings: List<ResolvedParamBinding>,
+        genericContext: GenericContext = GenericContext.EMPTY
     ): List<ApiParameter> {
         val result = ArrayList<ApiParameter>()
         for ((p, binding) in bindings) {
@@ -290,14 +291,14 @@ class SpringMvcClassExporter(
 
             try {
                 if (binding == ParameterBinding.Form) {
-                    val expandedParams = expandFormParameter(p)
+                    val expandedParams = expandFormParameter(p, genericContext)
                     if (expandedParams.isNotEmpty()) {
                         result.addAll(expandedParams)
                     } else {
                         result.add(buildSingleParameter(p, paramName, binding))
                     }
                 } else if (binding == ParameterBinding.Query) {
-                    val expandedParams = expandQueryParameter(p)
+                    val expandedParams = expandQueryParameter(p, genericContext)
                     if (expandedParams.isNotEmpty()) {
                         result.addAll(expandedParams)
                     } else {
@@ -378,23 +379,23 @@ class SpringMvcClassExporter(
         return result
     }
 
-    private suspend fun expandFormParameter(parameter: PsiParameter): List<ApiParameter> {
+    private suspend fun expandFormParameter(parameter: PsiParameter, genericContext: GenericContext = GenericContext.EMPTY): List<ApiParameter> {
         val formExpanded = settings.formExpanded
         if (!formExpanded) {
             return emptyList()
         }
-        return expandComplexParameter(parameter, ParameterBinding.Form)
+        return expandComplexParameter(parameter, ParameterBinding.Form, genericContext)
     }
 
-    private suspend fun expandQueryParameter(parameter: PsiParameter): List<ApiParameter> {
+    private suspend fun expandQueryParameter(parameter: PsiParameter, genericContext: GenericContext = GenericContext.EMPTY): List<ApiParameter> {
         val queryExpanded = settings.queryExpanded
         if (!queryExpanded) {
             return emptyList()
         }
-        return expandComplexParameter(parameter, ParameterBinding.Query)
+        return expandComplexParameter(parameter, ParameterBinding.Query, genericContext)
     }
 
-    private suspend fun expandComplexParameter(parameter: PsiParameter, binding: ParameterBinding): List<ApiParameter> {
+    private suspend fun expandComplexParameter(parameter: PsiParameter, binding: ParameterBinding, genericContext: GenericContext = GenericContext.EMPTY): List<ApiParameter> {
         val psiClass = PsiTypesUtil.getPsiClass(parameter.type) ?: return emptyList()
         val qualifiedName = psiClass.qualifiedName ?: return emptyList()
 
@@ -414,8 +415,13 @@ class SpringMvcClassExporter(
         val paramMaxDepth = engine.evaluate(RuleKeys.PARAM_MAX_DEPTH, parameter) ?: 5
 
         val helper = PsiClassHelper.getInstance(project)
-        val objectModel = helper.buildObjectModel(psiClass, actionContext, maxDepth = paramMaxDepth)
-            ?: return emptyList()
+        val objectModel = helper.buildObjectModelFromType(
+            psiType = parameter.type,
+            actionContext = actionContext,
+            genericContext = genericContext,
+            contextElement = parameter,
+            maxDepth = paramMaxDepth
+        ) ?: return emptyList()
 
         val objectData = objectModel.asObject() ?: return emptyList()
         val result = ArrayList<ApiParameter>()

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/GenericControllerExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/GenericControllerExportTest.kt
@@ -35,6 +35,8 @@ class GenericControllerExportTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/generic/TwoTypeBaseCtrl.java")
         loadFile("api/generic/MiddleCtrl.java")
         loadFile("api/generic/ConcreteCtrl.java")
+        loadFile("api/generic/GenericParamCtrl.java")
+        loadFile("model/UserInfo.java")
         exporter = SpringMvcClassExporter(actionContext)
     }
 
@@ -167,5 +169,114 @@ class GenericControllerExportTest : EasyApiLightCodeInsightFixtureTestCase() {
             "data should be string (R resolved to String), got: ${dataField.model}",
             dataField.model is ObjectModel.Single && (dataField.model as ObjectModel.Single).type == JsonType.STRING
         )
+    }
+
+    // ==================== Issue #1302 Tests ====================
+
+    /**
+     * Issue #1302: Test that generic type parameters are correctly resolved
+     * when using @ModelAttribute with generic types like Result<UserInfo>.
+     */
+    fun testIssue1302_ModelAttribute() = runTest {
+        val psiClass = findClass("com.itangcent.api.generic.GenericParamCtrl")
+        assertNotNull("Should find GenericParamCtrl", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        val endpoint = endpoints.find { it.path == "/generic-param/model-attribute" }
+        assertNotNull("Should export GET /generic-param/model-attribute", endpoint)
+
+        val params = endpoint!!.httpMetadata?.parameters
+        assertNotNull("Parameters should be populated", params)
+        assertTrue("Should have expanded parameters", params!!.isNotEmpty())
+
+        val paramNames = params.map { it.name }
+        assertTrue("Should have 'code' parameter", paramNames.contains("code"))
+        assertTrue("Should have 'msg' parameter", paramNames.contains("msg"))
+        assertTrue("Should have 'data.id' parameter (UserInfo.id)", paramNames.contains("data.id"))
+        assertTrue("Should have 'data.name' parameter (UserInfo.name)", paramNames.contains("data.name"))
+        assertTrue("Should have 'data.age' parameter (UserInfo.age)", paramNames.contains("data.age"))
+    }
+
+    /**
+     * Issue #1302: Test that generic type parameters are correctly resolved
+     * when using @RequestBody with generic types like Result<UserInfo>.
+     */
+    fun testIssue1302_RequestBody() = runTest {
+        val psiClass = findClass("com.itangcent.api.generic.GenericParamCtrl")
+        assertNotNull("Should find GenericParamCtrl", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        val endpoint = endpoints.find { it.path == "/generic-param/request-body" }
+        assertNotNull("Should export POST /generic-param/request-body", endpoint)
+
+        val body = endpoint!!.httpMetadata?.body
+        assertNotNull("Body should be populated", body)
+        assertTrue("Body should be Object", body is ObjectModel.Object)
+
+        val fields = (body as ObjectModel.Object).fields
+        assertTrue("Should have 'code' field", fields.containsKey("code"))
+        assertTrue("Should have 'msg' field", fields.containsKey("msg"))
+        assertTrue("Should have 'data' field", fields.containsKey("data"))
+
+        // data should be resolved to UserInfo (not unresolved T)
+        val dataField = fields["data"]!!
+        assertTrue(
+            "data should be object (UserInfo), got: ${dataField.model}",
+            dataField.model is ObjectModel.Object
+        )
+
+        // Verify that data contains UserInfo fields
+        val dataFields = (dataField.model as ObjectModel.Object).fields
+        assertTrue("data should have 'id' field (UserInfo.id)", dataFields.containsKey("id"))
+        assertTrue("data should have 'name' field (UserInfo.name)", dataFields.containsKey("name"))
+        assertTrue("data should have 'age' field (UserInfo.age)", dataFields.containsKey("age"))
+    }
+
+    /**
+     * Issue #1302: Test that generic type parameters are correctly resolved
+     * when using @RequestParam with generic types like Result<UserInfo>.
+     */
+    fun testIssue1302_RequestParam() = runTest {
+        val psiClass = findClass("com.itangcent.api.generic.GenericParamCtrl")
+        assertNotNull("Should find GenericParamCtrl", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        val endpoint = endpoints.find { it.path == "/generic-param/request-param" }
+        assertNotNull("Should export GET /generic-param/request-param", endpoint)
+
+        val params = endpoint!!.httpMetadata?.parameters
+        assertNotNull("Parameters should be populated", params)
+        assertTrue("Should have expanded parameters", params!!.isNotEmpty())
+
+        val paramNames = params.map { it.name }
+        assertTrue("Should have 'code' parameter", paramNames.contains("code"))
+        assertTrue("Should have 'msg' parameter", paramNames.contains("msg"))
+        assertTrue("Should have 'data.id' parameter (UserInfo.id)", paramNames.contains("data.id"))
+        assertTrue("Should have 'data.name' parameter (UserInfo.name)", paramNames.contains("data.name"))
+        assertTrue("Should have 'data.age' parameter (UserInfo.age)", paramNames.contains("data.age"))
+    }
+
+    /**
+     * Issue #1302: Test that generic type parameters are correctly resolved
+     * when using no annotation (defaults to query param) with generic types like Result<UserInfo>.
+     */
+    fun testIssue1302_NoAnnotation() = runTest {
+        val psiClass = findClass("com.itangcent.api.generic.GenericParamCtrl")
+        assertNotNull("Should find GenericParamCtrl", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        val endpoint = endpoints.find { it.path == "/generic-param/no-annotation" }
+        assertNotNull("Should export GET /generic-param/no-annotation", endpoint)
+
+        val params = endpoint!!.httpMetadata?.parameters
+        assertNotNull("Parameters should be populated", params)
+        assertTrue("Should have expanded parameters", params!!.isNotEmpty())
+
+        val paramNames = params.map { it.name }
+        assertTrue("Should have 'code' parameter", paramNames.contains("code"))
+        assertTrue("Should have 'msg' parameter", paramNames.contains("msg"))
+        assertTrue("Should have 'data.id' parameter (UserInfo.id)", paramNames.contains("data.id"))
+        assertTrue("Should have 'data.name' parameter (UserInfo.name)", paramNames.contains("data.name"))
+        assertTrue("Should have 'data.age' parameter (UserInfo.age)", paramNames.contains("data.age"))
     }
 }

--- a/src/test/resources/api/generic/GenericParamCtrl.java
+++ b/src/test/resources/api/generic/GenericParamCtrl.java
@@ -1,0 +1,52 @@
+package com.itangcent.api.generic;
+
+import com.itangcent.model.Result;
+import com.itangcent.model.UserInfo;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Test case for issue #1302: Generic type parameters should be correctly resolved
+ * when using different parameter bindings with generic types like Result<UserInfo>
+ */
+@RestController
+@RequestMapping("/generic-param")
+public class GenericParamCtrl {
+
+    /**
+     * test with @ModelAttribute
+     */
+    @GetMapping("/model-attribute")
+    public String testModelAttribute(@ModelAttribute Result<UserInfo> param) {
+        return "success";
+    }
+
+    /**
+     * test with @RequestBody
+     */
+    @PostMapping("/request-body")
+    public String testRequestBody(@RequestBody Result<UserInfo> param) {
+        return "success";
+    }
+
+    /**
+     * test with @RequestParam
+     */
+    @GetMapping("/request-param")
+    public String testRequestParam(@RequestParam Result<UserInfo> param) {
+        return "success";
+    }
+
+    /**
+     * test with no annotation (defaults to query param)
+     */
+    @GetMapping("/no-annotation")
+    public String testNoAnnotation(Result<UserInfo> param) {
+        return "success";
+    }
+}


### PR DESCRIPTION
- Pass GenericContext through parameter processing methods
- Use buildObjectModelFromType instead of buildObjectModel for generic type resolution
- Add test cases for @ModelAttribute, @RequestBody, @RequestParam, and no annotation

---

may fix: https://github.com/tangcent/easy-yapi/issues/1302
