### PR TITLE
feat: add rule-based configuration support with cache invalidation

### DIFF
--- a/.skills/write-test-case/SKILL.md
+++ b/.skills/write-test-case/SKILL.md
@@ -116,7 +116,7 @@ class MyExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     // Override to supply config rules for this test class
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     // Override to inject extra services into ActionContext
     override fun customizeContext(builder: ActionContextBuilder) {
@@ -260,7 +260,7 @@ class MyContextAwareServiceTest {
 ```kotlin
 class ExporterParityTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testAllExportersExist() = runTest {
         assertNotNull(SpringMvcClassExporter(actionContext))
@@ -292,7 +292,7 @@ Use to inject `.easy.api.config`-style rules without touching the filesystem.
 
 ```kotlin
 // No config
-TestConfigReader.EMPTY
+TestConfigReader.empty(project)
 
 // From key=value pairs
 TestConfigReader.fromRules(

--- a/src/main/kotlin/com/itangcent/easyapi/config/ConfigReader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/ConfigReader.kt
@@ -30,6 +30,21 @@ import com.intellij.openapi.components.service
  * }
  * ```
  *
+ * ## Important: Do NOT cache the instance
+ *
+ * Tests that share a light project fixture rely on `registerServiceInstance` to swap
+ * in different `ConfigReader` implementations per test class. Caching the instance
+ * in a `by lazy` property or a long-lived field causes later tests to see a stale
+ * reference from an earlier test. Use a computed property (`get()`) instead:
+ *
+ * ```kotlin
+ * // WRONG – captures a stale reference across test runs
+ * private val configReader: ConfigReader by lazy { ConfigReader.getInstance(project) }
+ *
+ * // CORRECT – always resolves the current instance
+ * private val configReader: ConfigReader get() = ConfigReader.getInstance(project)
+ * ```
+ *
  * @see LayeredConfigReader for layered configuration
  * @see ConfigProvider for configuration management
  */

--- a/src/main/kotlin/com/itangcent/easyapi/config/ConfigReloadListener.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/ConfigReloadListener.kt
@@ -1,0 +1,48 @@
+package com.itangcent.easyapi.config
+
+import com.intellij.util.messages.Topic
+
+/**
+ * Listener interface for configuration reload events.
+ *
+ * Published via [Topic] when configuration is reloaded, allowing services
+ * to invalidate caches or refresh their state.
+ *
+ * ## Usage
+ * Subscribe to [TOPIC] via the project's message bus:
+ * ```kotlin
+ * project.messageBus.connect().subscribe(ConfigReloadListener.TOPIC, object : ConfigReloadListener {
+ *     override fun onConfigReloaded() {
+ *         // Clear caches, refresh state, etc.
+ *     }
+ * })
+ * ```
+ *
+ * ## Publishers
+ * - [DefaultConfigReader.reload] publishes this event after loading new configuration
+ *
+ * ## Subscribers
+ * - [com.itangcent.easyapi.rule.RuleProvider] clears its rule cache
+ *
+ * @see DefaultConfigReader
+ * @see com.itangcent.easyapi.rule.RuleProvider
+ */
+interface ConfigReloadListener {
+
+    /**
+     * Called when configuration has been reloaded.
+     *
+     * Implementations should invalidate any cached data derived from configuration.
+     */
+    fun onConfigReloaded()
+
+    companion object {
+        /**
+         * Topic for configuration reload events.
+         */
+        val TOPIC: Topic<ConfigReloadListener> = Topic.create(
+            "EasyAPI Config Reloaded",
+            ConfigReloadListener::class.java
+        )
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/config/ConfigSyncService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/ConfigSyncService.kt
@@ -44,7 +44,7 @@ class ConfigSyncService(
     private val project: Project
 ) : Disposable {
 
-    private val configReader: ConfigReader by lazy { ConfigReader.getInstance(project) }
+    private val configReader: ConfigReader get() = ConfigReader.getInstance(project)
 
     private val connection = project.messageBus.connect(this)
 

--- a/src/main/kotlin/com/itangcent/easyapi/config/DefaultConfigReader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/DefaultConfigReader.kt
@@ -57,6 +57,7 @@ class DefaultConfigReader(
 
     override suspend fun reload() {
         delegate = buildDelegate().also { it.reload() }
+        project.messageBus.syncPublisher(ConfigReloadListener.TOPIC).onConfigReloaded()
     }
 
     override fun foreach(keyFilter: (String) -> Boolean, action: (String, String) -> Unit) {

--- a/src/main/kotlin/com/itangcent/easyapi/config/LayeredConfigReader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/LayeredConfigReader.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicReference
  * - Higher priority sources are processed first
  * - [getFirst] returns the value from the highest priority source
  * - [getAll] returns values ordered by source priority (highest first)
+ * - [foreach] iterates over entries in their original order from config files
  * 
  * This allows configuration to be layered, with higher priority sources overriding
  * or supplementing values from lower priority sources.
@@ -22,9 +23,16 @@ class LayeredConfigReader(
 ) : ConfigReader {
     companion object : IdeaLog
 
-    private val snapshotRef: AtomicReference<Map<String, List<String>>> = AtomicReference(emptyMap())
+    private data class Snapshot(
+        val orderedEntries: List<Pair<String, String>>,
+        val valuesByKey: Map<String, List<String>>
+    )
 
-    private fun values(key: String): List<String>? = snapshotRef.get()[key]
+    private val snapshotRef: AtomicReference<Snapshot> = AtomicReference(
+        Snapshot(emptyList(), emptyMap())
+    )
+
+    private fun values(key: String): List<String>? = snapshotRef.get().valuesByKey[key]
 
     override fun getFirst(key: String): String? {
         return values(key)?.firstOrNull()
@@ -45,25 +53,29 @@ class LayeredConfigReader(
             LOG.info("Loaded $count config entries from [${source.sourceId}] (priority=${source.priority})")
         }
 
-        val allResolved = LinkedHashMap<String, List<String>>()
-        val resolver = PropertyResolver(lookup = { k -> allResolved[k].orEmpty() })
+        val orderedEntries = ArrayList<Pair<String, String>>()
+        val valuesByKey = LinkedHashMap<String, List<String>>()
+        val resolver = PropertyResolver(lookup = { k -> valuesByKey[k].orEmpty() })
 
         for ((key, entryList) in allEntries) {
-            val resolvedValues = entryList.map { entry -> resolveEntry(entry, resolver) }
-            allResolved[key] = resolvedValues
+            val resolvedValues = ArrayList<String>()
+            for (entry in entryList) {
+                val resolvedValue = resolveEntry(entry, resolver)
+                resolvedValues.add(resolvedValue)
+                orderedEntries.add(key to resolvedValue)
+            }
+            valuesByKey[key] = resolvedValues
         }
 
-        snapshotRef.set(allResolved)
-        LOG.info("Config reload complete: ${allResolved.size} keys from ${sources.size} sources")
+        snapshotRef.set(Snapshot(orderedEntries, valuesByKey))
+        LOG.info("Config reload complete: ${valuesByKey.size} keys from ${sources.size} sources")
     }
 
     override fun foreach(keyFilter: (String) -> Boolean, action: (String, String) -> Unit) {
         val snapshot = snapshotRef.get()
-        for ((key, values) in snapshot) {
+        for ((key, value) in snapshot.orderedEntries) {
             if (keyFilter(key)) {
-                for (value in values) {
-                    action(key, value)
-                }
+                action(key, value)
             }
         }
     }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/ConfigRule.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/ConfigRule.kt
@@ -1,0 +1,27 @@
+package com.itangcent.easyapi.rule
+
+/**
+ * Represents a configuration rule with an optional filter expression.
+ *
+ * Configuration rules are loaded from config sources and evaluated by [RuleEngine].
+ * A rule consists of:
+ * - [expression]: The actual rule expression to evaluate (e.g., `"groovy: it.name()"`)
+ * - [filter]: An optional filter expression that determines if the rule should apply
+ *
+ * ## Filter Syntax
+ * Rules can be indexed with filter expressions in the config file:
+ * ```
+ * api.name=groovy:it.name()
+ * api.name[true]=groovy:it.name().toUpperCase()
+ * ```
+ * The filter `[true]` is evaluated first; if it returns true, the rule is applied.
+ *
+ * @property expression The rule expression to evaluate
+ * @property filter Optional filter expression; if null, the rule always applies
+ * @see RuleProvider
+ * @see com.itangcent.easyapi.rule.engine.RuleEngine
+ */
+data class ConfigRule(
+    val expression: String,
+    val filter: String? = null
+)

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleProvider.kt
@@ -1,0 +1,155 @@
+package com.itangcent.easyapi.rule
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.ConfigReloadListener
+import com.itangcent.easyapi.logging.IdeaLog
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Project-level service that provides cached configuration rules for [RuleEngine].
+ *
+ * This service bridges [ConfigReader] and [RuleEngine], providing:
+ * - **Caching**: Rules are cached by key name with a 30-second TTL
+ * - **Auto-invalidation**: Cache is cleared when configuration is reloaded
+ * - **Thread safety**: Uses [ConcurrentHashMap] for concurrent access
+ *
+ * ## Cache Invalidation
+ * The cache is invalidated when:
+ * 1. Configuration is reloaded ([ConfigReloadListener.onConfigReloaded] is called)
+ * 2. Cache entry TTL expires (30 seconds)
+ *
+ * ## Usage
+ * ```kotlin
+ * val ruleProvider = RuleProvider.getInstance(project)
+ * val rules = ruleProvider.getRules(RuleKeys.API_NAME)
+ * for (rule in rules) {
+ *     if (rule.filter == null || evaluateFilter(rule.filter)) {
+ *         evaluateExpression(rule.expression)
+ *     }
+ * }
+ * ```
+ *
+ * ## Architecture
+ * ```
+ * ConfigReader → RuleProvider (cached) → RuleEngine
+ *                     ↑
+ *              ConfigReloadListener (clears cache)
+ * ```
+ *
+ * @see ConfigRule
+ * @see com.itangcent.easyapi.rule.engine.RuleEngine
+ * @see ConfigReloadListener
+ */
+@Service(Service.Level.PROJECT)
+class RuleProvider(
+    private val project: Project
+) : ConfigReloadListener, Disposable, IdeaLog {
+
+    private val configReader: ConfigReader get() = ConfigReader.getInstance(project)
+
+    private val cache = ConcurrentHashMap<String, CachedRules>()
+
+    private val connection = project.messageBus.connect(this)
+
+    init {
+        connection.subscribe(ConfigReloadListener.TOPIC, this)
+    }
+
+    /**
+     * Gets all rules for the given [RuleKey].
+     *
+     * Results are cached for 30 seconds. If the cache is valid, returns cached rules.
+     * Otherwise, loads rules from [ConfigReader] and caches them.
+     *
+     * @param key The rule key to look up
+     * @return List of [ConfigRule] instances for the key (may be empty)
+     */
+    fun getRules(key: RuleKey<*>): List<ConfigRule> {
+        val now = System.currentTimeMillis()
+        val cached = cache[key.name]
+        if (cached != null && !cached.isExpired(now)) {
+            return cached.rules
+        }
+        val rules = loadRules(key)
+        cache[key.name] = CachedRules(rules, now + CACHE_TTL_MS)
+        return rules
+    }
+
+    /**
+     * Loads rules from [ConfigReader] for the given key.
+     *
+     * This method scans both direct rules and indexed rules (with filter expressions),
+     * preserving the original order from configuration files.
+     *
+     * @param key The rule key to load
+     * @return List of [ConfigRule] instances
+     */
+    private fun loadRules(key: RuleKey<*>): List<ConfigRule> {
+        val result = ArrayList<ConfigRule>()
+        for (k in key.allNames) {
+            configReader.foreach(
+                { cfgKey -> cfgKey == k || cfgKey.startsWith("$k[") },
+                { cfgKey, value ->
+                    val filterExp = if (cfgKey == k) {
+                        null
+                    } else {
+                        cfgKey.removePrefix(k).removeSurrounding("[", "]")
+                    }
+                    result.add(ConfigRule(value, filterExp))
+                }
+            )
+        }
+        return result
+    }
+
+    /**
+     * Called when configuration is reloaded.
+     * Clears all cached rules to ensure fresh data on next access.
+     */
+    override fun onConfigReloaded() {
+        LOG.info("RuleProvider: clearing cache due to config reload")
+        clearCache()
+    }
+
+    /**
+     * Clears all cached rules.
+     * Called internally on config reload or disposal.
+     */
+    private fun clearCache() {
+        cache.clear()
+    }
+
+    /**
+     * Cleans up resources when the service is disposed.
+     */
+    override fun dispose() {
+        clearCache()
+    }
+
+    /**
+     * Cached rules with expiration time.
+     */
+    private data class CachedRules(
+        val rules: List<ConfigRule>,
+        val expireTime: Long
+    ) {
+        fun isExpired(now: Long): Boolean = now >= expireTime
+    }
+
+    companion object {
+        /**
+         * Cache time-to-live in milliseconds (30 seconds).
+         */
+        private val CACHE_TTL_MS = 30.seconds.inWholeMilliseconds
+
+        /**
+         * Gets the [RuleProvider] instance for the given project.
+         */
+        fun getInstance(project: Project): RuleProvider = project.service()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
@@ -71,9 +71,7 @@ class RuleContext private constructor(
 
     val session: SessionStorage get() = sessionStorageInstance
 
-    val config: ConfigReader by lazy {
-        ConfigReader.getInstance(project)
-    }
+    val config: ConfigReader get() = ConfigReader.getInstance(project)
 
     val localStorage: LocalStorage by lazy {
         LocalStorage.getInstance(project)

--- a/src/main/kotlin/com/itangcent/easyapi/rule/engine/RuleEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/engine/RuleEngine.kt
@@ -4,9 +4,9 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.itangcent.easyapi.config.ConfigReader
 import com.itangcent.easyapi.rule.IntRuleMode
 import com.itangcent.easyapi.rule.RuleKey
+import com.itangcent.easyapi.rule.RuleProvider
 import com.itangcent.easyapi.rule.context.RuleContext
 import com.itangcent.easyapi.rule.parser.*
 
@@ -27,8 +27,8 @@ import com.itangcent.easyapi.rule.parser.*
 class RuleEngine internal constructor(
     private val project: Project
 ) {
-    private val configReader: ConfigReader
-        get() = ConfigReader.getInstance(project)
+    private val ruleProvider: RuleProvider
+        get() = RuleProvider.getInstance(project)
 
     private val parsers: List<RuleParser> = defaultParsers().also { list ->
         list.filterIsInstance<RuleEngineAware>().forEach { it.setRuleEngine(this) }
@@ -206,10 +206,10 @@ class RuleEngine internal constructor(
         ctx: RuleContext,
         action: suspend (String) -> Unit
     ) {
-        for ((exp, filterExp) in loadExpressionsWithFilters(key)) {
+        for ((expression, filter) in ruleProvider.getRules(key)) {
             ctx.regexGroups = null
-            val shouldApply = if (filterExp != null) {
-                runCatching { parse(filterExp, ctx, FILTER_KEY) }
+            val shouldApply = if (filter != null) {
+                runCatching { parse(filter, ctx, FILTER_KEY) }
                     .onFailure { e -> ctx.console.warn("Filter evaluation failed for key=${key.name}", e) }
                     .getOrNull()
                     ?.let { toBoolean(it) }
@@ -218,7 +218,7 @@ class RuleEngine internal constructor(
                 true
             }
             if (shouldApply) {
-                action(exp)
+                action(expression)
             }
             ctx.regexGroups = null
         }
@@ -227,28 +227,6 @@ class RuleEngine internal constructor(
     private suspend fun parse(expression: String, ctx: RuleContext, ruleKey: RuleKey<*>? = null): Any? {
         val parser = parsers.firstOrNull { it.canParse(expression) }
         return parser?.parse(expression, ctx, ruleKey)
-    }
-
-    private fun loadExpressionsWithFilters(key: RuleKey<*>): List<Pair<String, String?>> {
-        val result = ArrayList<Pair<String, String?>>()
-
-        for (k in key.allNames) {
-            val rules = configReader.getAll(k)
-            rules.forEach { exp ->
-                result.add(exp to null)
-            }
-
-            val indexedKeyPrefix = "$k["
-            configReader.foreach(
-                { cfgKey -> cfgKey.startsWith(indexedKeyPrefix) },
-                { indexedKey, value ->
-                    val filterExp = indexedKey.removePrefix(k).removeSurrounding("[", "]")
-                    result.add(value to filterExp)
-                }
-            )
-        }
-
-        return result
     }
 
     private fun toBoolean(value: Any): Boolean = when (value) {

--- a/src/test/kotlin/com/itangcent/easyapi/cache/ApiIndexManagerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/cache/ApiIndexManagerTest.kt
@@ -44,7 +44,7 @@ class ApiIndexManagerTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testGetInstance() {
         assertNotNull("ApiIndexManager should be retrievable", apiIndexManager)

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/GsonConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/GsonConfigIntegrationTest.kt
@@ -38,7 +38,7 @@ class GsonConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
     override fun createConfigReader(): TestConfigReader {
         val extension = ExtensionConfigRegistry.getExtension("gson")
         assertNotNull("gson extension should exist", extension)
-        return TestConfigReader.fromConfigText(extension?.content ?: "")
+        return TestConfigReader.fromConfigText(project, extension?.content ?: "")
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/JacksonConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/JacksonConfigIntegrationTest.kt
@@ -51,8 +51,10 @@ class JacksonConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/jackson/ViewDTO.java")
     }
 
-    override fun createConfigReader(): ConfigReader {
-        return extensionConfigReader("jackson")
+    override fun createConfigReader(): TestConfigReader {
+        val extension = ExtensionConfigRegistry.getExtension("jackson")
+        assertNotNull("jackson extension should exist", extension)
+        return TestConfigReader.fromConfigText(project, extension?.content ?: "")
     }
 
     fun testJacksonConfigLoadsCorrectly() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/JakartaValidationConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/JakartaValidationConfigIntegrationTest.kt
@@ -41,7 +41,7 @@ class JakartaValidationConfigIntegrationTest : EasyApiLightCodeInsightFixtureTes
         assertNotNull("jakarta-validation extension should exist", extension)
         val content = extension?.content ?: ""
         assertTrue("Extension content should not be blank", content.isNotBlank())
-        return TestConfigReader.fromConfigText(content)
+        return TestConfigReader.fromConfigText(project, content)
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/JavaxValidationConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/JavaxValidationConfigIntegrationTest.kt
@@ -41,7 +41,7 @@ class JavaxValidationConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestC
         assertNotNull("javax-validation extension should exist", extension)
         val content = extension?.content ?: ""
         assertTrue("Extension content should not be blank", content.isNotBlank())
-        return TestConfigReader.fromConfigText(content)
+        return TestConfigReader.fromConfigText(project, content)
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SpringConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SpringConfigIntegrationTest.kt
@@ -44,7 +44,7 @@ class SpringConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertNotNull("spring extension should exist", extension)
         val content = extension?.content ?: ""
         assertTrue("Extension content should not be blank", content.isNotBlank())
-        return TestConfigReader.fromConfigText(content)
+        return TestConfigReader.fromConfigText(project, content)
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SpringConfigurationConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SpringConfigurationConfigIntegrationTest.kt
@@ -21,7 +21,7 @@ class SpringConfigurationConfigIntegrationTest : EasyApiLightCodeInsightFixtureT
         assertNotNull("spring-configuration extension should exist", extension)
         val content = extension?.content ?: ""
         assertTrue("Extension content should not be blank", content.isNotBlank())
-        return TestConfigReader.fromConfigText(content)
+        return TestConfigReader.fromConfigText(project, content)
     }
 
     fun testSpringConfigurationConfigLoadsCorrectly() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SpringPropertiesConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SpringPropertiesConfigIntegrationTest.kt
@@ -15,7 +15,7 @@ class SpringPropertiesConfigIntegrationTest : EasyApiLightCodeInsightFixtureTest
         assertNotNull("spring-properties extension should exist", extension)
         val content = extension?.content ?: ""
         assertTrue("Extension content should not be blank", content.isNotBlank())
-        return TestConfigReader.fromConfigText(content)
+        return TestConfigReader.fromConfigText(project, content)
     }
 
     fun testSpringPropertiesConfigLoadsCorrectly() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SpringValidationsConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SpringValidationsConfigIntegrationTest.kt
@@ -41,7 +41,7 @@ class SpringValidationsConfigIntegrationTest : EasyApiLightCodeInsightFixtureTes
         assertNotNull("spring-validations extension should exist", extension)
         val content = extension?.content ?: ""
         assertTrue("Extension content should not be blank", content.isNotBlank())
-        return TestConfigReader.fromConfigText(content)
+        return TestConfigReader.fromConfigText(project, content)
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SpringWebFluxConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SpringWebFluxConfigIntegrationTest.kt
@@ -52,7 +52,7 @@ class SpringWebFluxConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCas
         
         val combinedContent = "$springContent\n\n$webFluxContent"
         assertTrue("Combined extension content should not be blank", combinedContent.isNotBlank())
-        return TestConfigReader.fromConfigText(combinedContent)
+        return TestConfigReader.fromConfigText(project, combinedContent)
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/Swagger3ConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/Swagger3ConfigIntegrationTest.kt
@@ -44,7 +44,7 @@ class Swagger3ConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     override fun createConfigReader(): TestConfigReader {
         val swagger3Config = loadConfigFromResource("extensions/swagger3.config")
-        return TestConfigReader.fromConfigText(swagger3Config)
+        return TestConfigReader.fromConfigText(project, swagger3Config)
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SwaggerConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SwaggerConfigIntegrationTest.kt
@@ -44,7 +44,7 @@ class SwaggerConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
     override fun createConfigReader(): TestConfigReader {
         val swaggerConfig = loadConfigFromResource("extensions/swagger.config")
         val swaggerAdvancedConfig = loadConfigFromResource("third/swagger.advanced.config")
-        return TestConfigReader.fromConfigText(swaggerConfig + "\n" + swaggerAdvancedConfig)
+        return TestConfigReader.fromConfigText(project, swaggerConfig + "\n" + swaggerAdvancedConfig)
     }
 
 

--- a/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiScannerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiScannerTest.kt
@@ -30,7 +30,7 @@ class ApiScannerTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testScanAllReturnsEndpoints() = runTest {
         val endpoints = apiScanner.scanAll()

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
@@ -35,7 +35,7 @@ class ExportOrchestratorTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testGetInstanceReturnsSameInstance() {
         val instance1 = ExportOrchestrator.getInstance(project)

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizerTest.kt
@@ -30,7 +30,7 @@ class CompositeApiClassRecognizerTest : EasyApiLightCodeInsightFixtureTestCase()
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testGetInstance() {
         val instance = CompositeApiClassRecognizer.getInstance(project)

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignAnnotationInheritanceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignAnnotationInheritanceTest.kt
@@ -25,7 +25,7 @@ class FeignAnnotationInheritanceTest : EasyApiLightCodeInsightFixtureTestCase() 
         loadFile("api/feign/UserFeignClient.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testOverrideMethodInheritsGetMappingFromSuperInterface() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporterLifecycleTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporterLifecycleTest.kt
@@ -34,6 +34,7 @@ class FeignClassExporterLifecycleTest : EasyApiLightCodeInsightFixtureTestCase()
     }
 
     override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
         """
         api.class.parse.before=groovy:logger.info("lifecycle:api.class.parse.before:" + it.name())
         api.class.parse.after=groovy:logger.info("lifecycle:api.class.parse.after:" + it.name())

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporterTest.kt
@@ -34,7 +34,7 @@ class FeignClassExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/feign/UserClient.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testExportFeignClient() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignClientRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignClientRecognizerTest.kt
@@ -24,7 +24,7 @@ class FeignClientRecognizerTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/feign/UserClient.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testRecognizeFeignClient() = runTest {
         val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignInheritanceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignInheritanceTest.kt
@@ -35,7 +35,7 @@ class FeignInheritanceTest : EasyApiLightCodeInsightFixtureTestCase() {
         exporter = FeignClassExporter(project, feignEnable = true)
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testInheritedMethodIsExported() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignPathResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignPathResolverTest.kt
@@ -29,7 +29,7 @@ class FeignPathResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/feign/UserClient.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testResolveFeignClientWithName() = runTest {
         val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignTitleExtractionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignTitleExtractionTest.kt
@@ -31,7 +31,7 @@ class FeignTitleExtractionTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/feign/TitleTestClient.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testClassTitleFromDocComment() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporterLifecycleTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporterLifecycleTest.kt
@@ -30,6 +30,7 @@ class GrpcClassExporterLifecycleTest : EasyApiLightCodeInsightFixtureTestCase() 
     }
 
     override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
         """
         api.class.parse.before=groovy:logger.info("lifecycle:api.class.parse.before:" + it.name())
         api.class.parse.after=groovy:logger.info("lifecycle:api.class.parse.after:" + it.name())

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporterTest.kt
@@ -43,7 +43,7 @@ class GrpcClassExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("grpc/UserInfo.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolverTest.kt
@@ -75,7 +75,7 @@ class GrpcMethodResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         }
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcServiceRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcServiceRecognizerTest.kt
@@ -44,7 +44,7 @@ class GrpcServiceRecognizerTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("grpc/UserInfo.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporterLifecycleTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporterLifecycleTest.kt
@@ -44,6 +44,7 @@ class JaxRsClassExporterLifecycleTest : EasyApiLightCodeInsightFixtureTestCase()
     }
 
     override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
         """
         api.class.parse.before=groovy:logger.info("lifecycle:api.class.parse.before:" + it.name())
         api.class.parse.after=groovy:logger.info("lifecycle:api.class.parse.after:" + it.name())

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporterTest.kt
@@ -38,7 +38,7 @@ class JaxRsClassExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/jaxrs/UserDTO.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testExportJaxRsResource() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsPathResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsPathResolverTest.kt
@@ -29,7 +29,7 @@ class JaxRsPathResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/jaxrs/UserResource.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testClassPath() = runTest {
         val psiClass = findClass("com.itangcent.jaxrs.UserResource")

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsResourceRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsResourceRecognizerTest.kt
@@ -27,7 +27,7 @@ class JaxRsResourceRecognizerTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/jaxrs/UserResource.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testRecognizeJaxRsResource() = runTest {
         val psiClass = findClass("com.itangcent.jaxrs.UserResource")

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsTitleExtractionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsTitleExtractionTest.kt
@@ -35,7 +35,7 @@ class JaxRsTitleExtractionTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/jaxrs/TitleTestResource.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testClassTitleFromDocComment() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/lifecycle/ApiLifecycleEventsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/lifecycle/ApiLifecycleEventsTest.kt
@@ -99,6 +99,7 @@ class ApiLifecycleEventsTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
         """
         api.class.parse.before=groovy:logger.info("lifecycle:api.class.parse.before:" + it.name())
         api.class.parse.after=groovy:logger.info("lifecycle:api.class.parse.after:" + it.name())

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanApiClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanApiClientTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert.*
 
 class PostmanApiClientTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testFormat(): Unit = runBlocking {
         val result = testFormatInternal()

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/postman/PostmanFormatterTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 
 class PostmanFormatterTest : com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     @Test
     fun testParsePath() {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporterTest.kt
@@ -44,7 +44,7 @@ class ActuatorEndpointExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
         restControllerAnnEndpointPsiClass = findClass("com.itangcent.springboot.demo.controller.RestControllerAnnEndpoint")!!
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     // --- Standard @Endpoint ---

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointRecognizerTest.kt
@@ -27,7 +27,7 @@ class ActuatorEndpointRecognizerTest : EasyApiLightCodeInsightFixtureTestCase() 
         loadFile("spring/PostMapping.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testRecognizesStandardEndpoint() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
@@ -44,7 +44,7 @@ class ActuatorEndpointScannerTest : EasyApiLightCodeInsightFixtureTestCase() {
         restControllerAnnEndpointPsiClass = findClass("com.itangcent.springboot.demo.controller.RestControllerAnnEndpoint")!!
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testExportStandard() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ContentTypeResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ContentTypeResolverTest.kt
@@ -33,7 +33,7 @@ class ContentTypeResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testResolveContentTypeForGetMethod() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/GenericControllerExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/GenericControllerExportTest.kt
@@ -40,7 +40,7 @@ class GenericControllerExportTest : EasyApiLightCodeInsightFixtureTestCase() {
         exporter = SpringMvcClassExporter(project)
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/InheritedControllerExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/InheritedControllerExportTest.kt
@@ -40,7 +40,7 @@ class InheritedControllerExportTest : EasyApiLightCodeInsightFixtureTestCase() {
         exporter = SpringMvcClassExporter(project)
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     // ========== Case 2: Annotations on super abstract class ==========

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/RequestMappingResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/RequestMappingResolverTest.kt
@@ -32,7 +32,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testResolveSimpleGetMapping() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")!!

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringControllerRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringControllerRecognizerTest.kt
@@ -26,7 +26,7 @@ class SpringControllerRecognizerTest : EasyApiLightCodeInsightFixtureTestCase() 
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testRecognizeRestController() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporterTest.kt
@@ -39,7 +39,7 @@ class SpringMvcClassExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testExportSimpleController() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcTitleExtractionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcTitleExtractionTest.kt
@@ -31,7 +31,7 @@ class SpringMvcTitleExtractionTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/TitleTestCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testClassTitleFromDocComment() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringParameterBindingResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringParameterBindingResolverTest.kt
@@ -35,7 +35,7 @@ class SpringParameterBindingResolverTest : EasyApiLightCodeInsightFixtureTestCas
         loadFile("api/TestCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testResolvePathVariable() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")!!

--- a/src/test/kotlin/com/itangcent/easyapi/gap/FeatureParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/gap/FeatureParityTest.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.*
 
 class FeatureParityTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testSpringMvcExporterExists() = runTest {
         val exporter = SpringMvcClassExporter(project)

--- a/src/test/kotlin/com/itangcent/easyapi/gap/FormatterParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/gap/FormatterParityTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert.*
 
 class FormatterParityTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testPostmanFormatterExists() {
         val formatter = PostmanFormatter(project = project)

--- a/src/test/kotlin/com/itangcent/easyapi/gap/PipelineComponentParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/gap/PipelineComponentParityTest.kt
@@ -13,7 +13,7 @@ import org.junit.Assert.*
 
 class PipelineComponentParityTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testSpringControllerRecognizerExists() = runTest {
         val ruleEngine = RuleEngine.getInstance(project)

--- a/src/test/kotlin/com/itangcent/easyapi/integration/EndToEndExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/integration/EndToEndExportTest.kt
@@ -38,7 +38,7 @@ class EndToEndExportTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testExportSpringMvcToPostman() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/integration/FormatConversionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/integration/FormatConversionTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.runBlocking
 
 class FormatConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
     private val testEndpoint = ApiEndpoint(
         name = "Get User",

--- a/src/test/kotlin/com/itangcent/easyapi/integration/FullExportIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/integration/FullExportIntegrationTest.kt
@@ -36,7 +36,7 @@ class FullExportIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/UserCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testFullExportPipeline() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/integration/MultiFrameworkExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/integration/MultiFrameworkExportTest.kt
@@ -46,7 +46,7 @@ class MultiFrameworkExportTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/jaxrs/UserResource.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testExportSpringMvcController() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/property/PsiAndExporterPropertyTests.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/property/PsiAndExporterPropertyTests.kt
@@ -230,7 +230,7 @@ class PsiAndExporterPropertyTests : EasyApiLightCodeInsightFixtureTestCase() {
         val field = psiClass.allFields.first { it.name == "name" }
         project.registerServiceInstance(
             serviceInterface = com.itangcent.easyapi.config.ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(mapOf("field.name" to listOf("@com.fasterxml.jackson.annotation.JsonProperty#value")))
+            instance = TestConfigReader.fromRules(project, "field.name" to "@com.fasterxml.jackson.annotation.JsonProperty#value")
         )
         val engine = RuleEngine.getInstance(project)
         val v = engine.evaluate(RuleKey.string("field.name", StringRuleMode.SINGLE), field)
@@ -254,7 +254,7 @@ class PsiAndExporterPropertyTests : EasyApiLightCodeInsightFixtureTestCase() {
         val field = psiClass.allFields.first { it.name == "a" }
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(mapOf("field.required" to listOf("@javax.validation.constraints.NotNull")))
+            instance = TestConfigReader.fromRules(project, "field.required" to "@javax.validation.constraints.NotNull")
         )
         val engine = RuleEngine.getInstance(project)
         val required = engine.evaluate(RuleKey.boolean("field.required"), field)
@@ -332,7 +332,7 @@ class PsiAndExporterPropertyTests : EasyApiLightCodeInsightFixtureTestCase() {
         val param = method.parameterList.parameters.first()
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(mapOf("doc.param" to listOf("param-doc")))
+            instance = TestConfigReader.fromRules(project, "doc.param" to "param-doc")
         )
         val engine = RuleEngine.getInstance(project)
         val v = engine.evaluate(RuleKeys.PARAM_DOC, param)
@@ -351,7 +351,11 @@ class PsiAndExporterPropertyTests : EasyApiLightCodeInsightFixtureTestCase() {
         val method = psiClass.methods.first { it.name == "x" }
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(mapOf("method.doc" to listOf("a", "b")))
+            instance = TestConfigReader.fromRules(
+                project,
+                "method.doc" to "a",
+                "method.doc" to "b"
+            )
         )
         val engine = RuleEngine.getInstance(project)
         val merged = engine.evaluate(RuleKey.string("method.doc", StringRuleMode.MERGE), method)
@@ -370,7 +374,7 @@ class PsiAndExporterPropertyTests : EasyApiLightCodeInsightFixtureTestCase() {
         val method = psiClass.methods.first { it.name == "x" }
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(mapOf("api.name" to listOf("groovy:1/0")))
+            instance = TestConfigReader.fromRules(project, "api.name" to "groovy:1/0")
         )
         val engine = RuleEngine.getInstance(project)
         val v = engine.evaluate(RuleKey.string("api.name", StringRuleMode.SINGLE), method)

--- a/src/test/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelperIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelperIntegrationTest.kt
@@ -1,8 +1,5 @@
 package com.itangcent.easyapi.psi
 
-import com.intellij.psi.JavaPsiFacade
-import com.intellij.psi.PsiClass
-import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.testFramework.registerServiceInstance
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelValueConverter
@@ -1063,11 +1060,7 @@ class DefaultPsiClassHelperIntegrationTest : EasyApiLightCodeInsightFixtureTestC
         val psiClass = findClass("model.CommentModel")!!
         project.registerServiceInstance(
             serviceInterface = com.itangcent.easyapi.config.ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(
-                mapOf(
-                    "field.doc" to listOf("groovy:it.doc()")
-                )
-            )
+            instance = TestConfigReader.fromRules(project, "field.doc" to "groovy:it.doc()")
         )
         project.registerServiceInstance(
             serviceInterface = RuleEngine::class.java,
@@ -1119,11 +1112,7 @@ class DefaultPsiClassHelperIntegrationTest : EasyApiLightCodeInsightFixtureTestC
         val psiClass = findClass("model.AnnotatedModel")!!
         project.registerServiceInstance(
             serviceInterface = com.itangcent.easyapi.config.ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(
-                mapOf(
-                    "field.doc" to listOf("@model.ApiModelProperty#value")
-                )
-            )
+            instance = TestConfigReader.fromRules(project, "field.doc" to "@model.ApiModelProperty#value")
         )
         project.registerServiceInstance(
             serviceInterface = RuleEngine::class.java,
@@ -1169,11 +1158,7 @@ class DefaultPsiClassHelperIntegrationTest : EasyApiLightCodeInsightFixtureTestC
         val psiClass = findClass("model.UserModel")!!
         project.registerServiceInstance(
             serviceInterface = com.itangcent.easyapi.config.ConfigReader::class.java,
-            instance = TestConfigReader.fromMap(
-                mapOf(
-                    "field.doc" to listOf("groovy:it.doc()")
-                )
-            )
+            instance = TestConfigReader.fromRules(project, "field.doc" to "groovy:it.doc()")
         )
         project.registerServiceInstance(
             serviceInterface = RuleEngine::class.java,

--- a/src/test/kotlin/com/itangcent/easyapi/psi/EnumResolutionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/EnumResolutionTest.kt
@@ -72,7 +72,7 @@ class EnumResolutionTest {
 
     class Case1_Default : EasyApiLightCodeInsightFixtureTestCase() {
 
-        override fun createConfigReader() = TestConfigReader.EMPTY
+        override fun createConfigReader() = TestConfigReader.empty(project)
 
         fun testEnumFieldDefaultJsonType() = runBlocking {
             myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
@@ -163,7 +163,7 @@ class EnumResolutionTest {
     class Case1_CustomCode : EasyApiLightCodeInsightFixtureTestCase() {
 
         override fun createConfigReader() = TestConfigReader.fromRules(
-            "enum.use.custom" to "code"
+            project, "enum.use.custom" to "code"
         )
 
         fun testEnumFieldCustomCodeJsonType() = runBlocking {
@@ -221,7 +221,7 @@ class EnumResolutionTest {
     class Case1_CustomDesc : EasyApiLightCodeInsightFixtureTestCase() {
 
         override fun createConfigReader() = TestConfigReader.fromRules(
-            "enum.use.custom" to "desc"
+            project, "enum.use.custom" to "desc"
         )
 
         fun testEnumFieldCustomDescJsonType() = runBlocking {
@@ -279,7 +279,7 @@ class EnumResolutionTest {
     class Case1_CustomName : EasyApiLightCodeInsightFixtureTestCase() {
 
         override fun createConfigReader() = TestConfigReader.fromRules(
-            "enum.use.custom" to "name"
+            project, "enum.use.custom" to "name"
         )
 
         fun testEnumFieldCustomNameJsonType() = runBlocking {
@@ -336,7 +336,7 @@ class EnumResolutionTest {
     class Case1_CustomOrdinal : EasyApiLightCodeInsightFixtureTestCase() {
 
         override fun createConfigReader() = TestConfigReader.fromRules(
-            "enum.use.custom" to "ordinal"
+            project, "enum.use.custom" to "ordinal"
         )
 
         fun testEnumFieldCustomOrdinalJsonType() = runBlocking {
@@ -393,7 +393,7 @@ class EnumResolutionTest {
 
     class Case2_SeeWithExplicitField : EasyApiLightCodeInsightFixtureTestCase() {
 
-        override fun createConfigReader() = TestConfigReader.EMPTY
+        override fun createConfigReader() = TestConfigReader.empty(project)
 
         fun testSeeEnumWithHashField() = runBlocking {
             myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
@@ -489,7 +489,7 @@ class EnumResolutionTest {
 
     class Case2_SeeWithAutoMatch : EasyApiLightCodeInsightFixtureTestCase() {
 
-        override fun createConfigReader() = TestConfigReader.EMPTY
+        override fun createConfigReader() = TestConfigReader.empty(project)
 
         fun testSeeEnumAutoMatchByIntType() = runBlocking {
             myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
@@ -614,7 +614,7 @@ class EnumResolutionTest {
 
     class Case2_OptionDescriptions : EasyApiLightCodeInsightFixtureTestCase() {
 
-        override fun createConfigReader() = TestConfigReader.EMPTY
+        override fun createConfigReader() = TestConfigReader.empty(project)
 
         fun testSeeEnumOptionsHaveDescriptions() = runBlocking {
             myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())

--- a/src/test/kotlin/com/itangcent/easyapi/psi/GenericInheritanceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/GenericInheritanceTest.kt
@@ -21,7 +21,7 @@ class GenericInheritanceTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("model/generic/ConcreteLeaf.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolverTest.kt
@@ -26,7 +26,7 @@ class ApiMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/TitleTestCtrl.java")
     }
 
-    override fun createConfigReader() = TestConfigReader.EMPTY
+    override fun createConfigReader() = TestConfigReader.empty(project)
 
 
     fun testResolveApiNameFromDocComment() = runTest {
@@ -68,7 +68,7 @@ class ApiMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertNotNull(method)
         val desc = metadataResolver.resolveMethodDoc(method!!)
         // resolveMethodDoc returns the doc comment even without a method.doc rule
-        // With TestConfigReader.EMPTY, no rule fires but the doc comment is still returned
+        // With TestConfigReader.empty(project), no rule fires but the doc comment is still returned
         assertTrue("method.doc should be blank when no rule configured and no doc comment on method",
             desc.isBlank() || desc.isNotBlank()) // just verify it doesn't throw
     }
@@ -80,7 +80,7 @@ class ApiMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertNotNull(method)
         val folder = metadataResolver.resolveFolderName(method!!)
         // resolveFolderName falls back to class doc / class name when no folder.name rule configured
-        // With TestConfigReader.EMPTY, it returns the class doc or class name
+        // With TestConfigReader.empty(project), it returns the class doc or class name
         assertNotNull("folder.name should fall back to class name when no rule configured", folder)
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/rule/ConfigRuleTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/ConfigRuleTest.kt
@@ -1,0 +1,54 @@
+package com.itangcent.easyapi.rule
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ConfigRuleTest {
+
+    @Test
+    fun testConfigRuleWithNoFilter() {
+        val rule = ConfigRule(expression = "groovy:it.name()")
+        
+        assertEquals("groovy:it.name()", rule.expression)
+        assertNull("Filter should be null", rule.filter)
+    }
+
+    @Test
+    fun testConfigRuleWithFilter() {
+        val rule = ConfigRule(
+            expression = "groovy:it.name().toUpperCase()",
+            filter = "true"
+        )
+        
+        assertEquals("groovy:it.name().toUpperCase()", rule.expression)
+        assertEquals("true", rule.filter)
+    }
+
+    @Test
+    fun testConfigRuleEquality() {
+        val rule1 = ConfigRule(expression = "test", filter = "true")
+        val rule2 = ConfigRule(expression = "test", filter = "true")
+        val rule3 = ConfigRule(expression = "test", filter = null)
+        
+        assertEquals("Same rules should be equal", rule1, rule2)
+        assertNotEquals("Different filters should not be equal", rule1, rule3)
+    }
+
+    @Test
+    fun testConfigRuleCopy() {
+        val original = ConfigRule(expression = "original", filter = "filter")
+        val copy = original.copy(expression = "copied")
+        
+        assertEquals("copied", copy.expression)
+        assertEquals("filter", copy.filter)
+    }
+
+    @Test
+    fun testConfigRuleToString() {
+        val rule = ConfigRule(expression = "test", filter = "true")
+        val str = rule.toString()
+        
+        assertTrue("toString should contain expression", str.contains("test"))
+        assertTrue("toString should contain filter", str.contains("true"))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/rule/RuleProviderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/RuleProviderTest.kt
@@ -1,0 +1,224 @@
+package com.itangcent.easyapi.rule
+
+import com.intellij.testFramework.registerServiceInstance
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.ConfigReloadListener
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.*
+import org.junit.Test
+
+class RuleProviderGetInstanceTest : EasyApiLightCodeInsightFixtureTestCase() {
+    @Test
+    fun testGetInstance() {
+        val instance = RuleProvider.getInstance(project)
+        assertNotNull(instance)
+        assertSame(instance, RuleProvider.getInstance(project))
+    }
+}
+
+class RuleProviderEmptyKeyTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.empty(project)
+
+    @Test
+    fun testGetRulesReturnsEmptyForNonExistentKey() {
+        val ruleProvider = RuleProvider.getInstance(project)
+        val rules = ruleProvider.getRules(RuleKey.string("nonexistent.key"))
+
+        assertTrue("Should return empty list for non-existent key", rules.isEmpty())
+    }
+}
+
+class RuleProviderSingleRuleTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.fromRules(
+        project,
+        "api.name" to "Test API",
+        "api.tag" to "tag1"
+    )
+
+    @Test
+    fun testGetRulesReturnsRulesFromConfig() {
+        val ruleProvider = RuleProvider.getInstance(project)
+        val rules = ruleProvider.getRules(RuleKey.string("api.name"))
+
+        assertEquals("Should return one rule", 1, rules.size)
+        assertEquals("Test API", rules[0].expression)
+        assertNull("Rule should have no filter", rules[0].filter)
+    }
+}
+
+class RuleProviderMultipleRulesTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.fromRules(
+        project,
+        "api.tag" to "tag1",
+        "api.tag" to "tag2",
+        "api.tag" to "tag3"
+    )
+
+    @Test
+    fun testGetRulesReturnsMultipleRules() {
+        val ruleProvider = RuleProvider.getInstance(project)
+        val rules = ruleProvider.getRules(RuleKey.string("api.tag"))
+
+        assertEquals("Should return all rules", 3, rules.size)
+        assertEquals("tag1", rules[0].expression)
+        assertEquals("tag2", rules[1].expression)
+        assertEquals("tag3", rules[2].expression)
+    }
+}
+
+class RuleProviderIndexedFiltersTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.fromRules(
+        project,
+        "api.name" to "Base API",
+        "api.name[true]" to "Filtered API",
+        "api.name[false]" to "Filtered API 2"
+    )
+
+    @Test
+    fun testGetRulesWithIndexedFilters() {
+        val ruleProvider = RuleProvider.getInstance(project)
+        val rules = ruleProvider.getRules(RuleKey.string("api.name"))
+
+        assertEquals("Should return all rules including indexed", 3, rules.size)
+
+        val baseRule = rules.find { it.filter == null }
+        assertNotNull("Should have base rule", baseRule)
+        assertEquals("Base API", baseRule?.expression)
+
+        val trueFilterRule = rules.find { it.filter == "true" }
+        assertNotNull("Should have rule with 'true' filter", trueFilterRule)
+        assertEquals("Filtered API", trueFilterRule?.expression)
+
+        val falseFilterRule = rules.find { it.filter == "false" }
+        assertNotNull("Should have rule with 'false' filter", falseFilterRule)
+        assertEquals("Filtered API 2", falseFilterRule?.expression)
+    }
+}
+
+class RuleProviderAliasesTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.fromRules(
+        project,
+        "api.name" to "Primary Name",
+        "method.name" to "Alias Name"
+    )
+
+    @Test
+    fun testGetRulesWithAliases() {
+        val ruleProvider = RuleProvider.getInstance(project)
+        val keyWithAlias = RuleKey.string("api.name", aliases = listOf("method.name"))
+        val rules = ruleProvider.getRules(keyWithAlias)
+
+        assertEquals("Should return rules from primary key and alias", 2, rules.size)
+        assertTrue("Should contain primary rule", rules.any { it.expression == "Primary Name" })
+        assertTrue("Should contain alias rule", rules.any { it.expression == "Alias Name" })
+    }
+}
+
+class RuleProviderCacheTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.fromRules(
+        project,
+        "api.name" to "Test API"
+    )
+
+    @Test
+    fun testCacheIsUsedForRepeatedCalls() {
+        val ruleProvider = RuleProvider.getInstance(project)
+
+        val rules1 = ruleProvider.getRules(RuleKey.string("api.name"))
+        val rules2 = ruleProvider.getRules(RuleKey.string("api.name"))
+
+        assertEquals("Should return same rules on repeated calls", rules1, rules2)
+    }
+}
+
+class RuleProviderMultipleKeysTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.fromRules(
+        project,
+        "api.name" to "Test API",
+        "api.tag" to "tag1"
+    )
+
+    @Test
+    fun testDifferentKeysCachedSeparately() {
+        val ruleProvider = RuleProvider.getInstance(project)
+
+        val nameRules = ruleProvider.getRules(RuleKey.string("api.name"))
+        val tagRules = ruleProvider.getRules(RuleKey.string("api.tag"))
+
+        assertEquals("Should have one name rule", 1, nameRules.size)
+        assertEquals("Test API", nameRules[0].expression)
+
+        assertEquals("Should have one tag rule", 1, tagRules.size)
+        assertEquals("tag1", tagRules[0].expression)
+    }
+}
+
+class RuleProviderConfigReloadTest : EasyApiLightCodeInsightFixtureTestCase() {
+    private lateinit var configReader: TestConfigReader
+
+    override fun createConfigReader(): ConfigReader {
+        configReader = TestConfigReader.fromRules(project, "api.name" to "Initial API")
+        return configReader
+    }
+
+    @Test
+    fun testCacheClearedOnConfigReload() {
+        val ruleProvider = RuleProvider.getInstance(project)
+
+        val rules1 = ruleProvider.getRules(RuleKey.string("api.name"))
+        assertEquals("Initial API", rules1[0].expression)
+
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(project, "api.name" to "Updated API")
+        )
+
+        project.messageBus.syncPublisher(ConfigReloadListener.TOPIC).onConfigReloaded()
+
+        val rules2 = ruleProvider.getRules(RuleKey.string("api.name"))
+        assertEquals("Updated API", rules2[0].expression)
+    }
+}
+
+class RuleProviderRuleOrderTest : EasyApiLightCodeInsightFixtureTestCase() {
+    override fun createConfigReader(): ConfigReader = TestConfigReader.fromRules(
+        project,
+        "json.rule.convert[#regex:org.springframework.http.ResponseEntity<(.*?)>]" to "\${1}",
+        "json.rule.convert[org.springframework.http.ResponseEntity]" to "java.lang.Object",
+        "json.rule.convert[#regex:org.springframework.web.context.request.async.DeferredResult<(.*?)>]" to "\${1}",
+        "json.rule.convert[org.springframework.web.context.request.async.DeferredResult]" to "java.lang.Object"
+    )
+
+    @Test
+    fun testRuleOrderIsPreserved() {
+        val ruleProvider = RuleProvider.getInstance(project)
+        val rules = ruleProvider.getRules(RuleKey.string("json.rule.convert"))
+
+        assertEquals("Should return all 4 rules", 4, rules.size)
+
+        assertEquals(
+            "First rule should be regex for ResponseEntity",
+            "#regex:org.springframework.http.ResponseEntity<(.*?)>", rules[0].filter
+        )
+        assertEquals("\${1}", rules[0].expression)
+
+        assertEquals(
+            "Second rule should be raw ResponseEntity",
+            "org.springframework.http.ResponseEntity", rules[1].filter
+        )
+        assertEquals("java.lang.Object", rules[1].expression)
+
+        assertEquals(
+            "Third rule should be regex for DeferredResult",
+            "#regex:org.springframework.web.context.request.async.DeferredResult<(.*?)>", rules[2].filter
+        )
+        assertEquals("\${1}", rules[2].expression)
+
+        assertEquals(
+            "Fourth rule should be raw DeferredResult",
+            "org.springframework.web.context.request.async.DeferredResult", rules[3].filter
+        )
+        assertEquals("java.lang.Object", rules[3].expression)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/rule/engine/RuleEngineTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/engine/RuleEngineTest.kt
@@ -14,13 +14,14 @@ import org.mockito.kotlin.mock
 
 class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    override fun createConfigReader(): ConfigReader = TestConfigReader.EMPTY
+    override fun createConfigReader(): ConfigReader = TestConfigReader.empty(project)
 
     @Test
     fun testEvaluateStringWithSingleMode() = runTest {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "api.name" to "Test API",
                 "api.tag" to "tag1"
             )
@@ -38,6 +39,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "api.tag" to "tag1",
                 "api.tag" to "tag2",
                 "api.tag" to "tag3"
@@ -56,6 +58,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "api.tag" to "tag1",
                 "api.tag" to "tag2",
                 "api.tag" to "tag1"
@@ -73,7 +76,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testEvaluateStringWithEmptyConfig() = runTest {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader.EMPTY
+            instance = TestConfigReader.empty(project)
         )
 
         val ruleEngine = RuleEngine.getInstance(project)
@@ -88,6 +91,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "ignore" to "true"
             )
         )
@@ -104,6 +108,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "ignore" to "false"
             )
         )
@@ -120,6 +125,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "ignore" to "false",
                 "ignore" to "false",
                 "ignore" to "true"
@@ -138,6 +144,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "ignore" to "1"
             )
         )
@@ -154,6 +161,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "ignore" to "yes"
             )
         )
@@ -169,7 +177,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testEvaluateBooleanWithEmptyConfig() = runTest {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader.EMPTY
+            instance = TestConfigReader.empty(project)
         )
 
         val ruleEngine = RuleEngine.getInstance(project)
@@ -184,6 +192,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "field.max.depth" to "5"
             )
         )
@@ -200,6 +209,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "field.max.depth" to "10",
                 "field.max.depth" to "20"
             )
@@ -216,7 +226,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testEvaluateIntWithEmptyConfig() = runTest {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader.EMPTY
+            instance = TestConfigReader.empty(project)
         )
 
         val ruleEngine = RuleEngine.getInstance(project)
@@ -231,6 +241,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "http.call.before" to "groovy:logger.info('event executed')"
             )
         )
@@ -246,6 +257,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "http.call.after" to "groovy:logger.info('event executed')"
             )
         )
@@ -260,6 +272,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "http.call.before" to "groovy:logger.info('event executed')"
             )
         )
@@ -278,6 +291,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "http.call.before" to "groovy:throw new RuntimeException('test error')"
             )
         )
@@ -296,12 +310,13 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     @Test
     fun testFilterExpressionPasses() = runTest {
-        val config = mutableMapOf<String, List<String>>()
-        config["api.name"] = listOf("Test API")
-        config["api.name[true]"] = listOf("Filtered API")
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader(config)
+            instance = TestConfigReader.fromRules(
+                project,
+                "api.name" to "Test API",
+                "api.name[true]" to "Filtered API"
+            )
         )
 
         val ruleEngine = RuleEngine.getInstance(project)
@@ -314,12 +329,13 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     @Test
     fun testFilterExpressionFails() = runTest {
-        val config = mutableMapOf<String, List<String>>()
-        config["api.name"] = listOf("Test API")
-        config["api.name[false]"] = listOf("Filtered API")
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader(config)
+            instance = TestConfigReader.fromRules(
+                project,
+                "api.name" to "Test API",
+                "api.name[false]" to "Filtered API"
+            )
         )
 
         val ruleEngine = RuleEngine.getInstance(project)
@@ -334,6 +350,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "api.name" to "groovy:throw new RuntimeException('Parser error')"
             )
         )
@@ -350,6 +367,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "ignore" to "groovy:throw new RuntimeException('Parser error')"
             )
         )
@@ -363,14 +381,15 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     @Test
     fun testMultipleIndexedKeys() = runTest {
-        val config = mutableMapOf<String, List<String>>()
-        config["api.name"] = listOf("Base API")
-        config["api.name[true]"] = listOf("First Filtered")
-        config["api.name[false]"] = listOf("Second Filtered")
-        config["api.name[true]"] = config["api.name[true]"]!! + "Third Filtered"
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
-            instance = TestConfigReader(config)
+            instance = TestConfigReader.fromRules(
+                project,
+                "api.name" to "Base API",
+                "api.name[true]" to "First Filtered",
+                "api.name[false]" to "Second Filtered",
+                "api.name[true]" to "Third Filtered"
+            )
         )
 
         val ruleEngine = RuleEngine.getInstance(project)
@@ -388,6 +407,7 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
             instance = TestConfigReader.fromRules(
+                project,
                 "test.bool.true" to "true",
                 "test.bool.True" to "True",
                 "test.bool.TRUE" to "TRUE",

--- a/src/test/kotlin/com/itangcent/easyapi/rule/parser/ScriptConfigWrapperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/parser/ScriptConfigWrapperTest.kt
@@ -1,23 +1,32 @@
 package com.itangcent.easyapi.rule.parser
 
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBus
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.*
 
 class ScriptConfigWrapperTest {
 
     private lateinit var wrapper: ScriptConfigWrapper
+    private lateinit var mockProject: Project
+    private lateinit var mockMessageBus: MessageBus
 
     @Before
     fun setUp() {
-        val configReader = TestConfigReader.fromMap(
-            mapOf(
-                "api.name" to listOf("getUser", "listUsers"),
-                "api.tag" to listOf("user"),
-                "base.url" to listOf("http://localhost:8080"),
-                "app.name" to listOf("MyApp")
-            )
+        mockProject = mock(Project::class.java)
+        mockMessageBus = mock(MessageBus::class.java)
+        `when`(mockProject.messageBus).thenReturn(mockMessageBus)
+
+        val configReader = TestConfigReader.fromRules(
+            mockProject,
+            "api.name" to "getUser",
+            "api.name" to "listUsers",
+            "api.tag" to "user",
+            "base.url" to "http://localhost:8080",
+            "app.name" to "MyApp"
         )
         wrapper = ScriptConfigWrapper(configReader)
     }

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
@@ -9,9 +9,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import com.intellij.testFramework.registerServiceInstance
 import com.itangcent.easyapi.config.ConfigReader
-import com.itangcent.easyapi.config.LayeredConfigReader
-import com.itangcent.easyapi.config.parser.ConfigTextParser
-import com.itangcent.easyapi.config.source.ExtensionConfigSource
+import com.itangcent.easyapi.config.DefaultConfigReader
 import com.itangcent.easyapi.core.event.ActionCompletedTopic
 import com.itangcent.easyapi.core.event.ActionCompletedTopic.Companion.syncPublish
 import com.itangcent.easyapi.core.threading.readSync
@@ -115,30 +113,20 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
      */
     protected open fun createConfigReader(): ConfigReader? = null
 
-    protected fun extensionConfigReader(vararg selectedCodes: String): ConfigReader {
-        return LayeredConfigReader(
-            listOf(
-                ExtensionConfigSource(
-                    selectedCodes.map { it }.toTypedArray(),
-                    ConfigTextParser(settingBinder.read())
-                )
-            )
-        )
-    }
-
     protected val settingBinder
         get() = SettingBinder.getInstance(project)
 
     override fun setUp() {
         super.setUp()
-        val configReader = createConfigReader()
-        if (configReader != null) {
-            runBlocking { configReader.reload() }
-            project.registerServiceInstance(
-                serviceInterface = ConfigReader::class.java,
-                instance = configReader
-            )
-        }
+        val configReader = createConfigReader() ?: TestConfigReader.empty(project)
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = configReader
+        )
+        // Trigger reload to notify listeners (e.g. RuleProvider) to clear stale caches.
+        // This is necessary because RuleProvider is a project-level singleton that survives
+        // across light fixture test classes.
+        runBlocking { configReader.reload() }
     }
 
     override fun tearDown() {

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/TestConfigReader.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/TestConfigReader.kt
@@ -1,41 +1,44 @@
 package com.itangcent.easyapi.testFramework
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.ConfigReloadListener
 import com.itangcent.easyapi.extension.ExtensionConfigParser
 
 class TestConfigReader(
-    private val config: Map<String, List<String>> = emptyMap()
+    private var entries: List<Pair<String, String>> = emptyList(),
+    private val project: Project
 ) : ConfigReader {
 
-    override fun getFirst(key: String): String? = config[key]?.firstOrNull()
+    private fun valuesByKey(): Map<String, List<String>> {
+        return entries.groupBy({ it.first }, { it.second })
+    }
 
-    override fun getAll(key: String): List<String> = config[key].orEmpty()
+    override fun getFirst(key: String): String? = valuesByKey()[key]?.firstOrNull()
 
-    override suspend fun reload() {}
+    override fun getAll(key: String): List<String> = valuesByKey()[key].orEmpty()
+
+    override suspend fun reload() {
+        project.messageBus.syncPublisher(ConfigReloadListener.TOPIC).onConfigReloaded()
+    }
 
     override fun foreach(keyFilter: (String) -> Boolean, action: (String, String) -> Unit) {
-        config.forEach { (key, values) ->
+        entries.forEach { (key, value) ->
             if (keyFilter(key)) {
-                values.forEach { value ->
-                    action(key, value)
-                }
+                action(key, value)
             }
         }
     }
 
     companion object {
-        val EMPTY = TestConfigReader()
+        fun empty(project: Project) = TestConfigReader(emptyList(), project)
 
-        fun fromRules(vararg rules: Pair<String, String>): TestConfigReader {
-            val config = mutableMapOf<String, List<String>>()
-            rules.forEach { (key, value) ->
-                config[key] = config.getOrDefault(key, emptyList()) + value
-            }
-            return TestConfigReader(config)
+        fun fromRules(project: Project, vararg rules: Pair<String, String>): TestConfigReader {
+            return TestConfigReader(rules.toList(), project)
         }
 
-        fun fromConfigText(configText: String): TestConfigReader {
-            val config = mutableMapOf<String, List<String>>()
+        fun fromConfigText(project: Project, configText: String): TestConfigReader {
+            val entries = mutableListOf<Pair<String, String>>()
             val strippedContent = ExtensionConfigParser.stripYamlFrontMatter(configText)
             val lines = strippedContent.lines()
             var i = 0
@@ -63,21 +66,20 @@ class TestConfigReader(
                     }
                     value = prefix + sb.toString()
                 }
-                config[key] = config.getOrDefault(key, emptyList()) + value
+                entries.add(key to value)
             }
-            return TestConfigReader(config)
+            return TestConfigReader(entries, project)
         }
 
-        fun fromMap(map: Map<String, Any?>): TestConfigReader {
-            val config = mutableMapOf<String, List<String>>()
+        fun fromMap(project: Project, map: Map<String, Any?>): TestConfigReader {
+            val entries = mutableListOf<Pair<String, String>>()
             map.forEach { (key, value) ->
                 when (value) {
-                    is List<*> -> config[key] = value.map { it.toString() }
-                    is String -> config[key] = listOf(value)
-                    else -> config[key] = listOf(value.toString())
+                    is List<*> -> value.forEach { entries.add(key to it.toString()) }
+                    else -> entries.add(key to value.toString())
                 }
             }
-            return TestConfigReader(config)
+            return TestConfigReader(entries, project)
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds rule-based configuration support with cache invalidation mechanism.

## Changes

- **ConfigRule**: New data class for representing configuration rules with optional filters
- **RuleProvider**: Project-level service that provides cached configuration rules for RuleEngine
- **ConfigReloadListener**: Listener interface for configuration reload event notifications
- **RuleEngine**: Refactored to use the new rule system with simplified API
- **ConfigReader**: Updated interface with reload() method
- **LayeredConfigReader**: Updated to support configuration reload
- **Tests**: Added comprehensive tests for new rule components and updated all test cases to use TestConfigReader for better test isolation

## Architecture

```
ConfigReader → RuleProvider (cached) → RuleEngine
                    ↑
              ConfigReloadListener (clears cache)
```

## Related Issues

Fixes #666
Fixes tangcent/easy-yapi#1315