### PR TITLE
feat: add variable resolution support in ApiDashboard

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/config/ConfigReader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/ConfigReader.kt
@@ -95,3 +95,18 @@ interface ConfigReader {
     }
 }
 
+private val DOLLAR_BRACE_PATTERN = Regex("\\$\\{([^}]+)}")
+private val DOUBLE_BRACE_PATTERN = Regex("\\{\\{([^}]+)}}")
+
+fun ConfigReader.resolveVariables(input: String): String {
+    var result = DOLLAR_BRACE_PATTERN.replace(input) { match ->
+        val key = match.groupValues[1].trim()
+        getFirst(key) ?: match.value
+    }
+    result = DOUBLE_BRACE_PATTERN.replace(result) { match ->
+        val key = match.groupValues[1].trim()
+        getFirst(key) ?: match.value
+    }
+    return result
+}
+

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
@@ -12,6 +12,8 @@ import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
 import com.itangcent.easyapi.cache.DefaultHttpContextCacheHelper
 import com.itangcent.easyapi.cache.HttpContextCacheHelper
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.resolveVariables
 import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.core.threading.swing
@@ -76,6 +78,9 @@ class EndpointDetailsPanel(
 
     /** Helper for managing host history cache */
     private val hostCacheHelper: HttpContextCacheHelper = DefaultHttpContextCacheHelper.getInstance(project)
+
+    /** Config reader for variable resolution in request fields */
+    private val configReader: ConfigReader get() = ConfigReader.getInstance(project)
 
     /** Service for persisting user edits */
     private val editCacheService: RequestEditCacheService = RequestEditCacheService.getInstance(project)
@@ -1013,28 +1018,49 @@ class EndpointDetailsPanel(
 
     private suspend fun sendHttpRequestInternal(endpoint: ApiEndpoint, host: String): RequestResult {
         return try {
+            val resolvedHost = configReader.resolveVariables(host)
+
             val pathParams = (0 until pathParamsTableModel.rowCount).map { row ->
-                pathParamsTableModel.getValueAt(row, 0)?.toString()?.trim().orEmpty() to
-                        pathParamsTableModel.getValueAt(row, 1)?.toString()?.trim().orEmpty()
+                val name = pathParamsTableModel.getValueAt(row, 0)?.toString()?.trim().orEmpty()
+                val value = configReader.resolveVariables(
+                    pathParamsTableModel.getValueAt(row, 1)?.toString()?.trim().orEmpty()
+                )
+                name to value
             }
             val resolvedPath = EndpointDetailsPanelLogic.resolvePath(pathField.text, pathParams)
-            val fullUrl = host + (if (resolvedPath.startsWith("/")) resolvedPath else "/$resolvedPath")
+            val fullUrl = resolvedHost + (if (resolvedPath.startsWith("/")) resolvedPath else "/$resolvedPath")
 
             LOG.info("HTTP request to $fullUrl")
 
-            val headers = extractKeyValuesFromTable(headersTableModel)
-            val query = extractKeyValuesFromTable(paramsTableModel)
+            val headers = extractKeyValuesFromTable(headersTableModel).map {
+                KeyValue(configReader.resolveVariables(it.name),
+                    configReader.resolveVariables(it.value))
+            }
+            val query = extractKeyValuesFromTable(paramsTableModel).map {
+                KeyValue(configReader.resolveVariables(it.name),
+                    configReader.resolveVariables(it.value))
+            }
 
             val formParams: List<FormParam>
             val body: String?
             val finalHeaders: List<KeyValue>
             if (hasFormData) {
-                formParams = buildFormParams()
+                formParams = buildFormParams().map { param ->
+                    when (param) {
+                        is FormParam.Text -> FormParam.Text(
+                            configReader.resolveVariables(param.name),
+                            configReader.resolveVariables(param.value)
+                        )
+                        is FormParam.File -> param
+                    }
+                }
                 body = null
                 finalHeaders = headers
             } else {
                 formParams = emptyList()
-                body = bodyArea.text.takeIf { it.isNotBlank() }
+                body = bodyArea.text.takeIf { it.isNotBlank() }?.let {
+                    configReader.resolveVariables(it)
+                }
                 finalHeaders = headers
             }
 
@@ -1070,6 +1096,8 @@ class EndpointDetailsPanel(
         val meta = endpoint.grpcMetadata ?: return RequestResult(body = "Error: Not a gRPC endpoint", isError = true)
         LOG.info("gRPC request initiated from UI: endpoint=${endpoint.name}, path=${meta.path}")
 
+        val resolvedHost = configReader.resolveVariables(host)
+
         val grpcClient = DynamicJarClient.getInstance(project)
 
         if (!grpcClient.isAvailable()) {
@@ -1085,15 +1113,17 @@ class EndpointDetailsPanel(
             return RequestResult(body = "Error: gRPC client not available", isError = true)
         }
 
-        val body = bodyArea.text.takeIf { it.isNotBlank() }
-        LOG.info("gRPC request details: host=$host, bodyLength=${body?.length ?: 0}")
+        val body = bodyArea.text.takeIf { it.isNotBlank() }?.let {
+            configReader.resolveVariables(it)
+        }
+        LOG.info("gRPC request details: host=$resolvedHost, bodyLength=${body?.length ?: 0}")
 
         return try {
             val sm = readSync { endpoint.sourceMethod }
             val grpcResult = if (sm != null) {
-                grpcClient.invoke(host, meta.path, body, sm)
+                grpcClient.invoke(resolvedHost, meta.path, body, sm)
             } else {
-                grpcClient.invoke(host, meta.path, body)
+                grpcClient.invoke(resolvedHost, meta.path, body)
             }
 
             LOG.info("gRPC response received: endpoint=${meta.path}, isError=${grpcResult.isError}, statusCode=${grpcResult.statusCode}, length=${grpcResult.body.length}")
@@ -1435,7 +1465,6 @@ class EndpointDetailsPanel(
  * No UI dependencies — all methods are stateless or take plain data as arguments.
  */
 internal object EndpointDetailsPanelLogic {
-
 
     /**
      * Pretty-prints a JSON string. Returns the original string if it is blank or not valid JSON.

--- a/src/test/kotlin/com/itangcent/easyapi/config/ConfigReaderResolveVariablesTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/ConfigReaderResolveVariablesTest.kt
@@ -1,0 +1,92 @@
+package com.itangcent.easyapi.config
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.*
+
+class ConfigReaderResolveVariablesTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var configReader: TestConfigReader
+
+    override fun setUp() {
+        super.setUp()
+        configReader = TestConfigReader.empty(project)
+    }
+
+    fun testResolveDollarBraceSyntax() {
+        configReader = TestConfigReader.fromRules(project, "host" to "api.example.com")
+        val result = configReader.resolveVariables("https://\${host}/users")
+        assertEquals("https://api.example.com/users", result)
+    }
+
+    fun testResolveDoubleBraceSyntax() {
+        configReader = TestConfigReader.fromRules(project, "host" to "api.example.com")
+        val result = configReader.resolveVariables("https://{{host}}/users")
+        assertEquals("https://api.example.com/users", result)
+    }
+
+    fun testResolveBothSyntaxesInSameString() {
+        configReader = TestConfigReader.fromRules(project, "host" to "api.example.com", "port" to "8080")
+        val result = configReader.resolveVariables("https://\${host}:{{port}}/users")
+        assertEquals("https://api.example.com:8080/users", result)
+    }
+
+    fun testLeaveUnresolvedPlaceholdersUnchanged() {
+        configReader = TestConfigReader.fromRules(project, "host" to "api.example.com")
+        val result = configReader.resolveVariables("https://\${host}/{{unknown}}")
+        assertEquals("https://api.example.com/{{unknown}}", result)
+    }
+
+    fun testReturnInputUnchangedWhenNoPlaceholders() {
+        configReader = TestConfigReader.empty(project)
+        val result = configReader.resolveVariables("https://api.example.com/users")
+        assertEquals("https://api.example.com/users", result)
+    }
+
+    fun testHandleMultipleSameVariable() {
+        configReader = TestConfigReader.fromRules(project, "token" to "abc123")
+        val result = configReader.resolveVariables("Bearer \${token} and {{token}}")
+        assertEquals("Bearer abc123 and abc123", result)
+    }
+
+    fun testHandleEmptyInput() {
+        configReader = TestConfigReader.empty(project)
+        val result = configReader.resolveVariables("")
+        assertEquals("", result)
+    }
+
+    fun testTrimWhitespaceInVariableName() {
+        configReader = TestConfigReader.fromRules(project, "host" to "api.example.com")
+        val result = configReader.resolveVariables("https://\${ host }/users")
+        assertEquals("https://api.example.com/users", result)
+    }
+
+    fun testResolveVariablesInHeaderValue() {
+        configReader = TestConfigReader.fromRules(project, "auth_token" to "Bearer xyz789")
+        val result = configReader.resolveVariables("\${auth_token}")
+        assertEquals("Bearer xyz789", result)
+    }
+
+    fun testResolveVariablesInJsonBody() {
+        configReader = TestConfigReader.fromRules(project, "user_id" to "12345", "api_key" to "secret123")
+        val result = configReader.resolveVariables("{\"userId\": \${user_id}, \"apiKey\": \"{{api_key}}\"}")
+        assertEquals("{\"userId\": 12345, \"apiKey\": \"secret123\"}", result)
+    }
+
+    fun testResolveMultipleDifferentVariables() {
+        configReader = TestConfigReader.fromRules(project, 
+            "scheme" to "https",
+            "host" to "api.example.com",
+            "port" to "8080",
+            "path" to "v1/users"
+        )
+        val result = configReader.resolveVariables("\${scheme}://{{host}}:\${port}/{{path}}")
+        assertEquals("https://api.example.com:8080/v1/users", result)
+    }
+
+    fun testHandleVariableWithUnderscoreAndDotsInName() {
+        configReader = TestConfigReader.fromRules(project, "api.gateway.host" to "gateway.example.com")
+        val result = configReader.resolveVariables("https://\${api.gateway.host}/api")
+        assertEquals("https://gateway.example.com/api", result)
+    }
+}


### PR DESCRIPTION
## Changes

- Add resolveVariables extension function to ConfigReader
- Support both ${variable} and {{variable}} syntax (like Postman)
- Apply variable resolution in HTTP and gRPC requests:
  - Host URL
  - Path parameters
  - Headers (names and values)
  - Query parameters
  - Form parameters (text only)
  - Request body
- Add comprehensive tests for resolveVariables

## Usage

Users can define variables in their `.easy-api.config` file:
```
api_host=prod-server.com
auth_token=Bearer xyz789
api_key=abc123
```

Then reference them in any request field in the ApiDashboard:
- **Host**: `https://${api_host}` or `https://{{api_host}}`
- **Headers**: `Authorization: ${auth_token}`
- **Query params**: `key=${api_key}`
- **Body**: `{"token": "${auth_token}"}`