### PR TITLE
feat: extract ClassNameConstants and InheritanceHelper with cached inheritance checks

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -19,6 +19,7 @@ import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelUtils
 import com.itangcent.easyapi.psi.type.GenericContext
+import com.itangcent.easyapi.psi.type.InheritanceHelper
 import com.itangcent.easyapi.psi.type.ResolvedType
 import com.itangcent.easyapi.psi.type.SpecialTypeHandler
 import com.itangcent.easyapi.psi.type.TypeResolver
@@ -453,16 +454,7 @@ class SpringMvcClassExporter(
         return result
     }
 
-    private fun isCollectionType(psiClass: PsiClass): Boolean {
-        val qualifiedName = psiClass.qualifiedName ?: return false
-        return qualifiedName == "java.util.Collection" ||
-                qualifiedName == "java.util.List" ||
-                qualifiedName == "java.util.Set" ||
-                qualifiedName == "java.util.ArrayList" ||
-                qualifiedName == "java.util.HashSet" ||
-                qualifiedName == "java.util.LinkedList" ||
-                qualifiedName.startsWith("kotlin.collections.")
-    }
+    private fun isCollectionType(psiClass: PsiClass): Boolean = InheritanceHelper.isCollection(psiClass)
 
     private fun resolveFieldType(fieldModel: FieldModel): ParameterType {
         val model = fieldModel.model

--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -863,26 +863,12 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
         }
     }
 
-    private fun isCollection(psiClass: PsiClass): Boolean {
-        val qualifiedName = psiClass.qualifiedName ?: return false
-        return qualifiedName == "java.util.Collection" ||
-                qualifiedName == "java.util.List" ||
-                qualifiedName == "java.util.Set" ||
-                qualifiedName == "java.util.ArrayList" ||
-                qualifiedName == "java.util.HashSet" ||
-                qualifiedName == "java.util.LinkedList"
-    }
+    private fun isCollection(psiClass: PsiClass): Boolean = InheritanceHelper.isCollection(psiClass)
 
