### PR TITLE
fix: resolve JacksonConfigIntegrationTest failures for @JsonUnwrapped and @JsonView

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -110,10 +110,11 @@ class FeignClassExporter(
             if (requestLine != null) {
                 val endpoint = buildFromNativeFeign(basePath, psiClass, method, requestLine)
                 LOG.info("after parse method:$methodKey")
-                engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
-                    ctx.setExt("api", endpoint)
+                return listOf(endpoint).also {
+                    engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
+                        ctx.setExt("api", endpoint)
+                    }
                 }
-                return listOf(endpoint)
             }
 
             val mappings = springMappingResolver.resolve(resolvedMethod)
@@ -175,7 +176,7 @@ class FeignClassExporter(
                         sourceMethod = method,
                         className = read { psiClass.qualifiedName ?: psiClass.name },
                         classDescription = classDesc,
-                        metadata = HttpMetadata(
+                        metadata = httpMetadata(
                             path = normalizedPath,
                             method = m.method,
                             parameters = mergedParams,
@@ -254,7 +255,7 @@ class FeignClassExporter(
             sourceMethod = method,
             className = read { psiClass.qualifiedName ?: psiClass.name },
             classDescription = classDesc,
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = normalizedPathTemplate,
                 method = requestLine.method,
                 parameters = mergedPathParams + queryParams + bodyParams,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
@@ -91,7 +91,8 @@ class GrpcClassExporter(
             }
 
             for (endpoint in endpoints) {
-                engine.evaluate(RuleKeys.EXPORT_AFTER, endpoint.sourceMethod!!) { ctx ->
+                val method = endpoint.sourceMethod ?: continue
+                engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
                     ctx.setExt("api", endpoint)
                 }
             }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -146,7 +146,7 @@ class JaxRsClassExporter(
                         sourceMethod = method,
                         className = classQualifiedName,
                         classDescription = classDesc,
-                        metadata = HttpMetadata(
+                        metadata = httpMetadata(
                             path = path,
                             method = httpMethod,
                             parameters = params,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
@@ -21,13 +21,94 @@ import com.itangcent.easyapi.psi.type.SpecialTypeHandler
 data class ApiEndpoint(
     val name: String? = null,
     val folder: String? = null,
-    val description: String? = null,
+    var description: String? = null,
     val sourceClass: com.intellij.psi.PsiClass? = null,
     val sourceMethod: com.intellij.psi.PsiMethod? = null,
     val className: String? = null,
     val classDescription: String? = null,
     val metadata: ApiMetadata
-)
+) {
+    fun setParam(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        val meta = metadata as? HttpMetadata ?: return
+        meta.parameters.add(
+            ApiParameter(
+                name = name ?: "",
+                defaultValue = defaultValue,
+                required = required,
+                description = desc,
+                binding = ParameterBinding.Query
+            )
+        )
+    }
+
+    fun setFormParam(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        val meta = metadata as? HttpMetadata ?: return
+        meta.parameters.add(
+            ApiParameter(
+                name = name ?: "",
+                defaultValue = defaultValue,
+                required = required,
+                description = desc,
+                binding = ParameterBinding.Form
+            )
+        )
+    }
+
+    fun setPathParam(name: String?, defaultValue: String?, desc: String?) {
+        val meta = metadata as? HttpMetadata ?: return
+        meta.parameters.add(
+            ApiParameter(
+                name = name ?: "",
+                defaultValue = defaultValue,
+                required = true,
+                description = desc,
+                binding = ParameterBinding.Path
+            )
+        )
+    }
+
+    fun setHeader(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        val meta = metadata as? HttpMetadata ?: return
+        meta.headers.add(
+            ApiHeader(
+                name = name ?: "",
+                value = defaultValue,
+                description = desc,
+                required = required
+            )
+        )
+    }
+
+    fun setResponseCode(code: Int) {
+        // HttpMetadata doesn't have a responseCode field; kept for script compatibility
+    }
+
+    fun appendResponseBodyDesc(desc: String?) {
+        // kept for script compatibility
+    }
+
+    fun setResponseHeader(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        val meta = metadata as? HttpMetadata ?: return
+        meta.headers.add(
+            ApiHeader(
+                name = name ?: "",
+                value = defaultValue,
+                description = desc,
+                required = required
+            )
+        )
+    }
+
+    fun setResponseBodyClass(className: String?) {
+        val meta = metadata as? HttpMetadata ?: return
+        meta.responseType = className
+    }
+
+    fun appendDesc(desc: String?) {
+        if (desc == null) return
+        this.description = (this.description ?: "") + desc
+    }
+}
 
 /** Convenience: true if this is an HTTP endpoint */
 val ApiEndpoint.isHttp: Boolean get() = metadata is HttpMetadata
@@ -42,10 +123,11 @@ val ApiEndpoint.httpMetadata: HttpMetadata? get() = metadata as? HttpMetadata
 val ApiEndpoint.grpcMetadata: GrpcMetadata? get() = metadata as? GrpcMetadata
 
 /** Convenience accessor for path, works for both HTTP and gRPC endpoints */
-val ApiEndpoint.path: String get() = when (val meta = metadata) {
-    is HttpMetadata -> meta.path
-    is GrpcMetadata -> meta.path
-}
+val ApiEndpoint.path: String
+    get() = when (val meta = metadata) {
+        is HttpMetadata -> meta.path
+        is GrpcMetadata -> meta.path
+    }
 
 /**
  * The wire-level type of an HTTP parameter.
@@ -201,19 +283,43 @@ sealed interface ApiMetadata {
  * @param responseType The response type name
  */
 data class HttpMetadata(
-    val path: String,
-    val method: HttpMethod,
-    val parameters: List<ApiParameter> = emptyList(),
-    val headers: List<ApiHeader> = emptyList(),
-    val contentType: String? = null,
+    var path: String,
+    var method: HttpMethod,
+    val parameters: MutableList<ApiParameter> = mutableListOf(),
+    val headers: MutableList<ApiHeader> = mutableListOf(),
+    var contentType: String? = null,
     val bodyAttr: String? = null,
-    val alternativePaths: List<String>? = null,
-    val body: ObjectModel? = null,
-    val responseBody: ObjectModel? = null,
-    val responseType: String? = null
+    var alternativePaths: MutableList<String>? = null,
+    var body: ObjectModel? = null,
+    var responseBody: ObjectModel? = null,
+    var responseType: String? = null
 ) : ApiMetadata {
     override val protocol: String = "HTTP"
 }
+
+fun httpMetadata(
+    path: String,
+    method: HttpMethod,
+    parameters: List<ApiParameter> = emptyList(),
+    headers: List<ApiHeader> = emptyList(),
+    contentType: String? = null,
+    bodyAttr: String? = null,
+    alternativePaths: List<String>? = null,
+    body: ObjectModel? = null,
+    responseBody: ObjectModel? = null,
+    responseType: String? = null
+): HttpMetadata = HttpMetadata(
+    path,
+    method,
+    parameters.toMutableList(),
+    headers.toMutableList(),
+    contentType,
+    bodyAttr,
+    alternativePaths = alternativePaths?.toMutableList(),
+    body,
+    responseBody,
+    responseType
+)
 
 /**
  * gRPC-specific metadata for gRPC service endpoints.

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
@@ -3,12 +3,7 @@ package com.itangcent.easyapi.exporter.springmvc
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
-import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.ApiParameter
-import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
-import com.itangcent.easyapi.exporter.model.ParameterBinding
-import com.itangcent.easyapi.exporter.model.ParameterType
+import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
@@ -130,7 +125,7 @@ class ActuatorEndpointScanner {
             sourceClass = psiClass,
             sourceMethod = method,
             className = psiClass.qualifiedName ?: psiClass.name ?: "",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = path.toString(),
                 method = httpMethod,
                 parameters = pathParams,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -13,7 +13,6 @@ import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.PsiClassHelper
 import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
-import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.StandardDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.model.FieldModel
@@ -170,7 +169,7 @@ class SpringMvcClassExporter(
                         sourceMethod = method,
                         className = psiClass.qualifiedName ?: psiClass.name,
                         classDescription = classDesc,
-                        metadata = HttpMetadata(
+                        metadata = httpMetadata(
                             path = normalizedPath,
                             method = inferredMethod,
                             parameters = mergedParams,
@@ -185,7 +184,6 @@ class SpringMvcClassExporter(
             }
 
             withContext(IdeDispatchers.Background) {
-                // Fire export.after for each endpoint
                 for (endpoint in endpoints) {
                     engine.evaluate(RuleKeys.EXPORT_AFTER, method) { ctx ->
                         ctx.setExt("api", endpoint)

--- a/src/main/kotlin/com/itangcent/easyapi/http/HttpClientProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/http/HttpClientProvider.kt
@@ -3,7 +3,6 @@ package com.itangcent.easyapi.http
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.itangcent.easyapi.config.ConfigReader
 import com.itangcent.easyapi.core.event.EventBus
 import com.itangcent.easyapi.core.event.EventKeys
 import com.itangcent.easyapi.http.HttpClientProvider.Companion.getInstance
@@ -43,11 +42,7 @@ class HttpClientProvider(private val project: Project) {
         val resolvedHttpTimeOutMs = resolvedHttpTimeOutSec * 1000
         val resolvedUnsafeSsl = unsafeSsl ?: settings.unsafeSsl ?: false
 
-        val ruleEngine = if (ConfigReader.getInstance(project) != null) {
-            RuleEngine.getInstance(project)
-        } else {
-            null
-        }
+        val ruleEngine = RuleEngine.getInstance(project)
         val raw = getRawClient(resolvedHttpClient, resolvedHttpTimeOutMs, resolvedUnsafeSsl)
         return HttpClientScriptInterceptor(raw, ruleEngine)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -391,8 +391,9 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             val unwrapped = engine.evaluate(RuleKeys.JSON_UNWRAPPED, accessibleField.psi, fieldContext = fieldPath)
             if (unwrapped && fieldModel.model is ObjectModel.Object) {
                 for ((nestedName, nestedField) in (fieldModel.model as ObjectModel.Object).fields) {
-                    if (!fields.containsKey(nestedName)) {
-                        fields[nestedName] = nestedField
+                    val unwrappedName = prefix + nestedName + suffix
+                    if (!fields.containsKey(unwrappedName)) {
+                        fields[unwrappedName] = nestedField
                     }
                 }
             } else {

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
@@ -3,6 +3,7 @@ package com.itangcent.easyapi.rule.context
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.logging.IdeaConsole
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.logging.IdeaConsoleProvider
@@ -101,6 +102,7 @@ class RuleContext private constructor(
         if (value == null) return null
         if (key == "fieldContext" && value is String) return ScriptFieldContext(value)
         if (value is PsiElement) return withElement(value).asScriptIt()
+        if (value is ApiEndpoint) return ScriptApiEndpoint(value)
         return value
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptApiEndpoint.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptApiEndpoint.kt
@@ -1,0 +1,72 @@
+package com.itangcent.easyapi.rule.context
+
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.HttpMethod
+
+class ScriptApiEndpoint(val endpoint: ApiEndpoint) {
+
+    private val http: HttpMetadata? get() = endpoint.metadata as? HttpMetadata
+
+    fun name(): String? = endpoint.name
+
+    fun path(): String? = http?.path
+
+    fun setPath(path: String) {
+        val meta = http ?: return
+        meta.path = path
+    }
+
+    fun method(): String? = http?.method?.name
+
+    fun setMethod(method: String) {
+        val meta = http ?: return
+        HttpMethod.values().find { it.name.equals(method, ignoreCase = true) }?.let {
+            meta.method = it
+        }
+    }
+
+    fun description(): String? = endpoint.description
+
+    fun setDescription(desc: String?) {
+        endpoint.description = desc
+    }
+
+    fun setParam(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        endpoint.setParam(name, defaultValue, required, desc)
+    }
+
+    fun setFormParam(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        endpoint.setFormParam(name, defaultValue, required, desc)
+    }
+
+    fun setPathParam(name: String?, defaultValue: String?, desc: String?) {
+        endpoint.setPathParam(name, defaultValue, desc)
+    }
+
+    fun setHeader(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        endpoint.setHeader(name, defaultValue, required, desc)
+    }
+
+    fun setResponseCode(code: Int) {
+        endpoint.setResponseCode(code)
+    }
+
+    fun appendResponseBodyDesc(desc: String?) {
+        endpoint.appendResponseBodyDesc(desc)
+    }
+
+    fun setResponseHeader(name: String?, defaultValue: String?, required: Boolean, desc: String?) {
+        endpoint.setResponseHeader(name, defaultValue, required, desc)
+    }
+
+    fun setResponseBodyClass(className: String?) {
+        endpoint.setResponseBodyClass(className)
+    }
+
+    fun appendDesc(desc: String?) {
+        endpoint.appendDesc(desc)
+    }
+
+    override fun toString(): String = endpoint.toString()
+}

--- a/src/main/resources/extensions/jackson.config
+++ b/src/main/resources/extensions/jackson.config
@@ -134,10 +134,12 @@ field.ignore=groovy:```
     if (jsonViews) {
         def fieldViews = it.annValue("com.fasterxml.jackson.annotation.JsonView")
         if (fieldViews) {
-            // Return true if none of the field's views are in the active JsonView
-            return !fieldViews.any{ fieldView-> jsonViews.any{ jsonView-> jsonView.isExtend(fieldView.name) } }
+            def jsonViewList = jsonViews instanceof List ? jsonViews : [jsonViews]
+            def fieldViewList = fieldViews instanceof List ? fieldViews : [fieldViews]
+            def jsonViewNames = jsonViewList.collect{ it instanceof String ? it : it.name() }
+            def fieldViewNames = fieldViewList.collect{ it instanceof String ? it : it.name() }
+            return !fieldViewNames.any{ fv -> jsonViewNames.any{ jv -> jv == fv || helper.findClass(jv)?.isExtend(fv) } }
         } else {
-            // If the field has no JsonView annotation, it should be ignored
             return true
         }
     }

--- a/src/test/kotlin/com/itangcent/easyapi/cache/ApiIndexManagerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/cache/ApiIndexManagerTest.kt
@@ -80,7 +80,7 @@ class ApiIndexManagerTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testCacheUpdateEndpoints() = runTest {
         val testEndpoints = listOf(
             ApiEndpoint(
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/test",
                     method = HttpMethod.GET
                 ),
@@ -99,7 +99,7 @@ class ApiIndexManagerTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testCacheInvalidate() = runTest {
         val testEndpoints = listOf(
             ApiEndpoint(
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/test",
                     method = HttpMethod.GET
                 ),
@@ -120,7 +120,7 @@ class ApiIndexManagerTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testCacheAwait() = runTest {
         val testEndpoints = listOf(
             ApiEndpoint(
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/test",
                     method = HttpMethod.POST
                 ),

--- a/src/test/kotlin/com/itangcent/easyapi/cache/ApiIndexTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/cache/ApiIndexTest.kt
@@ -3,6 +3,7 @@ package com.itangcent.easyapi.cache
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.exporter.model.path
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.wrap
@@ -38,7 +39,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
         runBlocking {
             val endpoint = ApiEndpoint(
                 name = "getUser",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.GET
                 ),
@@ -59,7 +60,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
             val endpoints = listOf(
                 ApiEndpoint(
                     name = "getUser",
-                    metadata = HttpMetadata(
+                    metadata = httpMetadata(
                         path = "/api/users/{id}",
                         method = HttpMethod.GET
                     ),
@@ -67,7 +68,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
                 ),
                 ApiEndpoint(
                     name = "createUser",
-                    metadata = HttpMetadata(
+                    metadata = httpMetadata(
                         path = "/api/users",
                         method = HttpMethod.POST
                     ),
@@ -88,7 +89,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
             val endpoints = listOf(
                 ApiEndpoint(
                     name = "getUser",
-                    metadata = HttpMetadata(
+                    metadata = httpMetadata(
                         path = "/api/users/{id}",
                         method = HttpMethod.GET
                     ),
@@ -96,7 +97,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
                 ),
                 ApiEndpoint(
                     name = "getOrder",
-                    metadata = HttpMetadata(
+                    metadata = httpMetadata(
                         path = "/api/orders/{id}",
                         method = HttpMethod.GET
                     ),
@@ -125,7 +126,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
                 "com.example.UserController" to listOf(
                     ApiEndpoint(
                         name = "getUser",
-                        metadata = HttpMetadata(
+                        metadata = httpMetadata(
                             path = "/api/users/{id}",
                             method = HttpMethod.GET
                         )
@@ -134,7 +135,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
                 "com.example.OrderController" to listOf(
                     ApiEndpoint(
                         name = "getOrder",
-                        metadata = HttpMetadata(
+                        metadata = httpMetadata(
                             path = "/api/orders/{id}",
                             method = HttpMethod.GET
                         )
@@ -156,7 +157,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
                 "com.example.UserController" to listOf(
                     ApiEndpoint(
                         name = "getUser",
-                        metadata = HttpMetadata(
+                        metadata = httpMetadata(
                             path = "/api/users/{id}",
                             method = HttpMethod.GET
                         )
@@ -180,7 +181,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
             val endpoints = listOf(
                 ApiEndpoint(
                     name = "getUser",
-                    metadata = HttpMetadata(
+                    metadata = httpMetadata(
                         path = "/api/users/{id}",
                         method = HttpMethod.GET
                     ),
@@ -188,7 +189,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
                 ),
                 ApiEndpoint(
                     name = "getOrder",
-                    metadata = HttpMetadata(
+                    metadata = httpMetadata(
                         path = "/api/orders/{id}",
                         method = HttpMethod.GET
                     ),
@@ -211,7 +212,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
         runBlocking {
             val endpoint = ApiEndpoint(
                 name = "getUser",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.GET
                 ),
@@ -228,7 +229,7 @@ class ApiIndexTest : EasyApiLightCodeInsightFixtureTestCase() {
         runBlocking {
             val endpoint = ApiEndpoint(
                 name = "getUser",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.GET
                 ),

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/JacksonConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/JacksonConfigIntegrationTest.kt
@@ -1,5 +1,8 @@
 package com.itangcent.easyapi.config.source
 
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.LayeredConfigReader
+import com.itangcent.easyapi.config.parser.ConfigTextParser
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.exporter.springmvc.SpringMvcClassExporter
@@ -34,14 +37,22 @@ class JacksonConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("com/fasterxml/jackson/annotation/JsonProperty.java")
         loadFile("com/fasterxml/jackson/annotation/JsonIgnore.java")
         loadFile("com/fasterxml/jackson/annotation/JsonFormat.java")
+        loadFile("com/fasterxml/jackson/annotation/JsonPropertyOrder.java")
+        loadFile("com/fasterxml/jackson/annotation/JsonIgnoreProperties.java")
+        loadFile("com/fasterxml/jackson/annotation/JsonUnwrapped.java")
+        loadFile("com/fasterxml/jackson/annotation/JsonView.java")
         loadFile("api/jackson/UserDTO.java")
         loadFile("api/jackson/UserController.java")
+        loadFile("api/jackson/OrderedDTO.java")
+        loadFile("api/jackson/IgnorePropertiesDTO.java")
+        loadFile("api/jackson/AddressDTO.java")
+        loadFile("api/jackson/UnwrappedDTO.java")
+        loadFile("api/jackson/JsonViewViews.java")
+        loadFile("api/jackson/ViewDTO.java")
     }
 
-    override fun createConfigReader(): TestConfigReader {
-        val extension = ExtensionConfigRegistry.getExtension("jackson")
-        assertNotNull("jackson extension should exist", extension)
-        return TestConfigReader.fromConfigText(extension?.content ?: "")
+    override fun createConfigReader(): ConfigReader {
+        return extensionConfigReader("jackson")
     }
 
     fun testJacksonConfigLoadsCorrectly() = runTest {
@@ -51,117 +62,196 @@ class JacksonConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertTrue("Extension should have content", extension?.content?.isNotBlank() == true)
     }
 
-    fun testUserControllerExportsEndpoints() = runTest {
-        val psiClass = findClass("com.itangcent.jackson.UserController")
-        assertNotNull("Should find UserController", psiClass)
+    // =====================================================================
+    // @JsonProperty - field renaming
+    // =====================================================================
 
-        val endpoints = exporter.export(psiClass!!)
-        assertEquals("Should export 2 endpoints", 2, endpoints.size)
-
-        val postEndpoint = endpoints.find { it.httpMetadata?.method == HttpMethod.POST }
-        assertNotNull("Should find POST endpoint", postEndpoint)
-        assertEquals("POST endpoint path should be /user/create", "/user/create", postEndpoint?.httpMetadata?.path)
-
-        val getEndpoint = endpoints.find { it.httpMetadata?.method == HttpMethod.GET }
-        assertNotNull("Should find GET endpoint", getEndpoint)
-        assertTrue("GET endpoint path should contain /user/get", getEndpoint?.httpMetadata?.path?.contains("/user/get") == true)
-    }
-
-    /**
-     * Verifies that @JsonProperty renames fields in the exported body.
-     * UserDTO.id -> "user_id", UserDTO.name -> "user_name"
-     */
     fun testJsonPropertyRenamesFields() = runTest {
-        val psiClass = findClass("com.itangcent.jackson.UserController")
-        assertNotNull(psiClass)
-        val endpoints = exporter.export(psiClass!!)
-
-        val postEndpoint = endpoints.find { it.httpMetadata?.method == HttpMethod.POST }
-        assertNotNull("Should find POST endpoint", postEndpoint)
-
-        val body = postEndpoint!!.httpMetadata!!.body
-        assertNotNull("POST endpoint should have a request body", body)
-
-        val fields = findFields(body!!) ?: run {
-            fail("Request body should be an object, was: ${body::class.simpleName}")
-            return@runTest
-        }
+        val fields = exportPostBodyFields("/user/create")
 
         assertTrue("Field 'user_id' should exist (renamed from 'id' via @JsonProperty)", fields.containsKey("user_id"))
-        assertTrue("Field 'user_name' should exist (renamed from 'name' via @JsonProperty)", fields.containsKey("user_name"))
+        assertTrue(
+            "Field 'user_name' should exist (renamed from 'name' via @JsonProperty)",
+            fields.containsKey("user_name")
+        )
         assertFalse("Original field 'id' should NOT exist", fields.containsKey("id"))
         assertFalse("Original field 'name' should NOT exist", fields.containsKey("name"))
     }
 
-    /**
-     * Verifies that @JsonIgnore excludes the field from the exported body.
-     * UserDTO.password is annotated with @JsonIgnore.
-     */
+    // =====================================================================
+    // @JsonIgnore - field exclusion
+    // =====================================================================
+
     fun testJsonIgnoreExcludesField() = runTest {
-        val psiClass = findClass("com.itangcent.jackson.UserController")
-        assertNotNull(psiClass)
-        val endpoints = exporter.export(psiClass!!)
-
-        val postEndpoint = endpoints.find { it.httpMetadata?.method == HttpMethod.POST }
-        assertNotNull("Should find POST endpoint", postEndpoint)
-
-        val body = postEndpoint!!.httpMetadata!!.body
-        assertNotNull("POST endpoint should have a request body", body)
-
-        val fields = findFields(body!!) ?: run {
-            fail("Request body should be an object, was: ${body::class.simpleName}")
-            return@runTest
-        }
+        val fields = exportPostBodyFields("/user/create")
 
         assertFalse("Field 'password' should be excluded by @JsonIgnore", fields.containsKey("password"))
     }
 
-    /**
-     * Verifies that @JsonFormat annotated field is present in the exported body.
-     * UserDTO.createTime has @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss").
-     */
-    fun testJsonFormatFieldIsPresent() = runTest {
-        val psiClass = findClass("com.itangcent.jackson.UserController")
-        assertNotNull(psiClass)
-        val endpoints = exporter.export(psiClass!!)
+    // =====================================================================
+    // @JsonFormat - date format pattern produces mock value
+    // =====================================================================
 
-        val postEndpoint = endpoints.find { it.httpMetadata?.method == HttpMethod.POST }
-        assertNotNull("Should find POST endpoint", postEndpoint)
+    fun testJsonFormatSetsMockValue() = runTest {
+        val fields = exportPostBodyFields("/user/create")
 
-        val body = postEndpoint!!.httpMetadata!!.body
-        assertNotNull("POST endpoint should have a request body", body)
-
-        val fields = findFields(body!!) ?: run {
-            fail("Request body should be an object, was: ${body::class.simpleName}")
-            return@runTest
-        }
-
-        // createTime should be present (not ignored) and @JsonFormat rule should not break parsing
-        assertTrue("Field 'createTime' should exist", fields.containsKey("createTime"))
+        val createTimeField = fields["createTime"]
+        assertNotNull("Field 'createTime' should exist", createTimeField)
+        val mock = createTimeField!!.mock
+        assertNotNull("@JsonFormat should produce a mock value for createTime", mock)
+        assertTrue(
+            "Mock value should contain @datetime with pattern, was: $mock",
+            mock!!.contains("@datetime") && mock.contains("yyyy-MM-dd HH:mm:ss")
+        )
     }
 
-    /**
-     * Verifies that the response body also applies jackson rules (field renaming, ignore).
-     */
+    // =====================================================================
+    // @JsonPropertyOrder - field ordering
+    // =====================================================================
+
+    fun testJsonPropertyOrderReordersFields() = runTest {
+        val fields = exportPostBodyFields("/user/ordered")
+
+        val fieldNames = fields.keys.toList()
+        assertTrue("Should have at least 3 fields", fieldNames.size >= 3)
+
+        val nameIdx = fieldNames.indexOf("name")
+        val emailIdx = fieldNames.indexOf("email")
+        val ageIdx = fieldNames.indexOf("age")
+
+        assertTrue("'name' should appear before 'email' per @JsonPropertyOrder", nameIdx < emailIdx)
+        assertTrue("'email' should appear before 'age' per @JsonPropertyOrder", emailIdx < ageIdx)
+    }
+
+    // =====================================================================
+    // @JsonIgnoreProperties - class-level field exclusion
+    // =====================================================================
+
+    fun testJsonIgnorePropertiesExcludesFields() = runTest {
+        val fields = exportPostBodyFields("/user/ignore-properties")
+
+        assertTrue("Field 'id' should exist", fields.containsKey("id"))
+        assertTrue("Field 'name' should exist", fields.containsKey("name"))
+        assertFalse("Field 'internalId' should be excluded by @JsonIgnoreProperties", fields.containsKey("internalId"))
+        assertFalse("Field 'secretKey' should be excluded by @JsonIgnoreProperties", fields.containsKey("secretKey"))
+    }
+
+    // =====================================================================
+    // @JsonUnwrapped - flatten nested object with optional prefix/suffix
+    // =====================================================================
+
+    fun testJsonUnwrappedFlattensNestedObject() = runTest {
+        val fields = exportPostBodyFields("/user/unwrapped")
+
+        assertTrue("Field 'name' should exist", fields.containsKey("name"))
+
+        assertTrue("Unwrapped field 'street' should exist (from address)", fields.containsKey("street"))
+        assertTrue("Unwrapped field 'city' should exist (from address)", fields.containsKey("city"))
+        assertTrue("Unwrapped field 'zipCode' should exist (from address)", fields.containsKey("zipCode"))
+
+        assertFalse("Nested object 'address' should NOT exist as a sub-object", fields.containsKey("address"))
+    }
+
+    fun testJsonUnwrappedWithPrefixAndSuffix() = runTest {
+        val fields = exportPostBodyFields("/user/unwrapped")
+
+        assertTrue(
+            "Unwrapped field 'home_street_addr' should exist (prefix=home_, suffix=_addr)",
+            fields.containsKey("home_street_addr")
+        )
+        assertTrue(
+            "Unwrapped field 'home_city_addr' should exist (prefix=home_, suffix=_addr)",
+            fields.containsKey("home_city_addr")
+        )
+        assertTrue(
+            "Unwrapped field 'home_zipCode_addr' should exist (prefix=home_, suffix=_addr)",
+            fields.containsKey("home_zipCode_addr")
+        )
+
+        assertFalse("Nested object 'homeAddress' should NOT exist as a sub-object", fields.containsKey("homeAddress"))
+    }
+
+    // =====================================================================
+    // @JsonView - view-based field filtering in response body
+    // =====================================================================
+
+    fun testJsonViewPublicOnlyShowsPublicFields() = runTest {
+        val fields = exportGetResponseBodyFields("/user/view/public")
+
+        assertTrue("Public field 'id' should exist in Public view", fields.containsKey("id"))
+        assertTrue("Public field 'name' should exist in Public view", fields.containsKey("name"))
+        assertFalse("Internal field 'email' should NOT exist in Public view", fields.containsKey("email"))
+        assertFalse("Admin field 'password' should NOT exist in Public view", fields.containsKey("password"))
+    }
+
+    fun testJsonViewInternalShowsPublicAndInternalFields() = runTest {
+        val fields = exportGetResponseBodyFields("/user/view/internal")
+
+        assertTrue("Public field 'id' should exist in Internal view", fields.containsKey("id"))
+        assertTrue("Public field 'name' should exist in Internal view", fields.containsKey("name"))
+        assertTrue("Internal field 'email' should exist in Internal view", fields.containsKey("email"))
+        assertFalse("Admin field 'password' should NOT exist in Internal view", fields.containsKey("password"))
+    }
+
+    fun testJsonViewAdminShowsAllFields() = runTest {
+        val fields = exportGetResponseBodyFields("/user/view/admin")
+
+        assertTrue("Public field 'id' should exist in Admin view", fields.containsKey("id"))
+        assertTrue("Public field 'name' should exist in Admin view", fields.containsKey("name"))
+        assertTrue("Internal field 'email' should exist in Admin view", fields.containsKey("email"))
+        assertTrue("Admin field 'password' should exist in Admin view", fields.containsKey("password"))
+    }
+
+    // =====================================================================
+    // Response body also applies jackson rules
+    // =====================================================================
+
     fun testResponseBodyAppliesJacksonRules() = runTest {
-        val psiClass = findClass("com.itangcent.jackson.UserController")
-        assertNotNull(psiClass)
-        val endpoints = exporter.export(psiClass!!)
-
-        val getEndpoint = endpoints.find { it.httpMetadata?.method == HttpMethod.GET }
-        assertNotNull("Should find GET endpoint", getEndpoint)
-
-        val responseBody = getEndpoint!!.httpMetadata!!.responseBody
-        assertNotNull("GET endpoint should have a response body", responseBody)
-
-        val fields = findFields(responseBody!!) ?: run {
-            fail("Response body should be an object, was: ${responseBody::class.simpleName}")
-            return@runTest
-        }
+        val fields = exportGetResponseBodyFields("/user/get")
 
         assertTrue("Response field 'user_id' should exist", fields.containsKey("user_id"))
         assertTrue("Response field 'user_name' should exist", fields.containsKey("user_name"))
         assertFalse("Response field 'password' should be excluded by @JsonIgnore", fields.containsKey("password"))
+    }
+
+    // =====================================================================
+    // Helper methods
+    // =====================================================================
+
+    private suspend fun exportEndpoints(): List<com.itangcent.easyapi.exporter.model.ApiEndpoint> {
+        val psiClass = findClass("com.itangcent.jackson.UserController")
+        assertNotNull("Should find UserController", psiClass)
+        return exporter.export(psiClass!!)
+    }
+
+    private suspend fun exportPostBodyFields(path: String): Map<String, FieldModel> {
+        val endpoints = exportEndpoints()
+        val endpoint = endpoints.find { it.httpMetadata?.method == HttpMethod.POST && it.httpMetadata?.path == path }
+        assertNotNull("Should find POST endpoint at $path", endpoint)
+
+        val body = endpoint!!.httpMetadata!!.body
+        assertNotNull("Endpoint at $path should have a request body", body)
+
+        return findFields(body!!) ?: run {
+            fail("Request body should be an object, was: ${body::class.simpleName}")
+            emptyMap()
+        }
+    }
+
+    private suspend fun exportGetResponseBodyFields(path: String): Map<String, FieldModel> {
+        val endpoints = exportEndpoints()
+        val endpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.GET && it.httpMetadata?.path?.startsWith(path) == true
+        }
+        assertNotNull("Should find GET endpoint at $path", endpoint)
+
+        val responseBody = endpoint!!.httpMetadata!!.responseBody
+        assertNotNull("Endpoint at $path should have a response body", responseBody)
+
+        return findFields(responseBody!!) ?: run {
+            fail("Response body should be an object, was: ${responseBody::class.simpleName}")
+            emptyMap()
+        }
     }
 
     private fun findFields(model: ObjectModel): Map<String, FieldModel>? = model.asObject()?.fields

--- a/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiTreeCellRendererTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiTreeCellRendererTest.kt
@@ -1,10 +1,6 @@
 package com.itangcent.easyapi.dashboard
 
-import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.GrpcMetadata
-import com.itangcent.easyapi.exporter.model.GrpcStreamingType
-import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import javax.swing.JTree
 import javax.swing.tree.DefaultMutableTreeNode
@@ -23,7 +19,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testGetTreeCellRendererComponentWithApiEndpoint() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET
             )
@@ -39,7 +35,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testGetTreeCellRendererComponentWithDefaultMutableTreeNode() {
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.POST
             )
@@ -62,7 +58,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testGetMethodColorForGet() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.GET))
         val component = renderer.getTreeCellRendererComponent(
             tree, endpoint, false, false, true, 0, false
         )
@@ -70,7 +66,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testGetMethodColorForPost() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.POST))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.POST))
         val component = renderer.getTreeCellRendererComponent(
             tree, endpoint, false, false, true, 0, false
         )
