### PR TITLE
fix: ensure fieldContext is always available for field rule evaluation

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -316,7 +316,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             // Build the field path for fieldContext injection into rule scripts
             val fieldPath = if (parentPath != null) "$parentPath.$fieldName" else fieldName
 
-            if (engine.evaluate(RuleKeys.FIELD_IGNORE, accessibleField.psi) { it.setExt("fieldContext", fieldPath) }) {
+            if (engine.evaluate(RuleKeys.FIELD_IGNORE, accessibleField.psi, fieldContext = fieldPath)) {
                 continue
             }
 
@@ -330,22 +330,22 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
                 }
             }
 
-            engine.evaluate(RuleKeys.JSON_FIELD_PARSE_BEFORE, accessibleField.psi) { it.setExt("fieldContext", fieldPath) }
+            engine.evaluate(RuleKeys.JSON_FIELD_PARSE_BEFORE, accessibleField.psi, fieldContext = fieldPath)
 
-            val customName = engine.evaluate(RuleKeys.FIELD_NAME, accessibleField.psi) { it.setExt("fieldContext", fieldPath) }
-            val prefix = engine.evaluate(RuleKeys.FIELD_NAME_PREFIX, accessibleField.psi) { it.setExt("fieldContext", fieldPath) } ?: ""
-            val suffix = engine.evaluate(RuleKeys.FIELD_NAME_SUFFIX, accessibleField.psi) { it.setExt("fieldContext", fieldPath) } ?: ""
+            val customName = engine.evaluate(RuleKeys.FIELD_NAME, accessibleField.psi, fieldContext = fieldPath)
+            val prefix = engine.evaluate(RuleKeys.FIELD_NAME_PREFIX, accessibleField.psi, fieldContext = fieldPath) ?: ""
+            val suffix = engine.evaluate(RuleKeys.FIELD_NAME_SUFFIX, accessibleField.psi, fieldContext = fieldPath) ?: ""
             val baseName = customName?.takeIf { it.isNotBlank() } ?: fieldName
             val jsonFieldName = prefix + baseName + suffix
 
             if (fields.containsKey(jsonFieldName)) continue
 
             val fieldDefaultValue =
-                engine.evaluate(RuleKeys.FIELD_DEFAULT_VALUE, accessibleField.psi)
-            val fieldRequired = engine.evaluate(RuleKeys.FIELD_REQUIRED, accessibleField.psi)
-            val fieldMock = engine.evaluate(RuleKeys.FIELD_MOCK, accessibleField.psi)
-            val fieldDemo = engine.evaluate(RuleKeys.FIELD_DEMO, accessibleField.psi)
-            val fieldAdvancedStr = engine.evaluate(RuleKeys.FIELD_ADVANCED, accessibleField.psi)
+                engine.evaluate(RuleKeys.FIELD_DEFAULT_VALUE, accessibleField.psi, fieldContext = fieldPath)
+            val fieldRequired = engine.evaluate(RuleKeys.FIELD_REQUIRED, accessibleField.psi, fieldContext = fieldPath)
+            val fieldMock = engine.evaluate(RuleKeys.FIELD_MOCK, accessibleField.psi, fieldContext = fieldPath)
+            val fieldDemo = engine.evaluate(RuleKeys.FIELD_DEMO, accessibleField.psi, fieldContext = fieldPath)
+            val fieldAdvancedStr = engine.evaluate(RuleKeys.FIELD_ADVANCED, accessibleField.psi, fieldContext = fieldPath)
             val fieldAdvanced = if (!fieldAdvancedStr.isNullOrBlank()) {
                 runCatching { GsonUtils.fromJson<Map<String, Any?>>(fieldAdvancedStr) }.getOrNull()
             } else null
@@ -355,7 +355,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
                     is PsiField -> docHelper.getAttrOfField(psi)
                     else -> docHelper.getAttrOfDocComment(psi)
                 }
-                val ruleComment = engine.evaluate(RuleKeys.FIELD_DOC, accessibleField.psi)
+                val ruleComment = engine.evaluate(RuleKeys.FIELD_DOC, accessibleField.psi, fieldContext = fieldPath)
                 mergeComments(directComment, ruleComment)
             } else null
 
@@ -388,7 +388,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             )
 
             // Check json.unwrapped — if true, merge the field's object fields into the parent