-    private fun isMap(psiClass: PsiClass): Boolean {
-        val qualifiedName = psiClass.qualifiedName ?: return false
-        return qualifiedName == "java.util.Map" ||
-                qualifiedName == "java.util.HashMap" ||
-                qualifiedName == "java.util.LinkedHashMap" ||
-                qualifiedName == "java.util.TreeMap"
-    }
+    private fun isMap(psiClass: PsiClass): Boolean = InheritanceHelper.isMap(psiClass)
 
     private fun isEnum(psiClass: PsiClass): Boolean {
-        return psiClass.isEnum || psiClass.supers.any { it.qualifiedName == "java.lang.Enum" }
+        return psiClass.isEnum || psiClass.supers.any { it.qualifiedName == ClassNameConstants.JAVA_LANG_ENUM }
     }
 
     private fun isSimpleType(psiClass: PsiClass): Boolean {

--- a/src/main/kotlin/com/itangcent/easyapi/psi/type/ClassNameConstants.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/type/ClassNameConstants.kt
@@ -1,0 +1,81 @@
+package com.itangcent.easyapi.psi.type
+
+/**
+ * Centralized constants for Java/Kotlin fully qualified class names.
+ *
+ * Eliminates hardcoded string literals scattered across the codebase
+ * by providing a single source of truth for commonly referenced class names.
+ * Used by [InheritanceHelper], [SpecialTypeHandler], and other PSI utilities.
+ *
+ * ## Organization
+ * - **Map types** — [JAVA_UTIL_MAP] and its common implementations
+ * - **Collection types** — [JAVA_UTIL_COLLECTION] and its common implementations
+ * - **Other core types** — [JAVA_LANG_ENUM], [JAVA_LANG_OBJECT]
+ * - **Kotlin collections** — [KOTLIN_COLLECTIONS_PREFIX] for prefix-based matching
+ *
+ * ## Pre-built Sets
+ * - [MAP_TYPES] — all Map-related FQNs for O(1) `contains` checks
+ * - [COLLECTION_TYPES] — all Collection-related FQNs for O(1) `contains` checks
+ *
+ * @see InheritanceHelper for type checking using these constants
+ * @see SpecialTypeHandler for special type detection (file, date, primitive wrappers)
+ */
+object ClassNameConstants {
+
+    const val JAVA_UTIL_MAP = "java.util.Map"
+    const val JAVA_UTIL_HASHMAP = "java.util.HashMap"
+    const val JAVA_UTIL_LINKEDHASHMAP = "java.util.LinkedHashMap"
+    const val JAVA_UTIL_TREEMAP = "java.util.TreeMap"
+    const val JAVA_UTIL_CONCURRENTMAP = "java.util.concurrent.ConcurrentMap"
+    const val JAVA_UTIL_CONCURRENTHASHMAP = "java.util.concurrent.ConcurrentHashMap"
+
+    const val JAVA_UTIL_COLLECTION = "java.util.Collection"
+    const val JAVA_UTIL_LIST = "java.util.List"
+    const val JAVA_UTIL_SET = "java.util.Set"
+    const val JAVA_UTIL_ARRAYLIST = "java.util.ArrayList"
+    const val JAVA_UTIL_HASHSET = "java.util.HashSet"
+    const val JAVA_UTIL_LINKEDLIST = "java.util.LinkedList"
+    const val JAVA_UTIL_LINKEDHASHSET = "java.util.LinkedHashSet"
+    const val JAVA_UTIL_VECTOR = "java.util.Vector"
+    const val JAVA_UTIL_STACK = "java.util.Stack"
+    const val JAVA_UTIL_TREESET = "java.util.TreeSet"
+
+    const val JAVA_LANG_ENUM = "java.lang.Enum"
+    const val JAVA_LANG_OBJECT = "java.lang.Object"
+
+    const val KOTLIN_COLLECTIONS_PREFIX = "kotlin.collections."
+
+    /**
+     * All Map-related fully qualified class names.
+     *
+     * Used by [InheritanceHelper.isMap] for fast-path O(1) FQN lookup
+     * before falling back to the more expensive inheritance traversal.
+     */
+    val MAP_TYPES: Set<String> = setOf(
+        JAVA_UTIL_MAP,
+        JAVA_UTIL_HASHMAP,
+        JAVA_UTIL_LINKEDHASHMAP,
+        JAVA_UTIL_TREEMAP,
+        JAVA_UTIL_CONCURRENTMAP,
+        JAVA_UTIL_CONCURRENTHASHMAP,
+    )
+
+    /**
+     * All Collection-related fully qualified class names.
+     *
+     * Used by [InheritanceHelper.isCollection] for fast-path O(1) FQN lookup
+     * before falling back to the more expensive inheritance traversal.
+     */
+    val COLLECTION_TYPES: Set<String> = setOf(
+        JAVA_UTIL_COLLECTION,
+        JAVA_UTIL_LIST,
+        JAVA_UTIL_SET,
+        JAVA_UTIL_ARRAYLIST,
+        JAVA_UTIL_HASHSET,
+        JAVA_UTIL_LINKEDLIST,
+        JAVA_UTIL_LINKEDHASHSET,
+        JAVA_UTIL_VECTOR,
+        JAVA_UTIL_STACK,
+        JAVA_UTIL_TREESET,
+    )
+}

--- a/src/main/kotlin/com/itangcent/easyapi/psi/type/InheritanceHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/type/InheritanceHelper.kt
@@ -1,0 +1,124 @@
+package com.itangcent.easyapi.psi.type
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.util.InheritanceUtil
+import com.itangcent.easyapi.core.threading.readSync
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Utility for checking PSI class inheritance relationships with caching.
+ *
+ * Provides efficient inheritance checks for common Java type hierarchies
+ * (Collection, Map, etc.) with a 10-second TTL cache to avoid redundant
+ * PSI traversals during intensive operations like API scanning.
+ *
+ * ## Thread Safety
+ * The cache uses [ConcurrentHashMap] for thread-safe concurrent access.
+ * Multiple coroutines can safely call any method concurrently.
+ *
+ * ## ReadAction Handling
+ * All public methods automatically acquire ReadAction context when needed
+ * for PSI access. Callers do NOT need to wrap calls in `readSync` — the
+ * helper handles this internally. Cached results are returned without
+ * acquiring ReadAction, making repeated lookups very fast.
+ *
+ * ## Cache Behavior
+ * - Cache TTL: 10 seconds per entry
+ * - Cache key: `"{sourceFQN}->{targetFQN}"` (e.g., `"java.util.ArrayList->java.util.Collection"`)
+ * - Cache is cleared on [clearCache] or automatically on TTL expiry
+ * - Fast-path FQN set lookups (e.g., [ClassNameConstants.COLLECTION_TYPES])
+ *   bypass the cache entirely as they are O(1) set contains checks
+ *
+ * ## Usage
+ * ```kotlin
+ * // No readSync needed — InheritanceHelper handles it
+ * val isCollection = InheritanceHelper.isCollection(psiClass)
+ * val isMap = InheritanceHelper.isMap(psiClass)
+ * val isInheritor = InheritanceHelper.isInheritor(psiClass, "java.lang.Exception")
+ * ```
+ *
+ * @see ClassNameConstants for the FQN constants and type sets used here
+ */
+object InheritanceHelper {
+
+    private val cache = ConcurrentHashMap<String, CacheEntry>()
+    private const val CACHE_TTL_MS = 10_000L
+
+    private class CacheEntry(val result: Boolean, val expiresAt: Long)
+
+    /**
+     * Checks if [psiClass] is equal to or inherits from [baseClassName].
+     *
+     * Results are cached for 10 seconds. If the cache is valid, returns the
+     * cached result without acquiring ReadAction. Otherwise, acquires ReadAction
+     * to perform the PSI traversal via [InheritanceUtil.isInheritor].
+     *
+     * @param psiClass the class to check
+     * @param baseClassName the fully qualified name of the base class or interface
+     * @return true if [psiClass] is or inherits from [baseClassName]
+     */
+    fun isInheritor(psiClass: PsiClass, baseClassName: String): Boolean {
+        val fqn = readSync { psiClass.qualifiedName } ?: return false
+        if (fqn == baseClassName) return true
+
+        val cacheKey = "$fqn->$baseClassName"
+        val now = System.currentTimeMillis()
+
+        val cached = cache[cacheKey]
+        if (cached != null && now < cached.expiresAt) {
+            return cached.result
+        }
+
+        val result = readSync { InheritanceUtil.isInheritor(psiClass, baseClassName) }
+        cache[cacheKey] = CacheEntry(result, now + CACHE_TTL_MS)
+        return result
+    }
+
+    /**
+     * Checks if [psiClass] represents a Java Collection type.
+     *
+     * Detection strategy (in order of speed):
+     * 1. **FQN set lookup** — O(1) check against [ClassNameConstants.COLLECTION_TYPES]
+     *    (includes Collection, List, Set, ArrayList, HashSet, LinkedList, etc.)
+     * 2. **Kotlin prefix check** — classes under `kotlin.collections.` are treated as collections
+     * 3. **Inheritance check** — delegates to [isInheritor] with `java.util.Collection`
+     *    (handles custom subclasses like `class MyList extends ArrayList<String>`)
+     *
+     * @param psiClass the class to check
+     * @return true if [psiClass] is a Collection type
+     */
+    fun isCollection(psiClass: PsiClass): Boolean {
+        val fqn = readSync { psiClass.qualifiedName } ?: return false
+        if (ClassNameConstants.COLLECTION_TYPES.contains(fqn)) return true
+        if (fqn.startsWith(ClassNameConstants.KOTLIN_COLLECTIONS_PREFIX)) return true
+        return isInheritor(psiClass, ClassNameConstants.JAVA_UTIL_COLLECTION)
+    }
+
+    /**
+     * Checks if [psiClass] represents a Java Map type.
+     *
+     * Detection strategy (in order of speed):
+     * 1. **FQN set lookup** — O(1) check against [ClassNameConstants.MAP_TYPES]
+     *    (includes Map, HashMap, LinkedHashMap, TreeMap, ConcurrentMap, etc.)
+     * 2. **Inheritance check** — delegates to [isInheritor] with `java.util.Map`
+     *    (handles custom subclasses like `class MyMap extends HashMap<String, Object>`)
+     *
+     * @param psiClass the class to check
+     * @return true if [psiClass] is a Map type
+     */
+    fun isMap(psiClass: PsiClass): Boolean {
+        val fqn = readSync { psiClass.qualifiedName } ?: return false
+        if (ClassNameConstants.MAP_TYPES.contains(fqn)) return true
+        return isInheritor(psiClass, ClassNameConstants.JAVA_UTIL_MAP)
+    }
+
+    /**
+     * Clears all cached inheritance check results.
+     *
+     * Useful for testing or when project state changes significantly
+     * (e.g., branch switch, dependency change).
+     */
+    fun clearCache() {
+        cache.clear()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
@@ -6,8 +6,8 @@ import com.intellij.psi.PsiEnumConstant
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
-import com.intellij.psi.util.InheritanceUtil
 import com.itangcent.easyapi.core.threading.readSync
+import com.itangcent.easyapi.psi.type.InheritanceHelper
 import com.itangcent.easyapi.psi.type.ResolvedField
 import com.itangcent.easyapi.psi.type.ResolvedMethod
 import com.itangcent.easyapi.psi.type.ResolvedParam
@@ -91,19 +91,14 @@ open class ScriptPsiClassContext(context: RuleContext) : ScriptItContext(context
         return ScriptTypeContext(context, ResolvedType.ClassType(psiClass()))
     }
 
-    fun isExtend(superClass: String): Boolean = readSync {
-        InheritanceUtil.isInheritor(psiClass(), superClass)
-    }
+    fun isExtend(superClass: String): Boolean =
+        InheritanceHelper.isInheritor(psiClass(), superClass)
 
-    fun isMap(): Boolean = readSync {
-        val fqn = psiClass().qualifiedName ?: return@readSync false
-        fqn == "java.util.Map" || InheritanceUtil.isInheritor(psiClass(), "java.util.Map")
-    }
+    fun isMap(): Boolean =
+        InheritanceHelper.isMap(psiClass())
 
-    fun isCollection(): Boolean = readSync {
-        val fqn = psiClass().qualifiedName ?: return@readSync false
-        fqn == "java.util.Collection" || InheritanceUtil.isInheritor(psiClass(), "java.util.Collection")
-    }
+    fun isCollection(): Boolean =
+        InheritanceHelper.isCollection(psiClass())
 
     fun isArray(): Boolean = name().endsWith("[]")
 
@@ -511,37 +506,20 @@ class ScriptTypeContext(private val context: RuleContext, private val resolvedTy
 
     override fun toString(): String = name()
 
-    fun isExtend(superClass: String): Boolean = readSync {
-        when (resolvedType) {
-            is ResolvedType.ClassType -> InheritanceUtil.isInheritor(resolvedType.psiClass, superClass)
-            else -> false
-        }
+    fun isExtend(superClass: String): Boolean = when (resolvedType) {
+        is ResolvedType.ClassType -> InheritanceHelper.isInheritor(resolvedType.psiClass, superClass)
+        else -> false
     }
 
-    fun isMap(): Boolean = readSync {
-        when (resolvedType) {
-            is ResolvedType.ClassType -> {
-                val fqn = resolvedType.psiClass.qualifiedName ?: return@readSync false
-                fqn == "java.util.Map" || InheritanceUtil.isInheritor(resolvedType.psiClass, "java.util.Map")
-            }
-
-            else -> false
-        }
+    fun isMap(): Boolean = when (resolvedType) {
+        is ResolvedType.ClassType -> InheritanceHelper.isMap(resolvedType.psiClass)
+        else -> false
     }
 
-    fun isCollection(): Boolean = readSync {
-        when (resolvedType) {
-            is ResolvedType.ClassType -> {
-                val fqn = resolvedType.psiClass.qualifiedName ?: return@readSync false
-                fqn == "java.util.Collection" || InheritanceUtil.isInheritor(
-                    resolvedType.psiClass,
-                    "java.util.Collection"
-                )
-            }
-
-            is ResolvedType.ArrayType -> true
-            else -> false
-        }
+    fun isCollection(): Boolean = when (resolvedType) {
+        is ResolvedType.ClassType -> InheritanceHelper.isCollection(resolvedType.psiClass)
+        is ResolvedType.ArrayType -> true
+        else -> false
     }
 
     fun isArray(): Boolean {

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/ClassNameConstantsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/ClassNameConstantsTest.kt
@@ -1,0 +1,77 @@
+package com.itangcent.easyapi.psi.type
+
+import junit.framework.TestCase
+
+class ClassNameConstantsTest : TestCase() {
+
+    fun testMapTypesContainsCoreMapInterfaces() {
+        assertTrue(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_MAP))
+        assertTrue(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_HASHMAP))
+        assertTrue(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_LINKEDHASHMAP))
+        assertTrue(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_TREEMAP))
+        assertTrue(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_CONCURRENTMAP))
+        assertTrue(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_CONCURRENTHASHMAP))
+    }
+
+    fun testMapTypesDoesNotContainCollectionTypes() {
+        assertFalse(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_COLLECTION))
+        assertFalse(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_LIST))
+        assertFalse(ClassNameConstants.MAP_TYPES.contains(ClassNameConstants.JAVA_UTIL_SET))
+    }
+
+    fun testCollectionTypesContainsCoreCollectionInterfaces() {
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_COLLECTION))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_LIST))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_SET))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_ARRAYLIST))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_HASHSET))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_LINKEDLIST))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_LINKEDHASHSET))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_VECTOR))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_STACK))
+        assertTrue(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_TREESET))
+    }
+
+    fun testCollectionTypesDoesNotContainMapTypes() {
+        assertFalse(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_MAP))
+        assertFalse(ClassNameConstants.COLLECTION_TYPES.contains(ClassNameConstants.JAVA_UTIL_HASHMAP))
+    }
+
+    fun testConstantValuesAreFullyQualified() {
+        assertEquals("java.util.Map", ClassNameConstants.JAVA_UTIL_MAP)
+        assertEquals("java.util.HashMap", ClassNameConstants.JAVA_UTIL_HASHMAP)
+        assertEquals("java.util.LinkedHashMap", ClassNameConstants.JAVA_UTIL_LINKEDHASHMAP)
+        assertEquals("java.util.TreeMap", ClassNameConstants.JAVA_UTIL_TREEMAP)
+        assertEquals("java.util.concurrent.ConcurrentMap", ClassNameConstants.JAVA_UTIL_CONCURRENTMAP)
+        assertEquals("java.util.concurrent.ConcurrentHashMap", ClassNameConstants.JAVA_UTIL_CONCURRENTHASHMAP)
+
+        assertEquals("java.util.Collection", ClassNameConstants.JAVA_UTIL_COLLECTION)
+        assertEquals("java.util.List", ClassNameConstants.JAVA_UTIL_LIST)
+        assertEquals("java.util.Set", ClassNameConstants.JAVA_UTIL_SET)
+        assertEquals("java.util.ArrayList", ClassNameConstants.JAVA_UTIL_ARRAYLIST)
+        assertEquals("java.util.HashSet", ClassNameConstants.JAVA_UTIL_HASHSET)
+        assertEquals("java.util.LinkedList", ClassNameConstants.JAVA_UTIL_LINKEDLIST)
+        assertEquals("java.util.LinkedHashSet", ClassNameConstants.JAVA_UTIL_LINKEDHASHSET)
+        assertEquals("java.util.Vector", ClassNameConstants.JAVA_UTIL_VECTOR)
+        assertEquals("java.util.Stack", ClassNameConstants.JAVA_UTIL_STACK)
+        assertEquals("java.util.TreeSet", ClassNameConstants.JAVA_UTIL_TREESET)
+
+        assertEquals("java.lang.Enum", ClassNameConstants.JAVA_LANG_ENUM)
+        assertEquals("java.lang.Object", ClassNameConstants.JAVA_LANG_OBJECT)
+
+        assertEquals("kotlin.collections.", ClassNameConstants.KOTLIN_COLLECTIONS_PREFIX)
+    }
+
+    fun testMapTypesIsNotEmpty() {
+        assertFalse(ClassNameConstants.MAP_TYPES.isEmpty())
+    }
+
+    fun testCollectionTypesIsNotEmpty() {
+        assertFalse(ClassNameConstants.COLLECTION_TYPES.isEmpty())
+    }
+
+    fun testNoOverlapBetweenMapAndCollectionTypes() {
+        val overlap = ClassNameConstants.MAP_TYPES.intersect(ClassNameConstants.COLLECTION_TYPES)
+        assertTrue("Map and Collection types should not overlap", overlap.isEmpty())
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/InheritanceHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/InheritanceHelperTest.kt
@@ -1,0 +1,223 @@
+package com.itangcent.easyapi.psi.type
+
+import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+
+class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        InheritanceHelper.clearCache()
+    }
+
+    fun testIsCollectionWithArrayList() {
+        val psiClass = loadJavaCollectionClass("ArrayList")
+        assertTrue("ArrayList should be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsCollectionWithHashSet() {
+        val psiClass = loadJavaCollectionClass("HashSet")
+        assertTrue("HashSet should be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsCollectionWithLinkedList() {
+        val psiClass = loadJavaCollectionClass("LinkedList")
+        assertTrue("LinkedList should be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsCollectionWithListInterface() {
+        val psiClass = loadJavaCollectionClass("List")
+        assertTrue("List should be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsCollectionWithSetInterface() {
+        val psiClass = loadJavaCollectionClass("Set")
+        assertTrue("Set should be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsCollectionWithCollectionInterface() {
+        val psiClass = loadJavaCollectionClass("Collection")
+        assertTrue("Collection should be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsCollectionWithNonCollectionClass() {
+        val source = """
+            package com.test;
+            public class NotACollection {
+                public int size() { return 0; }
+            }
+        """.trimIndent()
+        myFixture.addClass(source)
+        val psiClass = findClass("com.test.NotACollection")!!
+        assertFalse("Non-collection class should not be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsCollectionWithCustomCollectionSubclass() {
+        setupCollectionInheritanceStubs()
+        myFixture.addClass("""
+            package com.test;
+            import java.util.ArrayList;
+            public class MyList extends ArrayList<String> {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.MyList")!!
+        assertTrue("Subclass of ArrayList should be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsMapWithHashMap() {
+        val psiClass = loadJavaMapClass("HashMap")
+        assertTrue("HashMap should be detected as Map", InheritanceHelper.isMap(psiClass))
+    }
+
+    fun testIsMapWithLinkedHashMap() {
+        val psiClass = loadJavaMapClass("LinkedHashMap")
+        assertTrue("LinkedHashMap should be detected as Map", InheritanceHelper.isMap(psiClass))
+    }
+
+    fun testIsMapWithTreeMap() {
+        val psiClass = loadJavaMapClass("TreeMap")
+        assertTrue("TreeMap should be detected as Map", InheritanceHelper.isMap(psiClass))
+    }
+
+    fun testIsMapWithMapInterface() {
+        val psiClass = loadJavaMapClass("Map")
+        assertTrue("Map interface should be detected as Map", InheritanceHelper.isMap(psiClass))
+    }
+
+    fun testIsMapWithNonMapClass() {
+        val source = """
+            package com.test;
+            public class NotAMap {
+                public Object get(Object key) { return null; }
+            }
+        """.trimIndent()
+        myFixture.addClass(source)
+        val psiClass = findClass("com.test.NotAMap")!!
+        assertFalse("Non-map class should not be detected as Map", InheritanceHelper.isMap(psiClass))
+    }
+
+    fun testIsMapWithCustomMapSubclass() {
+        setupMapInheritanceStubs()
+        myFixture.addClass("""
+            package com.test;
+            import java.util.HashMap;
+            public class MyMap extends HashMap<String, Object> {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.MyMap")!!
+        assertTrue("Subclass of HashMap should be detected as Map", InheritanceHelper.isMap(psiClass))
+    }
+
+    fun testIsInheritorDirectMatch() {
+        val psiClass = loadJavaMapClass("Map")
+        assertTrue("Map should be inheritor of itself", InheritanceHelper.isInheritor(psiClass, "java.util.Map"))
+    }
+
+    fun testIsInheritorSubclass() {
+        setupCollectionInheritanceStubs()
+        myFixture.addClass("""
+            package com.test;
+            import java.util.ArrayList;
+            public class MyList extends ArrayList<String> {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.MyList")!!
+        assertTrue("MyList should be inheritor of Collection", InheritanceHelper.isInheritor(psiClass, "java.util.Collection"))
+    }
+
+    fun testIsInheritorNotRelated() {
+        val source = """
+            package com.test;
+            public class SimpleClass {}
+        """.trimIndent()
+        myFixture.addClass(source)
+        val psiClass = findClass("com.test.SimpleClass")!!
+        assertFalse("SimpleClass should not be inheritor of Collection", InheritanceHelper.isInheritor(psiClass, "java.util.Collection"))
+    }
+
+    fun testCacheReturnsSameResult() {
+        val psiClass = loadJavaCollectionClass("ArrayList")
+        val result1 = InheritanceHelper.isCollection(psiClass)
+        val result2 = InheritanceHelper.isCollection(psiClass)
+        assertEquals("Cached result should be the same", result1, result2)
+    }
+
+    fun testClearCache() {
+        val psiClass = loadJavaCollectionClass("ArrayList")
+        InheritanceHelper.isCollection(psiClass)
+        InheritanceHelper.clearCache()
+        val result = InheritanceHelper.isCollection(psiClass)
+        assertTrue("Result should still be correct after cache clear", result)
+    }
+
+    fun testIsCollectionReturnsFalseForMap() {
+        val psiClass = loadJavaMapClass("HashMap")
+        assertFalse("HashMap should not be detected as Collection", InheritanceHelper.isCollection(psiClass))
+    }
+
+    fun testIsMapReturnsFalseForCollection() {
+        val psiClass = loadJavaCollectionClass("ArrayList")
+        assertFalse("ArrayList should not be detected as Map", InheritanceHelper.isMap(psiClass))
+    }
+
+    private fun setupCollectionInheritanceStubs() {
+        myFixture.addClass("""
+            package java.util;
+            public interface Collection<E> extends Iterable<E> {}
+        """.trimIndent())
+        myFixture.addClass("""
+            package java.util;
+            public interface List<E> extends Collection<E> {}
+        """.trimIndent())
+        myFixture.addClass("""
+            package java.util;
+            public interface Set<E> extends Collection<E> {}
+        """.trimIndent())
+        myFixture.addClass("""
+            package java.util;
+            public abstract class AbstractCollection<E> implements Collection<E> {}
+        """.trimIndent())
+        myFixture.addClass("""
+            package java.util;
+            public abstract class AbstractList<E> extends AbstractCollection<E> implements List<E> {}
+        """.trimIndent())
+        myFixture.addClass("""
+            package java.util;
+            public class ArrayList<E> extends AbstractList<E> {}
+        """.trimIndent())
+    }
+
+    private fun setupMapInheritanceStubs() {
+        myFixture.addClass("""
+            package java.util;
+            public interface Map<K, V> {}
+        """.trimIndent())
+        myFixture.addClass("""
+            package java.util;
+            public abstract class AbstractMap<K, V> implements Map<K, V> {}
+        """.trimIndent())
+        myFixture.addClass("""
+            package java.util;
+            public class HashMap<K, V> extends AbstractMap<K, V> {}
+        """.trimIndent())
+    }
+
+    private fun loadJavaCollectionClass(className: String): PsiClass {
+        val fqn = "java.util.$className"
+        val existing = findClass(fqn)
+        if (existing != null) return existing
+        myFixture.addClass("""
+            package java.util;
+            public class $className {}
+        """.trimIndent())
+        return findClass(fqn)!!
+    }
+
+    private fun loadJavaMapClass(className: String): PsiClass {
+        val fqn = "java.util.$className"
+        val existing = findClass(fqn)
+        if (existing != null) return existing
+        myFixture.addClass("""
+            package java.util;
+            public class $className {}
+        """.trimIndent())
+        return findClass(fqn)!!
+    }
+}


### PR DESCRIPTION
## Changes

- Add ClassNameConstants: centralize Java/Kotlin FQN constants for Map, Collection, and core types
- Add InheritanceHelper: cached isInheritor/isCollection/isMap with 10s TTL and internal readSync
- Update DefaultPsiClassHelper, ScriptPsiContexts, SpringMvcClassExporter to use InheritanceHelper
- Remove redundant readSync wrappers in callers
- Add test cases for ClassNameConstants and InheritanceHelper