@@ -78,7 +74,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testGetMethodColorForPut() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.PUT))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.PUT))
         val component = renderer.getTreeCellRendererComponent(
             tree, endpoint, false, false, true, 0, false
         )
@@ -86,7 +82,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testGetMethodColorForDelete() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.DELETE))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.DELETE))
         val component = renderer.getTreeCellRendererComponent(
             tree, endpoint, false, false, true, 0, false
         )
@@ -94,7 +90,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testGetMethodColorForPatch() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.PATCH))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.PATCH))
         val component = renderer.getTreeCellRendererComponent(
             tree, endpoint, false, false, true, 0, false
         )
@@ -102,7 +98,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testGetMethodColorForHead() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.HEAD))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.HEAD))
         val component = renderer.getTreeCellRendererComponent(
             tree, endpoint, false, false, true, 0, false
         )
@@ -110,7 +106,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testGetMethodColorForOptions() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.OPTIONS))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.OPTIONS))
         val component = renderer.getTreeCellRendererComponent(
             tree, endpoint, false, false, true, 0, false
         )
@@ -120,7 +116,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testBuildApiTextWithName() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET
             )
@@ -134,7 +130,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testBuildApiTextWithoutName() {
         val endpoint = ApiEndpoint(
             name = null,
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.GET
             )
@@ -237,7 +233,7 @@ class ApiTreeCellRendererTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testHttpEndpointStillShowsMethodName() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET
             )

