### PR TITLE
test: add unit tests for ScriptSupport, EventBus, RequestPersistence, RepositoryService, MavenHelper, ModuleHelper

### DIFF
--- a/src/test/kotlin/com/itangcent/easyapi/core/event/EventBusTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/event/EventBusTest.kt
@@ -1,0 +1,185 @@
+package com.itangcent.easyapi.core.event
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class EventBusTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var eventBus: EventBus
+
+    override fun setUp() {
+        super.setUp()
+        eventBus = EventBus.getInstance(project)
+    }
+
+    fun testGetInstanceReturnsNonNull() {
+        assertNotNull("EventBus instance should not be null", eventBus)
+    }
+
+    fun testGetInstanceReturnsSameInstance() {
+        val instance1 = EventBus.getInstance(project)
+        val instance2 = EventBus.getInstance(project)
+        assertSame("EventBus should be a project-level singleton", instance1, instance2)
+    }
+
+    fun testRegisterHandlerIsCalledOnActionCompleted() {
+        val latch = CountDownLatch(1)
+        val called = AtomicInteger(0)
+
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            called.incrementAndGet()
+            latch.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+
+        assertTrue("Handler should be called within 5 seconds",
+            latch.await(5, TimeUnit.SECONDS))
+        assertEquals("Handler should be called exactly once", 1, called.get())
+    }
+
+    fun testRegisterMultipleHandlersForSameKey() {
+        val latch = CountDownLatch(2)
+        val callOrder = mutableListOf<Int>()
+
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            synchronized(callOrder) { callOrder.add(1) }
+            latch.countDown()
+        }
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            synchronized(callOrder) { callOrder.add(2) }
+            latch.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+
+        assertTrue("Both handlers should be called within 5 seconds",
+            latch.await(5, TimeUnit.SECONDS))
+        assertEquals("Both handlers should be called", 2, callOrder.size)
+    }
+
+    fun testPersistentHandlerIsCalledOnEachFire() {
+        val latch1 = CountDownLatch(1)
+        val latch2 = CountDownLatch(2)
+        val callCount = AtomicInteger(0)
+
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            callCount.incrementAndGet()
+            latch1.countDown()
+            latch2.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+        assertTrue("First call should complete within 5 seconds",
+            latch1.await(5, TimeUnit.SECONDS))
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+        assertTrue("Second call should complete within 5 seconds",
+            latch2.await(5, TimeUnit.SECONDS))
+
+        assertEquals("Persistent handler should be called twice", 2, callCount.get())
+    }
+
+    fun testRegisterOnceHandlerIsCalledOnlyOnce() {
+        val latch = CountDownLatch(1)
+        val callCount = AtomicInteger(0)
+
+        eventBus.registerOnce(EventKeys.ON_COMPLETED) {
+            callCount.incrementAndGet()
+            latch.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+        assertTrue("First call should complete within 5 seconds",
+            latch.await(5, TimeUnit.SECONDS))
+
+        Thread.sleep(200)
+
+        assertEquals("One-time handler should be called exactly once", 1, callCount.get())
+    }
+
+    fun testRegisterOnceHandlerIsNotCalledOnSecondFire() {
+        val latch = CountDownLatch(1)
+        val callCount = AtomicInteger(0)
+
+        eventBus.registerOnce(EventKeys.ON_COMPLETED) {
+            callCount.incrementAndGet()
+            latch.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+        assertTrue("First call should complete within 5 seconds",
+            latch.await(5, TimeUnit.SECONDS))
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+
+        Thread.sleep(200)
+
+        assertEquals("One-time handler should not be called again", 1, callCount.get())
+    }
+
+    fun testMixOfPersistentAndOneTimeHandlers() {
+        val latch1 = CountDownLatch(2)
+        val persistentCount = AtomicInteger(0)
+        val oneTimeCount = AtomicInteger(0)
+
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            persistentCount.incrementAndGet()
+            latch1.countDown()
+        }
+        eventBus.registerOnce(EventKeys.ON_COMPLETED) {
+            oneTimeCount.incrementAndGet()
+            latch1.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+        assertTrue("First fire should complete within 5 seconds",
+            latch1.await(5, TimeUnit.SECONDS))
+
+        assertEquals("After first fire: persistent=1, oneTime=1", 1, persistentCount.get())
+        assertEquals("After first fire: oneTime=1", 1, oneTimeCount.get())
+
+        val latch2 = CountDownLatch(1)
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            latch2.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+        assertTrue("Second fire should complete within 5 seconds",
+            latch2.await(5, TimeUnit.SECONDS))
+
+        Thread.sleep(200)
+
+        assertEquals("Persistent handler should be called twice (once per fire)", 2, persistentCount.get())
+        assertEquals("One-time handler should be called once total", 1, oneTimeCount.get())
+    }
+
+    fun testHandlerExceptionDoesNotPreventOtherHandlers() {
+        val latch = CountDownLatch(1)
+        val secondCalled = AtomicInteger(0)
+
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            throw RuntimeException("Test exception")
+        }
+        eventBus.register(EventKeys.ON_COMPLETED) {
+            secondCalled.incrementAndGet()
+            latch.countDown()
+        }
+
+        project.messageBus.syncPublisher(ActionCompletedTopic.TOPIC).onActionCompleted()
+
+        assertTrue("Second handler should still be called within 5 seconds",
+            latch.await(5, TimeUnit.SECONDS))
+        assertEquals("Second handler should be called despite first handler exception",
+            1, secondCalled.get())
+    }
+
+    fun testRegisterForUnknownKeyDoesNotCrash() {
+        eventBus.register("UNKNOWN_KEY") {
+        }
+        eventBus.registerOnce("ANOTHER_UNKNOWN_KEY") {
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/dashboard/RequestPersistenceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/dashboard/RequestPersistenceTest.kt
@@ -1,0 +1,203 @@
+package com.itangcent.easyapi.dashboard
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.*
+
+class RequestPersistenceTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var persistence: RequestPersistence
+
+    override fun setUp() {
+        super.setUp()
+        persistence = RequestPersistence(project)
+        persistence.reset()
+    }
+
+    override fun tearDown() {
+        persistence.reset()
+        super.tearDown()
+    }
+
+    fun testLoadAllReturnsEmptyWhenNoData() {
+        val result = persistence.loadAll()
+        assertTrue("Should return empty list when no data persisted", result.isEmpty())
+    }
+
+    fun testSaveAndLoadSingleRequest() {
+        val request = PersistedRequest(
+            endpointKey = "com.example.UserCtrl.getUser",
+            url = "http://localhost:8080/api/users/1",
+            method = "GET",
+            headers = mapOf("Authorization" to "Bearer token"),
+            body = null
+        )
+
+        persistence.saveAll(listOf(request))
+        val loaded = persistence.loadAll()
+
+        assertEquals("Should load one request", 1, loaded.size)
+        assertEquals("com.example.UserCtrl.getUser", loaded[0].endpointKey)
+        assertEquals("http://localhost:8080/api/users/1", loaded[0].url)
+        assertEquals("GET", loaded[0].method)
+        assertEquals("Bearer token", loaded[0].headers["Authorization"])
+        assertNull("Body should be null", loaded[0].body)
+    }
+
+    fun testSaveAndLoadMultipleRequests() {
+        val requests = listOf(
+            PersistedRequest(
+                endpointKey = "com.example.UserCtrl.getUser",
+                url = "http://localhost:8080/api/users/1",
+                method = "GET"
+            ),
+            PersistedRequest(
+                endpointKey = "com.example.UserCtrl.createUser",
+                url = "http://localhost:8080/api/users",
+                method = "POST",
+                headers = mapOf("Content-Type" to "application/json"),
+                body = "{\"name\":\"test\"}"
+            ),
+            PersistedRequest(
+                endpointKey = "com.example.UserCtrl.deleteUser",
+                url = "http://localhost:8080/api/users/1",
+                method = "DELETE"
+            )
+        )
+
+        persistence.saveAll(requests)
+        val loaded = persistence.loadAll()
+
+        assertEquals("Should load all three requests", 3, loaded.size)
+        assertEquals("GET", loaded[0].method)
+        assertEquals("POST", loaded[1].method)
+        assertEquals("DELETE", loaded[2].method)
+    }
+
+    fun testSaveOverwritesPreviousData() {
+        val request1 = PersistedRequest(
+            endpointKey = "key1",
+            url = "http://old.com",
+            method = "GET"
+        )
+        val request2 = PersistedRequest(
+            endpointKey = "key2",
+            url = "http://new.com",
+            method = "POST"
+        )
+
+        persistence.saveAll(listOf(request1))
+        persistence.saveAll(listOf(request2))
+        val loaded = persistence.loadAll()
+
+        assertEquals("Should have only the latest saved data", 1, loaded.size)
+        assertEquals("key2", loaded[0].endpointKey)
+        assertEquals("http://new.com", loaded[0].url)
+        assertEquals("POST", loaded[0].method)
+    }
+
+    fun testResetClearsAllData() {
+        val request = PersistedRequest(
+            endpointKey = "key1",
+            url = "http://test.com",
+            method = "GET"
+        )
+
+        persistence.saveAll(listOf(request))
+        assertEquals("Should have one request before reset", 1, persistence.loadAll().size)
+
+        persistence.reset()
+        assertTrue("Should return empty list after reset", persistence.loadAll().isEmpty())
+    }
+
+    fun testLoadAfterResetReturnsEmpty() {
+        val request = PersistedRequest(
+            endpointKey = "key1",
+            url = "http://test.com",
+            method = "GET"
+        )
+
+        persistence.saveAll(listOf(request))
+        persistence.reset()
+
+        val loaded = persistence.loadAll()
+        assertTrue("Should return empty list after reset", loaded.isEmpty())
+    }
+
+    fun testSaveEmptyList() {
+        persistence.saveAll(emptyList())
+        val loaded = persistence.loadAll()
+        assertTrue("Should return empty list when saved empty", loaded.isEmpty())
+    }
+
+    fun testSaveRequestWithBody() {
+        val request = PersistedRequest(
+            endpointKey = "com.example.UserCtrl.updateUser",
+            url = "http://localhost:8080/api/users/1",
+            method = "PUT",
+            headers = mapOf("Content-Type" to "application/json"),
+            body = "{\"name\":\"updated\"}"
+        )
+
+        persistence.saveAll(listOf(request))
+        val loaded = persistence.loadAll()
+
+        assertEquals("Should load one request", 1, loaded.size)
+        assertEquals("{\"name\":\"updated\"}", loaded[0].body)
+        assertEquals("application/json", loaded[0].headers["Content-Type"])
+    }
+
+    fun testSaveRequestWithMultipleHeaders() {
+        val request = PersistedRequest(
+            endpointKey = "test",
+            url = "http://test.com",
+            method = "POST",
+            headers = mapOf(
+                "Authorization" to "Bearer token",
+                "Content-Type" to "application/json",
+                "X-Custom-Header" to "custom-value"
+            ),
+            body = "{}"
+        )
+
+        persistence.saveAll(listOf(request))
+        val loaded = persistence.loadAll()
+
+        assertEquals("Should preserve all headers", 3, loaded[0].headers.size)
+        assertEquals("Bearer token", loaded[0].headers["Authorization"])
+        assertEquals("application/json", loaded[0].headers["Content-Type"])
+        assertEquals("custom-value", loaded[0].headers["X-Custom-Header"])
+    }
+
+    fun testResetWhenNoDataDoesNotCrash() {
+        persistence.reset()
+        assertTrue("Should not crash on reset with no data", persistence.loadAll().isEmpty())
+    }
+
+    fun testDoubleResetDoesNotCrash() {
+        persistence.reset()
+        persistence.reset()
+        assertTrue("Should not crash on double reset", persistence.loadAll().isEmpty())
+    }
+
+    fun testSaveAndLoadPreservesAllFields() {
+        val request = PersistedRequest(
+            endpointKey = "com.example.OrderCtrl.createOrder",
+            url = "http://api.example.com/v1/orders",
+            method = "POST",
+            headers = mapOf(
+                "Authorization" to "Bearer abc123",
+                "Accept" to "application/json"
+            ),
+            body = "{\"productId\":42,\"quantity\":2}"
+        )
+
+        persistence.saveAll(listOf(request))
+        val loaded = persistence.loadAll()
+
+        assertEquals("endpointKey should match", request.endpointKey, loaded[0].endpointKey)
+        assertEquals("url should match", request.url, loaded[0].url)
+        assertEquals("method should match", request.method, loaded[0].method)
+        assertEquals("headers should match", request.headers, loaded[0].headers)
+        assertEquals("body should match", request.body, loaded[0].body)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ide/script/ScriptSupportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/script/ScriptSupportTest.kt
@@ -1,0 +1,187 @@
+package com.itangcent.easyapi.ide.script
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class GeneralScriptSupportTest {
+
+    @Test
+    fun testBuildScriptReturnsInputUnchanged() {
+        val input = "some.annotation.RequestMapping"
+        assertEquals("GeneralScriptSupport should pass through script unchanged",
+            input, GeneralScriptSupport.buildScript(input))
+    }
+
+    @Test
+    fun testBuildPropertyReturnsInputUnchanged() {
+        val input = "property.expression"
+        assertEquals("GeneralScriptSupport should pass through property unchanged",
+            input, GeneralScriptSupport.buildProperty(input))
+    }
+
+    @Test
+    fun testCheckSupportAlwaysReturnsTrue() {
+        assertTrue("GeneralScriptSupport should always be supported",
+            GeneralScriptSupport.checkSupport())
+    }
+
+    @Test
+    fun testSuffixReturnsTxt() {
+        assertEquals("txt", GeneralScriptSupport.suffix())
+    }
+
+    @Test
+    fun testDemoCodeReturnsAnnotation() {
+        assertTrue("Demo code should contain Spring annotation",
+            GeneralScriptSupport.demoCode().contains("RequestMapping"))
+    }
+
+    @Test
+    fun testToStringReturnsGeneral() {
+        assertEquals("General", GeneralScriptSupport.toString())
+    }
+
+    @Test
+    fun testEqualsIsReferenceEquality() {
+        assertSame("GeneralScriptSupport is a singleton", GeneralScriptSupport, GeneralScriptSupport)
+        assertEquals("Same reference should be equal", GeneralScriptSupport, GeneralScriptSupport)
+        assertNotEquals("Different type should not be equal", GeneralScriptSupport, "General")
+    }
+
+    @Test
+    fun testBuildScriptWithEmptyString() {
+        assertEquals("", GeneralScriptSupport.buildScript(""))
+    }
+
+    @Test
+    fun testBuildPropertyWithEmptyString() {
+        assertEquals("", GeneralScriptSupport.buildProperty(""))
+    }
+}
+
+class GroovyScriptSupportTest {
+
+    @Test
+    fun testBuildScriptAddsPrefix() {
+        val result = GroovyScriptSupport.buildScript("println 'hello'")
+        assertEquals("groovy:println 'hello'", result)
+    }
+
+    @Test
+    fun testBuildPropertyWrapsInCodeBlock() {
+        val result = GroovyScriptSupport.buildProperty("it.name")
+        assertEquals("groovy:```\nit.name\n```", result)
+    }
+
+    @Test
+    fun testSuffixReturnsGroovy() {
+        assertEquals("groovy", GroovyScriptSupport.suffix())
+    }
+
+    @Test
+    fun testScriptTypeReturnsGroovy() {
+        assertEquals("groovy", GroovyScriptSupport.scriptType())
+    }
+
+    @Test
+    fun testPrefixReturnsScriptType() {
+        assertEquals("groovy", GroovyScriptSupport.prefix())
+    }
+
+    @Test
+    fun testToStringReturnsGroovy() {
+        assertEquals("Groovy", GroovyScriptSupport.toString())
+    }
+
+    @Test
+    fun testEqualsIsReferenceEquality() {
+        assertSame("GroovyScriptSupport is a singleton", GroovyScriptSupport, GroovyScriptSupport)
+        assertEquals("Same reference should be equal", GroovyScriptSupport, GroovyScriptSupport)
+        assertNotEquals("Different type should not be equal", GroovyScriptSupport, "Groovy")
+    }
+
+    @Test
+    fun testDemoCodeIsNotBlank() {
+        assertTrue("Demo code should not be blank", GroovyScriptSupport.demoCode().isNotBlank())
+    }
+
+    @Test
+    fun testDemoCodeContainsVariables() {
+        assertTrue("Demo code should reference tool variable",
+            GroovyScriptSupport.demoCode().contains("tool"))
+    }
+
+    @Test
+    fun testBuildScriptWithEmptyString() {
+        assertEquals("groovy:", GroovyScriptSupport.buildScript(""))
+    }
+
+    @Test
+    fun testBuildPropertyWithEmptyString() {
+        assertEquals("groovy:```\n\n```", GroovyScriptSupport.buildProperty(""))
+    }
+}
+
+class AbstractScriptSupportConcreteTest : AbstractScriptSupport() {
+
+    override fun suffix(): String = "test"
+
+    override fun scriptType(): String = "testengine"
+
+    override fun demoCode(): String = "test demo"
+
+    @Test
+    fun testBuildScriptAddsCustomPrefix() {
+        val concrete = AbstractScriptSupportConcreteTest()
+        assertEquals("testengine:script content", concrete.buildScript("script content"))
+    }
+
+    @Test
+    fun testBuildPropertyWrapsInCodeBlock() {
+        val concrete = AbstractScriptSupportConcreteTest()
+        assertEquals("testengine:```\nprop\n```", concrete.buildProperty("prop"))
+    }
+
+    @Test
+    fun testPrefixDefaultsToScriptType() {
+        val concrete = AbstractScriptSupportConcreteTest()
+        assertEquals("testengine", concrete.prefix())
+    }
+
+    @Test
+    fun testCheckSupportReturnsFalseForUnavailableEngine() {
+        val concrete = AbstractScriptSupportConcreteTest()
+        assertFalse("Non-existent engine should not be supported",
+            concrete.checkSupport())
+    }
+}
+
+class ScriptSupportsListTest {
+
+    @Test
+    fun testScriptSupportsContainsGeneral() {
+        assertTrue("scriptSupports should contain GeneralScriptSupport",
+            scriptSupports.contains(GeneralScriptSupport))
+    }
+
+    @Test
+    fun testScriptSupportsContainsGroovy() {
+        assertTrue("scriptSupports should contain GroovyScriptSupport",
+            scriptSupports.contains(GroovyScriptSupport))
+    }
+
+    @Test
+    fun testScriptSupportsSize() {
+        assertEquals("Should have 2 script support implementations", 2, scriptSupports.size)
+    }
+
+    @Test
+    fun testScriptSupportsGeneralIsFirst() {
+        assertSame("GeneralScriptSupport should be first", GeneralScriptSupport, scriptSupports[0])
+    }
+
+    @Test
+    fun testScriptSupportsGroovyIsSecond() {
+        assertSame("GroovyScriptSupport should be second", GroovyScriptSupport, scriptSupports[1])
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/repository/RepositoryServiceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/repository/RepositoryServiceTest.kt
@@ -1,0 +1,127 @@
+package com.itangcent.easyapi.repository
+
+import com.intellij.testFramework.registerServiceInstance
+import com.itangcent.easyapi.settings.DefaultSettingBinder
+import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+
+class RepositoryServiceTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var repositoryService: RepositoryService
+    private lateinit var defaultSettingBinder: DefaultSettingBinder
+
+    override fun setUp() {
+        super.setUp()
+        defaultSettingBinder = DefaultSettingBinder(project)
+        project.registerServiceInstance(
+            serviceInterface = DefaultSettingBinder::class.java,
+            instance = defaultSettingBinder
+        )
+        repositoryService = RepositoryService(project)
+    }
+
+    fun testGetRepositoriesReturnsNonNullWhenNoConfig() {
+        val repos = repositoryService.getRepositories()
+
+        assertNotNull("Should return non-null list", repos)
+    }
+
+    fun testGetRepositoriesReturnsEnabledRepositories() {
+        defaultSettingBinder.save(Settings(grpcRepositories = arrayOf(
+            "maven:true:/path/to/.m2/repository",
+            "gradle:false:/path/to/.gradle/caches"
+        )))
+
+        val repos = repositoryService.getRepositories()
+
+        assertEquals("Should return only enabled repositories", 1, repos.size)
+        assertEquals("Should be Maven type", RepositoryType.MAVEN_LOCAL, repos[0].type)
+        assertTrue("Should be enabled", repos[0].enabled)
+    }
+
+    fun testGetRepositoriesFallsBackToDefaultsWhenAllDisabled() {
+        defaultSettingBinder.save(Settings(grpcRepositories = arrayOf(
+            "maven:false:/path/to/.m2/repository",
+            "gradle:false:/path/to/.gradle/caches"
+        )))
+
+        val repos = repositoryService.getRepositories()
+
+        assertNotNull("Should fall back to defaults when all repositories are disabled", repos)
+    }
+
+    fun testGetAllRepositoriesIncludesDisabled() {
+        defaultSettingBinder.save(Settings(grpcRepositories = arrayOf(
+            "maven:true:/path/to/.m2/repository",
+            "gradle:false:/path/to/.gradle/caches"
+        )))
+
+        val repos = repositoryService.getAllRepositories()
+
+        assertEquals("Should return all repositories including disabled", 2, repos.size)
+    }
+
+    fun testGetRepositoriesIgnoresInvalidEntries() {
+        defaultSettingBinder.save(Settings(grpcRepositories = arrayOf(
+            "maven:true:/path/to/.m2/repository",
+            "invalid-entry",
+            "",
+            "unknown:/path"
+        )))
+
+        val repos = repositoryService.getRepositories()
+
+        assertEquals("Should only return valid and enabled entries", 1, repos.size)
+        assertEquals("Should be Maven type", RepositoryType.MAVEN_LOCAL, repos[0].type)
+    }
+
+    fun testGetRepositoriesWithCustomRepository() {
+        defaultSettingBinder.save(Settings(grpcRepositories = arrayOf(
+            "custom:true:/custom/repo/path"
+        )))
+
+        val repos = repositoryService.getRepositories()
+
+        assertEquals("Should return custom repository", 1, repos.size)
+        assertEquals("Should be Custom type", RepositoryType.CUSTOM, repos[0].type)
+        assertEquals("Path should match", "/custom/repo/path", repos[0].path)
+    }
+
+    fun testGetRepositoriesWithGradleRepository() {
+        defaultSettingBinder.save(Settings(grpcRepositories = arrayOf(
+            "gradle:true:/path/to/.gradle/caches"
+        )))
+
+        val repos = repositoryService.getRepositories()
+
+        assertEquals("Should return Gradle repository", 1, repos.size)
+        assertEquals("Should be Gradle type", RepositoryType.GRADLE_CACHE, repos[0].type)
+    }
+
+    fun testGetAllRepositoriesReturnsNonNullWhenNoConfig() {
+        val repos = repositoryService.getAllRepositories()
+
+        assertNotNull("Should return non-null list", repos)
+    }
+
+    fun testGetRepositoriesWithEmptyArrayFallsBackToDefaults() {
+        defaultSettingBinder.save(Settings(grpcRepositories = emptyArray()))
+
+        val repos = repositoryService.getRepositories()
+
+        assertNotNull("Should fall back to environment defaults", repos)
+    }
+
+    fun testGetAllRepositoriesWithEmptyArrayFallsBackToDefaults() {
+        defaultSettingBinder.save(Settings(grpcRepositories = emptyArray()))
+
+        val repos = repositoryService.getAllRepositories()
+
+        assertNotNull("Should fall back to environment defaults", repos)
+    }
+
+    fun testGetInstance() {
+        val service = RepositoryService.getInstance(project)
+        assertNotNull("Service instance should not be null", service)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/util/ide/MavenHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/ide/MavenHelperTest.kt
@@ -1,0 +1,50 @@
+package com.itangcent.easyapi.util.ide
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+
+class MavenHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    fun testGetMavenIdReturnsNullWhenNoMavenOrGradle() {
+        loadFile("model/UserInfo.java")
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+
+        val result = MavenHelper.getMavenId(psiClass)
+
+        assertNull("Should return null when neither Maven nor Gradle project is available", result)
+    }
+
+    fun testGetMavenIdReturnsNullGracefullyForAnyPsiClass() {
+        loadFile("model/Result.java")
+        val psiClass = findClass("com.itangcent.model.Result")!!
+
+        val result = MavenHelper.getMavenId(psiClass)
+
+        assertNull("Should return null gracefully when no build tool integration", result)
+    }
+
+    fun testMavenIdDataEquality() {
+        val data1 = MavenIdData("com.example", "app", "1.0")
+        val data2 = MavenIdData("com.example", "app", "1.0")
+        assertEquals("Same data should be equal", data1, data2)
+    }
+
+    fun testMavenIdDataInequality() {
+        val data1 = MavenIdData("com.example", "app", "1.0")
+        val data2 = MavenIdData("com.other", "app", "1.0")
+        assertTrue("Different groupId should not be equal", data1 != data2)
+    }
+
+    fun testMavenIdDataHashCode() {
+        val data1 = MavenIdData("com.example", "app", "1.0")
+        val data2 = MavenIdData("com.example", "app", "1.0")
+        assertEquals("Equal objects should have same hashCode", data1.hashCode(), data2.hashCode())
+    }
+
+    fun testMavenIdDataToString() {
+        val data = MavenIdData("com.example", "app", "1.0")
+        val str = data.toString()
+        assertTrue("toString should contain groupId", str.contains("com.example"))
+        assertTrue("toString should contain artifactId", str.contains("app"))
+        assertTrue("toString should contain version", str.contains("1.0"))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/util/ide/ModuleHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/ide/ModuleHelperTest.kt
@@ -1,0 +1,87 @@
+package com.itangcent.easyapi.util.ide
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+
+class ModuleHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    fun testResolveModuleNameByPathWithSrcDirectory() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/my-app/src/main/java/com/example/App.java")
+        assertEquals("Should extract module name before /src/", "my-app", result)
+    }
+
+    fun testResolveModuleNameByPathWithMainDirectory() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/my-app/main/java/com/example/App.java")
+        assertEquals("Should extract module name before /main/", "my-app", result)
+    }
+
+    fun testResolveModuleNameByPathWithJavaDirectory() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/my-app/java/com/example/App.java")
+        assertEquals("Should extract module name before /java/", "my-app", result)
+    }
+
+    fun testResolveModuleNameByPathWithKotlinDirectory() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/my-app/kotlin/com/example/App.kt")
+        assertEquals("Should extract module name before /kotlin/", "my-app", result)
+    }
+
+    fun testResolveModuleNameByPathWithScalaDirectory() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/my-app/scala/com/example/App.scala")
+        assertEquals("Should extract module name before /scala/", "my-app", result)
+    }
+
+    fun testResolveModuleNameByPathWithNoSourceMarker() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/my-app/com/example/App.java")
+        assertEquals("Should return last segment when no source marker", "App.java", result)
+    }
+
+    fun testResolveModuleNameByPathWithNullInput() {
+        val result = ModuleHelper.resolveModuleNameByPath(null)
+        assertNull("Should return null for null input", result)
+    }
+
+    fun testResolveModuleNameByPathWithBlankInput() {
+        val result = ModuleHelper.resolveModuleNameByPath("")
+        assertNull("Should return null for empty input", result)
+        val result2 = ModuleHelper.resolveModuleNameByPath("   ")
+        assertNull("Should return null for blank input", result2)
+    }
+
+    fun testResolveModuleNameByPathWithWindowsBackslash() {
+        val result = ModuleHelper.resolveModuleNameByPath("C:\\projects\\my-app\\src\\main\\java\\com\\example\\App.java")
+        assertEquals("Should handle Windows backslashes", "my-app", result)
+    }
+
+    fun testResolveModuleNameByPathWithNestedModule() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/parent/child-module/src/main/java/com/example/App.java")
+        assertEquals("Should extract innermost module name before /src/", "child-module", result)
+    }
+
+    fun testResolveModuleNameByPathWithTrailingSlash() {
+        val result = ModuleHelper.resolveModuleNameByPath("/projects/my-app/src/")
+        assertEquals("Should handle trailing slash", "my-app", result)
+    }
+
+    fun testResolveModuleNameByPathWithSimpleDirectoryName() {
+        val result = ModuleHelper.resolveModuleNameByPath("/my-module")
+        assertEquals("Should return the directory name itself", "my-module", result)
+    }
+
+    fun testResolveModuleReturnsModuleForPsiElement() = runBlocking {
+        loadFile("model/UserInfo.java")
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+
+        val module = ModuleHelper.resolveModule(psiClass)
+
+        assertNotNull("Should find module for PSI element in test fixture", module)
+    }
+
+    fun testResolveModuleNameReturnsNameForPsiElement() = runBlocking {
+        loadFile("model/UserInfo.java")
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+
+        val moduleName = ModuleHelper.resolveModuleName(psiClass)
+
+        assertNotNull("Should return module name for PSI element in test fixture", moduleName)
+    }
+}


### PR DESCRIPTION
## Changes

- Add `ScriptSupportTest` — 27 tests covering GeneralScriptSupport, GroovyScriptSupport, AbstractScriptSupport, and scriptSupports list
- Add `EventBusTest` — 10 tests covering persistent/one-time handler registration, event firing via ActionCompletedTopic, error isolation
- Add `RequestPersistenceTest` — 12 tests covering JSON round-trip serialization, save/load/reset, field preservation
- Add `RepositoryServiceTest` — 11 tests covering repository filtering, fallback to defaults, invalid entry handling
- Add `MavenHelperTest` — 6 tests covering MavenId resolution and MavenIdData properties
- Add `ModuleHelperTest` — 14 tests covering path parsing and PSI module resolution

## Test Patterns Used

- **Pattern A (Simple Unit Test):** ScriptSupportTest — no IntelliJ dependencies
- **Pattern B (IDE Fixture Test):** EventBusTest, RequestPersistenceTest, RepositoryServiceTest, MavenHelperTest, ModuleHelperTest — extend EasyApiLightCodeInsightFixtureTestCase

## Test Results

All 80 new tests pass ✅