### PR TITLE
release v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the EasyAPI plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2] - 2026-06-07
+
+### Fixed
+-  api.tag=#tag captures all @tag values instead of only the first
+-  avoid double-zip when downloading PR artifact (#712)
+-  properly handle array/collection return values from groovy scripts
+- fix(source helper): fix source file resolution for library classes (#711)
+-  Fix binary incompatibility with IntelliJ 2026.2 by removing Groovy runtime dependencies (#710)
+
+### Improved
+- chore: use org.jetbrains.changelog plugin for proper HTML rendering in marketplace
+
+---
+
 ## [3.1.1] - 2026-06-01
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.itangcent"
-version = "3.1.1.252.0"
+version = "3.1.2.252.0"
 
 changelog {
     val v = project.version.toString()


### PR DESCRIPTION
## Release Changes

* fix: api.tag=#tag captures all @tag values instead of only the first
* chore: use org.jetbrains.changelog plugin for proper HTML rendering in marketplace
* fix: avoid double-zip when downloading PR artifact (#712)
* fix: properly handle array/collection return values from groovy scripts
* fix(source helper): fix source file resolution for library classes (#711)
* fix: Fix binary incompatibility with IntelliJ 2026.2 by removing Groovy runtime dependencies (#710)
