### PR TITLE
fix: avoid double-zip when downloading PR artifact

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -58,12 +58,24 @@ jobs:
         run: |
           FILENAME=$(ls build/distributions/easy-api-*.zip | xargs basename)
           echo "plugin_filename=${FILENAME}" >> $GITHUB_OUTPUT
+          # Artifact name without the .zip extension. GitHub Actions always
+          # re-zips the uploaded path and serves it as <name>.zip on download,
+          # so naming the artifact without .zip yields the correct final name.
+          echo "artifact_name=${FILENAME%.zip}" >> $GITHUB_OUTPUT
+
+      - name: Extract plugin distribution
+        # Unzip the built plugin so we upload its contents, not the zip itself.
+        # Uploading the .zip directly would cause GitHub to wrap it in another
+        # zip, forcing users to unzip twice to reach the real plugin.
+        run: |
+          mkdir -p build/artifact
+          unzip -q build/distributions/easy-api-*.zip -d build/artifact
 
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.get_filename.outputs.plugin_filename }}
-          path: build/distributions/easy-api-*.zip
+          name: ${{ steps.get_filename.outputs.artifact_name }}
+          path: build/artifact/
           if-no-files-found: error
 
       - name: Comment on target issue


### PR DESCRIPTION
## Problem

When downloading the PR build artifact, users get a zip that contains another zip inside — requiring an extra unzip step to reach the actual plugin.

This happens because actions/upload-artifact@v4 always wraps the uploaded path in a zip. Uploading a .zip file results in a zip-inside-zip.

## Fix

- Extract the plugin distribution zip before uploading
- Upload the extracted directory contents instead of the zip itself
- Name the artifact without .zip extension so the downloaded file gets the correct name

Now the downloaded artifact is a single zip containing the plugin directly.