### PR TITLE
fix: keep api dashboard in bottom tool window

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,7 +62,6 @@
                              instance="com.itangcent.easyapi.settings.ui.EasyApiOtherConfigurable"/>
         <toolWindow
                 id="API Dashboard"
-                secondary="true"
                 icon="AllIcons.Toolwindows.ToolWindowRun"
                 anchor="bottom"
                 factoryClass="com.itangcent.easyapi.dashboard.ApiDashboardToolWindowFactory"/>


### PR DESCRIPTION
## Summary
- Remove secondary tool window registration from API Dashboard so its bottom anchor is respected by default.

## Testing
- ./gradlew test --tests com.itangcent.easyapi.dashboard.ApiDashboardToolWindowFactoryTest

## Risks / rollback
- Existing IDE workspace layouts may still need users to reset or move the saved tool window placement once.