### PR TITLE
feat: handle properties.prefix rule in FieldsToPropertiesAction

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/format/PropertiesFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/format/PropertiesFormatter.kt
@@ -40,10 +40,10 @@ import java.util.IdentityHashMap
  */
 class PropertiesFormatter(private val maxVisits: Int = 2) {
 
-    fun format(model: ObjectModel): String {
+    fun format(model: ObjectModel, prefix: String = ""): String {
         val sb = StringBuilder()
         val visitCounts = IdentityHashMap<ObjectModel.Object, Int>()
-        flatten("", model, null, sb, visitCounts)
+        flatten(prefix, model, null, sb, visitCounts)
         return sb.toString()
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/FieldsToPropertiesAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/FieldsToPropertiesAction.kt
@@ -4,12 +4,18 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.itangcent.easyapi.format.PropertiesFormatter
 import com.itangcent.easyapi.psi.PsiClassHelper
+import com.itangcent.easyapi.rule.RuleKeys
+import com.itangcent.easyapi.rule.engine.RuleEngine
 
 /**
  * Action to convert class fields to Java Properties format.
  *
  * Builds an object model from the class fields and formats it as
  * key-value pairs suitable for .properties files.
+ *
+ * Resolves the `properties.prefix` rule (typically from
+ * `@ConfigurationProperties(prefix=...)`) and prepends it to all
+ * generated property keys.
  *
  * @see FieldFormatAction for the base class
  */
@@ -18,6 +24,8 @@ class FieldsToPropertiesAction : FieldFormatAction("Fields To Properties") {
         val helper = PsiClassHelper.getInstance(project)
         val model = helper.buildObjectModel(psiClass, maxDepth = 10)
             ?: return ""
-        return PropertiesFormatter().format(model)
+        val ruleEngine = RuleEngine.getInstance(project)
+        val prefix = ruleEngine.evaluate(RuleKeys.PROPERTIES_PREFIX, psiClass).orEmpty()
+        return PropertiesFormatter().format(model, prefix)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
@@ -107,4 +107,7 @@ object RuleKeys {
     // ── Enum rules ────────────────────────────────────────────────
     val ENUM_USE_CUSTOM = RuleKey.string("enum.use.custom")
     val CONSTANT_FIELD_IGNORE = RuleKey.boolean("constant.field.ignore")
+
+    // ── Properties rules ──────────────────────────────────────────
+    val PROPERTIES_PREFIX = RuleKey.string("properties.prefix")
 }

--- a/src/test/kotlin/com/itangcent/easyapi/format/PropertiesFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/format/PropertiesFormatterTest.kt
@@ -145,4 +145,40 @@ class PropertiesFormatterTest {
         assertTrue(result.contains("count=0"))
         assertTrue(result.contains("enabled=false"))
     }
+
+    @Test
+    fun testFormatWithPrefix() {
+        val stringModel = ObjectModel.Single(JsonType.STRING)
+        val nameField = FieldModel(model = stringModel)
+        val obj = ObjectModel.Object(fields = mapOf("name" to nameField))
+        val formatter = PropertiesFormatter()
+
+        val result = formatter.format(obj, prefix = "my.app")
+        assertTrue(result.contains("my.app.name="))
+    }
+
+    @Test
+    fun testFormatWithPrefixNestedObject() {
+        val stringModel = ObjectModel.Single(JsonType.STRING)
+        val nameField = FieldModel(model = stringModel)
+        val userObj = ObjectModel.Object(fields = mapOf("name" to nameField))
+        val userField = FieldModel(model = userObj)
+        val rootObj = ObjectModel.Object(fields = mapOf("user" to userField))
+        val formatter = PropertiesFormatter()
+
+        val result = formatter.format(rootObj, prefix = "spring")
+        assertTrue(result.contains("spring.user.name="))
+    }
+
+    @Test
+    fun testFormatWithEmptyPrefix() {
+        val stringModel = ObjectModel.Single(JsonType.STRING)
+        val nameField = FieldModel(model = stringModel)
+        val obj = ObjectModel.Object(fields = mapOf("name" to nameField))
+        val formatter = PropertiesFormatter()
+
+        val resultWithoutPrefix = formatter.format(obj)
+        val resultWithEmptyPrefix = formatter.format(obj, prefix = "")
+        assertEquals(resultWithoutPrefix, resultWithEmptyPrefix)
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/rule/RuleKeysTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/RuleKeysTest.kt
@@ -62,4 +62,12 @@ class RuleKeysTest {
         assertEquals("class.is.spring.ctrl", RuleKeys.CLASS_IS_CTRL.name)
         assertEquals(listOf("class.is.ctrl"), RuleKeys.CLASS_IS_CTRL.aliases)
     }
+
+    @Test
+    fun testPropertiesPrefixKey() {
+        val key = RuleKeys.PROPERTIES_PREFIX
+        assertEquals("properties.prefix", key.name)
+        assertTrue(key.mode is StringRuleMode.SINGLE)
+        assertTrue(key.aliases.isEmpty())
+    }
 }


### PR DESCRIPTION
## Summary

Handle the `properties.prefix` rule from `spring-configuration.config` in FieldsToPropertiesAction.

### Changes

- Add `PROPERTIES_PREFIX` rule key to RuleKeys
- Add prefix parameter to PropertiesFormatter.format()
- Resolve prefix via RuleEngine in FieldsToPropertiesAction (supports @ConfigurationProperties(prefix="..."))
- Add tests for prefix functionality

### Example

Given:
```java
@ConfigurationProperties(prefix = "spring.datasource")
public class DataSourceProperties {
    private String url;
    private String username;
}
```

Output (before):
```properties
url=
username=
```

Output (after):
```properties
spring.datasource.url=
spring.datasource.username=
```