### PR TITLE
fix: Fix binary incompatibility with IntelliJ 2026.2 by removing Groovy runtime dependencies

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/script/pm/PmResponse.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/script/pm/PmResponse.kt
@@ -1,6 +1,6 @@
 package com.itangcent.easyapi.script.pm
 
-import groovy.json.JsonSlurper
+import com.itangcent.easyapi.util.json.GsonUtils
 
 /**
  * Represents an HTTP response received from the server, compatible with Postman's `pm.response` API.
@@ -40,26 +40,28 @@ class PmResponse(
     fun text(): String = rawBody
 
     /**
-     * Parses the response body as JSON using Groovy's [JsonSlurper].
+     * Parses the response body as JSON using Gson.
      *
      * @return The parsed JSON object (Map, List, etc.), or null if parsing fails
      */
     fun json(): Any? {
         return try {
-            JsonSlurper().parseText(rawBody)
+            GsonUtils.fromJson(rawBody)
         } catch (_: Exception) {
             null
         }
     }
 
     /**
-     * Parses the response body as XML using Groovy's [XmlSlurper].
+     * Parses the response body as XML using javax.xml.
      *
-     * @return The parsed XML GPathResult, or null if parsing fails
+     * @return The parsed XML as a DOM Document, or null if parsing fails
      */
     fun xml(): Any? {
         return try {
-            groovy.xml.XmlSlurper().parseText(rawBody)
+            val factory = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+            val builder = factory.newDocumentBuilder()
+            builder.parse(rawBody.byteInputStream())
         } catch (_: Exception) {
             null
         }

--- a/src/main/kotlin/com/itangcent/easyapi/util/json/GsonUtils.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/json/GsonUtils.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.util.json
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.ToNumberPolicy
 import com.google.gson.reflect.TypeToken
 import java.lang.reflect.Type
 
@@ -27,12 +28,17 @@ object GsonUtils {
     /**
      * Standard Gson instance for compact JSON output.
      */
-    val GSON: Gson = GsonBuilder().create()
+    val GSON: Gson = GsonBuilder()
+        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+        .create()
 
     /**
      * Gson instance with pretty printing enabled.
      */
-    val PRETTY: Gson = GsonBuilder().setPrettyPrinting().create()
+    val PRETTY: Gson = GsonBuilder()
+        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+        .setPrettyPrinting()
+        .create()
 
     /**
      * Serializes an object to compact JSON.

--- a/src/test/kotlin/com/itangcent/easyapi/script/pm/PmResponseTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/script/pm/PmResponseTest.kt
@@ -53,7 +53,7 @@ class PmResponseTest {
         val json = response.json() as? Map<*, *>
         assertNotNull(json)
         assertEquals("Alice", json!!["name"])
-        assertEquals(30, json["age"])
+        assertEquals(30L, json["age"])
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/util/json/GsonUtilsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/json/GsonUtilsTest.kt
@@ -93,7 +93,7 @@ class GsonUtilsTest {
         val json = "{\"name\":\"test\",\"value\":123}"
         val result: Map<String, Any> = GsonUtils.fromJson(json)
         assertEquals("test", result["name"])
-        assertEquals(123.0, result["value"])
+        assertEquals(123L, result["value"])
     }
 
     @Test
@@ -135,8 +135,8 @@ class GsonUtilsTest {
         val json = "{\"data\":{\"x\":1,\"y\":2}}"
         val result: Map<String, Any> = GsonUtils.fromJson(json)
         val data = result["data"] as Map<*, *>
-        assertEquals(1.0, data["x"])
-        assertEquals(2.0, data["y"])
+        assertEquals(1L, data["x"])
+        assertEquals(2L, data["y"])
     }
 
     @Test
@@ -157,7 +157,7 @@ class GsonUtilsTest {
         val json = GsonUtils.toJson(original)
         val restored: Map<String, Any> = GsonUtils.fromJson(json)
         assertEquals("value1", restored["key1"])
-        assertEquals(123.0, restored["key2"])
+        assertEquals(123L, restored["key2"])
         assertEquals(true, restored["key3"])
     }
 


### PR DESCRIPTION
IntelliJ 2026.2 no longer exposes groovy-json and groovy-xml modules to plugin classpath, causing NoSuchClassError for JsonSlurper and XmlSlurper at runtime. Replace them with Gson (already bundled) and javax.xml.parsers (JDK standard) respectively.