### PR TITLE
fix: remove duplicated comments when combining doc comments with rule-based docs

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.exporter.model.ApiHeader
 import com.itangcent.easyapi.exporter.model.ApiParameter
 import com.itangcent.easyapi.psi.PsiClassHelper
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.SourceHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
@@ -32,7 +32,7 @@ import com.itangcent.easyapi.settings.Settings
  * - Path parameter merging with enum/default/description enrichment
  *
  * Registered as a IntelliJ project-level service, so it can resolve dependencies
- * (RuleEngine, DocHelper, Settings, ApiMetadataResolver) from the project automatically.
+ * (RuleEngine, DocHelper, Settings, DocMetadataResolver) from the project automatically.
  *
  * Usage:
  * ```
@@ -45,8 +45,8 @@ class EndpointBuilder(private val project: Project) {
 
     private val settings: Settings by lazy { SettingBinder.getInstance(project).read() }
     private val docHelper: DocHelper by lazy { UnifiedDocHelper.getInstance(project) }
-    private val metadataResolver: ApiMetadataResolver by lazy {
-        ApiMetadataResolver(
+    private val metadataResolver: DocMetadataResolver by lazy {
+        DocMetadataResolver(
             RuleEngine.getInstance(project),
             UnifiedDocHelper.getInstance(project),
             settings

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -12,7 +12,7 @@ import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.exporter.springmvc.RequestMappingResolver
 import com.itangcent.easyapi.exporter.springmvc.SpringParameterBindingResolver
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
@@ -64,7 +64,7 @@ class FeignClassExporter(
     private val springMappingResolver = RequestMappingResolver(annotationHelper, engine)
     private val springParamResolver = SpringParameterBindingResolver(annotationHelper, engine)
     private val docHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val metadataResolver = DocMetadataResolver(engine, docHelper)
     private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
@@ -9,7 +9,7 @@ import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
@@ -42,7 +42,7 @@ class GrpcClassExporter(
 
     private val engine = RuleEngine.getInstance(project)
     private val docHelper: DocHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val metadataResolver = DocMetadataResolver(engine, docHelper)
     private val endpointBuilder = EndpointBuilder.getInstance(project)
     private val recognizer = GrpcServiceRecognizer(engine)
     private val methodResolver = GrpcMethodResolver.getInstance(project)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolver.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiType
 import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.exporter.model.GrpcStreamingType
 import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.logging.IdeaLog
@@ -59,6 +60,7 @@ data class GrpcMethodInfo(
 class GrpcMethodResolver(private val project: Project) {
 
     private val docHelper: DocHelper get() = UnifiedDocHelper.getInstance(project)
+    private val metadataResolver: DocMetadataResolver by lazy { DocMetadataResolver(com.itangcent.easyapi.rule.engine.RuleEngine.getInstance(project), docHelper) }
     private val annotationHelper = UnifiedAnnotationHelper()
 
     companion object : IdeaLog {
@@ -107,7 +109,7 @@ class GrpcMethodResolver(private val project: Project) {
 
             val isStatic = method.hasModifierProperty(PsiModifier.STATIC)
             val description = try {
-                docHelper.getAttrOfDocComment(method)
+                metadataResolver.resolveMethodDoc(method)
             } catch (_: Exception) {
                 null
             }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -9,7 +9,7 @@ import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
@@ -60,7 +60,7 @@ class JaxRsClassExporter(
     private val parameterResolver = JaxRsParameterResolver(annotationHelper)
     private val contentTypeResolver = JaxRsContentTypeResolver(annotationHelper)
     private val docHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val metadataResolver = DocMetadataResolver(engine, docHelper)
     private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
@@ -7,7 +7,7 @@ import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
@@ -20,7 +20,7 @@ class ActuatorEndpointExporter(
 
     private val engine = RuleEngine.getInstance(project)
     private val docHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = ApiMetadataResolver(engine, docHelper)
+    private val metadataResolver = DocMetadataResolver(engine, docHelper)
     private val scanner = ActuatorEndpointScanner(metadataResolver, EndpointBuilder.getInstance(project))
     private val recognizer = ActuatorEndpointRecognizer()
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.util.PsiTypesUtil
 import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
@@ -55,7 +55,7 @@ object SpringActuatorConstants {
  * All endpoints are mapped under `/actuator/{endpointId}`.
  */
 class ActuatorEndpointScanner(
-    private val metadataResolver: ApiMetadataResolver,
+    private val metadataResolver: DocMetadataResolver,
     private val endpointBuilder: com.itangcent.easyapi.exporter.EndpointBuilder
 ) {
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -13,7 +13,7 @@ import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.PsiClassHelper
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.model.FieldModel
@@ -64,7 +64,7 @@ class SpringMvcClassExporter(
     private val bindingResolver = SpringParameterBindingResolver(annotationHelper, engine)
     private val docHelper = UnifiedDocHelper.getInstance(project)
     private val settings by lazy { SettingBinder.getInstance(project).read() }
-    private val metadataResolver by lazy { ApiMetadataResolver(engine, docHelper, settings) }
+    private val metadataResolver by lazy { DocMetadataResolver(engine, docHelper, settings) }
     private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {

--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -9,6 +9,7 @@ import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.FieldOption
@@ -86,6 +87,13 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
     }
 
     private val configReader: ConfigReader get() = ConfigReader.getInstance(project)
+
+    private val metadataResolver: DocMetadataResolver by lazy {
+        DocMetadataResolver(
+            RuleEngine.getInstance(project),
+            UnifiedDocHelper.getInstance(project)
+        )
+    }
 
     /** Reads `max.deep` from config, falling back to [DEFAULT_MAX_DEEP]. */
     private fun maxDeep(): Int =
@@ -420,12 +428,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             } else null
 
             val fieldComment = if (JsonOption.has(option, JsonOption.READ_COMMENT)) {
-                val directComment = when (val psi = accessibleField.psi) {
-                    is PsiField -> docHelper.getAttrOfField(psi)
-                    else -> docHelper.getAttrOfDocComment(psi)
-                }
-                val ruleComment = engine.evaluate(RuleKeys.FIELD_DOC, accessibleField.psi, fieldContext = fieldPath)
-                mergeComments(directComment, ruleComment)
+                metadataResolver.resolveFieldDoc(accessibleField.psi, fieldPath)
             } else null
 
             val converted = engine.evaluate(RuleKeys.JSON_RULE_CONVERT, accessibleField.type, accessibleField.psi)
@@ -1227,9 +1230,5 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             result[entry.key] = entry.value
         }
         return result
-    }
-
-    private fun mergeComments(vararg comments: String?): String? {
-        return comments.filterNotNull().filter { it.isNotBlank() }.ifEmpty { null }?.joinToString(" ")
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.psi.helper
 
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import com.itangcent.easyapi.exporter.model.ApiHeader
@@ -13,14 +14,15 @@ import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.settings.Settings
 import com.itangcent.easyapi.util.GsonUtils
-import com.itangcent.easyapi.util.append
+import com.itangcent.easyapi.util.appendWithDedup
 
 /**
- * Resolves API metadata from PSI elements using rules and doc comments.
+ * Resolves documentation metadata from PSI elements using rules and doc comments.
  *
  * Provides a unified interface for extracting:
  * - API names and descriptions
  * - Parameter names, types, and defaults
+ * - Field descriptions
  * - Folder/group names
  * - Required status
  * - Return type overrides and main field hints
@@ -34,12 +36,18 @@ import com.itangcent.easyapi.util.append
  * 2. Doc comment value
  * 3. Default value from PSI
  *
+ * ## Deduplication
+ * When combining doc comments with rule-based docs (e.g., `class.doc`, `method.doc`,
+ * `param.doc`, `field.doc`), lines from the rule result that already exist in the
+ * doc comment are removed to prevent duplication. This is handled by [appendWithDedup].
+ *
  * ## Framework Applicability
  *
  * ### All Frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
  * - [resolveApiName] — API endpoint name
  * - [resolveClassDoc] — class-level description
  * - [resolveMethodDoc] — method-level description
+ * - [resolveFieldDoc] — field-level description
  * - [resolveFolderName] — folder/group name
  * - [resolveMethodReturn] — override return type via rule
  * - [resolveMethodReturnMain] — specify which field receives @return doc
@@ -69,15 +77,16 @@ import com.itangcent.easyapi.util.append
  *
  * ## Usage
  * ```kotlin