--- a/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiTreeNodeTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiTreeNodeTest.kt
@@ -39,7 +39,7 @@ class ApiTreeNodeTest {
     fun testEndpointNode() {
         val endpoint = ApiEndpoint(
             name = "getUsers",
-            metadata = HttpMetadata(path = "/users", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/users", method = HttpMethod.GET)
         )
         val node = ApiTreeNode.EndpointNode(endpoint)
         assertEquals("getUsers", node.endpoint.name)
@@ -49,7 +49,7 @@ class ApiTreeNodeTest {
     fun testNestedTree() {
         val endpoint = ApiEndpoint(
             name = "getUser",
-            metadata = HttpMetadata(path = "/users/{id}", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/users/{id}", method = HttpMethod.GET)
         )
         val tree = ApiTreeNode.ModuleNode(
             "api",

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
@@ -6,6 +6,7 @@ import com.itangcent.easyapi.exporter.model.ExportResult
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.OutputConfig
+import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 
@@ -123,7 +124,7 @@ class ExportOrchestratorTest : EasyApiLightCodeInsightFixtureTestCase() {
     ): ApiEndpoint {
         return ApiEndpoint(
             name = name,
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = path,
                 method = method
             )

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/curl/CurlFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/curl/CurlFormatterTest.kt
@@ -8,6 +8,7 @@ import com.itangcent.easyapi.exporter.model.GrpcStreamingType
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import org.junit.Assert.*
@@ -19,7 +20,7 @@ class CurlFormatterTest {
     fun testFormatSimpleGet() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/1",
                 method = HttpMethod.GET
             )
@@ -36,7 +37,7 @@ class CurlFormatterTest {
     fun testFormatPostWithJsonBody() {
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.POST,
                 contentType = "application/json",
@@ -68,7 +69,7 @@ class CurlFormatterTest {
     fun testFormatWithQueryParams() {
         val endpoint = ApiEndpoint(
             name = "List Users",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.GET,
                 parameters = listOf(
@@ -96,7 +97,7 @@ class CurlFormatterTest {
     fun testFormatWithHeaders() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/1",
                 method = HttpMethod.GET,
                 headers = listOf(
@@ -116,7 +117,7 @@ class CurlFormatterTest {
     fun testFormatWithFormUrlencoded() {
         val endpoint = ApiEndpoint(
             name = "Login",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/login",
                 method = HttpMethod.POST,
                 contentType = "application/x-www-form-urlencoded",
@@ -147,7 +148,7 @@ class CurlFormatterTest {
     fun testFormatWithMultipartFormData() {
         val endpoint = ApiEndpoint(
             name = "Upload File",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/upload",
                 method = HttpMethod.POST,
                 contentType = "multipart/form-data",
@@ -184,7 +185,7 @@ class CurlFormatterTest {
     fun testFormatWithSpecialCharsInPath() {
         val endpoint = ApiEndpoint(
             name = "Search",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/search/test's query",
                 method = HttpMethod.GET
             )
@@ -199,7 +200,7 @@ class CurlFormatterTest {
     fun testFormatWithPathVariable() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET,
                 parameters = listOf(
@@ -221,7 +222,7 @@ class CurlFormatterTest {
     fun testFormatPutRequest() {
         val endpoint = ApiEndpoint(
             name = "Update User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/1",
                 method = HttpMethod.PUT,
                 contentType = "application/json",
@@ -245,7 +246,7 @@ class CurlFormatterTest {
     fun testFormatDeleteRequest() {
         val endpoint = ApiEndpoint(
             name = "Delete User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/1",
                 method = HttpMethod.DELETE
             )
@@ -365,7 +366,7 @@ class CurlFormatterTest {
     fun testFormatAllWithMixedEndpoints() {
         val httpEndpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/1",
                 method = HttpMethod.GET
             )

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/httpclient/HttpClientFileFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/httpclient/HttpClientFileFormatterTest.kt
@@ -9,6 +9,7 @@ import com.itangcent.easyapi.exporter.model.GrpcStreamingType
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import org.junit.Assert.*
@@ -21,7 +22,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/1",
                     method = HttpMethod.GET
                 )
@@ -38,7 +39,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST,
                     contentType = "application/json",
@@ -63,7 +64,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "List Users",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.GET,
                     parameters = listOf(
@@ -85,9 +86,10 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/1",
                     method = HttpMethod.GET,
+                    parameters = emptyList(),
                     headers = listOf(
                         ApiHeader("Authorization", "Bearer token123"),
                         ApiHeader("X-Request-Id", "abc123")
@@ -105,9 +107,12 @@ class HttpClientFileFormatterTest {
     @Test
     fun testFormatMultipleEndpoints() {
         val endpoints = listOf(
-            ApiEndpoint(name = "Get User", metadata = HttpMetadata(path = "/api/users/1", method = HttpMethod.GET)),
-            ApiEndpoint(name = "Create User", metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)),
-            ApiEndpoint(name = "Delete User", metadata = HttpMetadata(path = "/api/users/1", method = HttpMethod.DELETE))
+            ApiEndpoint(name = "Get User", metadata = httpMetadata(path = "/api/users/1", method = HttpMethod.GET)),
+            ApiEndpoint(name = "Create User", metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)),
+            ApiEndpoint(
+                name = "Delete User",
+                metadata = httpMetadata(path = "/api/users/1", method = HttpMethod.DELETE)
+            )
         )
 
         val result = HttpClientFileFormatter.format(endpoints, "http://localhost:8080")
@@ -125,7 +130,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Login",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/login",
                     method = HttpMethod.POST,
                     contentType = "application/x-www-form-urlencoded",
@@ -149,7 +154,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Update User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/1",
                     method = HttpMethod.PUT,
                     contentType = "application/json",
@@ -171,7 +176,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Delete User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/1",
                     method = HttpMethod.DELETE
                 )
@@ -188,7 +193,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST,
                     contentType = "application/json;charset=UTF-8"
@@ -206,7 +211,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/1",
                     method = HttpMethod.GET
                 )
@@ -291,7 +296,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/1",
                     method = HttpMethod.GET
                 )
@@ -340,10 +345,11 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST,
                     contentType = "application/json",
+                    parameters = emptyList(),
                     headers = listOf(
                         ApiHeader("Content-Type", "application/json"),
                         ApiHeader("Authorization", "Bearer token123")
@@ -365,10 +371,11 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST,
                     contentType = null,
+                    parameters = emptyList(),
                     headers = listOf(
                         ApiHeader("Content-Type", "application/xml"),
                         ApiHeader("Authorization", "Bearer token123")
@@ -388,10 +395,11 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.GET,
                     contentType = null,
+                    parameters = emptyList(),
                     headers = listOf(
                         ApiHeader("Authorization", "Bearer token123")
                     )
@@ -410,7 +418,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST,
                     contentType = "application/json",
@@ -434,11 +442,11 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+                metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET)
             ),
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)
+                metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)
             )
         )
 
@@ -456,7 +464,7 @@ class HttpClientFileFormatterTest {
         val endpoint = ApiEndpoint(
             name = "Get User",
             description = "Retrieve user by ID",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/1",
                 method = HttpMethod.GET
             )
@@ -474,7 +482,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+                metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET)
             )
         )
 
@@ -488,7 +496,7 @@ class HttpClientFileFormatterTest {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "List Users",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.GET,
                     parameters = listOf(

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatterTest.kt
@@ -7,6 +7,7 @@ import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.ParameterBinding
 import com.itangcent.easyapi.exporter.model.ParameterType
+import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
@@ -22,7 +23,7 @@ class DefaultMarkdownFormatterTest {
     fun testFormatSimpleEndpoint() = runBlocking {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET,
                 parameters = listOf(
@@ -46,7 +47,7 @@ class DefaultMarkdownFormatterTest {
         val endpoint = ApiEndpoint(
             name = "Get User",
             description = "Retrieve user information by ID",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET
             )
@@ -61,7 +62,7 @@ class DefaultMarkdownFormatterTest {
     fun testFormatEndpointWithQueryParameters() = runBlocking {
         val endpoint = ApiEndpoint(
             name = "List Users",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.GET,
                 parameters = listOf(
@@ -84,7 +85,7 @@ class DefaultMarkdownFormatterTest {
     fun testFormatEndpointWithHeaders() = runBlocking {
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.POST,
                 headers = listOf(
@@ -108,7 +109,7 @@ class DefaultMarkdownFormatterTest {
             ApiEndpoint(
                 name = "Get User",
                 folder = "Users",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.GET
                 )
@@ -116,7 +117,7 @@ class DefaultMarkdownFormatterTest {
             ApiEndpoint(
                 name = "Create User",
                 folder = "Users",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST
                 )
@@ -124,7 +125,7 @@ class DefaultMarkdownFormatterTest {
             ApiEndpoint(
                 name = "Get Order",
                 folder = "Orders",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/orders/{id}",
                     method = HttpMethod.GET
                 )
@@ -148,7 +149,7 @@ class DefaultMarkdownFormatterTest {
 
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.POST,
                 body = bodyModel,
@@ -185,7 +186,7 @@ class DefaultMarkdownFormatterTest {
 
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET,
                 responseBody = responseModel
@@ -222,7 +223,7 @@ class DefaultMarkdownFormatterTest {
 
         val endpoint = ApiEndpoint(
             name = "List Users",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.GET,
                 responseBody = responseModel
@@ -239,7 +240,7 @@ class DefaultMarkdownFormatterTest {
     fun testFormatEndpointWithNoResponseBody() = runBlocking {
         val endpoint = ApiEndpoint(
             name = "Delete User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.DELETE
             )
@@ -254,10 +255,10 @@ class DefaultMarkdownFormatterTest {
     @Test
     fun testFormatMultipleEndpoints() = runBlocking {
         val endpoints = listOf(
-            ApiEndpoint(name = "Get User", metadata = HttpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)),
-            ApiEndpoint(name = "Create User", metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)),
-            ApiEndpoint(name = "Update User", metadata = HttpMetadata(path = "/api/users/{id}", method = HttpMethod.PUT)),
-            ApiEndpoint(name = "Delete User", metadata = HttpMetadata(path = "/api/users/{id}", method = HttpMethod.DELETE))
+            ApiEndpoint(name = "Get User", metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)),
+            ApiEndpoint(name = "Create User", metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)),
+            ApiEndpoint(name = "Update User", metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.PUT)),
+            ApiEndpoint(name = "Delete User", metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.DELETE))
         )
 
         val markdown = formatter.format(endpoints, "User API")
@@ -272,7 +273,7 @@ class DefaultMarkdownFormatterTest {
     fun testFormatEndpointWithFormParams() = runBlocking {
         val endpoint = ApiEndpoint(
             name = "Upload File",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/upload",
                 method = HttpMethod.POST,
                 parameters = listOf(
@@ -299,7 +300,7 @@ class DefaultMarkdownFormatterTest {
 
         val endpoint = ApiEndpoint(
             name = "Get Tree",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/tree",
                 method = HttpMethod.GET,
                 responseBody = treeNode
@@ -325,7 +326,7 @@ class DefaultMarkdownFormatterTest {
 
         val endpoint = ApiEndpoint(
             name = "Get Node",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/node",
                 method = HttpMethod.GET,
                 responseBody = selfRef
@@ -354,7 +355,7 @@ class DefaultMarkdownFormatterTest {
 
         val endpoint = ApiEndpoint(
             name = "Get Mutual",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/mutual",
                 method = HttpMethod.GET,
                 responseBody = objectA
@@ -384,7 +385,7 @@ class DefaultMarkdownFormatterTest {
 
         val endpoint = ApiEndpoint(
             name = "Get Nested",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/nested",
                 method = HttpMethod.GET,
                 responseBody = outer

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/model/ExportContextTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/model/ExportContextTest.kt
@@ -10,11 +10,11 @@ class ExportContextTest {
     fun testHasSelection() {
         val endpoint1 = ApiEndpoint(
             name = "getUser",
-            metadata = HttpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
         )
         val endpoint2 = ApiEndpoint(
             name = "createUser",
-            metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)
+            metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)
         )
 
         val contextWithoutSelection = ExportContext(
@@ -35,11 +35,11 @@ class ExportContextTest {
     fun testEndpointsToExport() {
         val endpoint1 = ApiEndpoint(
             name = "getUser",
-            metadata = HttpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
         )
         val endpoint2 = ApiEndpoint(
             name = "createUser",
-            metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)
+            metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)
         )
 
         val contextWithoutSelection = ExportContext(
@@ -61,11 +61,11 @@ class ExportContextTest {
     fun testWithSelectedEndpoints() {
         val endpoint1 = ApiEndpoint(
             name = "getUser",
-            metadata = HttpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
         )
         val endpoint2 = ApiEndpoint(
             name = "createUser",
-            metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)
+            metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)
         )
 
         val original = ExportContext(

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanApiClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanApiClientTest.kt
@@ -1,10 +1,6 @@
 package com.itangcent.easyapi.exporter.postman
 
-import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.ApiParameter
-import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
-import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import kotlinx.coroutines.runBlocking
@@ -33,7 +29,7 @@ class PostmanApiClientTest : EasyApiLightCodeInsightFixtureTestCase() {
         return ApiEndpoint(
             name = "Test API",
             description = "Test API description",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/test",
                 method = HttpMethod.GET,
                 parameters = listOf(

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanEndpointContextTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanEndpointContextTest.kt
@@ -13,7 +13,7 @@ class PostmanEndpointContextTest {
     fun testConstruction() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
         )
         val response = PostmanResponseData(name = "Success", statusCode = 200)
         val context = PostmanEndpointContext(
@@ -31,7 +31,7 @@ class PostmanEndpointContextTest {
 
     @Test
     fun testConstructionWithDefaults() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.GET))
         val context = PostmanEndpointContext(endpoint = endpoint)
         
         assertEquals("/test", context.endpoint.httpMetadata?.path)
@@ -44,7 +44,7 @@ class PostmanEndpointContextTest {
 
     @Test
     fun testCopy() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.POST))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.POST))
         val context = PostmanEndpointContext(endpoint = endpoint)
         
         val copy = context.copy(preRequestScript = "new script")
@@ -53,7 +53,7 @@ class PostmanEndpointContextTest {
 
     @Test
     fun testEquality() {
-        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        val endpoint = ApiEndpoint(metadata = httpMetadata(path = "/test", method = HttpMethod.GET))
         val context1 = PostmanEndpointContext(endpoint = endpoint)
         val context2 = PostmanEndpointContext(endpoint = endpoint)
         

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanFormatterTest.kt
@@ -33,7 +33,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
     fun testBuildUrlSimple() {
         val endpoint = ApiEndpoint(
             name = "Get Users",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.GET
             )
@@ -50,7 +50,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
     fun testBuildUrlWithQuery() {
         val endpoint = ApiEndpoint(
             name = "List Users",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.GET,
                 parameters = listOf(
@@ -72,7 +72,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
     fun testBuildUrlWithPathVariable() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET,
                 parameters = listOf(
@@ -93,7 +93,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
     fun testBuildBodyJson() {
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.POST,
                 contentType = "application/json",
@@ -117,7 +117,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
     fun testBuildBodyFormUrlencoded() {
         val endpoint = ApiEndpoint(
             name = "Login",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/login",
                 method = HttpMethod.POST,
                 contentType = "application/x-www-form-urlencoded",
@@ -142,7 +142,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
     fun testBuildBodyMultipart() {
         val endpoint = ApiEndpoint(
             name = "Upload",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/upload",
                 method = HttpMethod.POST,
                 contentType = "multipart/form-data",
@@ -165,7 +165,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
     fun testBuildBodyWithEndpointBody() {
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.POST,
                 contentType = "application/json",
@@ -200,7 +200,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
         val formatter = PostmanFormatter(project = project)
         val endpoint = ApiEndpoint(
             name = "Upload File",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/upload",
                 method = HttpMethod.POST,
                 contentType = "multipart/form-data",
@@ -228,7 +228,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
         val formatter = PostmanFormatter(project = project)
         val endpoint = ApiEndpoint(
             name = "Submit Form",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/submit",
                 method = HttpMethod.POST,
                 contentType = "application/x-www-form-urlencoded",
@@ -255,7 +255,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
         val formatter = PostmanFormatter(project = project, options = PostmanFormatOptions(appendTimestamp = false))
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.POST,
                 contentType = "application/json",
@@ -285,7 +285,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.GET,
                     parameters = listOf(
@@ -295,7 +295,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
             ),
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST,
                     contentType = "application/json",
@@ -321,7 +321,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.GET
                 )
@@ -338,7 +338,7 @@ class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCod
             ),
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users",
                     method = HttpMethod.POST
                 )

--- a/src/test/kotlin/com/itangcent/easyapi/ide/action/BaseExportActionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/action/BaseExportActionTest.kt
@@ -3,16 +3,12 @@ package com.itangcent.easyapi.ide.action
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.project.Project
-import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.ExportContext
-import com.itangcent.easyapi.exporter.model.ExportFormat
-import com.itangcent.easyapi.exporter.model.ExportResult
-import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
-import org.junit.Assert.*
+import com.itangcent.easyapi.exporter.model.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 class BaseExportActionTest {
 
@@ -47,7 +43,7 @@ class BaseExportActionTest {
     fun testExportContextHasCorrectFormat() {
         val endpoint = ApiEndpoint(
             name = "test",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = "/test",
                 method = HttpMethod.GET
             )

--- a/src/test/kotlin/com/itangcent/easyapi/ide/dialog/ExportDialogResultTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/dialog/ExportDialogResultTest.kt
@@ -1,10 +1,6 @@
 package com.itangcent.easyapi.ide.dialog
 
-import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.ExportFormat
-import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
-import com.itangcent.easyapi.exporter.model.OutputConfig
+import com.itangcent.easyapi.exporter.model.*
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -49,7 +45,7 @@ class ExportDialogResultTest {
         val config = OutputConfig()
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET)
         )
         val selection = EndpointSelection(endpoint)
         val result = ExportDialogResult(ExportFormat.MARKDOWN, config, listOf(selection))
@@ -62,7 +58,7 @@ class ExportDialogResultTest {
     fun testEndpointSelectionProperties() {
         val endpoint = ApiEndpoint(
             name = "Create User",
-            metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)
+            metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)
         )
         val selection = EndpointSelection(endpoint)
         assertSame(endpoint, selection.endpoint)
@@ -72,7 +68,7 @@ class ExportDialogResultTest {
     fun testEndpointSelectionEquality() {
         val endpoint = ApiEndpoint(
             name = "Get User",
-            metadata = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+            metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET)
         )
         val s1 = EndpointSelection(endpoint)
         val s2 = EndpointSelection(endpoint)

--- a/src/test/kotlin/com/itangcent/easyapi/ide/dialog/ExportDialogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/dialog/ExportDialogTest.kt
@@ -1,12 +1,6 @@
 package com.itangcent.easyapi.ide.dialog
 
-import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.ExportFormat
-import com.itangcent.easyapi.exporter.model.GrpcMetadata
-import com.itangcent.easyapi.exporter.model.GrpcStreamingType
-import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
-import com.itangcent.easyapi.exporter.model.OutputConfig
+import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 class ExportDialogTest : EasyApiLightCodeInsightFixtureTestCase() {
@@ -45,11 +39,11 @@ class ExportDialogTest : EasyApiLightCodeInsightFixtureTestCase() {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+                metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET)
             ),
             ApiEndpoint(
                 name = "Create User",
-                metadata = HttpMetadata(path = "/api/users", method = HttpMethod.POST)
+                metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)
             )
         )
         
@@ -79,7 +73,7 @@ class ExportDialogTest : EasyApiLightCodeInsightFixtureTestCase() {
         val endpoints = listOf(
             ApiEndpoint(
                 name = "Get User",
-                metadata = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+                metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET)
             ),
             ApiEndpoint(
                 name = "SayHello",

--- a/src/test/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributorTest.kt
@@ -19,7 +19,7 @@ class ApiSearchEverywhereContributorTest {
         description: String? = null
     ): ApiEndpoint {
         return ApiEndpoint(
-            metadata = HttpMetadata(path = path, method = method),
+            metadata = httpMetadata(path = path, method = method),
             name = name,
             className = className,
             description = description

--- a/src/test/kotlin/com/itangcent/easyapi/integration/FormatConversionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/integration/FormatConversionTest.kt
@@ -1,17 +1,12 @@
 package com.itangcent.easyapi.integration
 
-import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.ApiParameter
-import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
-import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.curl.CurlFormatter
+import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.exporter.postman.PostmanFormatOptions
 import com.itangcent.easyapi.exporter.postman.PostmanFormatter
-import com.itangcent.easyapi.exporter.curl.CurlFormatter
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.*
 
 class FormatConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -20,7 +15,7 @@ class FormatConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
     private val testEndpoint = ApiEndpoint(
         name = "Get User",
         description = "Retrieve user by ID",
-        metadata = HttpMetadata(
+        metadata = httpMetadata(
             path = "/api/users/{id}",
             method = HttpMethod.GET,
             parameters = listOf(
@@ -32,7 +27,7 @@ class FormatConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
     private val testPostEndpoint = ApiEndpoint(
         name = "Create User",
         description = "Create a new user",
-        metadata = HttpMetadata(
+        metadata = httpMetadata(
             path = "/api/users",
             method = HttpMethod.POST,
             contentType = "application/json",
@@ -79,7 +74,7 @@ class FormatConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
             testPostEndpoint,
             ApiEndpoint(
                 name = "Update User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.PUT,
                     contentType = "application/json",
@@ -91,7 +86,7 @@ class FormatConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
             ),
             ApiEndpoint(
                 name = "Delete User",
-                metadata = HttpMetadata(
+                metadata = httpMetadata(
                     path = "/api/users/{id}",
                     method = HttpMethod.DELETE,
                     parameters = listOf(

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/ApiFixtures.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/ApiFixtures.kt
@@ -7,6 +7,7 @@ import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.ParameterBinding
 import com.itangcent.easyapi.exporter.model.ParameterType
+import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.settings.Settings
 
 object ApiFixtures {
@@ -22,7 +23,7 @@ object ApiFixtures {
             name = name,
             description = description,
             folder = folder,
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = path,
                 method = method,
                 parameters = emptyList(),
@@ -39,7 +40,7 @@ object ApiFixtures {
             name = name,
             description = "Get user by ID",
             folder = "User API",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = path,
                 method = HttpMethod.GET,
                 parameters = listOf(
@@ -65,7 +66,7 @@ object ApiFixtures {
             name = name,
             description = "Create a new user",
             folder = "User API",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = path,
                 method = HttpMethod.POST,
                 parameters = listOf(
@@ -120,7 +121,7 @@ object ApiFixtures {
             name = name,
             description = "Upload a file",
             folder = "File API",
-            metadata = HttpMetadata(
+            metadata = httpMetadata(
                 path = path,
                 method = HttpMethod.POST,
                 parameters = listOf(

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
@@ -9,6 +9,9 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import com.intellij.testFramework.registerServiceInstance
 import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.LayeredConfigReader
+import com.itangcent.easyapi.config.parser.ConfigTextParser
+import com.itangcent.easyapi.config.source.ExtensionConfigSource
 import com.itangcent.easyapi.core.event.ActionCompletedTopic
 import com.itangcent.easyapi.core.event.ActionCompletedTopic.Companion.syncPublish
 import com.itangcent.easyapi.core.threading.readSync
@@ -98,6 +101,17 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
      */
     protected open fun createConfigReader(): ConfigReader? = null
 
+    protected fun extensionConfigReader(vararg selectedCodes: String): ConfigReader {
+        return LayeredConfigReader(
+            listOf(
+                ExtensionConfigSource(
+                    selectedCodes.map { it }.toTypedArray(),
+                    ConfigTextParser(settingBinder.read())
+                )
+            )
+        )
+    }
+
     protected val settingBinder
         get() = SettingBinder.getInstance(project)
 
@@ -105,6 +119,7 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
         super.setUp()
         val configReader = createConfigReader()
         if (configReader != null) {
+            runBlocking { configReader.reload() }
             project.registerServiceInstance(
                 serviceInterface = ConfigReader::class.java,
                 instance = configReader
@@ -132,6 +147,24 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
         return psiClass.findMethodsByName(name, false).firstOrNull() as? PsiMethod
     }
 
+    /**
+     * Loads a resource file into the test fixture's virtual file system.
+     *
+     * **Important:** In the IntelliJ PSI test fixture environment, all classes referenced
+     * by a Java file must be explicitly imported, even if they are in the same package.
+     * In normal Java compilation, same-package classes don't require imports, but the
+     * lightweight test fixture's PSI resolver cannot resolve unimported same-package types
+     * unless they are explicitly imported. Without proper imports, the PSI will treat
+     * unresolved type references as `UnresolvedType`, which causes `buildObjectModelFromType`
+     * to return `ObjectModel.Single` instead of `ObjectModel.Object`.
+     *
+     * For example, if `UserController.java` uses `OrderedDTO` from the same package,
+     * it must include `import com.itangcent.jackson.OrderedDTO;` even though they share
+     * the same package declaration.
+     *
+     * @param path the resource path relative to the test resources directory
+     * @return the loaded PsiFile
+     */
     protected fun loadFile(path: String): PsiFile {
         myFixture.findFileInTempDir(path)?.let { existing ->
             return myFixture.psiManager.findFile(existing)!!

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/TestConfigReader.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/TestConfigReader.kt
@@ -37,15 +37,33 @@ class TestConfigReader(
         fun fromConfigText(configText: String): TestConfigReader {
             val config = mutableMapOf<String, List<String>>()
             val strippedContent = ExtensionConfigParser.stripYamlFrontMatter(configText)
-            strippedContent.lines().forEach { line ->
-                if (line.isNotBlank() && !line.startsWith("#")) {
-                    val idx = line.indexOf('=')
-                    if (idx > 0) {
-                        val key = line.substring(0, idx).trim()
-                        val value = line.substring(idx + 1).trim()
-                        config[key] = config.getOrDefault(key, emptyList()) + value
+            val lines = strippedContent.lines()
+            var i = 0
+            while (i < lines.size) {
+                val line = lines[i].trim()
+                i++
+                if (line.isBlank() || line.startsWith("#")) continue
+                val idx = line.indexOf('=')
+                if (idx <= 0) continue
+                val key = line.substring(0, idx).trim()
+                var value = line.substring(idx + 1).trim()
+                if (value == "```" || value.endsWith("```")) {
+                    val prefix = if (value.endsWith("```") && value != "```") {
+                        value.dropLast(3)
+                    } else {
+                        ""
                     }
+                    val sb = StringBuilder()
+                    while (i < lines.size) {
+                        val next = lines[i]
+                        i++
+                        if (next.trim() == "```") break
+                        if (sb.isNotEmpty()) sb.append('\n')
+                        sb.append(next)
+                    }
+                    value = prefix + sb.toString()
                 }
+                config[key] = config.getOrDefault(key, emptyList()) + value
             }
             return TestConfigReader(config)
         }

--- a/src/test/resources/api/jackson/AddressDTO.java
+++ b/src/test/resources/api/jackson/AddressDTO.java
@@ -1,0 +1,15 @@
+package com.itangcent.jackson;
+
+public class AddressDTO {
+
+    private String street;
+    private String city;
+    private String zipCode;
+
+    public String getStreet() { return street; }
+    public void setStreet(String street) { this.street = street; }
+    public String getCity() { return city; }
+    public void setCity(String city) { this.city = city; }
+    public String getZipCode() { return zipCode; }
+    public void setZipCode(String zipCode) { this.zipCode = zipCode; }
+}

--- a/src/test/resources/api/jackson/IgnorePropertiesDTO.java
+++ b/src/test/resources/api/jackson/IgnorePropertiesDTO.java
@@ -1,0 +1,21 @@
+package com.itangcent.jackson;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties({"internalId", "secretKey"})
+public class IgnorePropertiesDTO {
+
+    private Long id;
+    private String name;
+    private String internalId;
+    private String secretKey;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getInternalId() { return internalId; }
+    public void setInternalId(String internalId) { this.internalId = internalId; }
+    public String getSecretKey() { return secretKey; }
+    public void setSecretKey(String secretKey) { this.secretKey = secretKey; }
+}

--- a/src/test/resources/api/jackson/JsonViewViews.java
+++ b/src/test/resources/api/jackson/JsonViewViews.java
@@ -1,0 +1,7 @@
+package com.itangcent.jackson;
+
+public class JsonViewViews {
+    public static class Public {}
+    public static class Internal extends Public {}
+    public static class Admin extends Internal {}
+}

--- a/src/test/resources/api/jackson/OrderedDTO.java
+++ b/src/test/resources/api/jackson/OrderedDTO.java
@@ -1,0 +1,22 @@
+package com.itangcent.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"name", "email", "age"})
+public class OrderedDTO {
+
+    private String email;
+
+    @JsonProperty(index = 0)
+    private String name;
+
+    private int age;
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public int getAge() { return age; }
+    public void setAge(int age) { this.age = age; }
+}

--- a/src/test/resources/api/jackson/UnwrappedDTO.java
+++ b/src/test/resources/api/jackson/UnwrappedDTO.java
@@ -1,0 +1,22 @@
+package com.itangcent.jackson;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.itangcent.jackson.AddressDTO;
+
+public class UnwrappedDTO {
+
+    private String name;
+
+    @JsonUnwrapped
+    private AddressDTO address;
+
+    @JsonUnwrapped(prefix = "home_", suffix = "_addr")
+    private AddressDTO homeAddress;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public AddressDTO getAddress() { return address; }
+    public void setAddress(AddressDTO address) { this.address = address; }
+    public AddressDTO getHomeAddress() { return homeAddress; }
+    public void setHomeAddress(AddressDTO homeAddress) { this.homeAddress = homeAddress; }
+}

--- a/src/test/resources/api/jackson/UserController.java
+++ b/src/test/resources/api/jackson/UserController.java
@@ -1,12 +1,18 @@
 package com.itangcent.jackson;
 
 import com.itangcent.jackson.UserDTO;
+import com.itangcent.jackson.OrderedDTO;
+import com.itangcent.jackson.IgnorePropertiesDTO;
+import com.itangcent.jackson.UnwrappedDTO;
+import com.itangcent.jackson.ViewDTO;
+import com.itangcent.jackson.JsonViewViews;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
+import com.fasterxml.jackson.annotation.JsonView;
 
 @RestController
 @RequestMapping("/user")
@@ -20,5 +26,38 @@ public class UserController {
     @GetMapping("/get/{id}")
     public UserDTO getUser(@PathVariable("id") Long id) {
         return new UserDTO();
+    }
+
+    @PostMapping("/ordered")
+    public OrderedDTO createOrdered(@RequestBody OrderedDTO dto) {
+        return dto;
+    }
+
+    @PostMapping("/ignore-properties")
+    public IgnorePropertiesDTO createIgnoreProperties(@RequestBody IgnorePropertiesDTO dto) {
+        return dto;
+    }
+
+    @PostMapping("/unwrapped")
+    public UnwrappedDTO createUnwrapped(@RequestBody UnwrappedDTO dto) {
+        return dto;
+    }
+
+    @JsonView(JsonViewViews.Public.class)
+    @GetMapping("/view/public/{id}")
+    public ViewDTO getPublicView(@PathVariable("id") Long id) {
+        return new ViewDTO();
+    }
+
+    @JsonView(JsonViewViews.Internal.class)
+    @GetMapping("/view/internal/{id}")
+    public ViewDTO getInternalView(@PathVariable("id") Long id) {
+        return new ViewDTO();
+    }
+
+    @JsonView(JsonViewViews.Admin.class)
+    @GetMapping("/view/admin/{id}")
+    public ViewDTO getAdminView(@PathVariable("id") Long id) {
+        return new ViewDTO();
     }
 }

--- a/src/test/resources/api/jackson/ViewDTO.java
+++ b/src/test/resources/api/jackson/ViewDTO.java
@@ -1,0 +1,28 @@
+package com.itangcent.jackson;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.itangcent.jackson.JsonViewViews;
+
+public class ViewDTO {
+
+    @JsonView(JsonViewViews.Public.class)
+    private Long id;
+
+    @JsonView(JsonViewViews.Public.class)
+    private String name;
+
+    @JsonView(JsonViewViews.Internal.class)
+    private String email;
+
+    @JsonView(JsonViewViews.Admin.class)
+    private String password;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/src/test/resources/com/fasterxml/jackson/annotation/JsonIgnoreProperties.java
+++ b/src/test/resources/com/fasterxml/jackson/annotation/JsonIgnoreProperties.java
@@ -1,0 +1,10 @@
+package com.fasterxml.jackson.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonIgnoreProperties {
+    String[] value() default {};
+    boolean ignoreUnknown() default false;
+}

--- a/src/test/resources/com/fasterxml/jackson/annotation/JsonPropertyOrder.java
+++ b/src/test/resources/com/fasterxml/jackson/annotation/JsonPropertyOrder.java
@@ -1,0 +1,10 @@
+package com.fasterxml.jackson.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonPropertyOrder {
+    String[] value() default {};
+    boolean alphabetic() default false;
+}

--- a/src/test/resources/com/fasterxml/jackson/annotation/JsonUnwrapped.java
+++ b/src/test/resources/com/fasterxml/jackson/annotation/JsonUnwrapped.java
@@ -4,7 +4,8 @@ import java.lang.annotation.*;
 
 @Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface JsonProperty {
-    String value() default "";
-    int index() default -1;
+public @interface JsonUnwrapped {
+    String prefix() default "";
+    String suffix() default "";
+    boolean enabled() default true;
 }

--- a/src/test/resources/com/fasterxml/jackson/annotation/JsonView.java
+++ b/src/test/resources/com/fasterxml/jackson/annotation/JsonView.java
@@ -1,0 +1,9 @@
+package com.fasterxml.jackson.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonView {
+    Class<?>[] value() default {};
+}


### PR DESCRIPTION
## Changes

- Add missing `import com.itangcent.jackson.AddressDTO` in `UnwrappedDTO.java` test fixture so PSI can resolve the type and detect `@JsonUnwrapped`
- Add missing `import com.itangcent.jackson.JsonViewViews` in `ViewDTO.java` test fixture so PSI can resolve `@JsonView` class references
- Fix `@JsonView` `field.ignore` rule in `jackson.config` to normalize single values to lists before calling `.collect{}` (Groovy iterates over characters when called on a String)
- Apply prefix/suffix to nested field names when merging `@JsonUnwrapped` fields in `DefaultPsiClassHelper`

All 2265 tests pass.