### PR TITLE
chore: remove unused module rule

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolver.kt
@@ -143,14 +143,6 @@ class ApiMetadataResolver(
         return engine.evaluate(RuleKeys.PARAM_MOCK, parameter)
     }
 
-    suspend fun resolveModule(method: PsiMethod): String? {
-        return engine.evaluate(RuleKeys.MODULE, method)
-    }
-
-    suspend fun resolveModule(psiClass: PsiClass): String? {
-        return engine.evaluate(RuleKeys.MODULE, psiClass)
-    }
-
     suspend fun isIgnored(element: PsiElement): Boolean {
         return engine.evaluate(RuleKeys.IGNORE, element)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
@@ -18,7 +18,6 @@ object RuleKeys {
     // ── API metadata ──────────────────────────────────────────────
     val API_NAME = RuleKey.string("api.name")
     val FOLDER_NAME = RuleKey.string("folder.name")
-    val MODULE = RuleKey.string("module")
     val IGNORE = RuleKey.boolean("ignore")
 
     // ── Method rules ──────────────────────────────────────────────

--- a/src/main/resources/extensions/module.config
+++ b/src/main/resources/extensions/module.config
@@ -1,7 +1,0 @@
----
-code: module
-description: Get the module from the comment, group the apis
-default-enabled: true
----
-
-module=#module

--- a/src/test/resources/result/com.itangcent.idea.plugin.config.EnhancedConfigReaderTest.SimpleEnhancedConfigReaderTest.foreach.txt
+++ b/src/test/resources/result/com.itangcent.idea.plugin.config.EnhancedConfigReaderTest.SimpleEnhancedConfigReaderTest.foreach.txt
@@ -1,5 +1,4 @@
 ignore=@Ignore
-module=#module
 ignore=#ignore
 field.ignore=groovy:!it.containingClass().name().startsWith("java.lang")&&it.defineClass().name().startsWith("java.lang")
 field.name=@com.fasterxml.jackson.annotation.JsonProperty#value

--- a/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigLoaderTest.txt
+++ b/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigLoaderTest.txt
@@ -1,5 +1,3 @@
-#Get the module from the comment,group the apis
-module=#module
 #Ignore class/api
 ignore=#ignore
 #ignore fields from java.lang system classes

--- a/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigSettingsHelperTest.txt
+++ b/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigSettingsHelperTest.txt
@@ -1,5 +1,3 @@
-#Get the module from the comment,group the apis
-module=#module
 #Ignore class/api
 ignore=#ignore
 #ignore fields from java.lang system classes


### PR DESCRIPTION
Remove the dead module rule (RuleKeys.MODULE, resolveModule, module.config) that had zero consumers. The folder field and resolveFolderName() already provides API grouping. ModuleHelper handles IntelliJ module resolution (a different concept).