### PR TITLE
fix: DocMetadataResolver now correctly reads settings.pathMulti dynamically

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
@@ -9,15 +9,14 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.exporter.model.ApiHeader
 import com.itangcent.easyapi.exporter.model.ApiParameter
 import com.itangcent.easyapi.psi.PsiClassHelper
-import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.SourceHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelUtils
 import com.itangcent.easyapi.psi.type.PrimitiveKind
 import com.itangcent.easyapi.psi.type.ResolvedType
-import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.settings.Settings
 
@@ -45,13 +44,7 @@ class EndpointBuilder(private val project: Project) {
 
     private val settings: Settings by lazy { SettingBinder.getInstance(project).read() }
     private val docHelper: DocHelper by lazy { UnifiedDocHelper.getInstance(project) }
-    private val metadataResolver: DocMetadataResolver by lazy {
-        DocMetadataResolver(
-            RuleEngine.getInstance(project),
-            UnifiedDocHelper.getInstance(project),
-            settings
-        )
-    }
+    private val metadataResolver: DocMetadataResolver get() = DocMetadataResolver.getInstance(project)
 
     /**
      * Strategy interface for building an [ObjectModel] from a [PsiClass].

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -14,7 +14,6 @@ import com.itangcent.easyapi.exporter.springmvc.SpringParameterBindingResolver
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
-import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.ResolvedMethod
 import com.itangcent.easyapi.psi.type.ResolvedType
@@ -63,8 +62,7 @@ class FeignClassExporter(
     private val nativeParser = NativeFeignAnnotationParser(annotationHelper)
     private val springMappingResolver = RequestMappingResolver(annotationHelper, engine)
     private val springParamResolver = SpringParameterBindingResolver(annotationHelper, engine)
-    private val docHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = DocMetadataResolver(engine, docHelper)
+    private val metadataResolver = DocMetadataResolver.getInstance(project)
     private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
@@ -10,8 +10,6 @@ import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
-import com.itangcent.easyapi.psi.helper.DocHelper
-import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.rule.RuleKeys
@@ -41,8 +39,7 @@ class GrpcClassExporter(
     override val frameworkName: String = "gRPC"
 
     private val engine = RuleEngine.getInstance(project)
-    private val docHelper: DocHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = DocMetadataResolver(engine, docHelper)
+    private val metadataResolver = DocMetadataResolver.getInstance(project)
     private val endpointBuilder = EndpointBuilder.getInstance(project)
     private val recognizer = GrpcServiceRecognizer(engine)
     private val methodResolver = GrpcMethodResolver.getInstance(project)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcMethodResolver.kt
@@ -10,9 +10,7 @@ import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiType
 import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.exporter.model.GrpcStreamingType
-import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
-import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.core.threading.read
@@ -59,8 +57,7 @@ data class GrpcMethodInfo(
 @Service(Service.Level.PROJECT)
 class GrpcMethodResolver(private val project: Project) {
 
-    private val docHelper: DocHelper get() = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver: DocMetadataResolver by lazy { DocMetadataResolver(com.itangcent.easyapi.rule.engine.RuleEngine.getInstance(project), docHelper) }
+    private val metadataResolver: DocMetadataResolver get() = DocMetadataResolver.getInstance(project)
     private val annotationHelper = UnifiedAnnotationHelper()
 
     companion object : IdeaLog {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -10,7 +10,6 @@ import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
-import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.ResolvedType
@@ -59,8 +58,7 @@ class JaxRsClassExporter(
     private val pathResolver = JaxRsPathResolver(annotationHelper)
     private val parameterResolver = JaxRsParameterResolver(annotationHelper)
     private val contentTypeResolver = JaxRsContentTypeResolver(annotationHelper)
-    private val docHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = DocMetadataResolver(engine, docHelper)
+    private val metadataResolver = DocMetadataResolver.getInstance(project)
     private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
@@ -7,8 +7,6 @@ import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.psi.helper.DocMetadataResolver
-import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 
@@ -19,9 +17,7 @@ class ActuatorEndpointExporter(
     override val frameworkName: String = "SpringActuator"
 
     private val engine = RuleEngine.getInstance(project)
-    private val docHelper = UnifiedDocHelper.getInstance(project)
-    private val metadataResolver = DocMetadataResolver(engine, docHelper)
-    private val scanner = ActuatorEndpointScanner(metadataResolver, EndpointBuilder.getInstance(project))
+    private val scanner = ActuatorEndpointScanner(project, EndpointBuilder.getInstance(project))
     private val recognizer = ActuatorEndpointRecognizer()
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.exporter.springmvc
 
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
@@ -55,9 +56,11 @@ object SpringActuatorConstants {
  * All endpoints are mapped under `/actuator/{endpointId}`.
  */
 class ActuatorEndpointScanner(
-    private val metadataResolver: DocMetadataResolver,
+    private val project: Project,
     private val endpointBuilder: com.itangcent.easyapi.exporter.EndpointBuilder
 ) {
+
+    private val metadataResolver: DocMetadataResolver get() = DocMetadataResolver.getInstance(project)
 
     suspend fun scan(psiClass: PsiClass): List<ApiEndpoint> {
         val endpointId = findEndpointId(psiClass) ?: return emptyList()

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -14,7 +14,6 @@ import com.itangcent.easyapi.exporter.model.*
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.PsiClassHelper
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
-import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
@@ -62,9 +61,7 @@ class SpringMvcClassExporter(
     private val controllerRecognizer = SpringControllerRecognizer(engine)
     private val mappingResolver = RequestMappingResolver(annotationHelper, engine)
     private val bindingResolver = SpringParameterBindingResolver(annotationHelper, engine)
-    private val docHelper = UnifiedDocHelper.getInstance(project)
-    private val settings by lazy { SettingBinder.getInstance(project).read() }
-    private val metadataResolver by lazy { DocMetadataResolver(engine, docHelper, settings) }
+    private val metadataResolver get() = DocMetadataResolver.getInstance(project)
     private val endpointBuilder = EndpointBuilder.getInstance(project)
 
     override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {

--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -88,12 +88,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
 
     private val configReader: ConfigReader get() = ConfigReader.getInstance(project)
 
-    private val metadataResolver: DocMetadataResolver by lazy {
-        DocMetadataResolver(
-            RuleEngine.getInstance(project),
-            UnifiedDocHelper.getInstance(project)
-        )
-    }
+    private val metadataResolver: DocMetadataResolver get() = DocMetadataResolver.getInstance(project)
 
     /** Reads `max.deep` from config, falling back to [DEFAULT_MAX_DEEP]. */
     private fun maxDeep(): Int =

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
@@ -1,5 +1,8 @@
 package com.itangcent.easyapi.psi.helper
 
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
@@ -12,7 +15,7 @@ import com.itangcent.easyapi.exporter.model.PathSelector
 import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.util.GsonUtils
 import com.itangcent.easyapi.util.appendWithDedup
 
@@ -77,7 +80,7 @@ import com.itangcent.easyapi.util.appendWithDedup
  *
  * ## Usage
  * ```kotlin
- * val resolver = DocMetadataResolver(ruleEngine, docHelper, settings)
+ * val resolver = DocMetadataResolver.getInstance(project)
  * val apiName = resolver.resolveApiName(method)
  * val paramType = resolver.resolveParamType(parameter, "java.lang.String")
  * val fieldDoc = resolver.resolveFieldDoc(field, fieldPath = "data")
@@ -86,11 +89,17 @@ import com.itangcent.easyapi.util.appendWithDedup
  * @see RuleEngine for rule evaluation
  * @see DocHelper for doc comment extraction
  */
-class DocMetadataResolver(
-    private val engine: RuleEngine,
-    private val docHelper: DocHelper,
-    private val settings: Settings = Settings()
+@Service(Service.Level.PROJECT)
+class DocMetadataResolver internal constructor(
+    private val project: Project
 ) {
+    private val engine: RuleEngine get() = RuleEngine.getInstance(project)
+    private val docHelper: DocHelper get() = UnifiedDocHelper.getInstance(project)
+    private val settings get() = SettingBinder.getInstance(project).read()
+
+    companion object {
+        fun getInstance(project: Project): DocMetadataResolver = project.service()
+    }
     /**
      * Resolves the API endpoint name.
      *

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,7 @@
         <projectService serviceImplementation="com.itangcent.easyapi.grpc.CompositeDescriptorResolver"/>
 
         <projectService serviceImplementation="com.itangcent.easyapi.exporter.EndpointBuilder"/>
+        <projectService serviceImplementation="com.itangcent.easyapi.psi.helper.DocMetadataResolver"/>
         <projectService serviceImplementation="com.itangcent.easyapi.cache.VcsBranchChangeListener"/>
 
         <postStartupActivity implementation="com.itangcent.easyapi.ide.ApiIndexStartupActivity"/>

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScannerTest.kt
@@ -5,10 +5,6 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
 import com.itangcent.easyapi.exporter.EndpointBuilder
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.httpMetadata
-import com.itangcent.easyapi.psi.helper.DocMetadataResolver
-import com.itangcent.easyapi.psi.helper.DocHelper
-import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
-import com.itangcent.easyapi.rule.engine.RuleEngine
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 
@@ -24,7 +20,7 @@ class ActuatorEndpointScannerTest : EasyApiLightCodeInsightFixtureTestCase() {
     override fun setUp() {
         super.setUp()
         loadTestFiles()
-        actuatorEndpointScanner = ActuatorEndpointScanner(DocMetadataResolver(RuleEngine.getInstance(project), UnifiedDocHelper.getInstance(project)), EndpointBuilder.getInstance(project))
+        actuatorEndpointScanner = ActuatorEndpointScanner(project, EndpointBuilder.getInstance(project))
     }
 
     private fun loadTestFiles() {

--- a/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverTest.kt
@@ -1,6 +1,5 @@
 package com.itangcent.easyapi.psi.helper
 
-import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 
@@ -11,9 +10,7 @@ class DocMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
     override fun setUp() {
         super.setUp()
         loadTestFiles()
-        val engine = RuleEngine.getInstance(project)
-        val docHelper = UnifiedDocHelper.getInstance(project)
-        metadataResolver = DocMetadataResolver(engine, docHelper)
+        metadataResolver = DocMetadataResolver.getInstance(project)
     }
 
     private fun loadTestFiles() {


### PR DESCRIPTION
Previously DocMetadataResolver accepted a Settings snapshot at construction time, so settings.pathMulti could become stale. Now it reads settings dynamically via SettingBinder.getInstance(project).read().

Refactored DocMetadataResolver to a project service that resolves RuleEngine, DocHelper, and Settings from Project automatically.

Changes:
- DocMetadataResolver is now @Service(Service.Level.PROJECT)
- Dependencies resolved from Project via computed get() properties
- Registered in plugin.xml
- Updated all 9 call sites
- Updated tests