### PR TITLE
fix: pass Disposable to addDocumentListener to resolve deprecation warning

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ScriptEditorPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ScriptEditorPanel.kt
@@ -78,12 +78,12 @@ class ScriptEditorPanel(private val project: Project) : JPanel(BorderLayout()) {
             override fun documentChanged(event: com.intellij.openapi.editor.event.DocumentEvent) {
                 markDirty()
             }
-        })
+        }, project)
         postResponseScriptArea.document.addDocumentListener(object : com.intellij.openapi.editor.event.DocumentListener {
             override fun documentChanged(event: com.intellij.openapi.editor.event.DocumentEvent) {
                 markDirty()
             }
-        })
+        }, project)
     }
 
     fun loadForScope(scope: ScriptScope, endpointCount: Int = 0) {


### PR DESCRIPTION
## Changes

- fix: pass Disposable to addDocumentListener to resolve deprecation warning

## Description

The IntelliJ API `Document.addDocumentListener(DocumentListener)` is deprecated and requires a `Disposable` parameter to ensure proper cleanup of listeners when the parent is disposed.

This fix passes the `project` as the `Disposable` parameter in `ScriptEditorPanel.kt` for both `preRequestScriptArea` and `postResponseScriptArea` document listeners.