### PR TITLE
perf: optimize rule engine with Flow-based lazy evaluation

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleKey.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleKey.kt
@@ -16,7 +16,7 @@ package com.itangcent.easyapi.rule
  */
 sealed class RuleKey<T>(
     val name: String,
-    val mode: RuleMode,
+    val mode: RuleMode<T>,
     val aliases: List<String> = emptyList()
 ) {
     /** All config key names (primary + aliases) that should be looked up. */
@@ -26,7 +26,7 @@ sealed class RuleKey<T>(
         name: String,
         mode: StringRuleMode = StringRuleMode.SINGLE,
         aliases: List<String> = emptyList()
-    ) : RuleKey<String?>(name, mode, aliases) {
+    ) : RuleKey<String>(name, mode, aliases) {
         val stringMode: StringRuleMode get() = mode as StringRuleMode
     }
 
@@ -41,7 +41,7 @@ sealed class RuleKey<T>(
     class IntKey(
         name: String,
         aliases: List<String> = emptyList()
-    ) : RuleKey<Int?>(name, IntRuleMode, aliases)
+    ) : RuleKey<Int>(name, IntRuleMode, aliases)
 
     class EventKey(
         name: String,
@@ -56,9 +56,12 @@ sealed class RuleKey<T>(
     companion object {
         fun string(name: String, mode: StringRuleMode = StringRuleMode.SINGLE, aliases: List<String> = emptyList()) =
             StringKey(name, mode, aliases)
+
         fun boolean(name: String, mode: BooleanRuleMode = BooleanRuleMode.ANY, aliases: List<String> = emptyList()) =
             BooleanKey(name, mode, aliases)
+
         fun int(name: String, aliases: List<String> = emptyList()) = IntKey(name, aliases)
+
         fun event(name: String, mode: EventRuleMode = EventRuleMode.IGNORE_ERROR, aliases: List<String> = emptyList()) =
             EventKey(name, mode, aliases)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleModes.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleModes.kt
@@ -1,33 +1,42 @@
 package com.itangcent.easyapi.rule
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.takeWhile
+
 /**
- * Base interface for rule evaluation modes.
+ * Defines how multiple rule values are aggregated into a single result.
  *
- * Determines how multiple rule values are aggregated when
- * the same rule is defined in multiple configuration files.
+ * @param T the type of values being aggregated
  */
-sealed interface RuleMode
+sealed interface RuleMode<T> {
+    /**
+     * Aggregates multiple rule results into a single value.
+     *
+     * @param values The flow of results to aggregate
+     * @return The aggregated result
+     */
+    suspend fun aggregate(values: Flow<RuleResult<T>>): T?
+}
 
 /**
  * Modes for rules that produce string values.
  *
  * Defines how multiple string values are combined.
  */
-sealed class StringRuleMode : RuleMode {
-    /**
-     * Aggregates multiple string values into a single result.
-     *
-     * @param values The list of values to aggregate
-     * @return The aggregated result
-     */
-    abstract fun aggregate(values: List<String?>): String?
+sealed class StringRuleMode : RuleMode<String> {
+    abstract override suspend fun aggregate(values: Flow<RuleResult<String>>): String?
 
     /**
      * Returns the first non-empty value.
      * Use for rules where only one value should be used.
      */
     data object SINGLE : StringRuleMode() {
-        override fun aggregate(values: List<String?>): String? = values.firstOrNull { !it.isNullOrEmpty() }
+        override suspend fun aggregate(values: Flow<RuleResult<String>>): String? =
+            values.mapNotNull { it.result }.firstOrNull { it.isNotEmpty() }
     }
 
     /**
@@ -35,7 +44,8 @@ sealed class StringRuleMode : RuleMode {
      * Use for rules where all values should be combined.
      */
     data object MERGE : StringRuleMode() {
-        override fun aggregate(values: List<String?>): String? = values.filterNotNull().filter { it.isNotEmpty() }.joinToString("\n").ifEmpty { null }
+        override suspend fun aggregate(values: Flow<RuleResult<String>>): String? =
+            values.mapNotNull { it.result }.filter { it.isNotEmpty() }.toList().joinToString("\n").ifEmpty { null }
     }
 
     /**
@@ -43,7 +53,9 @@ sealed class StringRuleMode : RuleMode {
      * Use for rules where duplicate values should be removed.
      */
     data object MERGE_DISTINCT : StringRuleMode() {
-        override fun aggregate(values: List<String?>): String? = values.filterNotNull().filter { it.isNotEmpty() }.distinct().joinToString("\n").ifEmpty { null }
+        override suspend fun aggregate(values: Flow<RuleResult<String>>): String? =
+            values.mapNotNull { it.result }.filter { it.isNotEmpty() }.toList().distinct().joinToString("\n")
+                .ifEmpty { null }
     }
 }
 
@@ -52,21 +64,16 @@ sealed class StringRuleMode : RuleMode {
  *
  * Defines how multiple boolean values are combined.
  */
-sealed class BooleanRuleMode : RuleMode {
-    /**
-     * Aggregates multiple boolean values into a single result.
-     *
-     * @param values The list of values to aggregate
-     * @return The aggregated result
-     */
-    abstract fun aggregate(values: List<Boolean?>): Boolean
+sealed class BooleanRuleMode : RuleMode<Boolean> {
+    abstract override suspend fun aggregate(values: Flow<RuleResult<Boolean>>): Boolean
 
     /**
      * Returns true if any value is true.
      * Use for rules like "ignore" or "required".
      */
     data object ANY : BooleanRuleMode() {
-        override fun aggregate(values: List<Boolean?>): Boolean = values.any { it == true }
+        override suspend fun aggregate(values: Flow<RuleResult<Boolean>>): Boolean =
+            values.mapNotNull { it.result }.firstOrNull { it } != null
     }
 
     /**
@@ -74,8 +81,8 @@ sealed class BooleanRuleMode : RuleMode {
      * Use for rules that require all conditions to be met.
      */
     data object ALL : BooleanRuleMode() {
-        override fun aggregate(values: List<Boolean?>): Boolean {
-            val nonNull = values.filterNotNull()
+        override suspend fun aggregate(values: Flow<RuleResult<Boolean>>): Boolean {
+            val nonNull = values.mapNotNull { it.result }.toList()
             return nonNull.isNotEmpty() && nonNull.all { it }
         }
     }
@@ -86,7 +93,10 @@ sealed class BooleanRuleMode : RuleMode {
  *
  * Event rules are executed for their side effects and don't produce values.
  */
-sealed class EventRuleMode : RuleMode {
+sealed class EventRuleMode : RuleMode<Unit> {
+
+    abstract override suspend fun aggregate(values: Flow<RuleResult<Unit>>): Unit?
+
     /**
      * Whether to throw an exception when an event handler fails.
      */
@@ -96,6 +106,11 @@ sealed class EventRuleMode : RuleMode {
      * Ignores errors and continues execution.
      */
     data object IGNORE_ERROR : EventRuleMode() {
+        override suspend fun aggregate(values: Flow<RuleResult<Unit>>): Unit? {
+            values.collect {}
+            return null
+        }
+
         override val throwOnError: Boolean = false
     }
 
@@ -103,6 +118,17 @@ sealed class EventRuleMode : RuleMode {
      * Throws an exception on error.
      */
     data object THROW_IN_ERROR : EventRuleMode() {
+        override suspend fun aggregate(values: Flow<RuleResult<Unit>>): Unit? {
+            var error: Throwable? = null
+            values.collect { result ->
+                if (result.error != null && error == null) {
+                    error = result.error
+                }
+            }
+            error?.let { throw it }
+            return null
+        }
+
         override val throwOnError: Boolean = true
     }
 }
@@ -112,12 +138,71 @@ sealed class EventRuleMode : RuleMode {
  *
  * Returns the first non-null value.
  */
-data object IntRuleMode : RuleMode {
+data object IntRuleMode : RuleMode<Int> {
     /**
      * Returns the first non-null integer value.
      *
-     * @param values The list of values to aggregate
+     * @param values The flow of results to aggregate
      * @return The first non-null value, or null
      */
-    fun aggregate(values: List<Int?>): Int? = values.firstOrNull { it != null }
+    override suspend fun aggregate(values: Flow<RuleResult<Int>>): Int? =
+        values.mapNotNull { it.result }.firstOrNull()
+}
+
+/**
+ * Result of a rule evaluation.
+ *
+ * @param T the type of the result value
+ */
+interface RuleResult<T> {
+    /**
+     * The result value, or null if the rule didn't produce a value or failed.
+     */
+    val result: T?
+
+    /**
+     * The error that occurred during evaluation, or null if successful.
+     */
+    val error: Throwable?
+
+    companion object {
+        /**
+         * Creates a successful result with the given value.
+         */
+        fun <T> success(result: T?): RuleResult<T> =
+            if (result == null) NULL() else Success(result)
+
+        /**
+         * Creates a failure result with the given error.
+         */
+        fun <T> failure(error: Throwable): RuleResult<T> = Failure(error)
+
+        /**
+         * Creates a null result.
+         */
+        fun <T> NULL() = NullInstance as RuleResult<T>
+    }
+}
+
+/**
+ * A successful rule result.
+ */
+data class Success<T>(override val result: T) : RuleResult<T> {
+    override val error: Throwable?
+        get() = null
+}
+
+/**
+ * A failed rule result.
+ */
+data class Failure<T>(override val error: Throwable) : RuleResult<T> {
+    override val result: T? = null
+}
+
+/**
+ * A null rule result.
+ */
+object NullInstance : RuleResult<Any> {
+    override val result = null
+    override val error: Throwable? = null
 }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/engine/RuleEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/engine/RuleEngine.kt
@@ -4,25 +4,17 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.itangcent.easyapi.rule.IntRuleMode
 import com.itangcent.easyapi.rule.RuleKey
 import com.itangcent.easyapi.rule.RuleProvider
+import com.itangcent.easyapi.rule.RuleResult
 import com.itangcent.easyapi.rule.context.RuleContext
 import com.itangcent.easyapi.rule.parser.*
+import com.itangcent.easyapi.util.asBoolean
+import com.itangcent.easyapi.util.asBooleanOrNull
+import com.itangcent.easyapi.util.asInt
+import kotlinx.coroutines.flow.flow
+import kotlin.coroutines.cancellation.CancellationException
 
-/**
- * Engine for evaluating configuration rules.
- *
- * ## Usage
- * ```kotlin
- * val engine = RuleEngine.getInstance(project)
- *
- * // Typed evaluation via RuleKey
- * val name: String? = engine.evaluate(RuleKeys.API_NAME, psiMethod)
- * val ignore: Boolean = engine.evaluate(RuleKeys.FIELD_IGNORE, psiField)
- * engine.evaluate(RuleKeys.JSON_CLASS_PARSE_BEFORE, psiClass)
- * ```
- */
 @Service(Service.Level.PROJECT)
 class RuleEngine internal constructor(
     private val project: Project
@@ -47,181 +39,109 @@ class RuleEngine internal constructor(
         )
     }
 
-    /**
-     * Parse a single expression using the parser chain.
-     * Exposed for parsers like [NegationParser] that need to delegate back to the engine.
-     */
     suspend fun parseExpression(expression: String, context: RuleContext, ruleKey: RuleKey<*>? = null): Any? {
         return parse(expression, context, ruleKey)
     }
 
-    // ════════════════════════════════════════════════════════════════
-    //  Typed evaluate — the single entry point
-    // ════════════════════════════════════════════════════════════════
-
-    /** Evaluate a string rule. Returns null when no rule matches or all values are empty. */
     suspend fun evaluate(key: RuleKey.StringKey, element: PsiElement, fieldContext: String? = null): String? {
-        val ctx = RuleContext.from(project, element, fieldContext)
-        val values = ArrayList<String?>()
-        forEachApplicable(key, ctx) { exp ->
-            val v = runCatching { parse(exp, ctx, key) }
-                .onFailure { e -> ctx.console.warn("Rule evaluation failed for key=${key.name}", e) }
-                .getOrNull()
-                ?.toString()
-            values.add(v)
-        }
-        return key.stringMode.aggregate(values)
+        return forEachApplicable(key) { RuleContext.from(project, element, fieldContext) }
     }
 
     suspend fun evaluate(key: RuleKey.StringKey, element: PsiElement, contextHandle: (RuleContext) -> Unit): String? {
-        val ctx = RuleContext.from(project, element)
-        contextHandle(ctx)
-        val values = ArrayList<String?>()
-        forEachApplicable(key, ctx) { exp ->
-            val v = runCatching { parse(exp, ctx, key) }
-                .onFailure { e -> ctx.console.warn("Rule evaluation failed for key=${key.name}", e) }
-                .getOrNull()
-                ?.toString()
-            values.add(v)
+        return forEachApplicable(key) {
+            RuleContext.from(project, element).also(contextHandle)
         }
-        return key.stringMode.aggregate(values)
     }
 
-    /** Evaluate a string rule without a PSI element (global/builtin rules). */
     suspend fun evaluate(key: RuleKey.StringKey): String? {
-        val ctx = RuleContext.withoutElement(project)
-        val values = ArrayList<String?>()
-        forEachApplicable(key, ctx) { exp ->
-            val v = runCatching { parse(exp, ctx, key) }
-                .onFailure { e -> ctx.console.warn("Rule evaluation failed for key=${key.name}", e) }
-                .getOrNull()
-                ?.toString()
-            values.add(v)
-        }
-        return key.stringMode.aggregate(values)
+        return forEachApplicable(key) { RuleContext.withoutElement(project) }
     }
 
-    /**
-     * Evaluate a string rule for a PsiType with an optional context element.
-     * Used for json.rule.convert rules where the type's canonical text is matched
-     * by regex filters, and scripts can access the type via `it.type()`.
-     */
     suspend fun evaluate(
         key: RuleKey.StringKey,
         psiType: com.intellij.psi.PsiType,
         contextElement: PsiElement? = null
     ): String? {
-        val ctx = RuleContext.withPsiType(project, psiType, contextElement)
-        val values = ArrayList<String?>()
-        forEachApplicable(key, ctx) { exp ->
-            val v = runCatching { parse(exp, ctx, key) }
-                .onFailure { e -> ctx.console.warn("Rule evaluation failed for key=${key.name}", e) }
-                .getOrNull()
-                ?.toString()
-            values.add(v)
-        }
-        return key.stringMode.aggregate(values)
+        return forEachApplicable(key) { RuleContext.withPsiType(project, psiType, contextElement) }
     }
 
-    /** Evaluate a boolean rule. Returns false when no rule matches. */
     suspend fun evaluate(key: RuleKey.BooleanKey, element: PsiElement, fieldContext: String? = null): Boolean {
-        val ctx = RuleContext.from(project, element, fieldContext)
-        val values = ArrayList<Boolean?>()
-        forEachApplicable(key, ctx) { exp ->
-            val v = runCatching { parse(exp, ctx, key) }
-                .onFailure { e -> ctx.console.warn("Rule evaluation failed for key=${key.name}", e) }
-                .getOrNull()
-                ?.let { toBoolean(it) }
-            values.add(v)
-        }
-        return key.booleanMode.aggregate(values)
+        return forEachApplicable(key) { RuleContext.from(project, element, fieldContext) } ?: false
     }
 
-    /** Evaluate a boolean rule with context customization. */
     suspend fun evaluate(key: RuleKey.BooleanKey, element: PsiElement, contextHandle: (RuleContext) -> Unit): Boolean {
-        val ctx = RuleContext.from(project, element)
-        contextHandle(ctx)
-        val values = ArrayList<Boolean?>()
-        forEachApplicable(key, ctx) { exp ->
-            val v = runCatching { parse(exp, ctx, key) }
-                .onFailure { e -> ctx.console.warn("Rule evaluation failed for key=${key.name}", e) }
-                .getOrNull()
-                ?.let { toBoolean(it) }
-            values.add(v)
-        }
-        return key.booleanMode.aggregate(values)
+        return forEachApplicable(key) {
+            RuleContext.from(project, element).also(contextHandle)
+        } ?: false
     }
 
-    /** Evaluate an int rule. Returns null when no rule matches. */
     suspend fun evaluate(key: RuleKey.IntKey, element: PsiElement): Int? {
-        val ctx = RuleContext.from(project, element)
-        val values = ArrayList<Int?>()
-        forEachApplicable(key, ctx) { exp ->
-            val v = runCatching { parse(exp, ctx, key) }
-                .onFailure { e -> ctx.console.warn("Rule evaluation failed for key=${key.name}", e) }
-                .getOrNull()
-                ?.let { toInt(it) }
-            values.add(v)
-        }
-        return IntRuleMode.aggregate(values)
+        return forEachApplicable(key) { RuleContext.from(project, element) }
     }
 
-    /** Fire an event rule (side-effect only). */
     suspend fun evaluate(key: RuleKey.EventKey, element: PsiElement, fieldContext: String? = null) {
-        val ctx = RuleContext.from(project, element, fieldContext)
-        fireEvent(key, ctx)
+        forEachApplicable(key) { RuleContext.from(project, element, fieldContext) }
     }
 
-    /** Fire an event rule with context customization. */
     suspend fun evaluate(key: RuleKey.EventKey, element: PsiElement, contextHandle: (RuleContext) -> Unit) {
-        val ctx = RuleContext.from(project, element)
-        contextHandle(ctx)
-        fireEvent(key, ctx)
+        forEachApplicable(key) {
+            RuleContext.from(project, element).also(contextHandle)
+        }
     }
 
-    /** Fire an event rule without a PSI element (global events). */
     suspend fun evaluate(key: RuleKey.EventKey, contextHandle: (RuleContext) -> Unit = {}) {
-        val ctx = RuleContext.withoutElement(project)
-        contextHandle(ctx)
-        fireEvent(key, ctx)
-    }
-
-    // ════════════════════════════════════════════════════════════════
-    //  Internal
-    // ════════════════════════════════════════════════════════════════
-
-    private suspend fun fireEvent(key: RuleKey.EventKey, ctx: RuleContext) {
-        forEachApplicable(key, ctx) { exp ->
-            try {
-                parse(exp, ctx, key)
-            } catch (e: Exception) {
-                ctx.console.warn("Rule event failed for key=${key.name}", e)
-                if (key.eventMode.throwOnError) throw e
-            }
+        forEachApplicable(key) {
+            RuleContext.withoutElement(project).also(contextHandle)
         }
     }
 
-    private suspend fun forEachApplicable(
-        key: RuleKey<*>,
-        ctx: RuleContext,
-        action: suspend (String) -> Unit
-    ) {
-        for ((expression, filter) in ruleProvider.getRules(key)) {
-            ctx.regexGroups = null
-            val shouldApply = if (filter != null) {
-                runCatching { parse(filter, ctx, FILTER_KEY) }
-                    .onFailure { e -> ctx.console.warn("Filter evaluation failed for key=${key.name}", e) }
-                    .getOrNull()
-                    ?.let { toBoolean(it) }
-                    ?: false
-            } else {
-                true
-            }
-            if (shouldApply) {
-                action(expression)
-            }
-            ctx.regexGroups = null
+    private suspend fun <T> forEachApplicable(
+        key: RuleKey<T>,
+        ctx: () -> RuleContext
+    ): T? {
+        val rules = ruleProvider.getRules(key)
+        if (rules.isEmpty()) {
+            return null
         }
+        val ruleContext = ctx()
+        val results = flow {
+            for ((expression, filter) in rules) {
+                ruleContext.regexGroups = null
+                val shouldApply = if (filter != null) {
+                    runCatching {
+                        parse(filter, ruleContext, FILTER_KEY)
+                    }.onFailure { e -> ruleContext.console.warn("Filter evaluation failed for key=${key.name}", e) }
+                        .getOrNull()
+                        ?.asBooleanOrNull()
+                        ?: false
+                } else {
+                    true
+                }
+                if (shouldApply) {
+                    try {
+                        val result = parse(expression, ruleContext, key)
+                        @Suppress("UNCHECKED_CAST")
+                        emit(RuleResult.success(key.castValue(result)))
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        emit(RuleResult.failure(e))
+                    }
+                }
+                ruleContext.regexGroups = null
+            }
+        }
+        return key.mode.aggregate(results)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> RuleKey<T>.castValue(value: Any?): T? {
+        return when (this) {
+            is RuleKey.StringKey -> value?.toString()
+            is RuleKey.BooleanKey -> value.asBooleanOrNull()
+            is RuleKey.IntKey -> value.asInt()
+            is RuleKey.EventKey -> null
+        } as T?
     }
 
     private suspend fun parse(expression: String, ctx: RuleContext, ruleKey: RuleKey<*>? = null): Any? {
@@ -229,23 +149,9 @@ class RuleEngine internal constructor(
         return parser?.parse(expression, ctx, ruleKey)
     }
 
-    private fun toBoolean(value: Any): Boolean = when (value) {
-        is Boolean -> value
-        is Number -> value.toInt() != 0
-        else -> {
-            val s = value.toString().trim()
-            s.equals("true", true) || s == "1" || s.equals("yes", true) || s.equals("y", true)
-        }
-    }
-
-    private fun toInt(value: Any): Int? = when (value) {
-        is Int -> value
-        is Number -> value.toInt()
-        else -> value.toString().trim().toIntOrNull()
-    }
+    private fun toBoolean(value: Any): Boolean = value.asBooleanOrNull() ?: false
 
     companion object {
-        /** Synthetic key used for filter expression evaluation. */
         private val FILTER_KEY = RuleKey.boolean("__filter__")
 
         fun getInstance(project: Project): RuleEngine = project.service()

--- a/src/main/kotlin/com/itangcent/easyapi/util/AnyKit.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/AnyKit.kt
@@ -1,0 +1,110 @@
+package com.itangcent.easyapi.util
+
+/**
+ * String values that represent boolean `true`.
+ * Used for lenient boolean parsing from strings.
+ */
+val TRUE_VALUES = arrayOf("true", "1", "yes", "y", "on")
+
+/**
+ * String values that represent boolean `false`.
+ * Used for lenient boolean parsing from strings.
+ */
+val FALSE_VALUES = arrayOf("false", "0", "no", "n", "off")
+
+/**
+ * Converts this string to an [Int], or returns `null` if the string is not a valid integer.
+ *
+ * Handles whitespace by trimming before parsing.
+ *
+ * @return The integer value, or `null` if parsing fails or this string is `null`.
+ */
+fun String?.asInt(): Int? {
+    return this?.trim()?.toIntOrNull()
+}
+
+/**
+ * Converts this string to a [Boolean], or returns `null` if the string is not a recognized boolean value.
+ *
+ * Recognized true values: "true", "1", "yes", "y", "on" (case-insensitive)
+ * Recognized false values: "false", "0", "no", "n", "off" (case-insensitive)
+ *
+ * Handles whitespace by trimming before parsing.
+ *
+ * @return The boolean value, or `null` if this string is `null` or not a recognized boolean value.
+ */
+fun String?.asBooleanOrNull(): Boolean? {
+    if (this == null) return null
+    val s = this.trim().lowercase()
+    return when (s) {
+        in TRUE_VALUES -> true
+        in FALSE_VALUES -> false
+        else -> null
+    }
+}
+
+/**
+ * Converts this string to a [Boolean], returning [defaultValue] if the string is not a recognized boolean value.
+ *
+ * @param defaultValue The value to return if parsing fails. Defaults to `false`.
+ * @return The boolean value, or [defaultValue] if parsing fails.
+ */
+fun String?.asBoolean(defaultValue: Boolean = false): Boolean {
+    return this.asBooleanOrNull() ?: defaultValue
+}
+
+/**
+ * Converts this value to an [Int], or returns `null` if conversion is not possible.
+ *
+ * Handles the following types:
+ * - `null` -> `null`
+ * - `Int` -> itself
+ * - `Number` -> `toInt()`
+ * - `String` -> parses as integer
+ * - `Boolean` -> `1` for `true`, `0` for `false`
+ * - Other types -> attempts to parse `toString()` as integer
+ *
+ * @return The integer value, or `null` if conversion fails.
+ */
+fun Any?.asInt(): Int? {
+    return when (this) {
+        null -> null
+        is Int -> this
+        is Number -> this.toInt()
+        is String -> this.asInt()
+        is Boolean -> if (this) 1 else 0
+        else -> this.toString().asInt()
+    }
+}
+
+/**
+ * Converts this value to a [Boolean], or returns `null` if conversion is not possible.
+ *
+ * Handles the following types:
+ * - `null` -> `null`
+ * - `Boolean` -> itself
+ * - `Number` -> `true` if non-zero, `false` if zero
+ * - `String` -> parses using [String.asBooleanOrNull]
+ * - Other types -> attempts to parse `toString()` as boolean
+ *
+ * @return The boolean value, or `null` if conversion fails.
+ */
+fun Any?.asBooleanOrNull(): Boolean? {
+    return when (this) {
+        null -> null
+        is Boolean -> this
+        is Number -> this.toDouble() != 0.0
+        is String -> this.asBooleanOrNull()
+        else -> this.toString().asBooleanOrNull()
+    }
+}
+
+/**
+ * Converts this value to a [Boolean], returning [defaultValue] if conversion is not possible.
+ *
+ * @param defaultValue The value to return if conversion fails. Defaults to `false`.
+ * @return The boolean value, or [defaultValue] if conversion fails.
+ */
+fun Any?.asBoolean(defaultValue: Boolean = false): Boolean {
+    return this.asBooleanOrNull() ?: defaultValue
+}

--- a/src/test/kotlin/com/itangcent/easyapi/rule/RuleModesTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/RuleModesTest.kt
@@ -1,53 +1,74 @@
 package com.itangcent.easyapi.rule
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 import org.junit.Test
 
 class RuleModesTest {
 
+    private fun <T> resultFlowOf(vararg values: T?): Flow<RuleResult<T>> = flow {
+        for (value in values) {
+            emit(if (value == null) RuleResult.NULL() else RuleResult.success(value))
+        }
+    }
+
     @Test
-    fun testStringRuleModeSingle() {
+    fun testStringRuleModeSingle() = runBlocking {
         val mode = StringRuleMode.SINGLE
 
-        assertNull(mode.aggregate(emptyList()))
-        assertNull(mode.aggregate(listOf(null, null)))
-        assertEquals("first", mode.aggregate(listOf("first", "second")))
-        assertEquals("value", mode.aggregate(listOf(null, "value")))
+        assertNull(mode.aggregate(resultFlowOf<String>()))
+        assertNull(mode.aggregate(resultFlowOf<String>(null, null)))
+        assertEquals("first", mode.aggregate(resultFlowOf("first", "second")))
+        assertEquals("value", mode.aggregate(resultFlowOf<String>(null, "value")))
     }
 
     @Test
-    fun testStringRuleModeMerge() {
+    fun testStringRuleModeMerge() = runBlocking {
         val mode = StringRuleMode.MERGE
 
-        assertNull(mode.aggregate(emptyList()))
-        assertNull(mode.aggregate(listOf(null, null)))
-        assertNull(mode.aggregate(listOf("", "")))
-        assertEquals("first\nsecond", mode.aggregate(listOf("first", "second")))
-        assertEquals("value", mode.aggregate(listOf(null, "value")))
-        assertEquals("a\nb\nc", mode.aggregate(listOf("a", "b", "c")))
+        assertNull(mode.aggregate(resultFlowOf<String>()))
+        assertNull(mode.aggregate(resultFlowOf<String>(null, null)))
+        assertNull(mode.aggregate(resultFlowOf("", "")))
+        assertEquals("first\nsecond", mode.aggregate(resultFlowOf("first", "second")))
+        assertEquals("value", mode.aggregate(resultFlowOf<String>(null, "value")))
+        assertEquals("a\nb\nc", mode.aggregate(resultFlowOf("a", "b", "c")))
     }
 
     @Test
-    fun testStringRuleModeMergeDistinct() {
+    fun testStringRuleModeMergeDistinct() = runBlocking {
         val mode = StringRuleMode.MERGE_DISTINCT
 
-        assertNull(mode.aggregate(emptyList()))
-        assertNull(mode.aggregate(listOf(null, null)))
-        assertEquals("first\nsecond", mode.aggregate(listOf("first", "second")))
-        assertEquals("value", mode.aggregate(listOf("value", "value")))
-        assertEquals("a\nb", mode.aggregate(listOf("a", "b", "a", "b")))
+        assertNull(mode.aggregate(resultFlowOf<String>()))
+        assertNull(mode.aggregate(resultFlowOf<String>(null, null)))
+        assertEquals("first\nsecond", mode.aggregate(resultFlowOf("first", "second")))
+        assertEquals("value", mode.aggregate(resultFlowOf("value", "value")))
+        assertEquals("a\nb", mode.aggregate(resultFlowOf("a", "b", "a", "b")))
     }
 
     @Test
-    fun testBooleanRuleModeAny() {
+    fun testBooleanRuleModeAny() = runBlocking {
         val mode = BooleanRuleMode.ANY
 
-        assertFalse(mode.aggregate(emptyList()))
-        assertFalse(mode.aggregate(listOf(null, null)))
-        assertFalse(mode.aggregate(listOf(false, false)))
-        assertTrue(mode.aggregate(listOf(true, false)))
-        assertTrue(mode.aggregate(listOf(false, true)))
-        assertTrue(mode.aggregate(listOf(true, true)))
+        assertFalse(mode.aggregate(resultFlowOf<Boolean>()))
+        assertFalse(mode.aggregate(resultFlowOf<Boolean>(null, null)))
+        assertFalse(mode.aggregate(resultFlowOf(false, false)))
+        assertTrue(mode.aggregate(resultFlowOf(true, false)))
+        assertTrue(mode.aggregate(resultFlowOf(false, true)))
+        assertTrue(mode.aggregate(resultFlowOf(true, true)))
+    }
+
+    @Test
+    fun testBooleanRuleModeAll() = runBlocking {
+        val mode = BooleanRuleMode.ALL
+
+        assertFalse(mode.aggregate(resultFlowOf<Boolean>()))
+        assertFalse(mode.aggregate(resultFlowOf<Boolean>(null, null)))
+        assertTrue(mode.aggregate(resultFlowOf(true, true)))
+        assertFalse(mode.aggregate(resultFlowOf(true, false)))
+        assertFalse(mode.aggregate(resultFlowOf(false, true)))
+        assertFalse(mode.aggregate(resultFlowOf(false, false)))
     }
 
     @Test
@@ -63,10 +84,10 @@ class RuleModesTest {
     }
 
     @Test
-    fun testIntRuleModeAggregate() {
-        assertNull(IntRuleMode.aggregate(emptyList()))
-        assertNull(IntRuleMode.aggregate(listOf(null, null)))
-        assertEquals(1, IntRuleMode.aggregate(listOf(1, 2, 3)))
-        assertEquals(5, IntRuleMode.aggregate(listOf(null, 5, 10)))
+    fun testIntRuleModeAggregate() = runBlocking {
+        assertNull(IntRuleMode.aggregate(resultFlowOf<Int>()))
+        assertNull(IntRuleMode.aggregate(resultFlowOf<Int>(null, null)))
+        assertEquals(1, IntRuleMode.aggregate(resultFlowOf(1, 2, 3)))
+        assertEquals(5, IntRuleMode.aggregate(resultFlowOf<Int>(null, 5, 10)))
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/util/AnyKitTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/AnyKitTest.kt
@@ -1,0 +1,217 @@
+package com.itangcent.easyapi.util
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class AnyKitTest {
+
+    @Test
+    fun testTrueValuesArray() {
+        assertTrue("true" in TRUE_VALUES)
+        assertTrue("1" in TRUE_VALUES)
+        assertTrue("yes" in TRUE_VALUES)
+        assertTrue("y" in TRUE_VALUES)
+        assertTrue("on" in TRUE_VALUES)
+        assertEquals(5, TRUE_VALUES.size)
+    }
+
+    @Test
+    fun testFalseValuesArray() {
+        assertTrue("false" in FALSE_VALUES)
+        assertTrue("0" in FALSE_VALUES)
+        assertTrue("no" in FALSE_VALUES)
+        assertTrue("n" in FALSE_VALUES)
+        assertTrue("off" in FALSE_VALUES)
+        assertEquals(5, FALSE_VALUES.size)
+    }
+
+    @Test
+    fun testStringAsInt_null() {
+        assertNull(null.asInt())
+    }
+
+    @Test
+    fun testStringAsInt_valid() {
+        assertEquals(42, "42".asInt())
+        assertEquals(-1, "-1".asInt())
+        assertEquals(0, "0".asInt())
+    }
+
+    @Test
+    fun testStringAsInt_invalid() {
+        assertNull("not a number".asInt())
+        assertNull("".asInt())
+        assertNull("  ".asInt())
+    }
+
+    @Test
+    fun testStringAsInt_withWhitespace() {
+        assertEquals(42, "  42  ".asInt())
+    }
+
+    @Test
+    fun testStringAsBooleanOrNull_null() {
+        assertNull(null.asBooleanOrNull())
+    }
+
+    @Test
+    fun testStringAsBooleanOrNull_trueValues() {
+        assertEquals(true, "true".asBooleanOrNull())
+        assertEquals(true, "TRUE".asBooleanOrNull())
+        assertEquals(true, "True".asBooleanOrNull())
+        assertEquals(true, "1".asBooleanOrNull())
+        assertEquals(true, "yes".asBooleanOrNull())
+        assertEquals(true, "YES".asBooleanOrNull())
+        assertEquals(true, "y".asBooleanOrNull())
+        assertEquals(true, "Y".asBooleanOrNull())
+        assertEquals(true, "on".asBooleanOrNull())
+        assertEquals(true, "ON".asBooleanOrNull())
+    }
+
+    @Test
+    fun testStringAsBooleanOrNull_falseValues() {
+        assertEquals(false, "false".asBooleanOrNull())
+        assertEquals(false, "FALSE".asBooleanOrNull())
+        assertEquals(false, "False".asBooleanOrNull())
+        assertEquals(false, "0".asBooleanOrNull())
+        assertEquals(false, "no".asBooleanOrNull())
+        assertEquals(false, "NO".asBooleanOrNull())
+        assertEquals(false, "n".asBooleanOrNull())
+        assertEquals(false, "N".asBooleanOrNull())
+        assertEquals(false, "off".asBooleanOrNull())
+        assertEquals(false, "OFF".asBooleanOrNull())
+    }
+
+    @Test
+    fun testStringAsBooleanOrNull_invalid() {
+        assertNull("maybe".asBooleanOrNull())
+        assertNull("".asBooleanOrNull())
+        assertNull("  ".asBooleanOrNull())
+    }
+
+    @Test
+    fun testStringAsBooleanOrNull_withWhitespace() {
+        assertEquals(true, "  true  ".asBooleanOrNull())
+        assertEquals(true, "  1  ".asBooleanOrNull())
+        assertEquals(false, "  false  ".asBooleanOrNull())
+        assertEquals(false, "  0  ".asBooleanOrNull())
+    }
+
+    @Test
+    fun testStringAsBoolean_defaultValue() {
+        assertFalse("maybe".asBoolean())
+        assertFalse("".asBoolean())
+        assertTrue("maybe".asBoolean(true))
+        assertTrue("".asBoolean(true))
+    }
+
+    @Test
+    fun testStringAsBoolean_validValues() {
+        assertTrue("true".asBoolean())
+        assertTrue("1".asBoolean())
+        assertFalse("false".asBoolean())
+        assertFalse("0".asBoolean())
+    }
+
+    @Test
+    fun testAnyAsInt_null() {
+        assertNull(null.asInt())
+    }
+
+    @Test
+    fun testAnyAsInt_int() {
+        assertEquals(42, 42.asInt())
+        assertEquals(-1, (-1).asInt())
+        assertEquals(0, 0.asInt())
+    }
+
+    @Test
+    fun testAnyAsInt_number() {
+        assertEquals(42, 42L.asInt())
+        assertEquals(42, 42.0.asInt())
+        assertEquals(42, 42.5.asInt())
+        assertEquals(42, 42.0f.asInt())
+        assertEquals(-1, (-1.5).asInt())
+    }
+
+    @Test
+    fun testAnyAsInt_string() {
+        assertEquals(42, "42".asInt())
+        assertEquals(-1, "-1".asInt())
+        assertEquals(0, "0".asInt())
+        assertNull("not a number".asInt())
+        assertNull("".asInt())
+        assertEquals(42, "  42  ".asInt())
+    }
+
+    @Test
+    fun testAnyAsInt_boolean() {
+        assertEquals(1, true.asInt())
+        assertEquals(0, false.asInt())
+    }
+
+    @Test
+    fun testAnyAsInt_otherTypes() {
+        assertEquals(42, AnyKitTestObject(42).asInt())
+        assertNull(AnyKitTestObject("not a number").asInt())
+    }
+
+    @Test
+    fun testAnyAsBooleanOrNull_null() {
+        assertNull(null.asBooleanOrNull())
+    }
+
+    @Test
+    fun testAnyAsBooleanOrNull_boolean() {
+        assertEquals(true, true.asBooleanOrNull())
+        assertEquals(false, false.asBooleanOrNull())
+    }
+
+    @Test
+    fun testAnyAsBooleanOrNull_number() {
+        assertEquals(true, 1.asBooleanOrNull())
+        assertEquals(true, 42.asBooleanOrNull())
+        assertEquals(true, (-1).asBooleanOrNull())
+        assertEquals(false, 0.asBooleanOrNull())
+        assertEquals(false, 0.0.asBooleanOrNull())
+        assertEquals(true, 0.5.asBooleanOrNull())
+    }
+
+    @Test
+    fun testAnyAsBooleanOrNull_string() {
+        assertEquals(true, "true".asBooleanOrNull())
+        assertEquals(true, "1".asBooleanOrNull())
+        assertEquals(true, "yes".asBooleanOrNull())
+        assertEquals(false, "false".asBooleanOrNull())
+        assertEquals(false, "0".asBooleanOrNull())
+        assertEquals(false, "no".asBooleanOrNull())
+        assertNull("maybe".asBooleanOrNull())
+    }
+
+    @Test
+    fun testAnyAsBooleanOrNull_otherTypes() {
+        assertEquals(true, AnyKitTestObject("true").asBooleanOrNull())
+        assertEquals(false, AnyKitTestObject("false").asBooleanOrNull())
+        assertNull(AnyKitTestObject("maybe").asBooleanOrNull())
+    }
+
+    @Test
+    fun testAnyAsBoolean_defaultValue() {
+        assertFalse("maybe".asBoolean())
+        assertFalse(AnyKitTestObject("maybe").asBoolean())
+        assertTrue("maybe".asBoolean(true))
+        assertTrue(AnyKitTestObject("maybe").asBoolean(true))
+    }
+
+    @Test
+    fun testAnyAsBoolean_validValues() {
+        assertTrue("true".asBoolean())
+        assertTrue(1.asBoolean())
+        assertFalse("false".asBoolean())
+        assertFalse(0.asBoolean())
+    }
+
+    private data class AnyKitTestObject(private val value: Any) {
+        override fun toString(): String = value.toString()
+    }
+}


### PR DESCRIPTION
- Replace Sequence with Flow for suspend function compatibility
- Enable early termination in aggregation modes (SINGLE, ANY, IntRuleMode)
- Add AnyKit utilities for lenient type conversion (asInt, asBoolean)
- Properly handle CancellationException for Flow exception transparency
- Add comprehensive documentation to RuleModes and AnyKit

This addresses performance issues by:
- Short-circuiting rule evaluation when terminal operators find satisfying results
- Avoiding eager collection of all rule results when only first is needed

Closes #669
