### PR TITLE
feat: support URL paste in API Search Everywhere with path variable matching

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributor.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributor.kt
@@ -104,11 +104,28 @@ class ApiSearchEverywhereContributor(
             else -> ""
         }
 
+        if (query.isPathQuery && searchLower.startsWith("/")) {
+            if (matchesPathWithVariables(searchLower, path.lowercase())) {
+                return true
+            }
+        }
+
         return path.lowercase().contains(searchLower) ||
                 endpoint.name?.lowercase()?.contains(searchLower) == true ||
                 endpoint.className?.lowercase()?.contains(searchLower) == true ||
                 endpoint.description?.lowercase()?.contains(searchLower) == true ||
                 endpoint.folder?.lowercase()?.contains(searchLower) == true
+    }
+
+    private fun matchesPathWithVariables(concretePath: String, patternPath: String): Boolean {
+        val regex = pathPatternToRegex(patternPath)
+        return regex.matches(concretePath)
+    }
+
+    private fun pathPatternToRegex(pattern: String): Regex {
+        val parts = pattern.split(Regex("\\{[^}]*\\}"))
+        val regexStr = parts.joinToString("[^/]+") { Regex.escape(it) }
+        return Regex("^$regexStr$")
     }
 
     override fun getDataForItem(element: ApiEndpoint, dataId: String): Any? {

--- a/src/main/kotlin/com/itangcent/easyapi/ide/search/ApiSearchQuery.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/search/ApiSearchQuery.kt
@@ -1,30 +1,50 @@
 package com.itangcent.easyapi.ide.search
 
 import com.itangcent.easyapi.exporter.model.HttpMethod
+import java.net.URI
 
 /**
  * Represents a parsed search query for API endpoints.
  *
  * Supports searching by HTTP method prefix followed by search text,
- * or just search text alone.
+ * or just search text alone. Also supports pasting full URLs to
+ * automatically extract the path for matching.
  *
  * ## Query Format
  * - `GET /users` - Search for GET endpoints matching "/users"
  * - `POST user` - Search for POST endpoints matching "user"
  * - `/api/users` - Search all endpoints matching "/api/users"
+ * - `http://127.0.0.1:3000/api/interface/get?id=116` - Extracts "/api/interface/get" for matching
+ * - `https://example.com/users` - Extracts "/users" for matching
+ * - `127.0.0.1:3000/api/users` - Extracts "/api/users" for matching
+ * - `/api/users?id=1` - Strips query params, matches "/api/users"
+ *
+ * ## Path Variable Matching
+ * When the search text is a concrete path (e.g., `/api/interface/116`),
+ * it can match endpoints with path variables (e.g., `/api/interface/{id}`).
  *
  * @param httpMethod Optional HTTP method filter (null means search all methods)
  * @param searchText The text to search for in path, name, class, or description
+ * @param isPathQuery Whether the search text was extracted from a URL/path (enables path variable matching)
  * @see ApiSearchEverywhereContributor for the search contributor
  */
 data class ApiSearchQuery(
     val httpMethod: HttpMethod?,
-    val searchText: String
+    val searchText: String,
+    val isPathQuery: Boolean = false
 ) {
     companion object {
         private val HTTP_METHOD_PATTERN = Regex(
             "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\\s+(.+)$",
             RegexOption.IGNORE_CASE
+        )
+
+        private val HOST_PORT_PATH_PATTERN = Regex(
+            "^[^/\\s]+:\\d+(/[\\S]*)?"
+        )
+
+        private val PATH_WITH_QUERY_PATTERN = Regex(
+            "^(/[^?\\s]*)[?\\s]"
         )
 
         /**
@@ -35,16 +55,78 @@ data class ApiSearchQuery(
          */
         fun parse(input: String): ApiSearchQuery {
             val trimmed = input.trim()
-            val match = HTTP_METHOD_PATTERN.find(trimmed)
 
-            return if (match != null) {
-                val methodStr = match.groupValues[1].uppercase()
+            // First check for HTTP method prefix
+            val methodMatch = HTTP_METHOD_PATTERN.find(trimmed)
+            if (methodMatch != null) {
+                val methodStr = methodMatch.groupValues[1].uppercase()
                 val method = HttpMethod.fromSpring(methodStr)
-                val text = match.groupValues[2].trim()
-                ApiSearchQuery(method, text)
-            } else {
-                ApiSearchQuery(null, trimmed)
+                val text = methodMatch.groupValues[2].trim()
+                val (path, isPath) = extractPath(text)
+                return ApiSearchQuery(method, path, isPath)
             }
+
+            // Then try to extract path from URL-like input
+            val (path, isPath) = extractPath(trimmed)
+            return ApiSearchQuery(null, path, isPath)
+        }
+
+        /**
+         * Extracts the path from various URL-like formats.
+         *
+         * Handles:
+         * - Full URLs: `http://127.0.0.1:3000/api/interface/get?id=116` -> `/api/interface/get`
+         * - Scheme-less URLs: `127.0.0.1:3000/api/interface/get?id=116` -> `/api/interface/get`
+         * - Paths with query: `/api/interface/get?id=116` -> `/api/interface/get`
+         * - Plain paths: `/api/interface/get` -> `/api/interface/get`
+         * - Non-path text: `user` -> `user`
+         *
+         * @return Pair of (extracted path, whether it was extracted from a URL/path)
+         */
+        private fun extractPath(input: String): Pair<String, Boolean> {
+            // Try java.net.URI for full URLs with scheme
+            val uriPath = tryParseUri(input)
+            if (uriPath != null) {
+                return uriPath to true
+            }
+
+            // Try host:port/path format (e.g., 127.0.0.1:3000/api/users)
+            val hostPortMatch = HOST_PORT_PATH_PATTERN.find(input)
+            if (hostPortMatch != null) {
+                val path = hostPortMatch.groupValues[1]
+                if (path != null && path.startsWith("/")) {
+                    return stripQueryParams(path) to true
+                } else {
+                    return "/" to true
+                }
+            }
+
+            // Try /path?query format
+            if (input.startsWith("/")) {
+                return stripQueryParams(input) to true
+            }
+
+            // Not a URL/path, return as-is
+            return input to false
+        }
+
+        private fun tryParseUri(input: String): String? {
+            return try {
+                val uri = URI(input)
+                if (uri.scheme != null && uri.path != null) {
+                    val path = uri.path
+                    if (path.isNotEmpty()) path else "/"
+                } else {
+                    null
+                }
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun stripQueryParams(path: String): String {
+            val match = PATH_WITH_QUERY_PATTERN.find(path)
+            return if (match != null) match.groupValues[1] else path
         }
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributorTest.kt
@@ -1,9 +1,11 @@
 package com.itangcent.easyapi.ide.search
 
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.exporter.model.GrpcMetadata
+import com.itangcent.easyapi.exporter.model.GrpcStreamingType
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -24,11 +26,34 @@ class ApiSearchEverywhereContributorTest {
         )
     }
 
+    private fun createGrpcEndpoint(
+        path: String,
+        serviceName: String,
+        methodName: String,
+        packageName: String,
+        name: String? = null,
+        className: String? = null
+    ): ApiEndpoint {
+        return ApiEndpoint(
+            metadata = GrpcMetadata(
+                path = path,
+                serviceName = serviceName,
+                methodName = methodName,
+                packageName = packageName,
+                streamingType = GrpcStreamingType.UNARY
+            ),
+            name = name,
+            className = className
+        )
+    }
+
+    // --- Basic matching tests ---
+
     @Test
     fun `matchesQuery with empty search text returns true`() {
         val endpoint = createEndpoint("/user")
         val query = ApiSearchQuery(null, "")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -36,7 +61,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with matching HTTP method returns true`() {
         val endpoint = createEndpoint("/user", HttpMethod.GET)
         val query = ApiSearchQuery(HttpMethod.GET, "")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -44,7 +69,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with non-matching HTTP method returns false`() {
         val endpoint = createEndpoint("/user", HttpMethod.GET)
         val query = ApiSearchQuery(HttpMethod.POST, "")
-        
+
         assertFalse(matchesQuery(endpoint, query))
     }
 
@@ -52,7 +77,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with matching path returns true`() {
         val endpoint = createEndpoint("/api/user")
         val query = ApiSearchQuery(null, "user")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -60,7 +85,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with non-matching path returns false`() {
         val endpoint = createEndpoint("/api/admin")
         val query = ApiSearchQuery(null, "user")
-        
+
         assertFalse(matchesQuery(endpoint, query))
     }
 
@@ -68,7 +93,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with matching name returns true`() {
         val endpoint = createEndpoint("/user", name = "Get User")
         val query = ApiSearchQuery(null, "Get")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -76,7 +101,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with matching className returns true`() {
         val endpoint = createEndpoint("/user", className = "UserController")
         val query = ApiSearchQuery(null, "Controller")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -84,7 +109,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with matching description returns true`() {
         val endpoint = createEndpoint("/user", description = "Get user by ID")
         val query = ApiSearchQuery(null, "ID")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -92,7 +117,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with HTTP method and matching path returns true`() {
         val endpoint = createEndpoint("/api/user", HttpMethod.POST)
         val query = ApiSearchQuery(HttpMethod.POST, "user")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -100,7 +125,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with HTTP method and non-matching path returns false`() {
         val endpoint = createEndpoint("/api/user", HttpMethod.POST)
         val query = ApiSearchQuery(HttpMethod.POST, "admin")
-        
+
         assertFalse(matchesQuery(endpoint, query))
     }
 
@@ -108,7 +133,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with HTTP method mismatch and matching path returns false`() {
         val endpoint = createEndpoint("/api/user", HttpMethod.GET)
         val query = ApiSearchQuery(HttpMethod.POST, "user")
-        
+
         assertFalse(matchesQuery(endpoint, query))
     }
 
@@ -116,7 +141,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery is case-insensitive`() {
         val endpoint = createEndpoint("/API/USER")
         val query = ApiSearchQuery(null, "user")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -124,7 +149,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with partial path match returns true`() {
         val endpoint = createEndpoint("/api/v1/user/profile")
         val query = ApiSearchQuery(null, "user")
-        
+
         assertTrue(matchesQuery(endpoint, query))
     }
 
@@ -132,7 +157,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with null name does not crash`() {
         val endpoint = createEndpoint("/user", name = null)
         val query = ApiSearchQuery(null, "test")
-        
+
         assertFalse(matchesQuery(endpoint, query))
     }
 
@@ -140,7 +165,7 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with null className does not crash`() {
         val endpoint = createEndpoint("/user", className = null)
         val query = ApiSearchQuery(null, "test")
-        
+
         assertFalse(matchesQuery(endpoint, query))
     }
 
@@ -148,9 +173,314 @@ class ApiSearchEverywhereContributorTest {
     fun `matchesQuery with null description does not crash`() {
         val endpoint = createEndpoint("/user", description = null)
         val query = ApiSearchQuery(null, "test")
-        
+
         assertFalse(matchesQuery(endpoint, query))
     }
+
+    // --- URL-based search tests ---
+
+    @Test
+    fun `matchesQuery with full URL extracts path and matches`() {
+        val endpoint = createEndpoint("/api/interface/get", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface/get?id=116")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with full URL does not match different path`() {
+        val endpoint = createEndpoint("/api/interface/list", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface/get?id=116")
+
+        assertFalse(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with HTTPS URL extracts path and matches`() {
+        val endpoint = createEndpoint("/api/users", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("https://example.com/api/users")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with scheme-less URL extracts path and matches`() {
+        val endpoint = createEndpoint("/api/interface/list_menu", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("127.0.0.1:3000/api/interface/list_menu?project_id=11")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with path and query params strips and matches`() {
+        val endpoint = createEndpoint("/api/interface/list_menu", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("/api/interface/list_menu?project_id=11")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with URL and method prefix filters method`() {
+        val endpoint = createEndpoint("/api/users", HttpMethod.POST)
+        val query = ApiSearchQuery.parse("GET http://127.0.0.1:3000/api/users")
+
+        assertFalse(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with URL and matching method prefix`() {
+        val endpoint = createEndpoint("/api/users", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("GET http://127.0.0.1:3000/api/users")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with URL matches by path contains when path variable match fails`() {
+        val endpoint = createEndpoint("/api/v1/user-profile", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://localhost:8080/api/v1/user-profile")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    // --- Path variable matching tests ---
+
+    @Test
+    fun `matchesQuery with path variable - concrete value matches pattern`() {
+        val endpoint = createEndpoint("/api/interface/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface/116")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with path variable - different concrete value matches`() {
+        val endpoint = createEndpoint("/api/interface/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface/abc-123")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with path variable - extra segment does not match`() {
+        val endpoint = createEndpoint("/api/interface/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface/116/sub")
+
+        assertFalse(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with path variable - missing segment still matches via contains`() {
+        val endpoint = createEndpoint("/api/interface/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with multiple path variables`() {
+        val endpoint = createEndpoint("/api/{version}/users/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://localhost:8080/api/v1/users/123")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with multiple path variables - wrong segment count does not match`() {
+        val endpoint = createEndpoint("/api/{version}/users/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://localhost:8080/api/users/123")
+
+        assertFalse(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery path variable - exact path also matches via contains`() {
+        val endpoint = createEndpoint("/api/users/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("/api/users/42")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery path variable - non-path query does not trigger variable matching`() {
+        val endpoint = createEndpoint("/api/users/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery(null, "users", isPathQuery = false)
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery path variable - concrete path with no variables matches exactly`() {
+        val endpoint = createEndpoint("/api/users/list", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://localhost:8080/api/users/list")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery path variable - concrete path does not match different fixed segment`() {
+        val endpoint = createEndpoint("/api/users/list", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://localhost:8080/api/users/other")
+
+        assertFalse(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery path variable with hyphen in path`() {
+        val endpoint = createEndpoint("/api/v1/user-profile/{id}", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://localhost:8080/api/v1/user-profile/123")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery path variable - variable at start of path`() {
+        val endpoint = createEndpoint("/{org}/projects", HttpMethod.GET)
+        val query = ApiSearchQuery.parse("http://localhost:8080/my-org/projects")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    // --- gRPC endpoint matching tests ---
+
+    @Test
+    fun `matchesQuery with gRPC URL matches grpc endpoint`() {
+        val endpoint = createGrpcEndpoint(
+            path = "/my.package.UserService/GetUser",
+            serviceName = "UserService",
+            methodName = "GetUser",
+            packageName = "my.package"
+        )
+        val query = ApiSearchQuery.parse("grpc://localhost:8080/my.package.UserService/GetUser")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with grpcs URL matches grpc endpoint`() {
+        val endpoint = createGrpcEndpoint(
+            path = "/my.package.Service/Method",
+            serviceName = "Service",
+            methodName = "Method",
+            packageName = "my.package"
+        )
+        val query = ApiSearchQuery.parse("grpcs://example.com/my.package.Service/Method")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with grpc URL and query params`() {
+        val endpoint = createGrpcEndpoint(
+            path = "/my.Service/Method",
+            serviceName = "Service",
+            methodName = "Method",
+            packageName = "my"
+        )
+        val query = ApiSearchQuery.parse("grpc://localhost:8080/my.Service/Method?timeout=5s")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with text search matches grpc endpoint by path`() {
+        val endpoint = createGrpcEndpoint(
+            path = "/my.package.UserService/GetUser",
+            serviceName = "UserService",
+            methodName = "GetUser",
+            packageName = "my.package"
+        )
+        val query = ApiSearchQuery(null, "UserService")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    @Test
+    fun `matchesQuery with text search matches grpc endpoint by name`() {
+        val endpoint = createGrpcEndpoint(
+            path = "/my.package.UserService/GetUser",
+            serviceName = "UserService",
+            methodName = "GetUser",
+            packageName = "my.package",
+            name = "Get User"
+        )
+        val query = ApiSearchQuery(null, "Get User")
+
+        assertTrue(matchesQuery(endpoint, query))
+    }
+
+    // --- Realistic scenario tests ---
+
+    @Test
+    fun `realistic - paste full URL from browser matches correct endpoint`() {
+        val endpoints = listOf(
+            createEndpoint("/api/interface/get", HttpMethod.GET, name = "getInterface"),
+            createEndpoint("/api/interface/list", HttpMethod.GET, name = "listInterfaces"),
+            createEndpoint("/api/interface/update", HttpMethod.PUT, name = "updateInterface"),
+            createEndpoint("/api/project/get", HttpMethod.GET, name = "getProject")
+        )
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface/get?id=116")
+
+        val matched = endpoints.filter { matchesQuery(it, query) }
+        assertEquals(1, matched.size)
+        assertEquals("getInterface", matched[0].name)
+    }
+
+    @Test
+    fun `realistic - paste URL with path variable matches correct endpoint`() {
+        val endpoints = listOf(
+            createEndpoint("/api/user/{id}", HttpMethod.GET, name = "getUser"),
+            createEndpoint("/api/user/list", HttpMethod.GET, name = "listUsers"),
+            createEndpoint("/api/user/{id}/profile", HttpMethod.GET, name = "getUserProfile")
+        )
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/user/42")
+
+        val matched = endpoints.filter { matchesQuery(it, query) }
+        assertEquals(1, matched.size)
+        assertEquals("getUser", matched[0].name)
+    }
+
+    @Test
+    fun `realistic - paste scheme-less URL matches correct endpoint`() {
+        val endpoints = listOf(
+            createEndpoint("/api/interface/list_menu", HttpMethod.GET, name = "listMenu"),
+            createEndpoint("/api/interface/get", HttpMethod.GET, name = "getInterface")
+        )
+        val query = ApiSearchQuery.parse("127.0.0.1:3000/api/interface/list_menu?project_id=11")
+
+        val matched = endpoints.filter { matchesQuery(it, query) }
+        assertEquals(1, matched.size)
+        assertEquals("listMenu", matched[0].name)
+    }
+
+    @Test
+    fun `realistic - paste path with query params matches correct endpoint`() {
+        val endpoints = listOf(
+            createEndpoint("/api/interface/list_menu", HttpMethod.GET, name = "listMenu"),
+            createEndpoint("/api/interface/get", HttpMethod.GET, name = "getInterface")
+        )
+        val query = ApiSearchQuery.parse("/api/interface/list_menu?project_id=11")
+
+        val matched = endpoints.filter { matchesQuery(it, query) }
+        assertEquals(1, matched.size)
+        assertEquals("listMenu", matched[0].name)
+    }
+
+    @Test
+    fun `realistic - URL with method prefix filters correctly`() {
+        val endpoints = listOf(
+            createEndpoint("/api/user/{id}", HttpMethod.GET, name = "getUser"),
+            createEndpoint("/api/user/{id}", HttpMethod.DELETE, name = "deleteUser"),
+            createEndpoint("/api/user/{id}", HttpMethod.PUT, name = "updateUser")
+        )
+        val query = ApiSearchQuery.parse("DELETE http://127.0.0.1:3000/api/user/42")
+
+        val matched = endpoints.filter { matchesQuery(it, query) }
+        assertEquals(1, matched.size)
+        assertEquals("deleteUser", matched[0].name)
+    }
+
+    // --- matchesQuery implementation matching ApiSearchEverywhereContributor ---
 
     private fun matchesQuery(endpoint: ApiEndpoint, query: ApiSearchQuery): Boolean {
         if (query.httpMethod != null && endpoint.httpMetadata?.method != query.httpMethod) {
@@ -162,14 +492,33 @@ class ApiSearchEverywhereContributorTest {
         }
 
         val searchLower = query.searchText.lowercase()
-        val path = endpoint.httpMetadata?.path ?: ""
+        val path = when (val meta = endpoint.metadata) {
+            is HttpMetadata -> meta.path
+            is GrpcMetadata -> meta.path
+            else -> ""
+        }
 
-        val matchesPath = path.lowercase().contains(searchLower)
-        val matchesName = endpoint.name?.lowercase()?.contains(searchLower) == true
-        val matchesClassName = endpoint.className?.lowercase()?.contains(searchLower) == true
-        val matchesDescription = endpoint.description?.lowercase()?.contains(searchLower) == true
-        val matchesFolder = endpoint.folder?.lowercase()?.contains(searchLower) == true
+        if (query.isPathQuery && searchLower.startsWith("/")) {
+            if (matchesPathWithVariables(searchLower, path.lowercase())) {
+                return true
+            }
+        }
 
-        return matchesPath || matchesName || matchesClassName || matchesDescription || matchesFolder
+        return path.lowercase().contains(searchLower) ||
+                endpoint.name?.lowercase()?.contains(searchLower) == true ||
+                endpoint.className?.lowercase()?.contains(searchLower) == true ||
+                endpoint.description?.lowercase()?.contains(searchLower) == true ||
+                endpoint.folder?.lowercase()?.contains(searchLower) == true
+    }
+
+    private fun matchesPathWithVariables(concretePath: String, patternPath: String): Boolean {
+        val regex = pathPatternToRegex(patternPath)
+        return regex.matches(concretePath)
+    }
+
+    private fun pathPatternToRegex(pattern: String): Regex {
+        val parts = pattern.split(Regex("\\{[^}]*\\}"))
+        val regexStr = parts.joinToString("[^/]+") { Regex.escape(it) }
+        return Regex("^$regexStr$")
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/ide/search/ApiSearchQueryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/search/ApiSearchQueryTest.kt
@@ -2,7 +2,9 @@ package com.itangcent.easyapi.ide.search
 
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ApiSearchQueryTest {
@@ -12,6 +14,7 @@ class ApiSearchQueryTest {
         val query = ApiSearchQuery.parse("")
         assertNull(query.httpMethod)
         assertEquals("", query.searchText)
+        assertFalse(query.isPathQuery)
     }
 
     @Test
@@ -26,6 +29,7 @@ class ApiSearchQueryTest {
         val query = ApiSearchQuery.parse("user")
         assertNull(query.httpMethod)
         assertEquals("user", query.searchText)
+        assertFalse(query.isPathQuery)
     }
 
     @Test
@@ -33,6 +37,7 @@ class ApiSearchQueryTest {
         val query = ApiSearchQuery.parse("GET /user")
         assertEquals(HttpMethod.GET, query.httpMethod)
         assertEquals("/user", query.searchText)
+        assertTrue(query.isPathQuery)
     }
 
     @Test
@@ -47,6 +52,7 @@ class ApiSearchQueryTest {
         val query = ApiSearchQuery.parse("PUT user")
         assertEquals(HttpMethod.PUT, query.httpMethod)
         assertEquals("user", query.searchText)
+        assertFalse(query.isPathQuery)
     }
 
     @Test
@@ -103,5 +109,177 @@ class ApiSearchQueryTest {
         val query = ApiSearchQuery.parse("OPTIONS /user")
         assertEquals(HttpMethod.OPTIONS, query.httpMethod)
         assertEquals("/user", query.searchText)
+    }
+
+    // --- URL parsing tests ---
+
+    @Test
+    fun `parse full URL with query parameters`() {
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/interface/get?id=116")
+        assertNull(query.httpMethod)
+        assertEquals("/api/interface/get", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse full URL without query parameters`() {
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000/api/users")
+        assertNull(query.httpMethod)
+        assertEquals("/api/users", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse HTTPS URL`() {
+        val query = ApiSearchQuery.parse("https://example.com/api/users")
+        assertNull(query.httpMethod)
+        assertEquals("/api/users", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse URL with no path`() {
+        val query = ApiSearchQuery.parse("http://127.0.0.1:3000")
+        assertNull(query.httpMethod)
+        assertEquals("/", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse URL with method prefix`() {
+        val query = ApiSearchQuery.parse("GET http://127.0.0.1:3000/api/users?id=1")
+        assertEquals(HttpMethod.GET, query.httpMethod)
+        assertEquals("/api/users", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse URL with port and complex path`() {
+        val query = ApiSearchQuery.parse("http://localhost:8080/api/v1/users/123/profile")
+        assertNull(query.httpMethod)
+        assertEquals("/api/v1/users/123/profile", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse plain path is treated as path query`() {
+        val query = ApiSearchQuery.parse("/api/users")
+        assertNull(query.httpMethod)
+        assertEquals("/api/users", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse grpc URL`() {
+        val query = ApiSearchQuery.parse("grpc://localhost:8080/my.service.Method")
+        assertNull(query.httpMethod)
+        assertEquals("/my.service.Method", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse grpcs URL`() {
+        val query = ApiSearchQuery.parse("grpcs://example.com/my.package.Service/Method")
+        assertNull(query.httpMethod)
+        assertEquals("/my.package.Service/Method", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse grpc URL with query parameters`() {
+        val query = ApiSearchQuery.parse("grpc://localhost:8080/my.Service/Method?timeout=5s")
+        assertNull(query.httpMethod)
+        assertEquals("/my.Service/Method", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    // --- Scheme-less URL tests ---
+
+    @Test
+    fun `parse scheme-less URL with port and query`() {
+        val query = ApiSearchQuery.parse("127.0.0.1:3000/api/interface/list_menu?project_id=11")
+        assertNull(query.httpMethod)
+        assertEquals("/api/interface/list_menu", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse scheme-less URL with port`() {
+        val query = ApiSearchQuery.parse("127.0.0.1:3000/api/interface/list_menu")
+        assertNull(query.httpMethod)
+        assertEquals("/api/interface/list_menu", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse localhost URL with port`() {
+        val query = ApiSearchQuery.parse("localhost:8080/api/users")
+        assertNull(query.httpMethod)
+        assertEquals("/api/users", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    // --- Path with query params tests ---
+
+    @Test
+    fun `parse path with query parameters`() {
+        val query = ApiSearchQuery.parse("/api/interface/list_menu?project_id=11")
+        assertNull(query.httpMethod)
+        assertEquals("/api/interface/list_menu", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    @Test
+    fun `parse path without query parameters`() {
+        val query = ApiSearchQuery.parse("/api/interface/list_menu")
+        assertNull(query.httpMethod)
+        assertEquals("/api/interface/list_menu", query.searchText)
+        assertTrue(query.isPathQuery)
+    }
+
+    // --- Path variable matching tests ---
+
+    @Test
+    fun `path variable matching - concrete path matches pattern`() {
+        val regex = pathPatternToRegex("/api/interface/{id}")
+        assertTrue(regex.matches("/api/interface/116"))
+        assertTrue(regex.matches("/api/interface/abc"))
+        assertFalse(regex.matches("/api/interface/116/sub"))
+        assertFalse(regex.matches("/api/interface"))
+    }
+
+    @Test
+    fun `path variable matching - multiple variables`() {
+        val regex = pathPatternToRegex("/api/{version}/users/{id}")
+        assertTrue(regex.matches("/api/v1/users/123"))
+        assertTrue(regex.matches("/api/v2/users/abc"))
+        assertFalse(regex.matches("/api/users/123"))
+        assertFalse(regex.matches("/api/v1/users/123/extra"))
+    }
+
+    @Test
+    fun `path variable matching - no variables`() {
+        val regex = pathPatternToRegex("/api/users/list")
+        assertTrue(regex.matches("/api/users/list"))
+        assertFalse(regex.matches("/api/users/other"))
+    }
+
+    @Test
+    fun `path variable matching - variable at end`() {
+        val regex = pathPatternToRegex("/api/users/{userId}")
+        assertTrue(regex.matches("/api/users/42"))
+        assertFalse(regex.matches("/api/users"))
+    }
+
+    @Test
+    fun `path variable matching - special chars in path`() {
+        val regex = pathPatternToRegex("/api/v1/user-profile/{id}")
+        assertTrue(regex.matches("/api/v1/user-profile/123"))
+    }
+
+    private fun pathPatternToRegex(pattern: String): Regex {
+        val parts = pattern.split(Regex("\\{[^}]*\\}"))
+        val regexStr = parts.joinToString("[^/]+") { Regex.escape(it) }
+        return Regex("^$regexStr$")
     }
 }


### PR DESCRIPTION
## Summary

Enable users to paste full URLs directly into Search Everywhere to find matching API endpoints.

## Changes

- URL parsing in ApiSearchQuery: Extract path from various URL formats using java.net.URI with regex fallback
- Support full URLs, scheme-less URLs, paths with query params, and grpc/grpcs protocols
- Path variable matching: /api/interface/116 matches /api/interface/{id}
- isPathQuery flag to enable path variable matching only for URL/path queries
- Comprehensive tests: 80 tests covering all scenarios