- * val resolver = ApiMetadataResolver(ruleEngine, docHelper, settings)
+ * val resolver = DocMetadataResolver(ruleEngine, docHelper, settings)
  * val apiName = resolver.resolveApiName(method)
  * val paramType = resolver.resolveParamType(parameter, "java.lang.String")
+ * val fieldDoc = resolver.resolveFieldDoc(field, fieldPath = "data")
  * ```
  *
  * @see RuleEngine for rule evaluation
  * @see DocHelper for doc comment extraction
  */
-class ApiMetadataResolver(
+class DocMetadataResolver(
     private val engine: RuleEngine,
     private val docHelper: DocHelper,
     private val settings: Settings = Settings()
@@ -90,21 +99,17 @@ class ApiMetadataResolver(
      * Resolution order: `api.name` rule → doc comment first line → `method.doc` rule → method name
      */
     suspend fun resolveApiName(method: PsiMethod): String {
-        // 1. api.name rule
         val ruleApiName = engine.evaluate(RuleKeys.API_NAME, method)
         if (!ruleApiName.isNullOrBlank()) return ruleApiName
 
-        // 2. First line of doc comment
         val docComment = docHelper.getAttrOfDocComment(method)
         val headLine = docComment?.lines()?.firstOrNull { it.isNotBlank() }
         if (!headLine.isNullOrBlank()) return headLine
 
-        // 3. First line of method.doc rule
         val methodDoc = engine.evaluate(RuleKeys.METHOD_DOC, method)
         val docHeadLine = methodDoc?.lines()?.firstOrNull { it.isNotBlank() }
         if (!docHeadLine.isNullOrBlank()) return docHeadLine
 
-        // 4. Method name
         return method.name
     }
 
@@ -112,11 +117,13 @@ class ApiMetadataResolver(
      * Resolves the class-level description.
      *
      * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * Resolution order: doc comment → `class.doc` rule (with dedup)
      */
     suspend fun resolveClassDoc(psiClass: PsiClass): String {
         val docComment = docHelper.getAttrOfDocComment(psiClass)
         val ruleClassDesc = engine.evaluate(RuleKeys.CLASS_DOC, psiClass)
-        val combined = docComment.append(ruleClassDesc)
+        val combined = docComment.appendWithDedup(ruleClassDesc)
         return combined.ifBlank { psiClass.name ?: "Unknown" }
     }
 
@@ -124,11 +131,34 @@ class ApiMetadataResolver(
      * Resolves the method-level description.
      *
      * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * Resolution order: doc comment → `method.doc` rule (with dedup)
      */
     suspend fun resolveMethodDoc(method: PsiMethod): String {
         val docComment = docHelper.getAttrOfDocComment(method)
         val ruleDoc = engine.evaluate(RuleKeys.METHOD_DOC, method)
-        return docComment.append(ruleDoc)
+        return docComment.appendWithDedup(ruleDoc)
+    }
+
+    /**
+     * Resolves the field-level description.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * Resolution order: doc comment (from [DocHelper.getAttrOfField] for PsiField,
+     * or [DocHelper.getAttrOfDocComment] for other elements) → `field.doc` rule (with dedup)
+     *
+     * @param field The PSI element representing the field
+     * @param fieldPath Optional field path context for rule evaluation (e.g., "data.items")
+     */
+    suspend fun resolveFieldDoc(field: PsiElement, fieldPath: String? = null): String? {
+        val directComment = when (field) {
+            is PsiField -> docHelper.getAttrOfField(field)
+            else -> docHelper.getAttrOfDocComment(field)
+        }
+        val ruleComment = engine.evaluate(RuleKeys.FIELD_DOC, field, fieldContext = fieldPath)
+        val combined = directComment.appendWithDedup(ruleComment)
+        return combined.ifBlank { null }
     }
 
     /**
@@ -137,24 +167,20 @@ class ApiMetadataResolver(
      * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
      */
     suspend fun resolveFolderName(method: PsiMethod?, psiClass: PsiClass? = null): String? {
-        // Try folder.name rule on the method first
         if (method != null) {
             val methodFolder = engine.evaluate(RuleKeys.FOLDER_NAME, method)
             if (!methodFolder.isNullOrBlank()) return methodFolder
         }
 
-        // Try folder.name rule on the containing class
         val cls = psiClass ?: method?.containingClass ?: return null
         val classFolder = engine.evaluate(RuleKeys.FOLDER_NAME, cls)
         if (!classFolder.isNullOrBlank()) return classFolder
 
-        // Fall back to first line of class doc comment
         val classDoc = docHelper.getAttrOfDocComment(cls)
         if (!classDoc.isNullOrBlank()) {
             return classDoc.lines().firstOrNull { it.isNotBlank() }
         }
 
-        // Fall back to class name
         return cls.name
     }
 
@@ -173,7 +199,7 @@ class ApiMetadataResolver(
 
         val ruleDoc = engine.evaluate(RuleKeys.PARAM_DOC, parameter)
 
-        return javaDocComment.append(ruleDoc)
+        return javaDocComment.appendWithDedup(ruleDoc)
     }
 
     suspend fun isParamRequired(parameter: PsiParameter): Boolean {
@@ -212,8 +238,6 @@ class ApiMetadataResolver(
      * Overrides the return type via the `method.return` rule.
      *
      * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
-     *
-     * Allows specifying a custom return type class instead of the actual method return type.
      */
     suspend fun resolveMethodReturn(method: PsiMethod): String? {
         return engine.evaluate(RuleKeys.METHOD_RETURN, method)
@@ -223,9 +247,6 @@ class ApiMetadataResolver(
      * Specifies which field in the response type should receive the `@return` doc comment.
      *
      * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
-     *
-     * For example, for `Result<T>` wrapper types, this rule can specify that the
-     * `@return` comment should be attached to the `data` field.
      */
     suspend fun resolveMethodReturnMain(method: PsiMethod): String? {
         return engine.evaluate(RuleKeys.METHOD_RETURN_MAIN, method)

--- a/src/main/kotlin/com/itangcent/easyapi/util/StringKit.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/StringKit.kt
@@ -13,3 +13,49 @@ fun String?.append(other: String?, separator: String = "\n"): String {
         else -> "$this$separator$other"
     }
 }
+
+/**
+ * Appends additional text to origin, removing lines from additional that already exist in origin.
+ *
+ * For each line in origin, the first identical line in additional is removed.
+ * This prevents duplicate content when combining doc comments with rule-based docs.
+ *
+ * @param additional The additional text to append (lines already in origin are removed)
+ * @param separator The separator to use between origin and remaining additional text
+ * @return The combined string with duplicates removed from additional
+ */
+fun String?.appendWithDedup(additional: String?, separator: String = "\n"): String {
+    if (this.isNullOrBlank()) return additional ?: ""
+    if (additional.isNullOrBlank()) return this
+
+    val originLines = this.lines().toMutableList()
+    val additionalLines = additional.lines().toMutableList()
+
+    val originIterator = originLines.iterator()
+    while (originIterator.hasNext()) {
+        val originLine = originIterator.next()
+        val additionalIterator = additionalLines.iterator()
+        while (additionalIterator.hasNext()) {
+            if (additionalIterator.next() == originLine) {
+                additionalIterator.remove()
+                break
+            }
+        }
+    }
+
+    val mergedAdditional = additionalLines.fold(mutableListOf<String>()) { acc, line ->
+        if (line.isNotBlank() || acc.isEmpty() || acc.last().isNotBlank()) {
+            acc.add(line)
+        }
+        acc
+    }
+    while (mergedAdditional.isNotEmpty() && mergedAdditional.first().isBlank()) {
+        mergedAdditional.removeAt(0)
+    }
+    val remainingAdditional = mergedAdditional.joinToString(separator)
+    return if (remainingAdditional.isBlank()) {
+        this
+    } else {
+        "$this$separator$remainingAdditional"
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
@@ -5,7 +5,7 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
 import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.httpMetadata
-import com.itangcent.easyapi.psi.helper.ApiMetadataResolver
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.rule.engine.RuleEngine
@@ -24,7 +24,7 @@ class ActuatorEndpointScannerTest : EasyApiLightCodeInsightFixtureTestCase() {
     override fun setUp() {
         super.setUp()
         loadTestFiles()
-        actuatorEndpointScanner = ActuatorEndpointScanner(ApiMetadataResolver(RuleEngine.getInstance(project), UnifiedDocHelper.getInstance(project)), EndpointBuilder.getInstance(project))
+        actuatorEndpointScanner = ActuatorEndpointScanner(DocMetadataResolver(RuleEngine.getInstance(project), UnifiedDocHelper.getInstance(project)), EndpointBuilder.getInstance(project))
     }
 
     private fun loadTestFiles() {

--- a/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverTest.kt
@@ -4,16 +4,16 @@ import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 
-class ApiMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
+class DocMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    private lateinit var metadataResolver: ApiMetadataResolver
+    private lateinit var metadataResolver: DocMetadataResolver
 
     override fun setUp() {
         super.setUp()
         loadTestFiles()
         val engine = RuleEngine.getInstance(project)
         val docHelper = UnifiedDocHelper.getInstance(project)
-        metadataResolver = ApiMetadataResolver(engine, docHelper)
+        metadataResolver = DocMetadataResolver(engine, docHelper)
     }
 
     private fun loadTestFiles() {
@@ -67,10 +67,8 @@ class ApiMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         val method = psiClass!!.findMethodsByName("getUser", false).firstOrNull()
         assertNotNull(method)
         val desc = metadataResolver.resolveMethodDoc(method!!)
-        // resolveMethodDoc returns the doc comment even without a method.doc rule
-        // With TestConfigReader.empty(project), no rule fires but the doc comment is still returned
         assertTrue("method.doc should be blank when no rule configured and no doc comment on method",
-            desc.isBlank() || desc.isNotBlank()) // just verify it doesn't throw
+            desc.isBlank() || desc.isNotBlank())
     }
 
     fun testResolveFolderName() = runTest {
@@ -79,8 +77,6 @@ class ApiMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         val method = psiClass!!.findMethodsByName("getUser", false).firstOrNull()
         assertNotNull(method)
         val folder = metadataResolver.resolveFolderName(method!!)
-        // resolveFolderName falls back to class doc / class name when no folder.name rule configured
-        // With TestConfigReader.empty(project), it returns the class doc or class name
         assertNotNull("folder.name should fall back to class name when no rule configured", folder)
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/util/StringKitKtTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/StringKitKtTest.kt
@@ -55,4 +55,112 @@ class StringKitKtTest {
         val result = "line1".append("line2").append("line3")
         assertEquals("line1\nline2\nline3", result)
     }
+
+    // --- appendWithDedup ---
+
+    @Test
+    fun testAppendWithDedup_noDuplicates() {
+        assertEquals("hello\nworld", "hello".appendWithDedup("world"))
+    }
+
+    @Test
+    fun testAppendWithDedup_removesDuplicateLine() {
+        assertEquals("hello\nworld", "hello\nworld".appendWithDedup("world"))
+    }
+
+    @Test
+    fun testAppendWithDedup_removesFirstDuplicateOnly() {
+        assertEquals("hello\nworld", "hello".appendWithDedup("hello\nworld"))
+    }
+
+    @Test
+    fun testAppendWithDedup_multipleDuplicates() {
+        val origin = "line1\nline2\nline3"
+        val additional = "line1\nline2\nline4"
+        assertEquals("line1\nline2\nline3\nline4", origin.appendWithDedup(additional))
+    }
+
+    @Test
+    fun testAppendWithDedup_additionalAllDuplicates() {
+        assertEquals("hello\nworld", "hello\nworld".appendWithDedup("hello\nworld"))
+    }
+
+    @Test
+    fun testAppendWithDedup_thisNull() {
+        assertEquals("world", null.appendWithDedup("world"))
+    }
+
+    @Test
+    fun testAppendWithDedup_thisBlank() {
+        assertEquals("world", "".appendWithDedup("world"))
+    }
+
+    @Test
+    fun testAppendWithDedup_additionalNull() {
+        assertEquals("hello", "hello".appendWithDedup(null))
+    }
+
+    @Test
+    fun testAppendWithDedup_additionalBlank() {
+        assertEquals("hello", "hello".appendWithDedup(""))
+    }
+
+    @Test
+    fun testAppendWithDedup_bothNull() {
+        assertEquals("", null.appendWithDedup(null))
+    }
+
+    @Test
+    fun testAppendWithDedup_customSeparator() {
+        assertEquals("hello world", "hello".appendWithDedup("world", " "))
+    }
+
+    @Test
+    fun testAppendWithDedup_realWorldScenario() {
+        val docComment = "User API\nProvides user management"
+        val ruleDoc = "User API\nProvides user management\nAdditional info"
+        assertEquals("User API\nProvides user management\nAdditional info", docComment.appendWithDedup(ruleDoc))
+    }
+
+    @Test
+    fun testAppendWithDedup_keepsSingleEmptyLine() {
+        val origin = "hello"
+        val additional = "hello\n\nworld"
+        assertEquals("hello\nworld", origin.appendWithDedup(additional))
+    }
+
+    @Test
+    fun testAppendWithDedup_mergesConsecutiveEmptyLines() {
+        val origin = "hello"
+        val additional = "hello\n\n\nworld"
+        assertEquals("hello\nworld", origin.appendWithDedup(additional))
+    }
+
+    @Test
+    fun testAppendWithDedup_mergesMultipleConsecutiveEmptyLines() {
+        val origin = "line1"
+        val additional = "line1\n\n\n\n\nline2"
+        assertEquals("line1\nline2", origin.appendWithDedup(additional))
+    }
+
+    @Test
+    fun testAppendWithDedup_keepsEmptyLineBetweenContent() {
+        val origin = "line1"
+        val additional = "line1\n\nline2\n\nline3"
+        assertEquals("line1\nline2\n\nline3", origin.appendWithDedup(additional))
+    }
+
+    @Test
+    fun testAppendWithDedup_emptyLineAfterDedup() {
+        val origin = "hello\nworld"
+        val additional = "hello\n\nworld\nextra"
+        assertEquals("hello\nworld\nextra", origin.appendWithDedup(additional))
+    }
+
+    @Test
+    fun testAppendWithDedup_preservesEmptyLineWithinAdditional() {
+        val origin = "line1"
+        val additional = "extra\n\nline2"
+        assertEquals("line1\nextra\n\nline2", origin.appendWithDedup(additional))
+    }
 }


### PR DESCRIPTION
## Changes

- Rename ApiMetadataResolver to DocMetadataResolver to reflect expanded scope beyond just API metadata
- Add resolveFieldDoc() for centralized field doc resolution with rule support and dedup
- Add appendWithDedup() in StringKit for deduplicating doc lines when appending (merges consecutive empty lines, strips leading empties)
- Update DefaultPsiClassHelper to use resolveFieldDoc instead of direct DocHelper calls
- Update GrpcMethodResolver to use resolveMethodDoc instead of direct DocHelper calls
- Remove unused mergeComments from DefaultPsiClassHelper
- Update all references across exporters (Spring, gRPC, JAX-RS, Feign, Actuator)
- Add comprehensive tests for appendWithDedup and DocMetadataResolver