### PR TITLE
fix: support extracting comments from JAR classes and fix gRPC runtime Guava resolution

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
@@ -11,6 +11,7 @@ import com.itangcent.easyapi.exporter.model.ApiParameter
 import com.itangcent.easyapi.psi.PsiClassHelper
 import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.SourceHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelUtils
@@ -90,6 +91,7 @@ class EndpointBuilder(private val project: Project) {
             LOG.info("buildResponseBody: method.return rule override: $returnTypeByRule")
             val psiClass = JavaPsiFacade.getInstance(project)
                 .findClass(returnTypeByRule.trim(), GlobalSearchScope.allScope(project))
+                ?.let { SourceHelper.getInstance(project).getSourceClassSync(it) }
             if (psiClass != null) {
                 return runCatching { modelBuilder.buildModel(psiClass) }.getOrNull()
             }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolver.kt
@@ -15,6 +15,7 @@ import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.psi.helper.SourceHelper
 
 /**
  * Resolved information about a single gRPC RPC method.
@@ -395,8 +396,9 @@ class GrpcMethodResolver(private val project: Project) {
      * Finds a PsiClass by its fully qualified name.
      */
     private fun findClass(fqn: String): PsiClass? {
-        return JavaPsiFacade.getInstance(project)
-            .findClass(fqn, GlobalSearchScope.allScope(project))
+        val cls = JavaPsiFacade.getInstance(project)
+            .findClass(fqn, GlobalSearchScope.allScope(project)) ?: return null
+        return SourceHelper.getInstance(project).getSourceClassSync(cls)
     }
 
     // ── Private helpers ──────────────────────────────────────────────

--- a/src/main/kotlin/com/itangcent/easyapi/grpc/GrpcRuntimeResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/grpc/GrpcRuntimeResolver.kt
@@ -128,7 +128,7 @@ class GrpcRuntimeResolver(private val project: Project) {
             }
             .forEach { path ->
                 val name = path.fileName?.toString() ?: return@forEach
-                val versionMatch = Regex("""-([\d]+\.[\d]+\.[\d]+)\.jar$""").find(name)
+                val versionMatch = Regex("""-([\d]+\.[\d]+\.[\d]+)(?:-[a-zA-Z]+)?\.jar$""").find(name)
                 if (versionMatch != null) {
                     val version = versionMatch.groupValues[1]
                     grpcJarsByVersion.getOrPut(version) { mutableListOf() }.add(path)
@@ -252,7 +252,7 @@ class GrpcRuntimeResolver(private val project: Project) {
     }
 
     private fun extractVersionFromFileName(fileName: String): String {
-        val match = Regex("""-([\d]+\.[\d]+\.[\d]+)\.jar$""").find(fileName)
+        val match = Regex("""-([\d]+\.[\d]+\.[\d]+)(?:-[a-zA-Z]+)?\.jar$""").find(fileName)
         return match?.groupValues?.get(1) ?: "0.0.0"
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/psi/LinkResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/LinkResolver.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.search.GlobalSearchScope
+import com.itangcent.easyapi.psi.helper.SourceHelper
 
 /**
  * Utility for resolving link references in documentation and scripts.
@@ -44,6 +45,8 @@ import com.intellij.psi.search.GlobalSearchScope
 @Service(Service.Level.PROJECT)
 class LinkResolver(private val project: Project) {
 
+    private val sourceHelper: SourceHelper by lazy { SourceHelper.getInstance(project) }
+
     /**
      * Parsed result of a link reference.
      */
@@ -77,9 +80,12 @@ class LinkResolver(private val project: Project) {
         val facade = JavaPsiFacade.getInstance(project)
         val scope = GlobalSearchScope.allScope(project)
 
-        return facade.findClass(className, scope)
+        val psiClass = facade.findClass(className, scope)
             ?: resolveClassFromPackage(className, contextElement, facade, scope)
             ?: resolveClassFromImports(className, contextElement, facade, scope)
+            ?: return null
+
+        return sourceHelper.getSourceClassSync(psiClass)
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/SourceHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/SourceHelper.kt
@@ -1,0 +1,329 @@
+package com.itangcent.easyapi.psi.helper
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.fileTypes.StdFileTypes
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMember
+import com.intellij.psi.impl.compiled.ClsClassImpl
+import com.itangcent.easyapi.core.threading.read
+import java.io.File
+import java.util.*
+
+/**
+ * Resolves compiled JAR classes to their source counterparts for documentation extraction.
+ *
+ * When working with VO/DTO classes from external JAR dependencies, IntelliJ loads them
+ * as compiled classes ([ClsClassImpl]) which don't have direct access to Javadoc comments.
+ * This helper resolves these compiled classes to their source versions when source JARs
+ * are attached, enabling proper documentation extraction.
+ *
+ * ## Resolution Strategy
+ *
+ * 1. **Local classes**: Return as-is (already in source form)
+ * 2. **Cached resolution**: Return previously resolved source class if available
+ * 3. **Navigation element**: Use IntelliJ's built-in navigation for decompiled classes
+ * 4. **Source JAR search**: Search attached source roots for matching source files
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val sourceHelper = SourceHelper.getInstance(project)
+ *
+ * // Resolve a class from JAR to source
+ * val sourceClass = sourceHelper.getSourceClassSync(jarClass)
+ *
+ * // Resolve any element (class, field, method) to source
+ * val sourceElement = sourceHelper.getSourceElementSync(compiledElement)
+ * ```
+ *
+ * ## Thread Safety
+ *
+ * - [getSourceClass] and [getSourceElement] are suspend functions that wrap PSI access
+ *   in [read] blocks for [ReadAction](https://plugins.jetbrains.com/docs/intellij/threading-model.html) compliance.
+ * - [getSourceClassSync] and [getSourceElementSync] are synchronous versions for use
+ *   when already inside a read action context.
+ *
+ * ## Performance
+ *
+ * - Resolved source classes are cached in the PSI element's user data to avoid repeated lookups
+ * - Source JAR search is skipped during dumb mode to prevent indexing conflicts
+ *
+ * @see ClsClassImpl IntelliJ's representation of compiled classes from JARs
+ * @see UnifiedDocHelper Uses SourceHelper for documentation extraction from JAR classes
+ * @see LinkResolver Uses SourceHelper for link resolution from JAR classes
+ */
+@Service(Service.Level.PROJECT)
+class SourceHelper(private val project: Project) {
+
+    companion object {
+        /**
+         * Cache key for storing resolved source classes on the original compiled class.
+         * This avoids repeated source resolution for the same class during an operation.
+         */
+        private val SOURCE_ELEMENT = Key.create<PsiClass>("EasyApi.SOURCE_ELEMENT")
+
+        /**
+         * Get the SourceHelper instance for a project.
+         *
+         * @param project The IntelliJ project
+         * @return The SourceHelper service instance
+         */
+        fun getInstance(project: Project): SourceHelper = project.service()
+    }
+
+    /**
+     * Resolves a compiled class to its source counterpart (suspend version).
+     *
+     * This is the preferred method when calling from a coroutine context.
+     * It wraps the PSI access in a read action automatically.
+     *
+     * @param original The potentially compiled PsiClass
+     * @return The source PsiClass if found, otherwise the original class
+     */
+    suspend fun getSourceClass(original: PsiClass): PsiClass {
+        return read {
+            tryGetSourceClass(original)
+        }
+    }
+
+    /**
+     * Resolves a compiled class to its source counterpart (synchronous version).
+     *
+     * Use this method when already inside a read action context.
+     * If not in a read action, consider using [getSourceClass] instead.
+     *
+     * @param original The potentially compiled PsiClass
+     * @return The source PsiClass if found, otherwise the original class
+     */
+    fun getSourceClassSync(original: PsiClass): PsiClass {
+        return tryGetSourceClass(original)
+    }
+
+    /**
+     * Internal implementation for resolving a class to source.
+     *
+     * Resolution order:
+     * 1. Local inner classes - return as-is (already source)
+     * 2. Cached result - return previously resolved source class
+     * 3. Navigation element - use IntelliJ's built-in source navigation
+     * 4. Source JAR search - find source file in attached source roots
+     *
+     * @param original The potentially compiled PsiClass
+     * @return The source PsiClass if found, otherwise the original class
+     */
+    private fun tryGetSourceClass(original: PsiClass): PsiClass {
+        try {
+            if (isLocalClass(original)) {
+                return original
+            }
+
+            val cached = original.getUserData(SOURCE_ELEMENT)
+            if (cached != null && cached.isValid) {
+                return cached
+            }
+
+            if (original is ClsClassImpl) {
+                val navigationElement = original.navigationElement
+                if (navigationElement != original && navigationElement is PsiClass) {
+                    return navigationElement
+                }
+            }
+
+            if (!DumbService.isDumb(project)) {
+                val vFile = original.containingFile?.virtualFile ?: return original
+                val idx = ProjectRootManager.getInstance(project).fileIndex
+                if (idx.isInLibraryClasses(vFile)) {
+                    val sourceRootForFile = idx.getSourceRootForFile(vFile)
+                    if (sourceRootForFile != null) {
+                        tryFindSourceClass(sourceRootForFile, original)?.let { return it }
+                    }
+
+                    val orderEntriesForFile = idx.getOrderEntriesForFile(vFile)
+                    orderEntriesForFile.asSequence()
+                        .flatMap { it.getFiles(OrderRootType.SOURCES).asSequence() }
+                        .distinct()
+                        .map { tryFindSourceClass(it, original) }
+                        .firstOrNull()
+                        ?.let { return it }
+                }
+            }
+        } catch (_: Exception) {
+        }
+
+        return original
+    }
+
+    /**
+     * Resolves any PSI element to its source counterpart (suspend version).
+     *
+     * Handles classes, fields, and methods by:
+     * 1. For PsiClass: delegates to [getSourceClass]
+     * 2. For PsiMember (field/method): resolves the containing class, then finds the member
+     * 3. For other elements: uses navigationElement fallback
+     *
+     * @param element The potentially compiled PSI element
+     * @return The source element if found, otherwise the original element
+     */
+    suspend fun getSourceElement(element: PsiElement): PsiElement {
+        return read {
+            tryGetSourceElement(element)
+        }
+    }
+
+    /**
+     * Resolves any PSI element to its source counterpart (synchronous version).
+     *
+     * Use this method when already inside a read action context.
+     * If not in a read action, consider using [getSourceElement] instead.
+     *
+     * @param element The potentially compiled PSI element
+     * @return The source element if found, otherwise the original element
+     */
+    fun getSourceElementSync(element: PsiElement): PsiElement {
+        return tryGetSourceElement(element)
+    }
+
+    /**
+     * Internal implementation for resolving any element to source.
+     *
+     * @param element The potentially compiled PSI element
+     * @return The source element if found, otherwise the original element
+     */
+    private fun tryGetSourceElement(element: PsiElement): PsiElement {
+        if (element is PsiClass) {
+            return tryGetSourceClass(element)
+        }
+
+        if (element is PsiMember) {
+            val containingClass = element.containingClass ?: return element
+            val sourceClass = tryGetSourceClass(containingClass)
+            if (sourceClass !== containingClass) {
+                return when (element) {
+                    is PsiField -> sourceClass.findFieldByName(element.name, false) ?: element
+                    is PsiMethod -> sourceClass.findMethodsByName(element.name, false)
+                        .firstOrNull() as? PsiMethod ?: element
+                    else -> element
+                }
+            }
+        }
+
+        val navigationElement = element.navigationElement
+        return if (navigationElement != element && navigationElement.isValid) {
+            navigationElement
+        } else {
+            element
+        }
+    }
+
+    /**
+     * Checks if a class is a local inner class (not from a JAR).
+     *
+     * Local inner classes are defined inside source files and don't need
+     * source resolution. This check avoids unnecessary lookups.
+     *
+     * @param psiClass The class to check
+     * @return true if the class is a local inner class in source form
+     */
+    private fun isLocalClass(psiClass: PsiClass): Boolean {
+        return psiClass.containingClass != null && psiClass.containingClass !is ClsClassImpl
+    }
+
+    /**
+     * Searches for a source class in a source root directory.
+     *
+     * Looks for a Java file matching the class's qualified name and caches
+     * the result on the original class for future lookups.
+     *
+     * @param sourceRoot The virtual file representing the source root
+     * @param original The compiled class to find source for
+     * @return The source PsiClass if found, null otherwise
+     */
+    private fun tryFindSourceClass(
+        sourceRoot: VirtualFile,
+        original: PsiClass
+    ): PsiClass? {
+        val qualifiedName = original.qualifiedName ?: return null
+        val find = findPsiFileInRoot(sourceRoot, qualifiedName)
+            ?: sourceRoot.findChild(qualifiedName)
+        if (find != null && find is PsiJavaFile) {
+            find.classes.forEach {
+                if (it.qualifiedName == qualifiedName) {
+                    original.putUserData(SOURCE_ELEMENT, it)
+                    return it
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Finds a Java source file in a source root by class qualified name.
+     *
+     * Uses a depth-first search to locate the file, handling nested packages
+     * and matching by qualified name to support classes that may not follow
+     * standard file naming conventions.
+     *
+     * @param dirFile The source root directory to search in
+     * @param className The fully qualified class name to find
+     * @return The PsiJavaFile if found, null otherwise
+     */
+    private fun findPsiFileInRoot(dirFile: VirtualFile, className: String): PsiJavaFile? {
+        val javaName = StringUtil.getQualifiedName(className, StdFileTypes.JAVA.defaultExtension)
+        if (className.isNotEmpty()) {
+            val classFile = dirFile.findChild(javaName)
+            if (classFile != null) {
+                val psiFile = PsiManager.getInstance(project).findFile(classFile)
+                if (psiFile is PsiJavaFile) {
+                    return psiFile
+                }
+            }
+        }
+
+        val dirs = Stack<VirtualFile>()
+        var dir: VirtualFile = dirFile
+        val rootPath = dirFile.path
+        while (true) {
+            val children = dir.children
+            for (child in children) {
+                if (StdFileTypes.JAVA == child.fileType && child.isValid) {
+                    val psiFile = PsiManager.getInstance(project).findFile(child)
+                    if (psiFile is PsiJavaFile) {
+                        if (child.name == javaName) {
+                            return psiFile
+                        }
+
+                        for (cls in psiFile.classes) {
+                            if (cls.qualifiedName == className) {
+                                return psiFile
+                            }
+                        }
+                    }
+                } else {
+                    val prefix = dir.path.removePrefix(rootPath)
+                        .replace(File.separatorChar, '.')
+                    if (javaName.startsWith(prefix)) {
+                        dirs.push(child)
+                    }
+                }
+            }
+            if (dirs.isEmpty()) {
+                break
+            }
+            dir = dirs.pop()
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/UnifiedDocHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/UnifiedDocHelper.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.javadoc.PsiDocComment
 import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.psi.adapter.PsiLanguageAdapter
 import com.itangcent.easyapi.psi.adapter.PsiLanguageAdapterLoader
+import com.itangcent.easyapi.psi.doc.DocComment
 
 /**
  * Language-aware implementation of [DocHelper] that supports multiple JVM languages.
@@ -38,24 +39,17 @@ import com.itangcent.easyapi.psi.adapter.PsiLanguageAdapterLoader
  * @see PsiLanguageAdapterLoader for adapter discovery
  */
 @Service(Service.Level.PROJECT)
-class UnifiedDocHelper : DocHelper {
+class UnifiedDocHelper(private val project: Project) : DocHelper {
 
     companion object {
         private const val COMMENT_PREFIX = "//"
         private val DOC_COMMENT_PREFIXES = listOf("*", "///", "//")
 
-        /**
-         * Returns the [UnifiedDocHelper] instance for the given [project].
-         */
         fun getInstance(project: Project): UnifiedDocHelper = project.service()
     }
 
-    /**
-     * Lazily loaded list of available language adapters.
-     *
-     * Adapters for unavailable language plugins are automatically excluded
-     * by [PsiLanguageAdapterLoader].
-     */
+    private val sourceHelper: SourceHelper by lazy { SourceHelper.getInstance(project) }
+
     private val adapters: List<PsiLanguageAdapter> by lazy {
         PsiLanguageAdapterLoader.loadAdapters()
     }
@@ -63,16 +57,14 @@ class UnifiedDocHelper : DocHelper {
     override suspend fun hasTag(psiElement: PsiElement?, tag: String?): Boolean {
         if (psiElement == null || tag == null) return false
         return read {
-            val adapter = findAdapter(psiElement)
-            adapter?.resolveDocComment(psiElement)?.tags?.any { it.name == tag } == true
+            resolveDocComment(psiElement)?.tags?.any { it.name == tag } == true
         }
     }
 
     override suspend fun findDocByTag(psiElement: PsiElement?, tag: String?): String? {
         if (psiElement == null || tag == null) return null
         return read {
-            val adapter = findAdapter(psiElement)
-            adapter?.resolveDocComment(psiElement)
+            resolveDocComment(psiElement)
                 ?.tags?.firstOrNull { it.name == tag }?.value
         }
     }
@@ -80,8 +72,7 @@ class UnifiedDocHelper : DocHelper {
     override suspend fun findDocsByTag(psiElement: PsiElement?, tag: String?): List<String>? {
         if (psiElement == null || tag == null) return null
         return read {
-            val adapter = findAdapter(psiElement)
-            val tags = adapter?.resolveDocComment(psiElement)
+            val tags = resolveDocComment(psiElement)
                 ?.tags?.filter { it.name == tag }?.map { it.value }
             tags?.takeIf { it.isNotEmpty() }
         }
@@ -90,8 +81,7 @@ class UnifiedDocHelper : DocHelper {
     override suspend fun findDocsByTagAndName(psiElement: PsiElement?, tag: String, name: String): String? {
         if (psiElement == null) return null
         return read {
-            val adapter = findAdapter(psiElement)
-            adapter?.resolveDocComment(psiElement)
+            resolveDocComment(psiElement)
                 ?.tags?.firstOrNull { docTag ->
                     docTag.name == tag && (
                         docTag.value == name ||
@@ -104,10 +94,20 @@ class UnifiedDocHelper : DocHelper {
     }
 
     override suspend fun getAttrOfDocComment(psiElement: PsiElement?): String? {
+        if (psiElement == null) return null
         return read {
-            val owner = psiElement as? PsiDocCommentOwner ?: return@read null
-            val docComment = owner.docComment ?: return@read null
-            getDocCommentContent(docComment)
+            val owner = psiElement as? PsiDocCommentOwner
+            if (owner?.docComment != null) {
+                return@read getDocCommentContent(owner.docComment!!)
+            }
+            val sourceElement = sourceHelper.getSourceElementSync(psiElement)
+            if (sourceElement !== psiElement) {
+                val sourceOwner = sourceElement as? PsiDocCommentOwner
+                if (sourceOwner?.docComment != null) {
+                    return@read getDocCommentContent(sourceOwner.docComment!!)
+                }
+            }
+            null
         }
     }
 
@@ -124,8 +124,7 @@ class UnifiedDocHelper : DocHelper {
     override suspend fun getSubTagMapOfDocComment(psiElement: PsiElement?, tag: String): Map<String, String?> {
         if (psiElement == null) return emptyMap()
         return read {
-            val adapter = findAdapter(psiElement)
-            adapter?.resolveDocComment(psiElement)
+            resolveDocComment(psiElement)
                 ?.tags?.filter { it.name == tag }
                 ?.associate {
                     val firstWord = it.value.substringBefore(" ")
@@ -139,8 +138,7 @@ class UnifiedDocHelper : DocHelper {
     override suspend fun getTagMapOfDocComment(psiElement: PsiElement?): Map<String, String?> {
         if (psiElement == null) return emptyMap()
         return read {
-            val adapter = findAdapter(psiElement)
-            adapter?.resolveDocComment(psiElement)
+            resolveDocComment(psiElement)
                 ?.tags?.associate { it.name to it.value }
                 ?: emptyMap()
         }
@@ -166,11 +164,32 @@ class UnifiedDocHelper : DocHelper {
 
     override suspend fun getAttrOfField(field: PsiField): String? {
         val attrInDoc = getAttrOfDocComment(field)
-        val eolComment = getEolComment(field)?.takeIf { it != attrInDoc }
+        val eolComment = read {
+            val commentElement = if ((field as? PsiDocCommentOwner)?.docComment == null) {
+                sourceHelper.getSourceElementSync(field)
+            } else {
+                field
+            }
+            getEolComment(commentElement)
+        }?.takeIf { it != attrInDoc }
         return listOfNotNull(attrInDoc, eolComment)
             .distinct()
             .joinToString("\n")
             .ifEmpty { null }
+    }
+
+    private fun resolveDocComment(psiElement: PsiElement): DocComment? {
+        val adapter = findAdapter(psiElement)
+        val docComment = adapter?.resolveDocComment(psiElement)
+        if (docComment != null) return docComment
+
+        val sourceElement = sourceHelper.getSourceElementSync(psiElement)
+        if (sourceElement !== psiElement) {
+            val sourceAdapter = findAdapter(sourceElement)
+            return sourceAdapter?.resolveDocComment(sourceElement)
+        }
+
+        return null
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/psi/type/ResolvedTypes.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/type/ResolvedTypes.kt
@@ -753,9 +753,10 @@ object TypeResolver {
         if (className.isBlank()) return null
         val facade = JavaPsiFacade.getInstance(project)
         val scope = GlobalSearchScope.allScope(project)
-
+        val sourceHelper = com.itangcent.easyapi.psi.helper.SourceHelper.getInstance(project)
+        
         // Fully qualified name
-        facade.findClass(className, scope)?.let { return it }
+        facade.findClass(className, scope)?.let { return sourceHelper.getSourceClassSync(it) }
 
         if (contextElement == null) return null
         val javaFile = contextElement.containingFile as? PsiJavaFile ?: return null
@@ -763,10 +764,9 @@ object TypeResolver {
         // Same package
         val packageName = javaFile.packageName
         if (packageName.isNotBlank()) {
-            facade.findClass("$packageName.$className", scope)?.let { return it }
+            facade.findClass("$packageName.$className", scope)?.let { return sourceHelper.getSourceClassSync(it) }
         }
 
-        // Import statements
         val imports = javaFile.importList?.importStatements
         if (imports != null) {
             for (importStmt in imports) {
@@ -776,12 +776,11 @@ object TypeResolver {
                     importRef.endsWith(".*") -> importRef.removeSuffix("*") + className
                     else -> continue
                 }
-                facade.findClass(candidate, scope)?.let { return it }
+                facade.findClass(candidate, scope)?.let { return sourceHelper.getSourceClassSync(it) }
             }
         }
 
-        // Default packages
-        facade.findClass("java.lang.$className", scope)?.let { return it }
+        facade.findClass("java.lang.$className", scope)?.let { return sourceHelper.getSourceClassSync(it) }
 
         return null
     }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
@@ -1,11 +1,13 @@
 package com.itangcent.easyapi.rule.parser
 
-import com.intellij.psi.PsiElement
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.http.HttpClientProvider
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.helper.SourceHelper
 import com.itangcent.easyapi.rule.RuleKey
 import com.itangcent.easyapi.rule.context.RuleContext
 import com.itangcent.easyapi.rule.context.ScriptPsiClassContext
@@ -167,10 +169,11 @@ class ScriptHelper(private val context: RuleContext) {
      */
     fun findClass(canonicalText: String): Any? {
         val project = context.project
+        val sourceHelper = SourceHelper.getInstance(project)
         val psiClass = readSync {
-            com.intellij.psi.JavaPsiFacade.getInstance(project)
-                .findClass(canonicalText, com.intellij.psi.search.GlobalSearchScope.allScope(project))
-        } ?: return null
+            JavaPsiFacade.getInstance(project)
+                .findClass(canonicalText, GlobalSearchScope.allScope(project))
+        }?.let { sourceHelper.getSourceClassSync(it) } ?: return null
         return ScriptPsiClassContext(context.withElement(psiClass))
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/psi/LinkResolverSourceResolutionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/LinkResolverSourceResolutionTest.kt
@@ -1,0 +1,293 @@
+package com.itangcent.easyapi.psi
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+
+class LinkResolverSourceResolutionTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var linkResolver: LinkResolver
+
+    override fun setUp() {
+        super.setUp()
+        linkResolver = LinkResolver.getInstance(project)
+    }
+
+    // --- resolveClass: source-level class ---
+
+    fun testResolveClassByFqn() {
+        loadFile("linkres/ResolvedClass.java", """
+            package com.test.linkres;
+            /**
+             * A resolvable class.
+             */
+            public class ResolvedClass {}
+        """.trimIndent())
+        val contextClass = loadFile("linkres/ContextClass.java", """
+            package com.test.linkres;
+            public class ContextClass {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.ContextClass")!!
+        val result = linkResolver.resolveClass("com.test.linkres.ResolvedClass", contextElement)
+        assertNotNull("Should resolve class by fully qualified name", result)
+        assertEquals("com.test.linkres.ResolvedClass", result!!.qualifiedName)
+    }
+
+    // --- resolveClass: same package ---
+
+    fun testResolveClassFromSamePackage() {
+        loadFile("linkres/SamePackageTarget.java", """
+            package com.test.linkres;
+            /**
+             * A target in the same package.
+             */
+            public class SamePackageTarget {}
+        """.trimIndent())
+        loadFile("linkres/SamePackageContext.java", """
+            package com.test.linkres;
+            public class SamePackageContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.SamePackageContext")!!
+        val result = linkResolver.resolveClass("SamePackageTarget", contextElement)
+        assertNotNull("Should resolve class from same package", result)
+        assertEquals("com.test.linkres.SamePackageTarget", result!!.qualifiedName)
+    }
+
+    // --- resolveClass: from import ---
+
+    fun testResolveClassFromImport() {
+        loadFile("linkres/ImportedTarget.java", """
+            package com.test.linkres.imported;
+            /**
+             * An imported target class.
+             */
+            public class ImportedTarget {}
+        """.trimIndent())
+        loadFile("linkres/ImportContext.java", """
+            package com.test.linkres;
+            import com.test.linkres.imported.ImportedTarget;
+            public class ImportContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.ImportContext")!!
+        val result = linkResolver.resolveClass("ImportedTarget", contextElement)
+        assertNotNull("Should resolve class from import statement", result)
+        assertEquals("com.test.linkres.imported.ImportedTarget", result!!.qualifiedName)
+    }
+
+    // --- resolveClass: not found ---
+
+    fun testResolveClassReturnsNullForUnknownClass() {
+        loadFile("linkres/NotFoundContext.java", """
+            package com.test.linkres;
+            public class NotFoundContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.NotFoundContext")!!
+        val result = linkResolver.resolveClass("com.test.linkres.NonExistentClass", contextElement)
+        assertNull("Should return null for unknown class", result)
+    }
+
+    // --- resolveLink: class only ---
+
+    fun testResolveLinkClassOnly() {
+        loadFile("linkres/LinkTargetClass.java", """
+            package com.test.linkres;
+            /**
+             * A link target.
+             */
+            public class LinkTargetClass {}
+        """.trimIndent())
+        loadFile("linkres/LinkContext.java", """
+            package com.test.linkres;
+            public class LinkContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.LinkContext")!!
+        val result = linkResolver.resolveLink("com.test.linkres.LinkTargetClass", contextElement)
+        assertNotNull("Should resolve link to class", result)
+        assertTrue("Result should be a PsiClass", result is com.intellij.psi.PsiClass)
+        assertEquals("com.test.linkres.LinkTargetClass", (result as com.intellij.psi.PsiClass).qualifiedName)
+    }
+
+    // --- resolveLink: class with field ---
+
+    fun testResolveLinkClassWithField() {
+        loadFile("linkres/LinkFieldTarget.java", """
+            package com.test.linkres;
+            /**
+             * A target with fields.
+             */
+            public class LinkFieldTarget {
+                /** The status code. */
+                private int statusCode;
+            }
+        """.trimIndent())
+        loadFile("linkres/LinkFieldContext.java", """
+            package com.test.linkres;
+            public class LinkFieldContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.LinkFieldContext")!!
+        val result = linkResolver.resolveLink("com.test.linkres.LinkFieldTarget#statusCode", contextElement)
+        assertNotNull("Should resolve link to field", result)
+        assertTrue("Result should be a PsiField", result is com.intellij.psi.PsiField)
+        assertEquals("statusCode", (result as com.intellij.psi.PsiField).name)
+    }
+
+    // --- resolveLink: class with method ---
+
+    fun testResolveLinkClassWithMethod() {
+        loadFile("linkres/LinkMethodTarget.java", """
+            package com.test.linkres;
+            /**
+             * A target with methods.
+             */
+            public class LinkMethodTarget {
+                /**
+                 * Gets the status.
+                 * @return the status
+                 */
+                public int getStatus() { return 0; }
+            }
+        """.trimIndent())
+        loadFile("linkres/LinkMethodContext.java", """
+            package com.test.linkres;
+            public class LinkMethodContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.LinkMethodContext")!!
+        val result = linkResolver.resolveLink("com.test.linkres.LinkMethodTarget#getStatus()", contextElement)
+        assertNotNull("Should resolve link to method", result)
+        assertTrue("Result should be a PsiMethod", result is com.intellij.psi.PsiMethod)
+        assertEquals("getStatus", (result as com.intellij.psi.PsiMethod).name)
+    }
+
+    // --- resolveLink: dot notation for field ---
+
+    fun testResolveLinkDotNotationField() {
+        loadFile("linkres/DotFieldTarget.java", """
+            package com.test.linkres;
+            /**
+             * A target for dot notation.
+             */
+            public class DotFieldTarget {
+                /** The priority. */
+                private int priority;
+            }
+        """.trimIndent())
+        loadFile("linkres/DotFieldContext.java", """
+            package com.test.linkres;
+            public class DotFieldContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.DotFieldContext")!!
+        val result = linkResolver.resolveLink("com.test.linkres.DotFieldTarget.priority", contextElement)
+        assertNotNull("Should resolve dot notation link to field", result)
+        assertTrue("Result should be a PsiField", result is com.intellij.psi.PsiField)
+        assertEquals("priority", (result as com.intellij.psi.PsiField).name)
+    }
+
+    // --- resolveLink: getter to property conversion ---
+
+    fun testResolveLinkGetterToProperty() {
+        loadFile("linkres/GetterTarget.java", """
+            package com.test.linkres;
+            /**
+             * A target with getter.
+             */
+            public class GetterTarget {
+                /** The active flag. */
+                private boolean active;
+                /**
+                 * Is active.
+                 * @return true if active
+                 */
+                public boolean isActive() { return active; }
+            }
+        """.trimIndent())
+        loadFile("linkres/GetterContext.java", """
+            package com.test.linkres;
+            public class GetterContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.GetterContext")!!
+        val result = linkResolver.resolveLink("com.test.linkres.GetterTarget#isActive()", contextElement)
+        assertNotNull("Should resolve getter method", result)
+        assertTrue("Result should be a PsiMethod for isActive", result is com.intellij.psi.PsiMethod)
+        assertEquals("isActive", (result as com.intellij.psi.PsiMethod).name)
+    }
+
+    fun testResolveLinkDotNotationGetterToProperty() {
+        loadFile("linkres/GetterDotTarget.java", """
+            package com.test.linkres;
+            /**
+             * A target for dot getter.
+             */
+            public class GetterDotTarget {
+                /** The status. */
+                private String status;
+            }
+        """.trimIndent())
+        loadFile("linkres/GetterDotContext.java", """
+            package com.test.linkres;
+            public class GetterDotContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.GetterDotContext")!!
+        val result = linkResolver.resolveLink("com.test.linkres.GetterDotTarget.getStatus", contextElement)
+        assertNotNull("Should resolve dot notation getter to field", result)
+        assertTrue("Result should be a PsiField", result is com.intellij.psi.PsiField)
+        assertEquals("status", (result as com.intellij.psi.PsiField).name)
+    }
+
+    // --- resolveLink: invalid link ---
+
+    fun testResolveLinkReturnsNullForInvalidLink() {
+        loadFile("linkres/InvalidLinkContext.java", """
+            package com.test.linkres;
+            public class InvalidLinkContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.InvalidLinkContext")!!
+        val result = linkResolver.resolveLink("", contextElement)
+        assertNull("Should return null for empty link", result)
+    }
+
+    // --- extractLinks ---
+
+    fun testExtractLinksFromJavaDocFormat() {
+        val text = "See {@link UserDTO} and {@link AccountDTO#name} for details."
+        val links = linkResolver.extractLinks(text)
+        assertEquals("Should extract 2 JavaDoc links", 2, links.size)
+        assertTrue("First link should be UserDTO", links.contains("UserDTO"))
+        assertTrue("Second link should be AccountDTO#name", links.contains("AccountDTO#name"))
+    }
+
+    fun testExtractLinksFromKDocFormat() {
+        val text = "See [UserDTO] and [AccountDTO.name] for details."
+        val links = linkResolver.extractLinks(text)
+        assertEquals("Should extract 1 KDoc link (only dot/hash links)", 1, links.size)
+        assertTrue("Should extract AccountDTO.name", links.contains("AccountDTO.name"))
+    }
+
+    // --- resolveAllLinks ---
+
+    fun testResolveAllLinks() {
+        loadFile("linkres/AllLinksTarget.java", """
+            package com.test.linkres;
+            /**
+             * A target for resolveAllLinks.
+             */
+            public class AllLinksTarget {}
+        """.trimIndent())
+        loadFile("linkres/AllLinksContext.java", """
+            package com.test.linkres;
+            public class AllLinksContext {}
+        """.trimIndent())
+        val contextElement = findClass("com.test.linkres.AllLinksContext")!!
+        val results = linkResolver.resolveAllLinks(
+            "See {@link com.test.linkres.AllLinksTarget}",
+            contextElement
+        )
+        assertEquals("Should resolve 1 link", 1, results.size)
+        assertTrue("Resolved element should be a PsiClass", results[0] is com.intellij.psi.PsiClass)
+    }
+
+    // --- getInstance ---
+
+    fun testGetInstanceReturnsSameInstance() {
+        val instance1 = LinkResolver.getInstance(project)
+        val instance2 = LinkResolver.getInstance(project)
+        assertSame("getInstance should return the same service instance", instance1, instance2)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/psi/helper/SourceHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/helper/SourceHelperTest.kt
@@ -1,0 +1,266 @@
+package com.itangcent.easyapi.psi.helper
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+
+class SourceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var sourceHelper: SourceHelper
+
+    override fun setUp() {
+        super.setUp()
+        sourceHelper = SourceHelper.getInstance(project)
+    }
+
+    // --- getInstance ---
+
+    fun testGetInstanceReturnsSameInstance() {
+        val instance1 = SourceHelper.getInstance(project)
+        val instance2 = SourceHelper.getInstance(project)
+        assertSame("getInstance should return the same service instance", instance1, instance2)
+    }
+
+    // --- getSourceClassSync: local source classes ---
+
+    fun testGetSourceClassSyncReturnsSameForSourceClass() {
+        loadFile("source/LocalSourceClass.java", """
+            package com.test.source;
+            /**
+             * A local source class.
+             */
+            public class LocalSourceClass {
+                /** The name field. */
+                private String name;
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.LocalSourceClass")!!
+        val result = sourceHelper.getSourceClassSync(psiClass)
+        assertSame("Should return same class for local source class", psiClass, result)
+    }
+
+    // --- getSourceClass: suspend version ---
+
+    fun testGetSourceClassReturnsSameForSourceClass() = runBlocking {
+        loadFile("source/LocalSourceClassSuspend.java", """
+            package com.test.source;
+            /**
+             * A local source class for suspend test.
+             */
+            public class LocalSourceClassSuspend {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.LocalSourceClassSuspend")!!
+        val result = sourceHelper.getSourceClass(psiClass)
+        assertSame("Should return same class for local source class", psiClass, result)
+    }
+
+    // --- getSourceElementSync: PsiClass ---
+
+    fun testGetSourceElementSyncReturnsSameForSourceClass() {
+        loadFile("source/ElementSourceClass.java", """
+            package com.test.source;
+            /**
+             * A class for element resolution test.
+             */
+            public class ElementSourceClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.ElementSourceClass")!!
+        val result = sourceHelper.getSourceElementSync(psiClass)
+        assertSame("Should return same element for source PsiClass", psiClass, result)
+    }
+
+    // --- getSourceElementSync: PsiField ---
+
+    fun testGetSourceElementSyncResolvesFieldFromSourceClass() {
+        loadFile("source/FieldSourceClass.java", """
+            package com.test.source;
+            /**
+             * A class with documented fields.
+             */
+            public class FieldSourceClass {
+                /** The user name. */
+                private String userName;
+                /** The user age. */
+                private int userAge;
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.FieldSourceClass")!!
+        val field = psiClass.findFieldByName("userName", false)!!
+        val result = sourceHelper.getSourceElementSync(field)
+        assertNotNull("Should resolve source element for field", result)
+        assertTrue("Result should be a PsiField", result is com.intellij.psi.PsiField)
+        assertEquals("Field name should match", "userName", (result as com.intellij.psi.PsiField).name)
+    }
+
+    // --- getSourceElementSync: PsiMethod ---
+
+    fun testGetSourceElementSyncResolvesMethodFromSourceClass() {
+        loadFile("source/MethodSourceClass.java", """
+            package com.test.source;
+            /**
+             * A class with documented methods.
+             */
+            public class MethodSourceClass {
+                /**
+                 * Gets the user name.
+                 * @return the user name
+                 */
+                public String getUserName() { return null; }
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.MethodSourceClass")!!
+        val method = findMethod(psiClass, "getUserName")!!
+        val result = sourceHelper.getSourceElementSync(method)
+        assertNotNull("Should resolve source element for method", result)
+        assertTrue("Result should be a PsiMethod", result is com.intellij.psi.PsiMethod)
+        assertEquals("Method name should match", "getUserName", (result as com.intellij.psi.PsiMethod).name)
+    }
+
+    // --- getSourceElement: suspend version ---
+
+    fun testGetSourceElementReturnsSameForSourceElement() = runBlocking {
+        loadFile("source/ElementSuspendClass.java", """
+            package com.test.source;
+            /**
+             * A class for suspend element test.
+             */
+            public class ElementSuspendClass {
+                /** The value. */
+                private int value;
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.ElementSuspendClass")!!
+        val result = sourceHelper.getSourceElement(psiClass)
+        assertSame("Should return same element for source PsiClass", psiClass, result)
+    }
+
+    // --- inner class handling ---
+
+    fun testGetSourceClassSyncHandlesInnerClass() {
+        loadFile("source/OuterSourceClass.java", """
+            package com.test.source;
+            /**
+             * An outer class.
+             */
+            public class OuterSourceClass {
+                /**
+                 * An inner class.
+                 */
+                public static class InnerClass {
+                    /** Inner field. */
+                    private String innerField;
+                }
+            }
+        """.trimIndent())
+        val innerClass = findClass("com.test.source.OuterSourceClass.InnerClass")!!
+        val result = sourceHelper.getSourceClassSync(innerClass)
+        assertSame("Should return same inner class for source inner class", innerClass, result)
+    }
+
+    // --- null qualified name handling ---
+
+    fun testGetSourceClassSyncHandlesAnonymousClass() {
+        loadFile("source/AnonymousClassHolder.java", """
+            package com.test.source;
+            /**
+             * A class that creates an anonymous inner class.
+             */
+            public class AnonymousClassHolder {
+                public Runnable getRunnable() {
+                    return new Runnable() {
+                        @Override
+                        public void run() {}
+                    };
+                }
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.AnonymousClassHolder")!!
+        val result = sourceHelper.getSourceClassSync(psiClass)
+        assertNotNull("Should handle class without errors", result)
+    }
+
+    // --- caching behavior ---
+
+    fun testGetSourceClassSyncCachesResult() {
+        loadFile("source/CachedSourceClass.java", """
+            package com.test.source;
+            /**
+             * A class for caching test.
+             */
+            public class CachedSourceClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.CachedSourceClass")!!
+        val result1 = sourceHelper.getSourceClassSync(psiClass)
+        val result2 = sourceHelper.getSourceClassSync(psiClass)
+        assertSame("Should return cached result on second call", result1, result2)
+    }
+
+    // --- field resolution from inner class ---
+
+    fun testGetSourceElementSyncResolvesFieldFromInnerClass() {
+        loadFile("source/InnerFieldClass.java", """
+            package com.test.source;
+            /**
+             * An outer class with inner fields.
+             */
+            public class InnerFieldClass {
+                /**
+                 * An inner class.
+                 */
+                public static class Inner {
+                    /** Inner name. */
+                    private String innerName;
+                }
+            }
+        """.trimIndent())
+        val innerClass = findClass("com.test.source.InnerFieldClass.Inner")!!
+        val field = innerClass.findFieldByName("innerName", false)!!
+        val result = sourceHelper.getSourceElementSync(field)
+        assertNotNull("Should resolve source element for inner class field", result)
+        assertEquals("Field name should match", "innerName", (result as com.intellij.psi.PsiField).name)
+    }
+
+    // --- method resolution from inner class ---
+
+    fun testGetSourceElementSyncResolvesMethodFromInnerClass() {
+        loadFile("source/InnerMethodClass.java", """
+            package com.test.source;
+            /**
+             * An outer class with inner methods.
+             */
+            public class InnerMethodClass {
+                /**
+                 * An inner class.
+                 */
+                public static class Inner {
+                    /**
+                     * Gets the inner value.
+                     * @return the inner value
+                     */
+                    public String getInnerValue() { return null; }
+                }
+            }
+        """.trimIndent())
+        val innerClass = findClass("com.test.source.InnerMethodClass.Inner")!!
+        val method = findMethod(innerClass, "getInnerValue")!!
+        val result = sourceHelper.getSourceElementSync(method)
+        assertNotNull("Should resolve source element for inner class method", result)
+        assertEquals("Method name should match", "getInnerValue", (result as com.intellij.psi.PsiMethod).name)
+    }
+
+    // --- element without containing class ---
+
+    fun testGetSourceElementSyncHandlesElementWithoutContainingClass() {
+        loadFile("source/StandaloneClass.java", """
+            package com.test.source;
+            /**
+             * A standalone class.
+             */
+            public class StandaloneClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.StandaloneClass")!!
+        val result = sourceHelper.getSourceElementSync(psiClass)
+        assertSame("Should handle PsiClass directly", psiClass, result)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/psi/helper/UnifiedDocHelperSourceResolutionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/helper/UnifiedDocHelperSourceResolutionTest.kt
@@ -1,0 +1,256 @@
+package com.itangcent.easyapi.psi.helper
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+
+class UnifiedDocHelperSourceResolutionTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var docHelper: UnifiedDocHelper
+
+    override fun setUp() {
+        super.setUp()
+        docHelper = UnifiedDocHelper.getInstance(project)
+    }
+
+    // --- getAttrOfDocComment: source-resolved class doc ---
+
+    fun testGetAttrOfDocCommentForSourceClass() = runBlocking {
+        loadFile("sourceres/DocumentedClass.java", """
+            package com.test.sourceres;
+            /**
+             * This is a documented class.
+             */
+            public class DocumentedClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.DocumentedClass")!!
+        val desc = docHelper.getAttrOfDocComment(psiClass)
+        assertNotNull("Should find doc description for source class", desc)
+        assertTrue("Description should contain 'documented class'", desc!!.contains("documented class"))
+    }
+
+    // --- getAttrOfDocComment: source-resolved field doc ---
+
+    fun testGetAttrOfDocCommentForDocumentedField() = runBlocking {
+        loadFile("sourceres/FieldDocClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with documented fields.
+             */
+            public class FieldDocClass {
+                /** The user identifier. */
+                private String userId;
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.FieldDocClass")!!
+        val field = psiClass.findFieldByName("userId", false)!!
+        val desc = docHelper.getAttrOfDocComment(field)
+        assertNotNull("Should find doc description for field", desc)
+        assertTrue("Description should contain 'user identifier'", desc!!.contains("user identifier"))
+    }
+
+    // --- getAttrOfDocComment: source-resolved method doc ---
+
+    fun testGetAttrOfDocCommentForDocumentedMethod() = runBlocking {
+        loadFile("sourceres/MethodDocClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with documented methods.
+             */
+            public class MethodDocClass {
+                /**
+                 * Retrieves the account balance.
+                 * @return the balance
+                 */
+                public double getBalance() { return 0.0; }
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.MethodDocClass")!!
+        val method = findMethod(psiClass, "getBalance")!!
+        val desc = docHelper.getAttrOfDocComment(method)
+        assertNotNull("Should find doc description for method", desc)
+        assertTrue("Description should contain 'Retrieves the account balance'", desc!!.contains("Retrieves the account balance"))
+    }
+
+    // --- hasTag: source-resolved element ---
+
+    fun testHasTagOnSourceClass() = runBlocking {
+        loadFile("sourceres/TaggedClass.java", """
+            package com.test.sourceres;
+            /**
+             * A tagged class.
+             * @author TestAuthor
+             * @version 2.0
+             */
+            public class TaggedClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.TaggedClass")!!
+        assertTrue("Should find @author tag on source class", docHelper.hasTag(psiClass, "author"))
+        assertTrue("Should find @version tag on source class", docHelper.hasTag(psiClass, "version"))
+        assertFalse("Should not find @deprecated tag", docHelper.hasTag(psiClass, "deprecated"))
+    }
+
+    // --- findDocByTag: source-resolved element ---
+
+    fun testFindDocByTagOnSourceClass() = runBlocking {
+        loadFile("sourceres/TagValueClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with tag values.
+             * @author Jane Smith
+             */
+            public class TagValueClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.TagValueClass")!!
+        val author = docHelper.findDocByTag(psiClass, "author")
+        assertNotNull("Should find @author value on source class", author)
+        assertTrue("Author should contain 'Jane Smith'", author!!.contains("Jane Smith"))
+    }
+
+    // --- findDocsByTag: source-resolved element ---
+
+    fun testFindDocsByTagOnSourceClass() = runBlocking {
+        loadFile("sourceres/MultiTagClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with multiple @see tags.
+             * @see UserDTO
+             * @see AccountDTO
+             */
+            public class MultiTagClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.MultiTagClass")!!
+        val seeDocs = docHelper.findDocsByTag(psiClass, "see")
+        assertNotNull("Should find @see values on source class", seeDocs)
+        assertEquals("Should have 2 @see tags", 2, seeDocs!!.size)
+    }
+
+    // --- getTagMapOfDocComment: source-resolved element ---
+
+    fun testGetTagMapOfDocCommentOnSourceClass() = runBlocking {
+        loadFile("sourceres/TagMapClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with tag map.
+             * @author DevTeam
+             * @since 1.0
+             */
+            public class TagMapClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.TagMapClass")!!
+        val tagMap = docHelper.getTagMapOfDocComment(psiClass)
+        assertTrue("Tag map should contain 'author'", tagMap.containsKey("author"))
+        assertTrue("Tag map should contain 'since'", tagMap.containsKey("since"))
+    }
+
+    // --- getSubTagMapOfDocComment: source-resolved element ---
+
+    fun testGetSubTagMapOfDocCommentOnSourceMethod() = runBlocking {
+        loadFile("sourceres/SubTagClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with param tags.
+             */
+            public class SubTagClass {
+                /**
+                 * Creates a new user.
+                 * @param name the user name
+                 * @param email the user email
+                 */
+                public void createUser(String name, String email) {}
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.SubTagClass")!!
+        val method = findMethod(psiClass, "createUser")!!
+        val paramMap = docHelper.getSubTagMapOfDocComment(method, "param")
+        assertTrue("Param map should contain 'name'", paramMap.containsKey("name"))
+        assertTrue("Param map should contain 'email'", paramMap.containsKey("email"))
+        assertTrue("Name param should contain 'user name'", paramMap["name"]!!.contains("user name"))
+    }
+
+    // --- getAttrOfField: doc comment on field ---
+
+    fun testGetAttrOfFieldWithDocComment() = runBlocking {
+        loadFile("sourceres/FieldAttrClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with field attributes.
+             */
+            public class FieldAttrClass {
+                /** The product code. */
+                private String productCode;
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.FieldAttrClass")!!
+        val field = psiClass.findFieldByName("productCode", false)!!
+        val attr = docHelper.getAttrOfField(field)
+        assertNotNull("Should find field attribute from doc comment", attr)
+        assertTrue("Field attribute should contain 'product code'", attr!!.contains("product code"))
+    }
+
+    // --- getAttrOfField: EOL comment on field ---
+
+    fun testGetAttrOfFieldWithEolComment() = runBlocking {
+        loadFile("sourceres/EolFieldClass.java", """
+            package com.test.sourceres;
+            /**
+             * A class with EOL comments.
+             */
+            public class EolFieldClass {
+                private String productCode; // the product code
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.EolFieldClass")!!
+        val field = psiClass.findFieldByName("productCode", false)!!
+        val attr = docHelper.getAttrOfField(field)
+        assertNotNull("Should find field attribute from EOL comment", attr)
+        assertTrue("Field attribute should contain 'product code'", attr!!.contains("product code"))
+    }
+
+    // --- getAttrOfDocComment: null element ---
+
+    fun testGetAttrOfDocCommentReturnsNullForNullElement() = runBlocking {
+        assertNull("Should return null for null element", docHelper.getAttrOfDocComment(null))
+    }
+
+    // --- resolveDocComment via hasTag for method ---
+
+    fun testHasTagOnSourceMethod() = runBlocking {
+        loadFile("sourceres/MethodTagClass.java", """
+            package com.test.sourceres;
+            public class MethodTagClass {
+                /**
+                 * Validates the input.
+                 * @param input the input to validate
+                 * @return true if valid
+                 * @throws IllegalArgumentException if invalid
+                 */
+                public boolean validate(String input) { return true; }
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.MethodTagClass")!!
+        val method = findMethod(psiClass, "validate")!!
+        assertTrue("Should find @param tag on method", docHelper.hasTag(method, "param"))
+        assertTrue("Should find @return tag on method", docHelper.hasTag(method, "return"))
+        assertTrue("Should find @throws tag on method", docHelper.hasTag(method, "throws"))
+    }
+
+    // --- findDocByTag on method ---
+
+    fun testFindDocByTagOnSourceMethod() = runBlocking {
+        loadFile("sourceres/MethodTagValueClass.java", """
+            package com.test.sourceres;
+            public class MethodTagValueClass {
+                /**
+                 * Calculates the total.
+                 * @return the total amount
+                 */
+                public double calculateTotal() { return 0.0; }
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.sourceres.MethodTagValueClass")!!
+        val method = findMethod(psiClass, "calculateTotal")!!
+        val returnDoc = docHelper.findDocByTag(method, "return")
+        assertNotNull("Should find @return value on method", returnDoc)
+        assertTrue("Return doc should contain 'total amount'", returnDoc!!.contains("total amount"))
+    }
+}


### PR DESCRIPTION
- Add SourceHelper service to resolve compiled JAR classes (ClsClassImpl) to their source counterparts for documentation extraction
- Integrate SourceHelper into UnifiedDocHelper for doc comment extraction
- Integrate SourceHelper into LinkResolver for link resolution
- Integrate SourceHelper into ResolvedTypes for type resolution
- Integrate SourceHelper into Jsr223ScriptParser for script class lookup
- Integrate SourceHelper into GrpcMethodResolver and EndpointBuilder
- Fix extractVersionFromFileName regex to handle Maven classifier suffixes (-jre, -android) that caused old Guava 10.0.1 to be selected over newer versions like 33.2.1-jre
- Add test cases for SourceHelper, UnifiedDocHelper, and LinkResolver