### PR TITLE
fix: resolve EDT threading violations in API dashboard navigation

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
@@ -358,9 +358,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
     private fun navigateToSource(endpoint: ApiEndpoint) {
         val method = endpoint.sourceMethod ?: return
         if (method.canNavigate()) {
-            IdeDispatchers.readSync {
-                method.navigate(true)
-            }
+            method.navigate(true)
         }
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProvider.kt
@@ -123,9 +123,11 @@ class ApiMethodLineMarkerProvider : LineMarkerProvider {
                 val service = ApiDashboardService.getInstance(project)
                 val found = service.navigateToMethod(method)
 
-                com.intellij.openapi.wm.ToolWindowManager.getInstance(project)
-                    .getToolWindow("API Dashboard")
-                    ?.activate(null)
+                swing {
+                    com.intellij.openapi.wm.ToolWindowManager.getInstance(project)
+                        .getToolWindow("API Dashboard")
+                        ?.activate(null)
+                }
 
                 if (!found) {
                     // Endpoint not in index — trigger re-scan of the containing file,


### PR DESCRIPTION
## Changes

- **ApiDashboardPanel**: Remove `readSync` wrapper around `method.navigate(true)` in `navigateToSource`. Calling `navigate()` inside a `ReadAction` causes `WriteIntentReadAction can not be called from ReadAction` because `navigate()` internally acquires `WriteIntentReadAction`. Both call sites are already on EDT (mouse event handlers), so no lock is needed.

- **ApiMethodLineMarkerProvider**: Wrap `toolWindow.activate(null)` in `swing {}` to ensure it runs on EDT. Previously called from a background coroutine, triggering `ToolWindow.activate must be called from EDT` assertion and hanging the UI.

## Root Cause

These bugs only manifest in the packaged plugin (not `runIde`) because the IDE version used in production enforces stricter threading checks introduced in 2026.1.