-            val unwrapped = engine.evaluate(RuleKeys.JSON_UNWRAPPED, accessibleField.psi)
+            val unwrapped = engine.evaluate(RuleKeys.JSON_UNWRAPPED, accessibleField.psi, fieldContext = fieldPath)
             if (unwrapped && fieldModel.model is ObjectModel.Object) {
                 for ((nestedName, nestedField) in (fieldModel.model as ObjectModel.Object).fields) {
                     if (!fields.containsKey(nestedName)) {
@@ -399,7 +399,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
                 fields[jsonFieldName] = fieldModel
             }
 
-            engine.evaluate(RuleKeys.JSON_FIELD_PARSE_AFTER, accessibleField.psi)
+            engine.evaluate(RuleKeys.JSON_FIELD_PARSE_AFTER, accessibleField.psi, fieldContext = fieldPath)
         }
 
         val additional = engine.evaluate(RuleKeys.JSON_ADDITIONAL_FIELD, psiClass)

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
@@ -46,7 +46,7 @@ object RuleKeys {
     val PARAM_MOCK          = RuleKey.string("param.mock")
 
     // ── Field rules ───────────────────────────────────────────────
-    val FIELD_NAME          = RuleKey.string("field.name")
+    val FIELD_NAME          = RuleKey.string("field.name", aliases = listOf("json.rule.field.name"))
     val FIELD_NAME_PREFIX   = RuleKey.string("field.name.prefix")
     val FIELD_NAME_SUFFIX   = RuleKey.string("field.name.suffix")
     val FIELD_REQUIRED      = RuleKey.boolean("field.required")
@@ -62,8 +62,8 @@ object RuleKeys {
     val PARAM_MAX_DEPTH     = RuleKey.int("param.max.depth")
 
     // ── JSON rules ────────────────────────────────────────────────
-    val JSON_FIELD_PARSE_BEFORE = RuleKey.event("json.field.parse.before")
-    val JSON_FIELD_PARSE_AFTER  = RuleKey.event("json.field.parse.after")
+    val JSON_FIELD_PARSE_BEFORE = RuleKey.event("json.field.parse.before", aliases = listOf("field.parse.before"))
+    val JSON_FIELD_PARSE_AFTER  = RuleKey.event("json.field.parse.after", aliases = listOf("field.parse.after"))
     val JSON_CLASS_PARSE_BEFORE = RuleKey.event("json.class.parse.before")
     val JSON_CLASS_PARSE_AFTER  = RuleKey.event("json.class.parse.after")
     val JSON_ADDITIONAL_FIELD   = RuleKey.string("json.additional.field", StringRuleMode.MERGE)
@@ -75,8 +75,8 @@ object RuleKeys {
     val API_CLASS_PARSE_AFTER   = RuleKey.event("api.class.parse.after")
     val API_METHOD_PARSE_BEFORE = RuleKey.event("api.method.parse.before")
     val API_METHOD_PARSE_AFTER  = RuleKey.event("api.method.parse.after")
-    val API_PARAM_PARSE_BEFORE  = RuleKey.event("api.param.parse.before")
-    val API_PARAM_PARSE_AFTER   = RuleKey.event("api.param.parse.after")
+    val API_PARAM_PARSE_BEFORE  = RuleKey.event("api.param.parse.before", aliases = listOf("param.before"))
+    val API_PARAM_PARSE_AFTER   = RuleKey.event("api.param.parse.after", aliases = listOf("param.after"))
     val EXPORT_AFTER            = RuleKey.event("export.after")
 
     // ── Additional headers/params ─────────────────────────────────

--- a/src/main/kotlin/com/itangcent/easyapi/rule/engine/RuleEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/engine/RuleEngine.kt
@@ -60,8 +60,8 @@ class RuleEngine internal constructor(
     // ════════════════════════════════════════════════════════════════
 
     /** Evaluate a string rule. Returns null when no rule matches or all values are empty. */
-    suspend fun evaluate(key: RuleKey.StringKey, element: PsiElement): String? {
-        val ctx = RuleContext.from(project, element)
+    suspend fun evaluate(key: RuleKey.StringKey, element: PsiElement, fieldContext: String? = null): String? {
+        val ctx = RuleContext.from(project, element, fieldContext)
         val values = ArrayList<String?>()
         forEachApplicable(key, ctx) { exp ->
             val v = runCatching { parse(exp, ctx, key) }
@@ -124,8 +124,8 @@ class RuleEngine internal constructor(
     }
 
     /** Evaluate a boolean rule. Returns false when no rule matches. */
-    suspend fun evaluate(key: RuleKey.BooleanKey, element: PsiElement): Boolean {
-        val ctx = RuleContext.from(project, element)
+    suspend fun evaluate(key: RuleKey.BooleanKey, element: PsiElement, fieldContext: String? = null): Boolean {
+        val ctx = RuleContext.from(project, element, fieldContext)
         val values = ArrayList<Boolean?>()
         forEachApplicable(key, ctx) { exp ->
             val v = runCatching { parse(exp, ctx, key) }
@@ -167,8 +167,8 @@ class RuleEngine internal constructor(
     }
 
     /** Fire an event rule (side-effect only). */
-    suspend fun evaluate(key: RuleKey.EventKey, element: PsiElement) {
-        val ctx = RuleContext.from(project, element)
+    suspend fun evaluate(key: RuleKey.EventKey, element: PsiElement, fieldContext: String? = null) {
+        val ctx = RuleContext.from(project, element, fieldContext)
         fireEvent(key, ctx)
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
@@ -110,13 +110,14 @@ abstract class Jsr223ScriptParser(
         // localStorage (wrapped to match legacy Storage API)
         bindings["localStorage"] = ScriptStorageWrapper(context.localStorage)
 
-        // fieldContext default — may be overridden by exts() below if set via contextHandle
-        bindings["fieldContext"] = context.wrapExt("fieldContext", context.fieldContext)
-
-        // extensions from rule context — overrides defaults; fieldContext strings are
-        // auto-wrapped as ScriptFieldContext via context.wrapExt()
+        // extensions from rule context — fieldContext strings are auto-wrapped as ScriptFieldContext
         context.exts().forEach { (key, value) ->
             bindings[key] = context.wrapExt(key, value)
+        }
+
+        // fieldContext fallback — use context.fieldContext if not set via extensions
+        if (!bindings.containsKey("fieldContext")) {
+            bindings["fieldContext"] = context.wrapExt("fieldContext", context.fieldContext)
         }
 
         // httpClient

--- a/src/main/resources/extensions/jackson.config
+++ b/src/main/resources/extensions/jackson.config
@@ -54,6 +54,7 @@ field.order.with=groovy:```
 # Support for Jackson annotation JsonIgnoreProperties
 field.ignore=groovy:it.containingClass().annValue("com.fasterxml.jackson.annotation.JsonIgnoreProperties")?.contains(it.name())
 field.parse.before[@com.fasterxml.jackson.annotation.JsonIgnoreProperties]=groovy:```
+    if (!fieldContext) return
     def properties = it.annValue("com.fasterxml.jackson.annotation.JsonIgnoreProperties")
     for(property in properties){
         def path = fieldContext.property(property)
@@ -61,6 +62,7 @@ field.parse.before[@com.fasterxml.jackson.annotation.JsonIgnoreProperties]=groov
     }
 ```
 field.parse.after[@com.fasterxml.jackson.annotation.JsonIgnoreProperties]=groovy:```
+    if (!fieldContext) return
     def properties = it.annValue("com.fasterxml.jackson.annotation.JsonIgnoreProperties")
     for(property in properties){
         def path = fieldContext.property(property)
@@ -68,11 +70,12 @@ field.parse.after[@com.fasterxml.jackson.annotation.JsonIgnoreProperties]=groovy
     }
 ```
 field.ignore=groovy:```
-    return session.get("json-ignore", fieldContext.path())
+    return fieldContext ? session.get("json-ignore", fieldContext.path()) : null
 ```
 
 # Support for Jackson annotation JsonUnwrapped
 json.field.parse.before[@com.fasterxml.jackson.annotation.JsonUnwrapped]=groovy:```
+    if (!fieldContext) return
     def prefix = it.ann("com.fasterxml.jackson.annotation.JsonUnwrapped","prefix")
     if(tool.notNullOrEmpty(prefix)){
         session.set("field.prefix", fieldContext.path(), prefix)
@@ -83,15 +86,18 @@ json.field.parse.before[@com.fasterxml.jackson.annotation.JsonUnwrapped]=groovy:
     }
 ```
 field.name.prefix=groovy:```
+    if (!fieldContext) return null
     def parentPath = tool.substringBeforeLast(fieldContext.path(),".")
     return session.get("field.prefix",parentPath)
 ```
 field.name.suffix=groovy:```
+    if (!fieldContext) return null
     def parentPath = tool.substringBeforeLast(fieldContext.path(),".")
     return session.get("field.suffix",parentPath)
 ```
 json.unwrapped=@com.fasterxml.jackson.annotation.JsonUnwrapped
 json.field.parse.after[@com.fasterxml.jackson.annotation.JsonUnwrapped]=groovy:```
+    if (!fieldContext) return
     def prefix = it.ann("com.fasterxml.jackson.annotation.JsonUnwrapped","prefix")
     if(tool.notNullOrEmpty(prefix)){
         session.remove("field.prefix", fieldContext.path())


### PR DESCRIPTION
## Problem

Commit a0c1927 partially fixed the fieldContext NPE but missed several field rule evaluations and config key aliases.

### Missing fieldContext injection
These field rules were evaluated without `fieldContext`, causing NPE when Groovy scripts called `fieldContext.path()`:
- `FIELD_DEFAULT_VALUE`, `FIELD_REQUIRED`, `FIELD_MOCK`, `FIELD_DEMO`, `FIELD_ADVANCED`, `FIELD_DOC`, `JSON_UNWRAPPED`

### Missing config key aliases
These config keys in extension configs had no matching RuleKey alias, so their rules were silently ignored:
- `field.parse.before` / `field.parse.after` (jackson.config `@JsonIgnoreProperties`)
- `json.rule.field.name` (swagger.config `@ApiModelProperty`)
- `param.before` / `param.after` (jakarta/javax-validation-strict.config)

## Changes

- **RuleEngine**: Add `fieldContext: String?` parameter to `evaluate` overloads for `StringKey`, `BooleanKey`, and `EventKey`, passing it directly to `RuleContext.from()` instead of using `setExt` workaround
- **DefaultPsiClassHelper**: Pass `fieldContext = fieldPath` to every field rule evaluation in `buildTypeObject`
- **RuleKeys**: Add missing aliases (`field.parse.before/after`, `json.rule.field.name`, `param.before/after`)
- **Jsr223ScriptParser**: Reorder fieldContext binding — extensions first, `context.fieldContext` as fallback
- **jackson.config**: Add null guards for `fieldContext` in all Groovy scripts