### PR TITLE
feat: unify rule-based metadata resolution across frameworks

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
@@ -1,0 +1,349 @@
+package com.itangcent.easyapi.exporter
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiParameter
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypes
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTypesUtil
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.ApiParameter
+import com.itangcent.easyapi.psi.PsiClassHelper
+import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.StandardDocHelper
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelUtils
+import com.itangcent.easyapi.psi.type.GenericContext
+import com.itangcent.easyapi.rule.engine.RuleEngine
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.Settings
+
+/**
+ * Shared utility for building API endpoint components across all framework exporters.
+ *
+ * Centralizes common logic that was previously duplicated in SpringMVC, JAX-RS, Feign,
+ * gRPC, and Actuator exporters, including:
+ * - Response body construction with rule-based overrides (`method.return`, `method.return.main`)
+ * - Header deduplication and merging from multiple sources
+ * - Request body parameter expansion
+ * - Path parameter merging with enum/default/description enrichment
+ *
+ * Registered as a IntelliJ project-level service, so it can resolve dependencies
+ * (RuleEngine, DocHelper, Settings, ApiMetadataResolver) from the project automatically.
+ *
+ * Usage:
+ * ```
+ * val builder = EndpointBuilder.getInstance(project)
+ * val headers = builder.buildHeaders(contentType, paramHeaders, additionalHeaders)
+ * val responseBody = builder.buildResponseBody(method, genericContext)
+ * ```
+ */
+class EndpointBuilder(private val project: Project) {
+
+    private val settings: Settings by lazy { SettingBinder.getInstance(project).read() }
+    private val docHelper: DocHelper by lazy { StandardDocHelper.getInstance(project) }
+    private val metadataResolver: ApiMetadataResolver by lazy {
+        ApiMetadataResolver(
+            RuleEngine.getInstance(project),
+            StandardDocHelper.getInstance(project),
+            settings
+        )
+    }
+
+    /**
+     * Strategy interface for building an [ObjectModel] from a [PsiClass].
+     *
+     * Allows framework-specific model construction (e.g., gRPC uses protobuf parsing,
+     * Actuator uses [JsonType], while standard SpringMVC/JAX-RS/Feign use [PsiClassHelper]).
+     */
+    fun interface ResponseModelBuilder {
+        suspend fun buildModel(psiClass: PsiClass): ObjectModel?
+    }
+
+    /**
+     * Builds the response body [ObjectModel] for the given method.
+     *
+     * Resolution order:
+     * 1. **`method.return` rule** — if set, resolves the class by qualified name and delegates
+     *    to [modelBuilder] to construct the model (e.g., `method.return = com.example.Result`).
+     * 2. **Original return type** — uses [PsiClassHelper] to build from the method's declared
+     *    return type, which respects `json.rule.convert` rules (e.g., `Mono<T>` → `T`).
+     * 3. **Return type override** — if the original type yields no model and [returnTypeOverride]
+     *    is provided, tries the unwrapped type (e.g., `ResponseEntity<T>` → `T` for SpringMVC).
+     * 4. **`method.return.main` rule** — after building the model, applies the `@return` doc
+     *    comment to a specific field within the response type (e.g., `data` in `Result<T>`).
+     *
+     * @param method The PSI method whose response body is being built
+     * @param genericContext Generic type resolution context for the method's class
+     * @param modelBuilder Strategy for constructing an ObjectModel from a PsiClass;
+     *        defaults to [DefaultResponseModelBuilder] which uses [PsiClassHelper]
+     * @param returnTypeOverride Optional function to unwrap container types (e.g., ResponseEntity, Mono);
+     *        receives the original return type and returns the unwrapped type, or null if no unwrapping applies
+     * @return The response body model, or null if the method returns void or no model could be built
+     */
+    suspend fun buildResponseBody(
+        method: PsiMethod,
+        genericContext: GenericContext = GenericContext.EMPTY,
+        modelBuilder: ResponseModelBuilder = DefaultResponseModelBuilder(project, genericContext, method),
+        returnTypeOverride: ((PsiType) -> PsiType?)? = null
+    ): ObjectModel? {
+        val returnTypeByRule = metadataResolver.resolveMethodReturn(method)
+        if (!returnTypeByRule.isNullOrBlank()) {
+            val psiClass = JavaPsiFacade.getInstance(project)
+                .findClass(returnTypeByRule.trim(), GlobalSearchScope.allScope(project))
+            if (psiClass != null) {
+                return runCatching { modelBuilder.buildModel(psiClass) }.getOrNull()
+            }
+        }
+
+        val returnType = method.returnType ?: return null
+        if (returnType == PsiTypes.voidType()) return null
+
+        var responseModel = runCatching {
+            val helper = PsiClassHelper.getInstance(project)
+            helper.buildObjectModelFromType(
+                psiType = returnType,
+                genericContext = genericContext,
+                contextElement = method
+            )
+        }.getOrNull()
+
+        if (responseModel == null && returnTypeOverride != null) {
+            val unwrappedType = returnTypeOverride(returnType)
+            if (unwrappedType != null && unwrappedType != PsiTypes.voidType() && unwrappedType !== returnType) {
+                responseModel = runCatching {
+                    val helper = PsiClassHelper.getInstance(project)
+                    helper.buildObjectModelFromType(
+                        psiType = unwrappedType,
+                        genericContext = genericContext,
+                        contextElement = method
+                    )
+                }.getOrNull()
+            }
+        }
+
+        if (responseModel == null) return null
+
+        return applyReturnMain(method, responseModel)
+    }
+
+    /**
+     * Applies the `method.return.main` rule to a response model.
+     *
+     * The `method.return.main` rule specifies a field name within the response type where
+     * the `@return` doc comment should be placed. For example, with `Result<T>`:
+     * - Rule: `method.return.main[groovy:it.returnType().isExtend("Result")]=data`
+     * - `@return "processed result"` is attached to the `data` field instead of the root
+     *
+     * If no explicit rule is set and `settings.inferReturnMain` is true, auto-detects
+     * the generic type parameter field (e.g., `data: T` in `Result<T>`).
+     *
+     * @param method The PSI method to resolve the rule from
+     * @param responseModel The response model to apply the rule to
+     * @return The updated model with the field comment applied, or the original model unchanged
+     */
+    suspend fun applyReturnMain(
+        method: PsiMethod,
+        responseModel: ObjectModel
+    ): ObjectModel {
+        val returnMain = metadataResolver.resolveMethodReturnMain(method)
+        val mainField = if (!returnMain.isNullOrBlank()) {
+            returnMain
+        } else if (settings.inferReturnMain) {
+            ObjectModelUtils.findGenericFieldName(responseModel)
+        } else null
+
+        if (!mainField.isNullOrBlank()) {
+            val descOfReturn = docHelper.findDocByTag(method, "return")
+            if (!descOfReturn.isNullOrBlank()) {
+                val updated = ObjectModelUtils.addFieldComment(responseModel, mainField, descOfReturn)
+                if (updated != null) return updated
+            }
+        }
+
+        return responseModel
+    }
+
+    /**
+     * Builds a deduplicated list of HTTP headers from multiple sources.
+     *
+     * Headers are added in priority order (first occurrence wins):
+     * 1. **Content-Type** — from the resolved content type string
+     * 2. **Mapping headers** — from annotation attributes (e.g., `@RequestMapping(headers=...)`);
+     *    Content-Type in mapping headers is skipped since it's handled in step 1
+     * 3. **Parameter headers** — from `@RequestHeader`-annotated method parameters
+     * 4. **Additional headers** — from `method.additional.header` rule
+     * 5. **Additional response headers** — from `method.additional.response.header` rule
+     *
+     * Deduplication is case-insensitive (e.g., "Content-Type" and "content-type" are the same).
+     *
+     * @param contentType The resolved Content-Type value, or null if not applicable
+     * @param paramHeaders Headers from `@RequestHeader` parameters
+     * @param additionalHeaders Headers from `method.additional.header` rule
+     * @param additionalResponseHeaders Headers from `method.additional.response.header` rule
+     * @param mappingHeaders Headers from annotation attributes as name-value pairs
+     * @return Deduplicated list of headers in priority order
+     */
+    fun buildHeaders(
+        contentType: String?,
+        paramHeaders: List<ApiHeader> = emptyList(),
+        additionalHeaders: List<ApiHeader> = emptyList(),
+        additionalResponseHeaders: List<ApiHeader> = emptyList(),
+        mappingHeaders: List<Pair<String, String>> = emptyList()
+    ): List<ApiHeader> {
+        val seen = mutableSetOf<String>()
+        val result = ArrayList<ApiHeader>()
+
+        if (!contentType.isNullOrBlank()) {
+            result.add(ApiHeader(name = "Content-Type", value = contentType))
+            seen.add("content-type")
+        }
+
+        for ((name, value) in mappingHeaders) {
+            if (!name.equals("Content-Type", ignoreCase = true) && name.lowercase() !in seen) {
+                result.add(ApiHeader(name = name, value = value))
+                seen.add(name.lowercase())
+            }
+        }
+
+        for (h in paramHeaders) {
+            val key = h.name.lowercase()
+            if (key !in seen) {
+                result.add(h)
+                seen.add(key)
+            }
+        }
+
+        for (h in additionalHeaders) {
+            val key = h.name.lowercase()
+            if (key !in seen) {
+                result.add(h)
+                seen.add(key)
+            }
+        }
+
+        for (h in additionalResponseHeaders) {
+            val key = h.name.lowercase()
+            if (key !in seen) {
+                result.add(h)
+                seen.add(key)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Expands a body parameter into its [ObjectModel] representation.
+     *
+     * Skips primitive/wrapper types (java.lang.* and String) since they don't have
+     * expandable fields. For complex types, uses [PsiClassHelper] which respects
+     * `json.rule.convert` rules (e.g., `Mono<T>` → `T`, `RequestEntity<T>` → `T`).
+     *
+     * @param parameter The PSI parameter annotated as `@RequestBody`
+     * @param genericContext Generic type resolution context
+     * @return The expanded object model, or null for simple types or if expansion fails
+     */
+    suspend fun expandBodyParam(
+        parameter: PsiParameter,
+        genericContext: GenericContext = GenericContext.EMPTY
+    ): ObjectModel? {
+        val psiClass = PsiTypesUtil.getPsiClass(parameter.type) ?: return null
+        val qualifiedName = psiClass.qualifiedName ?: return null
+        if (qualifiedName.startsWith("java.lang.") || qualifiedName == "java.lang.String") return null
+        return runCatching {
+            val helper = PsiClassHelper.getInstance(project)
+            helper.buildObjectModelFromType(
+                psiType = parameter.type,
+                genericContext = genericContext,
+                contextElement = parameter
+            )
+        }.getOrNull()
+    }
+
+    /**
+     * Merges method parameters with path parameters extracted from the URL pattern.
+     *
+     * Path parameters from the URL pattern (e.g., `{id}` in `/users/{id}`) may carry
+     * additional metadata (enum values, default values, descriptions) that should enrich
+     * the corresponding method parameters. This method:
+     *
+     * 1. For each method parameter with `ParameterBinding.Path`, if a matching path param
+     *    exists (by name), merges the path param's metadata:
+     *    - `enumValues` from path param takes priority if present (path enums are authoritative)
+     *    - `defaultValue` from method param takes priority; path param used as fallback if blank
+     *    - `description` from method param takes priority; path param used as fallback if blank
+     * 2. Appends any path params not already present in the method params list
+     *
+     * @param methodParams Parameters resolved from the method signature
+     * @param pathParams Parameters extracted from the URL path pattern
+     * @return Merged parameter list with enriched path parameters
+     */
+    fun mergePathParameters(
+        methodParams: List<ApiParameter>,
+        pathParams: List<ApiParameter>
+    ): List<ApiParameter> {
+        if (pathParams.isEmpty()) return methodParams
+        val pathParamMap = pathParams.associateBy { it.name }
+        val result = mutableListOf<ApiParameter>()
+
+        for (param in methodParams) {
+            if (param.binding == com.itangcent.easyapi.exporter.model.ParameterBinding.Path) {
+                val pathParam = pathParamMap[param.name]
+                if (pathParam != null) {
+                    result.add(
+                        param.copy(
+                            enumValues = pathParam.enumValues ?: param.enumValues,
+                            defaultValue = param.defaultValue?.takeIf { it.isNotBlank() }
+                                ?: pathParam.defaultValue,
+                            description = param.description?.takeIf { it.isNotBlank() }
+                                ?: pathParam.description
+                        )
+                    )
+                } else {
+                    result.add(param)
+                }
+            } else {
+                result.add(param)
+            }
+        }
+
+        val existingNames = result.map { it.name }.toSet()
+        for (pathParam in pathParams) {
+            if (pathParam.name !in existingNames) {
+                result.add(pathParam)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Default [ResponseModelBuilder] that uses [PsiClassHelper] to build models.
+     */
+    private class DefaultResponseModelBuilder(
+        private val project: Project,
+        private val genericContext: GenericContext,
+        private val method: PsiMethod
+    ) : ResponseModelBuilder {
+        override suspend fun buildModel(psiClass: PsiClass): ObjectModel? {
+            return runCatching {
+                val helper = PsiClassHelper.getInstance(project)
+                helper.buildObjectModel(psiClass)
+            }.getOrNull()
+        }
+    }
+
+    companion object {
+        /**
+         * Returns the [EndpointBuilder] instance for the given project.
+         * The instance is managed by the IntelliJ service container.
+         */
+        fun getInstance(project: Project): EndpointBuilder = project.service()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.util.PsiTypesUtil
 import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
+import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.exporter.springmvc.RequestMappingResolver
 import com.itangcent.easyapi.exporter.springmvc.SpringParameterBindingResolver
@@ -64,6 +65,7 @@ class FeignClassExporter(
     private val springParamResolver = SpringParameterBindingResolver(annotationHelper, engine)
     private val docHelper = StandardDocHelper.getInstance(project)
     private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!recognizer.isFeignClient(psiClass)) return emptyList()
@@ -135,23 +137,31 @@ class FeignClassExporter(
                 val classDesc = metadataResolver.resolveClassDoc(psiClass)
 
                 val params = buildSpringParams(method)
+                val additionalParams = metadataResolver.resolveAdditionalParams(method)
                 val body = buildSpringRequestBody(method)
-                val responseBody = buildResponseBody(method)
+                val responseBody = endpointBuilder.buildResponseBody(method)
+                val additionalHeaders = metadataResolver.resolveAdditionalHeaders(method)
+                val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
 
                 LOG.info("after parse method:$methodKey")
 
-                endpoints = mappings.map { m ->
-                    val contentType = m.consumes.firstOrNull()
-                    val headers = buildList {
-                        if (!contentType.isNullOrBlank()) {
-                            add(ApiHeader(name = "Content-Type", value = contentType))
-                        }
-                        for ((name, value) in m.headers) {
-                            if (!name.equals("Content-Type", ignoreCase = true)) {
-                                add(ApiHeader(name = name, value = value))
-                            }
-                        }
+                // Filter mappings by path.multi strategy before building endpoints
+                val pathSelector = metadataResolver.resolvePathMulti(method)
+                val selectedMappings = pathSelector.select(mappings) { it.path }
+
+                endpoints = selectedMappings.map { m ->
+                    val contentTypeOverride = engine.evaluate(RuleKeys.METHOD_CONTENT_TYPE, method)
+                    val contentType = if (!contentTypeOverride.isNullOrBlank()) {
+                        contentTypeOverride
+                    } else {
+                        m.consumes.firstOrNull()
                     }
+                    val headers = endpointBuilder.buildHeaders(
+                        contentType = contentType,
+                        additionalHeaders = additionalHeaders,
+                        additionalResponseHeaders = additionalResponseHeaders,
+                        mappingHeaders = m.headers.toList()
+                    )
 
                     val rawPath = normalizePath(join(basePath, m.path))
                     val pathVariablePatterns = PathVariablePattern.extractPathVariablesFromPath(rawPath)
@@ -169,7 +179,7 @@ class FeignClassExporter(
                         )
                     }
 
-                    val mergedParams = mergePathParameters(params, pathParamsFromPath)
+                    val mergedParams = endpointBuilder.mergePathParameters(params + additionalParams, pathParamsFromPath)
 
                     ApiEndpoint(
                         name = name,
@@ -232,10 +242,32 @@ class FeignClassExporter(
         } else emptyList()
 
         val expandedBody = buildNativeFeignBody(method, bodyParams)
-        val responseBody = buildResponseBody(method)
+        val responseBody = endpointBuilder.buildResponseBody(method)
+        val additionalHeaders = metadataResolver.resolveAdditionalHeaders(method)
+        val additionalParams = metadataResolver.resolveAdditionalParams(method)
+        val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
+
+        val mergedHeaders = endpointBuilder.buildHeaders(
+            contentType = null,
+            paramHeaders = finalHeaders,
+            additionalHeaders = additionalHeaders,
+            additionalResponseHeaders = additionalResponseHeaders
+        )
 
         val name = metadataResolver.resolveApiName(method)
         val classDesc = metadataResolver.resolveClassDoc(psiClass)
+
+        val contentTypeOverride = engine.evaluate(RuleKeys.METHOD_CONTENT_TYPE, method)
+        val finalHeadersWithContentType = if (!contentTypeOverride.isNullOrBlank()) {
+            endpointBuilder.buildHeaders(
+                contentType = contentTypeOverride,
+                paramHeaders = mergedHeaders.filter { !it.name.equals("Content-Type", ignoreCase = true) },
+                additionalHeaders = emptyList(),
+                additionalResponseHeaders = emptyList()
+            )
+        } else {
+            mergedHeaders
+        }
 
         val pathParamsFromPath = pathVariablePatterns.map { pattern ->
             ApiParameter(
@@ -249,7 +281,7 @@ class FeignClassExporter(
             )
         }
 
-        val mergedPathParams = mergePathParameters(pathParams, pathParamsFromPath)
+        val mergedPathParams = endpointBuilder.mergePathParameters(pathParams, pathParamsFromPath)
 
         return ApiEndpoint(
             name = name,
@@ -261,9 +293,9 @@ class FeignClassExporter(
             metadata = httpMetadata(
                 path = normalizedPathTemplate,
                 method = requestLine.method,
-                parameters = mergedPathParams + queryParams + bodyParams,
-                headers = finalHeaders,
-                contentType = finalHeaders.firstOrNull { it.name.equals("Content-Type", true) }?.value,
+                parameters = mergedPathParams + queryParams + bodyParams + additionalParams,
+                headers = finalHeadersWithContentType,
+                contentType = finalHeadersWithContentType.firstOrNull { it.name.equals("Content-Type", true) }?.value,
                 body = expandedBody,
                 responseBody = responseBody
             )
@@ -308,7 +340,7 @@ class FeignClassExporter(
             val binding = springParamResolver.resolve(p) ?: continue
             if (binding == ParameterBinding.Ignored) continue
             if (binding != ParameterBinding.Body) continue
-            return expandBodyParam(p)
+            return endpointBuilder.expandBodyParam(p)
         }
         return null
     }
@@ -319,31 +351,9 @@ class FeignClassExporter(
             val psiClass = PsiTypesUtil.getPsiClass(p.type) ?: continue
             val qualifiedName = psiClass.qualifiedName ?: continue
             if (qualifiedName.startsWith("java.lang.") || qualifiedName == "java.lang.String") continue
-            return expandBodyParam(p)
+            return endpointBuilder.expandBodyParam(p)
         }
         return null
-    }
-
-    private suspend fun expandBodyParam(parameter: PsiParameter): ObjectModel? {
-        val psiClass = PsiTypesUtil.getPsiClass(parameter.type) ?: return null
-        val qualifiedName = psiClass.qualifiedName ?: return null
-        if (qualifiedName.startsWith("java.lang.") || qualifiedName == "java.lang.String") return null
-        return runCatching {
-            val helper = PsiClassHelper.getInstance(project!!)
-            helper.buildObjectModel(psiClass)
-        }.getOrNull()
-    }
-
-    private suspend fun buildResponseBody(method: PsiMethod): ObjectModel? {
-        val returnType = method.returnType ?: return null
-        if (returnType == com.intellij.psi.PsiTypes.voidType()) return null
-        return runCatching {
-            val helper = PsiClassHelper.getInstance(project!!)
-            helper.buildObjectModelFromType(
-                psiType = returnType,
-                contextElement = method
-            )
-        }.getOrNull()
     }
 
     private fun join(a: String, b: String): String {
@@ -356,45 +366,6 @@ class FeignClassExporter(
         if (path.isBlank()) return "/"
         val p = if (path.startsWith("/")) path else "/$path"
         return p.replace(Regex("/+"), "/")
-    }
-
-    private fun mergePathParameters(
-        methodParams: List<ApiParameter>,
-        pathParams: List<ApiParameter>
-    ): List<ApiParameter> {
-        if (pathParams.isEmpty()) return methodParams
-        val pathParamMap = pathParams.associateBy { it.name }
-        val result = mutableListOf<ApiParameter>()
-
-        for (param in methodParams) {
-            if (param.binding == ParameterBinding.Path) {
-                val pathParam = pathParamMap[param.name]
-                if (pathParam != null) {
-                    result.add(
-                        param.copy(
-                            enumValues = pathParam.enumValues ?: param.enumValues,
-                            defaultValue = param.defaultValue?.takeIf { it.isNotBlank() }
-                                ?: pathParam.defaultValue,
-                            description = param.description?.takeIf { it.isNotBlank() }
-                                ?: pathParam.description
-                        )
-                    )
-                } else {
-                    result.add(param)
-                }
-            } else {
-                result.add(param)
-            }
-        }
-
-        val existingNames = result.map { it.name }.toSet()
-        for (pathParam in pathParams) {
-            if (pathParam.name !in existingNames) {
-                result.add(pathParam)
-            }
-        }
-
-        return result
     }
 
     companion object : IdeaLog

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
@@ -2,14 +2,18 @@ package com.itangcent.easyapi.exporter.grpc
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
 import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
+import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.StandardDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelUtils
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 
@@ -38,6 +42,8 @@ class GrpcClassExporter(
 
     private val engine = RuleEngine.getInstance(project)
     private val docHelper: DocHelper = StandardDocHelper.getInstance(project)
+    private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val endpointBuilder = EndpointBuilder.getInstance(project)
     private val recognizer = GrpcServiceRecognizer(engine)
     private val methodResolver = GrpcMethodResolver.getInstance(project)
     private val typeParser = GrpcTypeParser()
@@ -52,8 +58,9 @@ class GrpcClassExporter(
 
         engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
 
-        val classDescription = resolveClassDescription(psiClass)
-        val folder = classDescription?.lines()?.firstOrNull { it.isNotBlank() }
+        val classDescription = metadataResolver.resolveClassDoc(psiClass)
+        val folder = metadataResolver.resolveFolderName(null, psiClass)
+            ?: classDescription?.lines()?.firstOrNull { it.isNotBlank() }
             ?: read { psiClass.name }
             ?: "Unknown"
 
@@ -63,14 +70,19 @@ class GrpcClassExporter(
             endpoints = rpcMethods.mapNotNull { methodInfo ->
                 try {
                     val requestBody = buildRequestBody(methodInfo.requestType)
-                    val responseBody = buildResponseBody(methodInfo.responseType)
+                    val responseBody = buildResponseBody(methodInfo.responseType, methodInfo.psiMethod)
                     val responseTypeName = read { methodInfo.responseType?.qualifiedName }
 
+                    val apiName = metadataResolver.resolveApiName(methodInfo.psiMethod)
+                    val methodDescription = metadataResolver.resolveMethodDoc(methodInfo.psiMethod)
+
                     ApiEndpoint(
-                        name = methodInfo.description
+                        name = apiName
+                            ?: methodInfo.description
                             ?: methodInfo.methodName,
                         folder = folder,
-                        description = methodInfo.description,
+                        description = methodDescription
+                            ?: methodInfo.description,
                         sourceClass = psiClass,
                         sourceMethod = methodInfo.psiMethod,
                         className = className,
@@ -106,14 +118,6 @@ class GrpcClassExporter(
         return endpoints
     }
 
-    private suspend fun resolveClassDescription(psiClass: PsiClass): String? {
-        return try {
-            docHelper.getAttrOfDocComment(psiClass)
-        } catch (_: Exception) {
-            null
-        }
-    }
-
     private suspend fun buildRequestBody(requestType: PsiClass?): ObjectModel? {
         if (requestType == null) return null
         return try {
@@ -123,7 +127,21 @@ class GrpcClassExporter(
         }
     }
 
-    private suspend fun buildResponseBody(responseType: PsiClass?): ObjectModel? {
+    private suspend fun buildResponseBody(responseType: PsiClass?, psiMethod: PsiMethod? = null): ObjectModel? {
+        if (psiMethod != null) {
+            val grpcModelBuilder = EndpointBuilder.ResponseModelBuilder { psiClass ->
+                try {
+                    read { typeParser.parseMessageType(psiClass) }
+                } catch (_: Exception) {
+                    null
+                }
+            }
+            return endpointBuilder.buildResponseBody(
+                method = psiMethod,
+                modelBuilder = grpcModelBuilder
+            )
+        }
+
         if (responseType == null) return null
         return try {
             read { typeParser.parseMessageType(responseType) }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -3,14 +3,12 @@ package com.itangcent.easyapi.exporter.jaxrs
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiParameter
-import com.intellij.psi.util.PsiTypesUtil
 import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
+import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.psi.PsiClassHelper
 import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
 import com.itangcent.easyapi.psi.helper.StandardDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
@@ -64,6 +62,7 @@ class JaxRsClassExporter(
     private val contentTypeResolver = JaxRsContentTypeResolver(annotationHelper)
     private val docHelper = StandardDocHelper.getInstance(project)
     private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!recognizer.isResource(psiClass)) return emptyList()
@@ -113,7 +112,14 @@ class JaxRsClassExporter(
         val classQualifiedName = read { psiClass.qualifiedName ?: psiClass.name }
 
         try {
-            val httpMethod = methodResolver.resolve(annotatedMethod)
+            var httpMethod = methodResolver.resolve(annotatedMethod)
+            if (httpMethod == null) {
+                // Try default HTTP method from rule
+                val defaultHttpMethod = metadataResolver.resolveDefaultHttpMethod(method)
+                if (!defaultHttpMethod.isNullOrBlank()) {
+                    httpMethod = HttpMethod.fromSpring(defaultHttpMethod)
+                }
+            }
             if (httpMethod == null) {
                 LOG.info("after parse method:$methodKey")
                 return emptyList()
@@ -130,12 +136,20 @@ class JaxRsClassExporter(
                 val classDesc = metadataResolver.resolveClassDoc(psiClass)
 
                 val params = buildParameters(method)
+                val additionalParams = metadataResolver.resolveAdditionalParams(method)
                 val paramHeaders = extractParamHeaders(method)
-                val contentType = types.consumes.firstOrNull()
-                val headers = buildHeaders(contentType, paramHeaders)
+                val additionalHeaders = metadataResolver.resolveAdditionalHeaders(method)
+                val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
+                val contentTypeOverride = engine.evaluate(RuleKeys.METHOD_CONTENT_TYPE, method)
+                val contentType = if (!contentTypeOverride.isNullOrBlank()) {
+                    contentTypeOverride
+                } else {
+                    types.consumes.firstOrNull()
+                }
+                val headers = endpointBuilder.buildHeaders(contentType, paramHeaders, additionalHeaders, additionalResponseHeaders)
                 val genericContext = GenericContext(TypeResolver.resolveGenericParams(psiClass, emptyList()))
                 val body = buildRequestBody(method, genericContext)
-                val responseBody = buildResponseBody(method)
+                val responseBody = endpointBuilder.buildResponseBody(method, genericContext)
                 val responseTypeName = read { method.returnType?.canonicalText }
 
                 LOG.info("after parse method:$methodKey")
@@ -152,7 +166,7 @@ class JaxRsClassExporter(
                         metadata = httpMetadata(
                             path = path,
                             method = httpMethod,
-                            parameters = params,
+                            parameters = params + additionalParams,
                             headers = headers,
                             contentType = contentType,
                             body = body,
@@ -194,60 +208,16 @@ class JaxRsClassExporter(
         return headers
     }
 
-    private fun buildHeaders(contentType: String?, paramHeaders: List<ApiHeader>): List<ApiHeader> {
-        val seen = mutableSetOf<String>()
-        val result = ArrayList<ApiHeader>()
 
-        if (!contentType.isNullOrBlank()) {
-            result.add(ApiHeader(name = "Content-Type", value = contentType))
-            seen.add("content-type")
-        }
-
-        for (h in paramHeaders) {
-            val key = h.name.lowercase()
-            if (key !in seen) {
-                result.add(h)
-                seen.add(key)
-            }
-        }
-
-        return result
-    }
 
     private suspend fun buildRequestBody(method: PsiMethod, genericContext: GenericContext = GenericContext.EMPTY): ObjectModel? = read {
         for (p in method.parameterList.parameters) {
             val resolved = parameterResolver.resolve(p)
             if (resolved.any { it.binding == ParameterBinding.Body }) {
-                return@read expandBodyParam(p, genericContext)
+                return@read endpointBuilder.expandBodyParam(p, genericContext)
             }
         }
         return@read null
-    }
-
-    private suspend fun expandBodyParam(parameter: PsiParameter, genericContext: GenericContext = GenericContext.EMPTY): ObjectModel? {
-        val psiClass = PsiTypesUtil.getPsiClass(parameter.type) ?: return null
-        val qualifiedName = psiClass.qualifiedName ?: return null
-        if (qualifiedName.startsWith("java.lang.") || qualifiedName == "java.lang.String") return null
-        return runCatching {
-            val helper = PsiClassHelper.getInstance(project)
-            helper.buildObjectModelFromType(
-                psiType = parameter.type,
-                genericContext = genericContext,
-                contextElement = parameter
-            )
-        }.getOrNull()
-    }
-
-    private suspend fun buildResponseBody(method: PsiMethod): ObjectModel? {
-        val returnType = read { method.returnType } ?: return null
-        if (returnType == com.intellij.psi.PsiTypes.voidType()) return null
-        return runCatching {
-            val helper = PsiClassHelper.getInstance(project)
-            helper.buildObjectModelFromType(
-                psiType = returnType,
-                contextElement = method
-            )
-        }.getOrNull()
     }
 
     private suspend fun buildParameters(method: PsiMethod): List<ApiParameter> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
@@ -3,9 +3,12 @@ package com.itangcent.easyapi.exporter.springmvc
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.StandardDocHelper
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 
@@ -15,9 +18,11 @@ class ActuatorEndpointExporter(
 
     override val frameworkName: String = "SpringActuator"
 
-    private val scanner = ActuatorEndpointScanner()
-    private val recognizer = ActuatorEndpointRecognizer()
     private val engine = RuleEngine.getInstance(project)
+    private val docHelper = StandardDocHelper.getInstance(project)
+    private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val scanner = ActuatorEndpointScanner(metadataResolver, EndpointBuilder.getInstance(project))
+    private val recognizer = ActuatorEndpointRecognizer()
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!recognizer.isApiClass(psiClass)) return emptyList()

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
@@ -3,7 +3,11 @@ package com.itangcent.easyapi.exporter.springmvc
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
+import com.intellij.psi.PsiTypes
+import com.intellij.psi.util.PsiTypesUtil
+import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
+import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
@@ -49,7 +53,10 @@ object SpringActuatorConstants {
  *
  * All endpoints are mapped under `/actuator/{endpointId}`.
  */
-class ActuatorEndpointScanner {
+class ActuatorEndpointScanner(
+    private val metadataResolver: ApiMetadataResolver,
+    private val endpointBuilder: com.itangcent.easyapi.exporter.EndpointBuilder
+) {
 
     suspend fun scan(psiClass: PsiClass): List<ApiEndpoint> {
         val endpointId = findEndpointId(psiClass) ?: return emptyList()
@@ -76,7 +83,7 @@ class ActuatorEndpointScanner {
         return null
     }
 
-    private fun processMethod(psiClass: PsiClass, method: PsiMethod, basePath: String): ApiEndpoint? {
+    private suspend fun processMethod(psiClass: PsiClass, method: PsiMethod, basePath: String): ApiEndpoint? {
         val operation = findOperation(method) ?: return null
 
         val (httpMethod, hasBody) = when (operation) {
@@ -86,7 +93,11 @@ class ActuatorEndpointScanner {
             else -> return null
         }
 
-        val apiName = method.name
+        val apiName = metadataResolver.resolveApiName(method)
+        val folder = metadataResolver.resolveFolderName(method, psiClass)
+        val description = metadataResolver.resolveMethodDoc(method)
+        val classDesc = metadataResolver.resolveClassDoc(psiClass)
+
         val path = StringBuilder(basePath)
         val pathParams = ArrayList<ApiParameter>()
         val bodyFields = HashMap<String, FieldModel>()
@@ -120,16 +131,23 @@ class ActuatorEndpointScanner {
             null
         }
 
+        // Build response body using method.return and method.return.main rules
+        val responseBody = buildResponseBody(method)
+
         return ApiEndpoint(
             name = apiName,
+            folder = folder,
+            description = description,
             sourceClass = psiClass,
             sourceMethod = method,
             className = psiClass.qualifiedName ?: psiClass.name ?: "",
+            classDescription = classDesc,
             metadata = httpMetadata(
                 path = path.toString(),
                 method = httpMethod,
                 parameters = pathParams,
-                body = body
+                body = body,
+                responseBody = responseBody
             )
         )
     }
@@ -159,5 +177,21 @@ class ActuatorEndpointScanner {
             }
         }
         return null
+    }
+
+    private suspend fun buildResponseBody(method: PsiMethod): ObjectModel? {
+        val actuatorModelBuilder = EndpointBuilder.ResponseModelBuilder { psiClass ->
+            try {
+                val jsonType = JsonType.fromPsiType(PsiTypesUtil.getClassType(psiClass))
+                ObjectModel.Single(jsonType)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        return endpointBuilder.buildResponseBody(
+            method = method,
+            modelBuilder = actuatorModelBuilder
+        )
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.util.PsiTypesUtil
 import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.ClassExporter
+import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.PsiClassHelper
@@ -17,7 +18,6 @@ import com.itangcent.easyapi.psi.helper.StandardDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
-import com.itangcent.easyapi.psi.model.ObjectModelUtils
 import com.itangcent.easyapi.psi.type.GenericContext
 import com.itangcent.easyapi.psi.type.InheritanceHelper
 import com.itangcent.easyapi.psi.type.ResolvedType
@@ -63,8 +63,8 @@ class SpringMvcClassExporter(
     private val mappingResolver = RequestMappingResolver(annotationHelper, engine)
     private val bindingResolver = SpringParameterBindingResolver(annotationHelper, engine)
     private val docHelper = StandardDocHelper.getInstance(project)
-    private val settings by lazy { SettingBinder.getInstance(project).read() }
-    private val metadataResolver by lazy { ApiMetadataResolver(engine, docHelper, settings) }
+    private val metadataResolver by lazy { ApiMetadataResolver(engine, docHelper, SettingBinder.getInstance(project).read()) }
+    private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
         if (!controllerRecognizer.isController(psiClass)) return emptyList()
@@ -163,7 +163,7 @@ class SpringMvcClassExporter(
                         )
                     }
 
-                    val mergedParams = mergePathParameters(params + additionalParams, pathParamsFromPath)
+                    val mergedParams = endpointBuilder.mergePathParameters(params + additionalParams, pathParamsFromPath)
 
                     ApiEndpoint(
                         name = apiName,
@@ -335,51 +335,11 @@ class SpringMvcClassExporter(
         )
     }
 
-
-    private fun mergePathParameters(
-        methodParams: List<ApiParameter>,
-        pathParams: List<ApiParameter>
-    ): List<ApiParameter> {
-        if (pathParams.isEmpty()) return methodParams
-        val pathParamMap = pathParams.associateBy { it.name }
-        val result = mutableListOf<ApiParameter>()
-
-        for (param in methodParams) {
-            if (param.binding == ParameterBinding.Path) {
-                val pathParam = pathParamMap[param.name]
-                if (pathParam != null) {
-                    result.add(
-                        param.copy(
-                            enumValues = pathParam.enumValues ?: param.enumValues,
-                            defaultValue = param.defaultValue?.takeIf { it.isNotBlank() }
-                                ?: pathParam.defaultValue,
-                            description = param.description?.takeIf { it.isNotBlank() }
-                                ?: pathParam.description
-                        )
-                    )
-                } else {
-                    result.add(param)
-                }
-            } else {
-                result.add(param)
-            }
-        }
-
-        val existingNames = result.map { it.name }.toSet()
-        for (pathParam in pathParams) {
-            if (pathParam.name !in existingNames) {
-                result.add(pathParam)
-            }
-        }
-
-        return result
-    }
-
     private suspend fun expandFormParameter(
         parameter: PsiParameter,
         genericContext: GenericContext = GenericContext.EMPTY
     ): List<ApiParameter> {
-        val formExpanded = settings.formExpanded
+        val formExpanded = SettingBinder.getInstance(project).read().formExpanded
         if (!formExpanded) {
             return emptyList()
         }
@@ -390,7 +350,7 @@ class SpringMvcClassExporter(
         parameter: PsiParameter,
         genericContext: GenericContext = GenericContext.EMPTY
     ): List<ApiParameter> {
-        val queryExpanded = settings.queryExpanded
+        val queryExpanded = SettingBinder.getInstance(project).read().queryExpanded
         if (!queryExpanded) {
             return emptyList()
         }
@@ -502,45 +462,12 @@ class SpringMvcClassExporter(
         mapping: ResolvedMapping,
         paramHeaders: List<ApiHeader>,
         additionalHeaders: List<ApiHeader> = emptyList()
-    ): List<ApiHeader> {
-        val seen = mutableSetOf<String>()
-        val result = ArrayList<ApiHeader>()
-
-        // Content-Type header
-        if (!contentType.isNullOrBlank()) {
-            result.add(ApiHeader(name = "Content-Type", value = contentType))
-            seen.add("content-type")
-        }
-
-        // Headers from @RequestMapping(headers = {...})
-        for ((name, value) in mapping.headers) {
-            val key = name.lowercase()
-            if (key !in seen) {
-                result.add(ApiHeader(name = name, value = value))
-                seen.add(key)
-            }
-        }
-
-        // Headers from @RequestHeader parameters
-        for (h in paramHeaders) {
-            val key = h.name.lowercase()
-            if (key !in seen) {
-                result.add(h)
-                seen.add(key)
-            }
-        }
-
-        // Additional headers from method.additional.header rule
-        for (h in additionalHeaders) {
-            val key = h.name.lowercase()
-            if (key !in seen) {
-                result.add(h)
-                seen.add(key)
-            }
-        }
-
-        return result
-    }
+    ): List<ApiHeader> = endpointBuilder.buildHeaders(
+        contentType = contentType,
+        paramHeaders = paramHeaders,
+        additionalHeaders = additionalHeaders,
+        mappingHeaders = mapping.headers.toList()
+    )
 
     private suspend fun buildRequestBody(
         bindings: List<ResolvedParamBinding>,
@@ -548,7 +475,7 @@ class SpringMvcClassExporter(
     ): ObjectModel? {
         for ((p, binding) in bindings) {
             if (binding != ParameterBinding.Body) continue
-            return expandBodyParam(p, genericContext)
+            return endpointBuilder.expandBodyParam(p, genericContext)
         }
         return null
     }
@@ -556,89 +483,18 @@ class SpringMvcClassExporter(
     private suspend fun buildResponseBody(
         method: PsiMethod,
         genericContext: GenericContext = GenericContext.EMPTY
-    ): ObjectModel? {
-        // Check method.return rule for custom return type override
-        val returnTypeByRule = metadataResolver.resolveMethodReturn(method)
-        if (!returnTypeByRule.isNullOrBlank()) {
-            val psiClass = com.intellij.psi.JavaPsiFacade.getInstance(method.project)
-                .findClass(returnTypeByRule.trim(), com.intellij.psi.search.GlobalSearchScope.allScope(method.project))
-            if (psiClass != null) {
-                return runCatching {
-                    val helper = PsiClassHelper.getInstance(project)
-                    helper.buildObjectModel(psiClass)
-                }.getOrNull()
-            }
-        }
-
-        val returnType = method.returnType ?: return null
-
-        // First try with the original return type — json.rule.convert rules
-        // (e.g., for ResponseEntity, Mono, Flux) may handle unwrapping.
-        var responseModel = runCatching {
-            val helper = PsiClassHelper.getInstance(project)
-            helper.buildObjectModelFromType(
-                psiType = returnType,
-                genericContext = genericContext,
-                contextElement = method
-            )
-        }.getOrNull()
-
-        // If the original type didn't produce a model, try the unwrapped type as fallback
-        if (responseModel == null) {
+    ): ObjectModel? = endpointBuilder.buildResponseBody(
+        method = method,
+        genericContext = genericContext,
+        returnTypeOverride = { returnType ->
             val unwrappedType = ReturnTypeUnwrapper.unwrapPsiType(returnType)
-            if (unwrappedType == null || unwrappedType == PsiTypes.voidType()) return null
-            if (unwrappedType !== returnType) {
-                responseModel = runCatching {
-                    val helper = PsiClassHelper.getInstance(project)
-                    helper.buildObjectModelFromType(
-                        psiType = unwrappedType,
-                        genericContext = genericContext,
-                        contextElement = method
-                    )
-                }.getOrNull()
+            if (unwrappedType != null && unwrappedType != PsiTypes.voidType() && unwrappedType !== returnType) {
+                unwrappedType
+            } else {
+                null
             }
         }
-
-        if (responseModel == null) return null
-
-        // method.return.main rule — specifies a field name within the response type
-        // where the @return doc comment should be placed.
-        // e.g., rule: method.return.main[groovy:it.returnType().isExtend("Result")]=data
-        // For Result<Void> with @return "processed result", this attaches "processed result" to the "data" field.
-        val returnMain = metadataResolver.resolveMethodReturnMain(method)
-        val mainField = if (!returnMain.isNullOrBlank()) {
-            returnMain
-        } else if (settings.inferReturnMain) {
-            // Auto-detect: find the generic type parameter field (e.g., data: T in Result<T>)
-            ObjectModelUtils.findGenericFieldName(responseModel)
-        } else null
-
-        if (!mainField.isNullOrBlank()) {
-            val descOfReturn = docHelper.findDocByTag(method, "return")
-            if (!descOfReturn.isNullOrBlank()) {
-                val updated = ObjectModelUtils.addFieldComment(responseModel, mainField, descOfReturn)
-                if (updated != null) return updated
-            }
-        }
-
-        return responseModel
-    }
-
-    private suspend fun expandBodyParam(
-        parameter: PsiParameter,
-        genericContext: GenericContext = GenericContext.EMPTY
-    ): ObjectModel? {
-        // Use buildObjectModelFromType which evaluates json.rule.convert rules
-        // (e.g., Mono<T> → T, RequestEntity<T> → T)
-        return runCatching {
-            val helper = PsiClassHelper.getInstance(project)
-            helper.buildObjectModelFromType(
-                psiType = parameter.type,
-                genericContext = genericContext,
-                contextElement = parameter
-            )
-        }.getOrNull()
-    }
+    )
 
     companion object : IdeaLog
 }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolver.kt
@@ -23,12 +23,49 @@ import com.itangcent.easyapi.util.append
  * - Parameter names, types, and defaults
  * - Folder/group names
  * - Required status
+ * - Return type overrides and main field hints
+ * - Additional headers, parameters, and response headers
+ * - Default HTTP methods and content types
+ * - Path selection strategies
  *
  * ## Resolution Priority
  * For most metadata, the resolution order is:
  * 1. Rule-based value (e.g., `api.name`, `param.type`)
  * 2. Doc comment value
  * 3. Default value from PSI
+ *
+ * ## Framework Applicability
+ *
+ * ### All Frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+ * - [resolveApiName] — API endpoint name
+ * - [resolveClassDoc] — class-level description
+ * - [resolveMethodDoc] — method-level description
+ * - [resolveFolderName] — folder/group name
+ * - [resolveMethodReturn] — override return type via rule
+ * - [resolveMethodReturnMain] — specify which field receives @return doc
+ * - [isIgnored] — skip element during export
+ * - [resolveParamName], [resolveParamDoc], [resolveParamType],
+ *   [resolveParamDefaultValue], [resolveParamDemo], [resolveParamMock],
+ *   [isParamRequired], [isParamIgnored] — parameter metadata
+ *
+ * ### HTTP Frameworks (SpringMVC, JAX-RS, Feign, Actuator)
+ * - [resolveAdditionalHeaders] — add extra request headers
+ * - [resolveAdditionalParams] — add extra request parameters
+ * - [resolveAdditionalResponseHeaders] — add extra response headers
+ * - [resolveDefaultHttpMethod] — fallback HTTP method when not annotated
+ * - [resolvePathMulti] — strategy for selecting paths when multiple exist
+ *
+ * ### Framework-Specific Notes
+ * - **JAX-RS**: [resolveDefaultHttpMethod] is used as fallback when no HTTP method
+ *   annotation is found. [resolvePathMulti] is not applicable since `@Path` only
+ *   supports a single value.
+ * - **Feign**: [resolvePathMulti] applies to Spring-style `@RequestMapping` with
+ *   multiple paths. Native Feign uses `@RequestLine` which is always single-path.
+ * - **gRPC**: HTTP-specific rules ([resolveAdditionalHeaders], [resolveAdditionalParams],
+ *   [resolveAdditionalResponseHeaders], [resolveDefaultHttpMethod], [resolvePathMulti])
+ *   are not applicable since gRPC uses its own protocol, not HTTP semantics.
+ * - **Actuator**: [resolveDefaultHttpMethod] is not applicable since operation annotations
+ *   (@ReadOperation, @WriteOperation, @DeleteOperation) always specify the method.
  *
  * ## Usage
  * ```kotlin
@@ -45,6 +82,13 @@ class ApiMetadataResolver(
     private val docHelper: DocHelper,
     private val settings: Settings = Settings()
 ) {
+    /**
+     * Resolves the API endpoint name.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * Resolution order: `api.name` rule → doc comment first line → `method.doc` rule → method name
+     */
     suspend fun resolveApiName(method: PsiMethod): String {
         // 1. api.name rule
         val ruleApiName = engine.evaluate(RuleKeys.API_NAME, method)
@@ -64,6 +108,11 @@ class ApiMetadataResolver(
         return method.name
     }
 
+    /**
+     * Resolves the class-level description.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     */
     suspend fun resolveClassDoc(psiClass: PsiClass): String {
         val docComment = docHelper.getAttrOfDocComment(psiClass)
         val ruleClassDesc = engine.evaluate(RuleKeys.CLASS_DOC, psiClass)
@@ -71,19 +120,31 @@ class ApiMetadataResolver(
         return combined.ifBlank { psiClass.name ?: "Unknown" }
     }
 
+    /**
+     * Resolves the method-level description.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     */
     suspend fun resolveMethodDoc(method: PsiMethod): String {
         val docComment = docHelper.getAttrOfDocComment(method)
         val ruleDoc = engine.evaluate(RuleKeys.METHOD_DOC, method)
         return docComment.append(ruleDoc)
     }
 
-    suspend fun resolveFolderName(method: PsiMethod, psiClass: PsiClass? = null): String? {
+    /**
+     * Resolves the folder/group name for an API endpoint.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     */
+    suspend fun resolveFolderName(method: PsiMethod?, psiClass: PsiClass? = null): String? {
         // Try folder.name rule on the method first
-        val methodFolder = engine.evaluate(RuleKeys.FOLDER_NAME, method)
-        if (!methodFolder.isNullOrBlank()) return methodFolder
+        if (method != null) {
+            val methodFolder = engine.evaluate(RuleKeys.FOLDER_NAME, method)
+            if (!methodFolder.isNullOrBlank()) return methodFolder
+        }
 
         // Try folder.name rule on the containing class
-        val cls = psiClass ?: method.containingClass ?: return null
+        val cls = psiClass ?: method?.containingClass ?: return null
         val classFolder = engine.evaluate(RuleKeys.FOLDER_NAME, cls)
         if (!classFolder.isNullOrBlank()) return classFolder
 
@@ -147,28 +208,72 @@ class ApiMetadataResolver(
         return engine.evaluate(RuleKeys.IGNORE, element)
     }
 
+    /**
+     * Overrides the return type via the `method.return` rule.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * Allows specifying a custom return type class instead of the actual method return type.
+     */
     suspend fun resolveMethodReturn(method: PsiMethod): String? {
         return engine.evaluate(RuleKeys.METHOD_RETURN, method)
     }
 
+    /**
+     * Specifies which field in the response type should receive the `@return` doc comment.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * For example, for `Result<T>` wrapper types, this rule can specify that the
+     * `@return` comment should be attached to the `data` field.
+     */
     suspend fun resolveMethodReturnMain(method: PsiMethod): String? {
         return engine.evaluate(RuleKeys.METHOD_RETURN_MAIN, method)
     }
 
+    /**
+     * Resolves the default HTTP method when not explicitly set by annotations.
+     *
+     * **Applicable to**: SpringMVC, JAX-RS (as fallback when no annotation found)
+     *
+     * **Not applicable to**: Feign (requires explicit method annotations),
+     * gRPC (uses its own protocol), Actuator (operation annotations always specify method)
+     */
     suspend fun resolveDefaultHttpMethod(method: PsiMethod): String? {
         return engine.evaluate(RuleKeys.METHOD_DEFAULT_HTTP, method)
     }
 
+    /**
+     * Resolves additional request headers to add to all endpoints.
+     *
+     * **Applicable to**: HTTP frameworks (SpringMVC, JAX-RS, Feign, Actuator)
+     *
+     * **Not applicable to**: gRPC (uses metadata, not HTTP headers)
+     */
     suspend fun resolveAdditionalHeaders(method: PsiMethod): List<ApiHeader> {
         val raw = engine.evaluate(RuleKeys.METHOD_ADDITIONAL_HEADER, method) ?: return emptyList()
         return parseHeaderLines(raw)
     }
 
+    /**
+     * Resolves additional request parameters to add to all endpoints.
+     *
+     * **Applicable to**: HTTP frameworks (SpringMVC, JAX-RS, Feign, Actuator)
+     *
+     * **Not applicable to**: gRPC (fixed request message schema)
+     */
     suspend fun resolveAdditionalParams(method: PsiMethod): List<ApiParameter> {
         val raw = engine.evaluate(RuleKeys.METHOD_ADDITIONAL_PARAM, method) ?: return emptyList()
         return parseParamLines(raw)
     }
 
+    /**
+     * Resolves additional response headers to add to all endpoints.
+     *
+     * **Applicable to**: HTTP frameworks (SpringMVC, JAX-RS, Feign, Actuator)
+     *
+     * **Not applicable to**: gRPC (uses trailing metadata)
+     */
     suspend fun resolveAdditionalResponseHeaders(method: PsiMethod): List<ApiHeader> {
         val raw = engine.evaluate(RuleKeys.METHOD_ADDITIONAL_RESPONSE_HEADER, method) ?: return emptyList()
         return parseHeaderLines(raw)
@@ -219,6 +324,14 @@ class ApiMetadataResolver(
         return result
     }
 
+    /**
+     * Resolves the path selection strategy when a method has multiple path mappings.
+     *
+     * **Applicable to**: SpringMVC, Feign (Spring-style @RequestMapping with multiple paths)
+     *
+     * **Not applicable to**: JAX-RS (@Path only supports single value),
+     * gRPC (single path per method), Actuator (single path per operation)
+     */
     suspend fun resolvePathMulti(method: PsiMethod): PathSelector {
         val raw = engine.evaluate(RuleKeys.PATH_MULTI, method)
         if (!raw.isNullOrBlank()) return PathSelector.fromRule(raw)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,7 @@
         <projectService serviceImplementation="com.itangcent.easyapi.exporter.grpc.GrpcMethodResolver"/>
         <projectService serviceImplementation="com.itangcent.easyapi.grpc.CompositeDescriptorResolver"/>
 
+        <projectService serviceImplementation="com.itangcent.easyapi.exporter.EndpointBuilder"/>
         <projectService serviceImplementation="com.itangcent.easyapi.cache.VcsBranchChangeListener"/>
 
         <postStartupActivity implementation="com.itangcent.easyapi.ide.ApiIndexStartupActivity"/>

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/EndpointBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/EndpointBuilderTest.kt
@@ -1,0 +1,388 @@
+package com.itangcent.easyapi.exporter
+
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.ApiParameter
+import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.ParameterType
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.*
+
+class EndpointBuilderTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var endpointBuilder: EndpointBuilder
+
+    override fun setUp() {
+        super.setUp()
+        endpointBuilder = EndpointBuilder.getInstance(project)
+    }
+
+    override fun createConfigReader() = TestConfigReader.empty(project)
+
+    // ========================================================================
+    // buildHeaders tests
+    // ========================================================================
+
+    fun testBuildHeaders_emptyInputs() {
+        val headers = endpointBuilder.buildHeaders(null)
+        assertTrue(headers.isEmpty())
+    }
+
+    fun testBuildHeaders_contentTypeOnly() {
+        val headers = endpointBuilder.buildHeaders("application/json")
+        assertEquals(1, headers.size)
+        assertEquals("Content-Type", headers[0].name)
+        assertEquals("application/json", headers[0].value)
+    }
+
+    fun testBuildHeaders_blankContentTypeIgnored() {
+        val headers = endpointBuilder.buildHeaders("  ")
+        assertTrue(headers.isEmpty())
+    }
+
+    fun testBuildHeaders_paramHeaders() {
+        val paramHeaders = listOf(
+            ApiHeader(name = "Authorization", value = "Bearer token"),
+            ApiHeader(name = "X-Request-Id", value = "123")
+        )
+        val headers = endpointBuilder.buildHeaders(null, paramHeaders = paramHeaders)
+        assertEquals(2, headers.size)
+        assertEquals("Authorization", headers[0].name)
+        assertEquals("X-Request-Id", headers[1].name)
+    }
+
+    fun testBuildHeaders_mappingHeaders() {
+        val mappingHeaders = listOf("Accept" to "application/json", "X-Custom" to "value")
+        val headers = endpointBuilder.buildHeaders(null, mappingHeaders = mappingHeaders)
+        assertEquals(2, headers.size)
+        assertEquals("Accept", headers[0].name)
+        assertEquals("X-Custom", headers[1].name)
+    }
+
+    fun testBuildHeaders_mappingContentTypeSkippedWhenAlreadySet() {
+        val mappingHeaders = listOf("Content-Type" to "text/plain", "Accept" to "application/json")
+        val headers = endpointBuilder.buildHeaders("application/json", mappingHeaders = mappingHeaders)
+        assertEquals(2, headers.size)
+        assertEquals("Content-Type", headers[0].name)
+        assertEquals("application/json", headers[0].value)
+        assertEquals("Accept", headers[1].name)
+    }
+
+    fun testBuildHeaders_deduplicationCaseInsensitive() {
+        val paramHeaders = listOf(ApiHeader(name = "authorization", value = "token1"))
+        val additionalHeaders = listOf(ApiHeader(name = "Authorization", value = "token2"))
+        val headers = endpointBuilder.buildHeaders(null, paramHeaders = paramHeaders, additionalHeaders = additionalHeaders)
+        assertEquals(1, headers.size)
+        assertEquals("authorization", headers[0].name)
+        assertEquals("token1", headers[0].value)
+    }
+
+    fun testBuildHeaders_priorityOrder() {
+        val paramHeaders = listOf(ApiHeader(name = "X-Custom", value = "from-param"))
+        val additionalHeaders = listOf(ApiHeader(name = "X-Custom", value = "from-additional"))
+        val mappingHeaders = listOf("X-Custom" to "from-mapping")
+        val headers = endpointBuilder.buildHeaders(
+            contentType = null,
+            paramHeaders = paramHeaders,
+            additionalHeaders = additionalHeaders,
+            mappingHeaders = mappingHeaders
+        )
+        assertEquals(1, headers.size)
+        assertEquals("from-mapping", headers[0].value)
+    }
+
+    fun testBuildHeaders_allSources() {
+        val headers = endpointBuilder.buildHeaders(
+            contentType = "application/json",
+            paramHeaders = listOf(ApiHeader(name = "Authorization", value = "Bearer")),
+            additionalHeaders = listOf(ApiHeader(name = "X-Trace-Id", value = "trace-123")),
+            additionalResponseHeaders = listOf(ApiHeader(name = "X-Response-Time", value = "50ms")),
+            mappingHeaders = listOf("Accept" to "application/json")
+        )
+        assertEquals(5, headers.size)
+        val headerNames = headers.map { it.name }
+        assertTrue(headerNames.contains("Content-Type"))
+        assertTrue(headerNames.contains("Accept"))
+        assertTrue(headerNames.contains("Authorization"))
+        assertTrue(headerNames.contains("X-Trace-Id"))
+        assertTrue(headerNames.contains("X-Response-Time"))
+    }
+
+    fun testBuildHeaders_additionalResponseHeadersDeduplicated() {
+        val paramHeaders = listOf(ApiHeader(name = "Authorization", value = "Bearer"))
+        val additionalResponseHeaders = listOf(ApiHeader(name = "Authorization", value = "Duplicate"))
+        val headers = endpointBuilder.buildHeaders(null, paramHeaders = paramHeaders, additionalResponseHeaders = additionalResponseHeaders)
+        assertEquals(1, headers.size)
+        assertEquals("Bearer", headers[0].value)
+    }
+
+    // ========================================================================
+    // mergePathParameters tests
+    // ========================================================================
+
+    fun testMergePathParameters_emptyPathParams() {
+        val methodParams = listOf(
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path)
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, emptyList())
+        assertEquals(1, result.size)
+        assertEquals("id", result[0].name)
+    }
+
+    fun testMergePathParameters_enrichMethodParamFromPathParam() {
+        val methodParams = listOf(
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path)
+        )
+        val pathParams = listOf(
+            ApiParameter(
+                name = "id",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                enumValues = listOf("1", "2", "3"),
+                defaultValue = "1",
+                description = "User ID"
+            )
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(1, result.size)
+        assertEquals(listOf("1", "2", "3"), result[0].enumValues)
+        assertEquals("1", result[0].defaultValue)
+        assertEquals("User ID", result[0].description)
+    }
+
+    fun testMergePathParameters_methodParamValuesTakePriority() {
+        val methodParams = listOf(
+            ApiParameter(
+                name = "id",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                defaultValue = "42",
+                description = "From method"
+            )
+        )
+        val pathParams = listOf(
+            ApiParameter(
+                name = "id",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                defaultValue = "1",
+                description = "From path"
+            )
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(1, result.size)
+        assertEquals("42", result[0].defaultValue)
+        assertEquals("From method", result[0].description)
+    }
+
+    fun testMergePathParameters_pathParamFallbackForBlankValues() {
+        val methodParams = listOf(
+            ApiParameter(
+                name = "id",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                defaultValue = "",
+                description = ""
+            )
+        )
+        val pathParams = listOf(
+            ApiParameter(
+                name = "id",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                defaultValue = "1",
+                description = "From path"
+            )
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(1, result.size)
+        assertEquals("1", result[0].defaultValue)
+        assertEquals("From path", result[0].description)
+    }
+
+    fun testMergePathParameters_enumValuesFromPathParamTakePriority() {
+        val methodParams = listOf(
+            ApiParameter(
+                name = "status",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                enumValues = listOf("active")
+            )
+        )
+        val pathParams = listOf(
+            ApiParameter(
+                name = "status",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                enumValues = listOf("active", "inactive", "pending")
+            )
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(1, result.size)
+        assertEquals(listOf("active", "inactive", "pending"), result[0].enumValues)
+    }
+
+    fun testMergePathParameters_enumValuesFallbackFromPathParam() {
+        val methodParams = listOf(
+            ApiParameter(
+                name = "status",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                enumValues = null
+            )
+        )
+        val pathParams = listOf(
+            ApiParameter(
+                name = "status",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                enumValues = listOf("active", "inactive")
+            )
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(1, result.size)
+        assertEquals(listOf("active", "inactive"), result[0].enumValues)
+    }
+
+    fun testMergePathParameters_nonPathParamsUnaffected() {
+        val methodParams = listOf(
+            ApiParameter(name = "query", type = ParameterType.TEXT, binding = ParameterBinding.Query),
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path)
+        )
+        val pathParams = listOf(
+            ApiParameter(
+                name = "id",
+                type = ParameterType.TEXT,
+                binding = ParameterBinding.Path,
+                description = "Path ID"
+            )
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(2, result.size)
+        assertEquals(ParameterBinding.Query, result[0].binding)
+        assertNull(result[0].description)
+        assertEquals(ParameterBinding.Path, result[1].binding)
+        assertEquals("Path ID", result[1].description)
+    }
+
+    fun testMergePathParameters_appendMissingPathParams() {
+        val methodParams = listOf(
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path)
+        )
+        val pathParams = listOf(
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path),
+            ApiParameter(name = "version", type = ParameterType.TEXT, binding = ParameterBinding.Path, description = "API version")
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(2, result.size)
+        assertEquals("id", result[0].name)
+        assertEquals("version", result[1].name)
+        assertEquals("API version", result[1].description)
+    }
+
+    fun testMergePathParameters_noDuplicateAppend() {
+        val methodParams = listOf(
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path)
+        )
+        val pathParams = listOf(
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path, description = "ID")
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(1, result.size)
+    }
+
+    fun testMergePathParameters_mixedBindings() {
+        val methodParams = listOf(
+            ApiParameter(name = "query", type = ParameterType.TEXT, binding = ParameterBinding.Query),
+            ApiParameter(name = "body", type = ParameterType.TEXT, binding = ParameterBinding.Body),
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path)
+        )
+        val pathParams = listOf(
+            ApiParameter(name = "id", type = ParameterType.TEXT, binding = ParameterBinding.Path, enumValues = listOf("1", "2")),
+            ApiParameter(name = "section", type = ParameterType.TEXT, binding = ParameterBinding.Path, description = "Section")
+        )
+        val result = endpointBuilder.mergePathParameters(methodParams, pathParams)
+        assertEquals(4, result.size)
+        assertEquals("query", result[0].name)
+        assertEquals("body", result[1].name)
+        assertEquals("id", result[2].name)
+        assertEquals(listOf("1", "2"), result[2].enumValues)
+        assertEquals("section", result[3].name)
+        assertEquals("Section", result[3].description)
+    }
+
+    // ========================================================================
+    // buildResponseBody tests (require PSI)
+    // ========================================================================
+
+    fun testBuildResponseBody_voidMethodReturnsNull() = runTest {
+        loadSpringAnnotations()
+        loadFile("model/IResult.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("api/springmvc/VoidMethodCtrl.java")
+
+        val psiClass = findClass("com.itangcent.springboot.demo.controller.VoidMethodCtrl")!!
+        val method = findMethod(psiClass, "voidMethod")!!
+        val result = endpointBuilder.buildResponseBody(method)
+        assertNull(result)
+    }
+
+    fun testBuildResponseBody_returnsModelForComplexType() = runTest {
+        loadSpringAnnotations()
+        loadFile("model/IResult.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("api/springmvc/SimpleReturnCtrl.java")
+
+        val psiClass = findClass("com.itangcent.springboot.demo.controller.SimpleReturnCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val result = endpointBuilder.buildResponseBody(method)
+        assertNotNull(result)
+    }
+
+    // ========================================================================
+    // expandBodyParam tests (require PSI)
+    // ========================================================================
+
+    fun testExpandBodyParam_simpleTypeReturnsNull() = runTest {
+        loadSpringAnnotations()
+        loadFile("model/UserInfo.java")
+        loadFile("api/springmvc/BodyParamCtrl.java")
+
+        val psiClass = findClass("com.itangcent.springboot.demo.controller.BodyParamCtrl")!!
+        val method = findMethod(psiClass, "simpleBody")!!
+        val param = method.parameterList.parameters.firstOrNull()!!
+        val result = endpointBuilder.expandBodyParam(param)
+        assertNull(result)
+    }
+
+    fun testExpandBodyParam_complexTypeReturnsModel() = runTest {
+        loadSpringAnnotations()
+        loadFile("model/UserInfo.java")
+        loadFile("api/springmvc/BodyParamCtrl.java")
+
+        val psiClass = findClass("com.itangcent.springboot.demo.controller.BodyParamCtrl")!!
+        val method = findMethod(psiClass, "complexBody")!!
+        val param = method.parameterList.parameters.firstOrNull()!!
+        val result = endpointBuilder.expandBodyParam(param)
+        assertNotNull(result)
+    }
+
+    private fun loadSpringAnnotations() {
+        loadFile("spring/RestController.java")
+        loadFile("spring/Controller.java")
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/PutMapping.java")
+        loadFile("spring/DeleteMapping.java")
+        loadFile("spring/PatchMapping.java")
+        loadFile("spring/RequestParam.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("spring/RequestHeader.java")
+        loadFile("spring/ResponseBody.java")
+        loadFile("spring/RequestMethod.java")
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignRuleIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignRuleIntegrationTest.kt
@@ -1,0 +1,177 @@
+package com.itangcent.easyapi.exporter.feign
+
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.StandardDocHelper
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+class FeignRuleIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var exporter: FeignClassExporter
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        exporter = FeignClassExporter(project, feignEnable = true)
+    }
+
+    private fun loadTestFiles() {
+        loadFile("spring/FeignClient.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/PutMapping.java")
+        loadFile("spring/DeleteMapping.java")
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/RequestParam.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("spring/RestController.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("api/feign/UserClient.java")
+    }
+
+    override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
+        """
+        api.name=groovy:it.name().toUpperCase()
+        folder.name=groovy:"feign-custom-folder"
+        method.doc=groovy:"Rule doc: " + it.name()
+        method.return=groovy:"com.itangcent.model.Result"
+        method.return.main=groovy:"data"
+        method.additional.header={"name":"X-Feign-Header","value":"feign-value","desc":"feign header from rule","required":true}
+        method.additional.param={"name":"requestId","type":"String","required":true,"desc":"request id from rule","value":"default-req"}
+        method.additional.response.header={"name":"X-Feign-Resp-Id","value":"feign-resp-123","desc":"feign response header from rule"}
+        method.content.type=groovy:"application/json"
+        """.trimIndent()
+    )
+
+    fun testRuleApiNameOverridesDefault() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val greeting = endpoints.find { it.sourceMethod?.name == "greeting" }
+        assertNotNull(greeting)
+        assertEquals("GREETING", greeting!!.name)
+    }
+
+    fun testRuleFolderNameOverridesDefault() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertEquals("feign-custom-folder", endpoint.folder)
+        }
+    }
+
+    fun testRuleMethodDocAppended() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val greeting = endpoints.find { it.sourceMethod?.name == "greeting" }
+        assertNotNull(greeting)
+        assertNotNull(greeting!!.description)
+        assertTrue(
+            "Description should contain rule-based doc",
+            greeting.description!!.contains("Rule doc:")
+        )
+    }
+
+    fun testRuleMethodReturnOverridesType() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val addEndpoint = endpoints.find { it.sourceMethod?.name == "add" }
+        assertNotNull(addEndpoint)
+        assertNotNull(
+            "Response body should be set from method.return rule",
+            addEndpoint!!.httpMetadata?.responseBody
+        )
+    }
+
+    fun testRuleAdditionalHeadersAdded() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            val headers = endpoint.httpMetadata?.headers ?: emptyList()
+            val customHeader = headers.find { it.name == "X-Feign-Header" }
+            assertNotNull(
+                "Each endpoint should have X-Feign-Header from rule",
+                customHeader
+            )
+            assertEquals("feign-value", customHeader!!.value)
+            assertEquals("feign header from rule", customHeader.description)
+            assertTrue(customHeader.required)
+        }
+    }
+
+    fun testRuleAdditionalParamsAdded() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            val params = endpoint.httpMetadata?.parameters ?: emptyList()
+            val reqParam = params.find { it.name == "requestId" }
+            assertNotNull(
+                "Each endpoint should have requestId param from rule",
+                reqParam
+            )
+            assertEquals("default-req", reqParam!!.defaultValue)
+            assertTrue(reqParam.required)
+        }
+    }
+
+    fun testRuleAdditionalResponseHeadersAdded() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            val headers = endpoint.httpMetadata?.headers ?: emptyList()
+            val respHeader = headers.find { it.name == "X-Feign-Resp-Id" }
+            assertNotNull(
+                "Each endpoint should have X-Feign-Resp-Id header from rule",
+                respHeader
+            )
+            assertEquals("feign-resp-123", respHeader!!.value)
+        }
+    }
+
+    fun testRuleContentTypeOverride() = runTest {
+        val psiClass = findClass("com.itangcent.springboot.demo.client.UserClient")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val addEndpoint = endpoints.find { it.sourceMethod?.name == "add" }
+        assertNotNull(addEndpoint)
+        assertEquals(
+            "application/json",
+            addEndpoint!!.httpMetadata?.contentType
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcRuleIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcRuleIntegrationTest.kt
@@ -1,0 +1,85 @@
+package com.itangcent.easyapi.exporter.grpc
+
+import com.itangcent.easyapi.exporter.model.grpcMetadata
+import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.StandardDocHelper
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+class GrpcRuleIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var exporter: GrpcClassExporter
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        exporter = GrpcClassExporter(project)
+    }
+
+    private fun loadTestFiles() {
+        loadFile("grpc/BindableService.java")
+        loadFile("grpc/StreamObserver.java")
+        loadFile("grpc/GrpcService.java")
+        loadFile("grpc/EchoRequest.java")
+        loadFile("grpc/EchoResponse.java")
+        loadFile("grpc/EchoServiceGrpc.java")
+        loadFile("grpc/EchoServiceImpl.java")
+        loadFile("grpc/UserInfo.java")
+        loadFile("model/Result.java")
+    }
+
+    override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
+        """
+        api.name=groovy:it.name().toUpperCase()
+        folder.name=groovy:"grpc-custom-folder"
+        method.doc=groovy:"Rule doc: " + it.name()
+        """.trimIndent()
+    )
+
+    fun testRuleApiNameOverridesDefault() = runTest {
+        val psiClass = findClass("com.itangcent.grpc.service.EchoServiceImpl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val echo = endpoints.find { it.sourceMethod?.name == "echo" }
+        assertNotNull(echo)
+        assertEquals("ECHO", echo!!.name)
+    }
+
+    fun testRuleFolderNameOverridesDefault() = runTest {
+        val psiClass = findClass("com.itangcent.grpc.service.EchoServiceImpl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertEquals("grpc-custom-folder", endpoint.folder)
+        }
+    }
+
+    fun testRuleMethodDocAppended() = runTest {
+        val psiClass = findClass("com.itangcent.grpc.service.EchoServiceImpl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val echo = endpoints.find { it.sourceMethod?.name == "echo" }
+        assertNotNull(echo)
+        assertNotNull(echo!!.description)
+        assertTrue(
+            "Description should contain rule-based doc",
+            echo.description!!.contains("Rule doc:")
+        )
+    }
+
+    // Note: method.return and method.return.main rules cannot be tested with
+    // plain Java test fixtures because GrpcTypeParser.parseMessageType() returns
+    // null for non-protobuf-generated classes. These rules are tested indirectly
+    // through JaxRsRuleIntegrationTest and FeignRuleIntegrationTest which use
+    // standard Java type resolution.
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsRuleIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsRuleIntegrationTest.kt
@@ -1,0 +1,185 @@
+package com.itangcent.easyapi.exporter.jaxrs
+
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.StandardDocHelper
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+class JaxRsRuleIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var exporter: JaxRsClassExporter
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        exporter = JaxRsClassExporter(project, jaxrsEnable = true)
+    }
+
+    private fun loadTestFiles() {
+        loadFile("jaxrs/Path.java")
+        loadFile("jaxrs/GET.java")
+        loadFile("jaxrs/POST.java")
+        loadFile("jaxrs/PUT.java")
+        loadFile("jaxrs/DELETE.java")
+        loadFile("jaxrs/PATCH.java")
+        loadFile("jaxrs/OPTIONS.java")
+        loadFile("jaxrs/HEAD.java")
+        loadFile("jaxrs/PathParam.java")
+        loadFile("jaxrs/QueryParam.java")
+        loadFile("jaxrs/FormParam.java")
+        loadFile("jaxrs/HeaderParam.java")
+        loadFile("jaxrs/CookieParam.java")
+        loadFile("jaxrs/BeanParam.java")
+        loadFile("jaxrs/DefaultValue.java")
+        loadFile("jaxrs/Consumes.java")
+        loadFile("jaxrs/Produces.java")
+        loadFile("jaxrs/HttpMethod.java")
+        loadFile("api/jaxrs/MyGet.java")
+        loadFile("api/jaxrs/MyPut.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("constant/UserType.java")
+        loadFile("api/jaxrs/UserResource.java")
+        loadFile("api/jaxrs/UserDTO.java")
+    }
+
+    override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
+        """
+        api.name=groovy:it.name().toUpperCase()
+        folder.name=groovy:"jaxrs-custom-folder"
+        method.doc=groovy:"Rule doc: " + it.name()
+        method.return=groovy:"com.itangcent.model.Result"
+        method.return.main=groovy:"data"
+        method.additional.header={"name":"X-Custom-Header","value":"custom-value","desc":"custom header from rule","required":true}
+        method.additional.param={"name":"traceId","type":"String","required":true,"desc":"trace id from rule","value":"default-trace"}
+        method.additional.response.header={"name":"X-Response-Id","value":"resp-123","desc":"response header from rule"}
+        method.default.http.method=groovy:"POST"
+        """.trimIndent()
+    )
+
+    fun testRuleApiNameOverridesDefault() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val greeting = endpoints.find { it.sourceMethod?.name == "greeting" }
+        assertNotNull(greeting)
+        assertEquals("GREETING", greeting!!.name)
+    }
+
+    fun testRuleFolderNameOverridesDefault() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertEquals("jaxrs-custom-folder", endpoint.folder)
+        }
+    }
+
+    fun testRuleMethodDocAppended() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val greeting = endpoints.find { it.sourceMethod?.name == "greeting" }
+        assertNotNull(greeting)
+        assertNotNull(greeting!!.description)
+        assertTrue(
+            "Description should contain rule-based doc",
+            greeting.description!!.contains("Rule doc:")
+        )
+    }
+
+    fun testRuleMethodReturnOverridesType() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val typesEndpoint = endpoints.find { it.sourceMethod?.name == "types" }
+        assertNotNull(typesEndpoint)
+        assertNotNull("Response body should be set from method.return rule", typesEndpoint!!.httpMetadata?.responseBody)
+    }
+
+    fun testRuleAdditionalHeadersAdded() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            val headers = endpoint.httpMetadata?.headers ?: emptyList()
+            val customHeader = headers.find { it.name == "X-Custom-Header" }
+            assertNotNull(
+                "Each endpoint should have X-Custom-Header from rule",
+                customHeader
+            )
+            assertEquals("custom-value", customHeader!!.value)
+            assertEquals("custom header from rule", customHeader.description)
+            assertTrue(customHeader.required)
+        }
+    }
+
+    fun testRuleAdditionalParamsAdded() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            val params = endpoint.httpMetadata?.parameters ?: emptyList()
+            val traceParam = params.find { it.name == "traceId" }
+            assertNotNull(
+                "Each endpoint should have traceId param from rule",
+                traceParam
+            )
+            assertEquals("default-trace", traceParam!!.defaultValue)
+            assertTrue(traceParam.required)
+        }
+    }
+
+    fun testRuleAdditionalResponseHeadersAdded() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            val headers = endpoint.httpMetadata?.headers ?: emptyList()
+            val respHeader = headers.find { it.name == "X-Response-Id" }
+            assertNotNull(
+                "Each endpoint should have X-Response-Id header from rule",
+                respHeader
+            )
+            assertEquals("resp-123", respHeader!!.value)
+        }
+    }
+
+    fun testRuleDefaultHttpMethodNotOverrideExisting() = runTest {
+        val psiClass = findClass("com.itangcent.jaxrs.UserResource")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue(endpoints.isNotEmpty())
+
+        val getEndpoints = endpoints.filter { it.httpMetadata?.method == HttpMethod.GET }
+        assertTrue("Should have GET endpoints from @GET annotation", getEndpoints.isNotEmpty())
+
+        val postEndpoints = endpoints.filter { it.httpMetadata?.method == HttpMethod.POST }
+        assertTrue("Should have POST endpoints from @POST annotation", postEndpoints.isNotEmpty())
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
@@ -2,10 +2,13 @@ package com.itangcent.easyapi.exporter.springmvc
 
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
+import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.StandardDocHelper
+import com.itangcent.easyapi.rule.engine.RuleEngine
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 
@@ -21,7 +24,7 @@ class ActuatorEndpointScannerTest : EasyApiLightCodeInsightFixtureTestCase() {
     override fun setUp() {
         super.setUp()
         loadTestFiles()
-        actuatorEndpointScanner = ActuatorEndpointScanner()
+        actuatorEndpointScanner = ActuatorEndpointScanner(ApiMetadataResolver(RuleEngine.getInstance(project), StandardDocHelper()), EndpointBuilder.getInstance(project))
     }
 
     private fun loadTestFiles() {

--- a/src/test/resources/api/springmvc/BodyParamCtrl.java
+++ b/src/test/resources/api/springmvc/BodyParamCtrl.java
@@ -1,0 +1,17 @@
+package com.itangcent.springboot.demo.controller;
+
+import com.itangcent.model.UserInfo;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/body")
+public class BodyParamCtrl {
+
+    @PostMapping("/simple")
+    public void simpleBody(@RequestBody String name) {
+    }
+
+    @PostMapping("/complex")
+    public void complexBody(@RequestBody UserInfo user) {
+    }
+}

--- a/src/test/resources/api/springmvc/SimpleReturnCtrl.java
+++ b/src/test/resources/api/springmvc/SimpleReturnCtrl.java
@@ -1,0 +1,15 @@
+package com.itangcent.springboot.demo.controller;
+
+import com.itangcent.model.Result;
+import com.itangcent.model.UserInfo;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/simple")
+public class SimpleReturnCtrl {
+
+    @GetMapping("/user")
+    public Result<UserInfo> getUser() {
+        return Result.success(new UserInfo());
+    }
+}

--- a/src/test/resources/api/springmvc/VoidMethodCtrl.java
+++ b/src/test/resources/api/springmvc/VoidMethodCtrl.java
@@ -1,0 +1,12 @@
+package com.itangcent.springboot.demo.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/void")
+public class VoidMethodCtrl {
+
+    @GetMapping("/nothing")
+    public void voidMethod() {
+    }
+}


### PR DESCRIPTION
## Summary
Ensure rules like method.return, method.return.main, method.additional.header, and method.additional.response.header work consistently across all framework exporters (SpringMVC, JAX-RS, Feign, gRPC).

## Changes
- Extract shared endpoint building logic (buildResponseBody, buildHeaders, expandBodyParam, mergePathParameters) into centralized EndpointBuilder
- Convert EndpointBuilder to IntelliJ project service for clean dependency injection
- Add comprehensive KDoc documentation to EndpointBuilder
- Add 24 test cases covering all EndpointBuilder methods
- Remove redundant settings caching from all ClassExporters (JAX-RS, Feign, gRPC, SpringMVC)
- Update ActuatorEndpointScanner to use EndpointBuilder service

## Motivation
Previously, the logic for applying rules (like method.return for response body override) was duplicated across ClassExporters, leading to inconsistent behavior. Now all exporters use the same EndpointBuilder implementation, ensuring rules work uniformly regardless of framework.

## Test Plan
- All 24 new EndpointBuilderTest cases pass
- All existing exporter tests pass