### PR TITLE
feat: add Hoppscotch export channel as beta feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Export API endpoints from your source code to multiple formats:
 |--------|:----:|:----:|--------|
 | **Markdown** | ✓ | ✓ | `.md` documentation file |
 | **Postman** | ✓ | — | JSON file or direct upload to Postman |
+| **Hoppscotch** *(Beta)* | ✓ | — | JSON file or direct upload to Hoppscotch |
 | **cURL** | ✓ | ✓ | Executable shell script |
 | **HTTP Client** | ✓ | ✓ | IntelliJ HTTP Client scratch file |
 
@@ -117,7 +118,7 @@ Support for gRPC service implementations:
 
 1. Right-click on a controller file, class, or method in the editor or project view
 2. Select **EasyApi → Export** (or press `Ctrl+E` on macOS / `Alt+Shift+E`)
-3. Choose the target format (Postman / Markdown / cURL / HTTP Client)
+3. Choose the target format (Postman / Hoppscotch *(Beta)* / Markdown / cURL / HTTP Client)
 4. The APIs will be exported automatically
 
 ### Call an API

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/ChannelConfig.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/ChannelConfig.kt
@@ -11,6 +11,7 @@ package com.itangcent.easyapi.exporter.channel
  * - [Empty] — No configuration needed (e.g., cURL export)
  * - [FileConfig] — File-based export configuration (e.g., Markdown)
  * - [PostmanConfig] — Postman-specific configuration
+ * - [HoppscotchConfig] — Hoppscotch-specific configuration
  *
  * @see ApiChannel.createOptionsPanel for the UI that creates these configs
  */
@@ -42,6 +43,19 @@ sealed class ChannelConfig {
     data class PostmanConfig(
         val workspaceId: String? = null,
         val workspaceName: String? = null,
+        val collectionId: String? = null,
+        val collectionName: String? = null,
+        val isUpdate: Boolean = false
+    ) : ChannelConfig()
+
+    /**
+     * Configuration for Hoppscotch export channel.
+     *
+     * @property collectionId the Hoppscotch collection ID (for updates)
+     * @property collectionName the Hoppscotch collection name
+     * @property isUpdate whether to update an existing collection
+     */
+    data class HoppscotchConfig(
         val collectionId: String? = null,
         val collectionName: String? = null,
         val isUpdate: Boolean = false

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannel.kt
@@ -1,0 +1,336 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.fileChooser.FileSaverDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileWrapper
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.swing
+import com.itangcent.easyapi.exporter.channel.ApiChannel
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
+import com.itangcent.easyapi.exporter.hoppscotch.*
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.hoppscotch.model.hoppscotchGson
+import com.itangcent.easyapi.exporter.model.ExportContext
+import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.http.HttpClientProvider
+import com.itangcent.easyapi.ide.support.NotificationUtils
+import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * [ApiChannel] implementation for exporting API endpoints to Hoppscotch.
+ *
+ * Supports two export modes:
+ * 1. **File export** — when no Hoppscotch access token is configured, serializes the
+ *    collection to a JSON file using [hoppscotchGson]
+ * 2. **Cloud upload** — when an access token is available, uploads the collection to
+ *    Hoppscotch via the GraphQL API. Supports both creating new collections and
+ *    updating existing ones (create-first-then-delete strategy).
+ *
+ * ## Cloud upload flow
+ * - On 401 errors, automatically attempts token refresh via [HoppscotchAuthService.refreshToken]
+ * - If refresh fails, prompts the user to re-authenticate
+ * - Progress is reported via [IdeaConsoleProvider]
+ * - GraphQL errors are translated to user-friendly messages via [formatGraphQLError]
+ *
+ * @see HoppscotchFormatter for the ApiEndpoint → HoppCollection conversion
+ * @see HoppscotchOptionsPanel for the dual-mode options UI
+ * @see HoppscotchApiClient for the GraphQL API client
+ */
+class HoppscotchChannel : ApiChannel, IdeaLog {
+
+    override val id: String = "hoppscotch"
+    override val displayName: String = "Hoppscotch (Beta)"
+    override val supportsGrpc: Boolean = false
+    override val exposeAsAction: Boolean = true
+    override val actionText: String = "Export to Hoppscotch (Beta)"
+
+    override fun createOptionsPanel(project: Project): ChannelOptionsPanel {
+        return HoppscotchOptionsPanel(project)
+    }
+
+    override suspend fun export(context: ExportContext): ExportResult {
+        val project = context.project
+        val settings = SettingBinder.getInstance(project).read()
+        val token = settings.hoppscotchToken
+        val collectionName = project.name
+
+        val formatter = HoppscotchFormatter(project)
+        val collection = formatter.format(context.endpointsToExport, collectionName)
+
+        if (token.isNullOrBlank()) {
+            return ExportResult.Success(
+                count = countRequests(collection),
+                target = "Hoppscotch Collection",
+                metadata = HoppscotchExportMetadata(
+                    collectionName = collection.name,
+                    collectionData = collection
+                )
+            )
+        }
+
+        val hoppscotchConfig = context.channelConfig as? ChannelConfig.HoppscotchConfig
+        return uploadToHoppscotch(project, token, collection, settings, hoppscotchConfig)
+    }
+
+    private suspend fun uploadToHoppscotch(
+        project: Project,
+        token: String,
+        collection: HoppCollection,
+        settings: com.itangcent.easyapi.settings.Settings,
+        hoppscotchConfig: ChannelConfig.HoppscotchConfig?
+    ): ExportResult {
+        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val serverUrl = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+        val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+        val httpClient = HttpClientProvider.getInstance(project).getClient()
+        val client = HoppscotchApiClient(token, serverUrl, backendUrl, httpClient).asCached()
+
+        val collectionId = hoppscotchConfig?.collectionId
+        val isUpdate = hoppscotchConfig?.isUpdate == true && collectionId != null
+
+        if (isUpdate) {
+            console.info("Updating Hoppscotch collection \"${hoppscotchConfig.collectionName}\"...")
+            val confirmed = swing {
+                val choice = Messages.showYesNoDialog(
+                    project,
+                    "Update existing collection \"${hoppscotchConfig.collectionName}\"?\n" +
+                            "This will create a new collection and delete the old one.\n" +
+                            "Note: The collection ID will change and shared links will break.",
+                    "Confirm Update",
+                    Messages.getQuestionIcon()
+                )
+                choice == Messages.YES
+            }
+            if (!confirmed) {
+                console.info("Update cancelled by user")
+                return ExportResult.Error("Update cancelled by user")
+            }
+
+            console.info("Uploading collection to Hoppscotch...")
+            val result = try {
+                client.updateCollection(collectionId, collection)
+            } catch (e: HoppscotchAuthException) {
+                return handleAuthErrorWithRefresh(project, token, collection, serverUrl, backendUrl, httpClient, hoppscotchConfig, console)
+            }
+            return if (result.success) {
+                console.info("Collection updated successfully (new ID: ${result.collectionId})")
+                ExportResult.Success(
+                    count = countRequests(collection),
+                    target = "Hoppscotch",
+                    metadata = HoppscotchExportMetadata(
+                        collectionName = collection.name,
+                        collectionId = result.collectionId ?: collectionId
+                    )
+                )
+            } else {
+                val userMessage = formatGraphQLError(result.message)
+                console.warn("Upload failed: $userMessage")
+                ExportResult.Error(userMessage)
+            }
+        }
+
+        console.info("Uploading collection \"${collection.name}\" to Hoppscotch...")
+        val result = try {
+            client.uploadCollection(collection)
+        } catch (e: HoppscotchAuthException) {
+            return handleAuthErrorWithRefresh(project, token, collection, serverUrl, backendUrl, httpClient, hoppscotchConfig, console)
+        }
+        return if (result.success) {
+            console.info("Collection uploaded successfully (ID: ${result.collectionId})")
+            ExportResult.Success(
+                count = countRequests(collection),
+                target = "Hoppscotch",
+                metadata = HoppscotchExportMetadata(
+                    collectionName = collection.name,
+                    collectionId = result.collectionId
+                )
+            )
+        } else {
+            val userMessage = formatGraphQLError(result.message)
+            console.warn("Upload failed: $userMessage")
+            ExportResult.Error(userMessage)
+        }
+    }
+
+    private suspend fun handleAuthErrorWithRefresh(
+        project: Project,
+        token: String,
+        collection: HoppCollection,
+        serverUrl: String,
+        backendUrl: String?,
+        httpClient: com.itangcent.easyapi.http.HttpClient,
+        hoppscotchConfig: ChannelConfig.HoppscotchConfig?,
+        console: com.itangcent.easyapi.logging.IdeaConsole = IdeaConsoleProvider.getInstance(project).getConsole()
+    ): ExportResult {
+        console.info("Token expired, attempting refresh...")
+        LOG.info("Hoppscotch token expired, attempting refresh...")
+        val authService = HoppscotchAuthService.getInstance()
+        val refreshed = authService.refreshToken(project)
+        if (refreshed) {
+            console.info("Token refreshed successfully, retrying upload...")
+            LOG.info("Token refreshed successfully, retrying upload...")
+            val newSettings = SettingBinder.getInstance(project).read()
+            val newToken = newSettings.hoppscotchToken ?: return handleAuthError(
+                project, HoppscotchAuthException("Token lost after refresh"), console
+            )
+            val newClient = HoppscotchApiClient(newToken, serverUrl, backendUrl, httpClient).asCached()
+            val collectionId = hoppscotchConfig?.collectionId
+            val isUpdate = hoppscotchConfig?.isUpdate == true && collectionId != null
+
+            return try {
+                val result = if (isUpdate) {
+                    newClient.updateCollection(collectionId!!, collection)
+                } else {
+                    newClient.uploadCollection(collection)
+                }
+                if (result.success) {
+                    console.info("Collection uploaded successfully after token refresh")
+                    ExportResult.Success(
+                        count = countRequests(collection),
+                        target = "Hoppscotch",
+                        metadata = HoppscotchExportMetadata(
+                            collectionName = collection.name,
+                            collectionId = result.collectionId ?: collectionId
+                        )
+                    )
+                } else {
+                    ExportResult.Error(formatGraphQLError(result.message))
+                }
+            } catch (e: HoppscotchAuthException) {
+                handleAuthError(project, e, console)
+            }
+        }
+        console.warn("Token refresh failed. Please login again.")
+        return handleAuthError(project, HoppscotchAuthException("Token refresh failed"), console)
+    }
+
+    private suspend fun handleAuthError(
+        project: Project,
+        e: HoppscotchAuthException,
+        console: com.itangcent.easyapi.logging.IdeaConsole = IdeaConsoleProvider.getInstance(project).getConsole()
+    ): ExportResult {
+        LOG.warn("Hoppscotch authentication error: ${e.message}")
+        console.error("Authentication failed: ${e.message}")
+        swing {
+            NotificationUtils.notifyWarning(
+                project,
+                "Hoppscotch Authentication Failed",
+                "Your Hoppscotch token has expired. Please login again via Settings > Hoppscotch."
+            )
+        }
+        return ExportResult.Error("Authentication failed: ${e.message}. Please login again.")
+    }
+
+    private fun formatGraphQLError(message: String?): String {
+        if (message.isNullOrBlank()) return "Upload failed with an unknown error"
+        return when {
+            message.contains("UNAUTHENTICATED", ignoreCase = true) ->
+                "Authentication failed. Please login again via Settings > Hoppscotch."
+            message.contains("FORBIDDEN", ignoreCase = true) ->
+                "Permission denied. You may not have access to this collection or team."
+            message.contains("NOT_FOUND", ignoreCase = true) ->
+                "The specified collection was not found on the server."
+            message.contains("already exists", ignoreCase = true) ->
+                "A collection with this name already exists. Try updating instead."
+            message.contains("rate limit", ignoreCase = true) ->
+                "Rate limit exceeded. Please wait a moment and try again."
+            else -> "Upload failed: $message"
+        }
+    }
+
+    override suspend fun handleResult(
+        project: Project,
+        result: ExportResult.Success,
+        config: ChannelConfig
+    ): Boolean {
+        val metadata = result.metadata as? HoppscotchExportMetadata ?: return false
+
+        if (metadata.collectionData != null) {
+            return handleFileExport(project, result, metadata, config)
+        }
+
+        val details = metadata.formatDisplay()
+        val message = buildString {
+            append("Successfully exported ${result.count} endpoints to Hoppscotch")
+            if (!details.isNullOrBlank()) {
+                append("\n$details")
+            }
+        }
+        swing {
+            Messages.showInfoMessage(project, message, "Export API")
+        }
+        return true
+    }
+
+    private suspend fun handleFileExport(
+        project: Project,
+        result: ExportResult.Success,
+        metadata: HoppscotchExportMetadata,
+        config: ChannelConfig
+    ): Boolean {
+        val fileConfig = config as? ChannelConfig.FileConfig
+        val targetFile = resolveTargetFile(project, fileConfig, "hoppscotch_collection.json")
+            ?: throw CancellationException("User cancelled file selection")
+
+        val gson = hoppscotchGson()
+        val content = gson.toJson(metadata.collectionData)
+
+        withContext(IdeDispatchers.Background) {
+            targetFile.writeText(content)
+        }
+
+        swing {
+            Messages.showInfoMessage(
+                project,
+                "Successfully exported ${result.count} endpoints to ${targetFile.absolutePath}",
+                "Export API"
+            )
+        }
+        return true
+    }
+
+    private suspend fun resolveTargetFile(
+        project: Project,
+        fileConfig: ChannelConfig.FileConfig?,
+        defaultFileName: String
+    ): File? {
+        val outputDir = fileConfig?.outputDir
+        val fileName = fileConfig?.fileName
+        if (!outputDir.isNullOrBlank()) {
+            val dir = File(outputDir)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            val name = if (!fileName.isNullOrBlank()) "$fileName.json" else defaultFileName
+            return File(dir, name)
+        }
+        return selectTargetFile(project, defaultFileName)
+    }
+
+    private suspend fun selectTargetFile(project: Project, defaultFileName: String): File? {
+        return swing {
+            val descriptor = FileSaverDescriptor(
+                "Save Hoppscotch Collection",
+                "Choose where to save the Hoppscotch collection file"
+            )
+            val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
+            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, defaultFileName)
+            wrapper?.file
+        }
+    }
+
+    private fun countRequests(collection: HoppCollection): Int {
+        fun count(coll: HoppCollection): Int =
+            coll.requests.size + coll.folders.sumOf { count(it) }
+        return count(collection)
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchOptionsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchOptionsPanel.kt
@@ -1,0 +1,180 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.backgroundAsync
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
+import com.itangcent.easyapi.exporter.hoppscotch.CachedHoppscotchApiClient
+import com.itangcent.easyapi.exporter.hoppscotch.HoppCollectionInfo
+import com.itangcent.easyapi.exporter.hoppscotch.HoppscotchApiClient
+import com.itangcent.easyapi.exporter.hoppscotch.asCached
+import com.itangcent.easyapi.http.HttpClientProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.event.ItemEvent
+import javax.swing.*
+
+/**
+ * Dual-mode options panel for the Hoppscotch export channel.
+ *
+ * Automatically switches between two modes based on authentication state:
+ * - **File export mode** — shown when no Hoppscotch access token is configured.
+ *   Provides output directory and file name fields.
+ * - **Cloud upload mode** — shown when an access token is available.
+ *   Provides a collection selector combo box for choosing an existing collection
+ *   to update, or "(New)" to create a new one.
+ *
+ * Implements [ChannelOptionsPanel] with [component] and [buildConfig] methods.
+ *
+ * @param project the IntelliJ project context
+ * @see HoppscotchChannel
+ * @see ChannelConfig.HoppscotchConfig
+ */
+class HoppscotchOptionsPanel(private val project: Project) : ChannelOptionsPanel, IdeaLog {
+
+    private val cardLayout = CardLayout()
+    private val cardPanel = JPanel(cardLayout)
+
+    private val outputDirField = TextFieldWithBrowseButton().apply {
+        text = project.basePath ?: ""
+        addBrowseFolderListener(
+            project,
+            FileChooserDescriptorFactory.createSingleFolderDescriptor()
+                .withTitle("Select Output Directory")
+                .withDescription("Choose the directory to export the Hoppscotch collection to")
+        )
+    }
+
+    private val fileNameField = com.intellij.ui.components.JBTextField().apply {
+        text = "hoppscotch_collection"
+        columns = 30
+    }
+
+    private val collectionComboBox = ComboBox<String>()
+    private var collectionItems: List<HoppCollectionInfo> = emptyList()
+    private var selectedCollection: HoppCollectionInfo? = null
+
+    private val filePanel = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        add(JPanel(BorderLayout()).apply {
+            add(JLabel("Output Directory:"), BorderLayout.WEST)
+            add(outputDirField, BorderLayout.CENTER)
+        })
+        add(Box.createVerticalStrut(5))
+        add(JPanel(BorderLayout()).apply {
+            add(JLabel("File Name (without extension):"), BorderLayout.WEST)
+            add(fileNameField, BorderLayout.CENTER)
+        })
+    }
+
+    private val cloudPanel = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        add(JPanel(BorderLayout()).apply {
+            add(JLabel("Collection:"), BorderLayout.WEST)
+            add(collectionComboBox, BorderLayout.CENTER)
+        })
+        add(Box.createVerticalStrut(5))
+        add(JLabel("Select an existing collection to update, or choose (New) to create a new one."))
+    }
+
+    private val modeLabel = JLabel()
+
+    init {
+        cardPanel.add(filePanel, FILE_CARD)
+        cardPanel.add(cloudPanel, CLOUD_CARD)
+
+        collectionComboBox.addItemListener { e ->
+            if (e.stateChange == ItemEvent.SELECTED) {
+                val idx = collectionComboBox.selectedIndex
+                val hasNewEntry = collectionItems.isEmpty()
+                        || collectionComboBox.getItemAt(0)?.startsWith("(New)") == true
+                val collectionIdx = if (hasNewEntry) idx - 1 else idx
+                if (collectionIdx >= 0 && collectionIdx < collectionItems.size) {
+                    selectedCollection = collectionItems[collectionIdx]
+                } else {
+                    selectedCollection = null
+                }
+            }
+        }
+    }
+
+    override fun onShown() {
+        initializeMode()
+    }
+
+    private fun initializeMode() {
+        val settings = SettingBinder.getInstance(project).read()
+        val token = settings.hoppscotchToken
+
+        if (token.isNullOrBlank()) {
+            cardLayout.show(cardPanel, FILE_CARD)
+            modeLabel.text = "Mode: File Export (login to enable cloud upload)"
+        } else {
+            cardLayout.show(cardPanel, CLOUD_CARD)
+            modeLabel.text = "Mode: Cloud Upload"
+            loadCollections(token, settings.hoppscotchServerUrl, settings.hoppscotchBackendUrl)
+        }
+    }
+
+    private fun loadCollections(token: String, serverUrl: String?, backendUrl: String? = null) {
+        val url = serverUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+        backgroundAsync {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+                val client = HoppscotchApiClient(token, url, backendUrl, httpClient).asCached()
+                val collections = client.listCollections(useCache = true)
+                swing {
+                    collectionItems = collections
+                    collectionComboBox.removeAllItems()
+                    collectionComboBox.addItem("(New) Create new collection")
+                    collections.forEach { collectionComboBox.addItem(it.name) }
+                    if (collections.isNotEmpty()) {
+                        collectionComboBox.selectedIndex = 0
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to load Hoppscotch collections", e)
+            }
+        }
+    }
+
+    private fun swing(block: () -> Unit) {
+        com.itangcent.easyapi.core.threading.swingSync { block() }
+    }
+
+    override val component: JComponent = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        add(modeLabel)
+        add(Box.createVerticalStrut(5))
+        add(cardPanel)
+    }
+
+    override fun buildConfig(): ChannelConfig {
+        val settings = SettingBinder.getInstance(project).read()
+        val token = settings.hoppscotchToken
+
+        return if (token.isNullOrBlank()) {
+            ChannelConfig.FileConfig(
+                outputDir = outputDirField.text.takeIf { it.isNotBlank() },
+                fileName = fileNameField.text.takeIf { it.isNotBlank() }
+            )
+        } else {
+            ChannelConfig.HoppscotchConfig(
+                collectionId = selectedCollection?.id,
+                collectionName = selectedCollection?.name,
+                isUpdate = selectedCollection != null
+            )
+        }
+    }
+
+    companion object {
+        private const val FILE_CARD = "file"
+        private const val CLOUD_CARD = "cloud"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/CachedHoppscotchApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/CachedHoppscotchApiClient.kt
@@ -1,0 +1,145 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.itangcent.easyapi.cache.AppCacheRepository
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.util.json.GsonUtils
+
+/**
+ * Caching decorator for [HoppscotchApiClient].
+ *
+ * Caches [listTeams] and [listCollections] results in [AppCacheRepository] to reduce
+ * API calls and improve UI responsiveness. Write operations (upload, update, delete)
+ * are delegated directly to the underlying client without caching.
+ *
+ * Use the [asCached] extension function to create an instance:
+ * ```kotlin
+ * val client = HoppscotchApiClient(token, serverUrl, httpClient).asCached()
+ * ```
+ *
+ * @property client the underlying API client to delegate to
+ * @see HoppscotchApiClient
+ */
+class CachedHoppscotchApiClient(
+    private val client: HoppscotchApiClient
+) : IdeaLog {
+
+    companion object : IdeaLog {
+        private const val TEAMS_CACHE_KEY = "hoppscotch/teams.json"
+        private const val COLLECTIONS_CACHE_KEY_PREFIX = "hoppscotch/collections_"
+    }
+
+    suspend fun listTeams(useCache: Boolean = true): List<HoppTeam> {
+        if (useCache) {
+            val cached = loadCachedTeams()
+            if (cached.isNotEmpty()) {
+                LOG.info("Returning ${cached.size} cached Hoppscotch teams")
+                return cached
+            }
+        }
+
+        val teams = client.listTeams()
+        if (teams.isNotEmpty()) {
+            cacheTeams(teams)
+        }
+        return teams
+    }
+
+    private fun cacheTeams(teams: List<HoppTeam>) {
+        try {
+            AppCacheRepository.getInstance().write(TEAMS_CACHE_KEY, GsonUtils.toJson(teams))
+        } catch (e: Exception) {
+            LOG.warn("Failed to cache Hoppscotch teams", e)
+        }
+    }
+
+    private fun loadCachedTeams(): List<HoppTeam> {
+        return try {
+            val cached = AppCacheRepository.getInstance().read(TEAMS_CACHE_KEY)
+            if (cached != null) {
+                GsonUtils.fromJson<Array<HoppTeam>>(cached, Array<HoppTeam>::class.java).toList()
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to load cached Hoppscotch teams", e)
+            emptyList()
+        }
+    }
+
+    fun clearTeamsCache() {
+        AppCacheRepository.getInstance().delete(TEAMS_CACHE_KEY)
+    }
+
+    suspend fun listCollections(teamId: String? = null, useCache: Boolean = true): List<HoppCollectionInfo> {
+        val cacheKey = if (teamId != null) {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}${teamId}.json"
+        } else {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}personal.json"
+        }
+
+        if (useCache) {
+            val cached = loadCachedCollections(cacheKey)
+            if (cached.isNotEmpty()) {
+                LOG.info("Returning ${cached.size} cached Hoppscotch collections")
+                return cached
+            }
+        }
+
+        val collections = client.listCollections(teamId)
+        if (collections.isNotEmpty()) {
+            cacheCollections(cacheKey, collections)
+        }
+        return collections
+    }
+
+    private fun cacheCollections(cacheKey: String, collections: List<HoppCollectionInfo>) {
+        try {
+            AppCacheRepository.getInstance().write(cacheKey, GsonUtils.toJson(collections))
+        } catch (e: Exception) {
+            LOG.warn("Failed to cache Hoppscotch collections", e)
+        }
+    }
+
+    private fun loadCachedCollections(cacheKey: String): List<HoppCollectionInfo> {
+        return try {
+            val cached = AppCacheRepository.getInstance().read(cacheKey)
+            if (cached != null) {
+                GsonUtils.fromJson<Array<HoppCollectionInfo>>(cached, Array<HoppCollectionInfo>::class.java).toList()
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to load cached Hoppscotch collections", e)
+            emptyList()
+        }
+    }
+
+    fun clearCollectionsCache(teamId: String? = null) {
+        val cacheKey = if (teamId != null) {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}${teamId}.json"
+        } else {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}personal.json"
+        }
+        AppCacheRepository.getInstance().delete(cacheKey)
+    }
+
+    suspend fun testConnection(): Boolean = client.testConnection()
+
+    suspend fun uploadCollection(collection: HoppCollection, teamId: String? = null): HoppUploadResult {
+        return client.uploadCollection(collection, teamId)
+    }
+
+    suspend fun updateCollection(collectionId: String, collection: HoppCollection): HoppUploadResult {
+        return client.updateCollection(collectionId, collection)
+    }
+
+    suspend fun deleteCollection(collectionId: String, teamId: String? = null): Boolean {
+        return client.deleteCollection(collectionId, teamId)
+    }
+}
+
+/**
+ * Wraps this [HoppscotchApiClient] with a caching decorator.
+ */
+fun HoppscotchApiClient.asCached() = CachedHoppscotchApiClient(this)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchApiClient.kt
@@ -1,0 +1,425 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.hoppscotch.model.hoppscotchGson
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.KeyValue
+import com.itangcent.easyapi.logging.IdeaLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * GraphQL API client for Hoppscotch cloud operations.
+ *
+ * Communicates with Hoppscotch's GraphQL endpoint to manage collections and teams.
+ * Uses the project's [HttpClient] interface (not `java.net.http.HttpClient`) for all
+ * network requests, and always includes an `Authorization: Bearer <token>` header.
+ *
+ * Supports custom server URLs for self-hosted Hoppscotch instances via [serverUrl].
+ *
+ * ## Cloud vs Self-Hosted URL Resolution
+ * - **Cloud** (`https://hoppscotch.io`): API calls go to `https://api.hoppscotch.io`
+ * - **Self-hosted** (`https://your-instance.com`): API calls go to the same URL
+ *
+ * This matches the Hoppscotch frontend's `VITE_BACKEND_GQL_URL` default:
+ * `https://api.hoppscotch.io/graphql`
+ *
+ * ## Key operations
+ * - [testConnection] — validate the access token
+ * - [listTeams] / [listCollections] — discover workspaces and collections
+ * - [uploadCollection] — import a collection via JSON
+ * - [updateCollection] — replace an existing collection (create-first-then-delete)
+ * - [deleteCollection] — remove a collection by ID
+ *
+ * @property token Hoppscotch access token (Bearer token)
+ * @property serverUrl Hoppscotch server base URL (default: https://hoppscotch.io)
+ * @property HttpClient the HTTP client used for network requests
+ * @see CachedHoppscotchApiClient for a caching decorator
+ * @see HoppscotchAuthException thrown on 401 responses
+ */
+class HoppscotchApiClient(
+    private val token: String,
+    private val serverUrl: String = DEFAULT_SERVER_URL,
+    private val backendUrl: String? = null,
+    private val httpClient: HttpClient
+) : IdeaLog {
+
+    private val gson = hoppscotchGson(prettyPrint = false)
+
+    private val apiBaseUrl: String
+        get() = resolveApiBaseUrl(serverUrl)
+
+    suspend fun testConnection(): Boolean {
+        if (token.isBlank()) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                val query = """{ me { uid displayName } }"""
+                val response = executeGraphQL(query)
+                response != null && !response.has("errors")
+            } catch (e: Exception) {
+                LOG.warn("Hoppscotch connection test failed", e)
+                false
+            }
+        }
+    }
+
+    suspend fun listTeams(): List<HoppTeam> {
+        if (token.isBlank()) return emptyList()
+        return withContext(Dispatchers.IO) {
+            try {
+                val query = """{ myTeams { id name } }"""
+                val response = executeGraphQL(query) ?: return@withContext emptyList()
+                val data = response.getAsJsonObject("data") ?: return@withContext emptyList()
+                val teamsArray = data.getAsJsonArray("myTeams") ?: return@withContext emptyList()
+                teamsArray.map { element ->
+                    val obj = element.asJsonObject
+                    HoppTeam(
+                        id = obj.get("id").asString,
+                        name = obj.get("name").asString
+                    )
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to list Hoppscotch teams", e)
+                emptyList()
+            }
+        }
+    }
+
+    suspend fun listCollections(teamId: String? = null): List<HoppCollectionInfo> {
+        if (token.isBlank()) return emptyList()
+        return withContext(Dispatchers.IO) {
+            try {
+                val query = if (teamId != null) {
+                    """{ rootCollectionsOfTeam(teamID: "$teamId") { id title } }"""
+                } else {
+                    """{ rootCollectionsOfTeam { id title } }"""
+                }
+                val response = executeGraphQL(query) ?: return@withContext emptyList()
+                val data = response.getAsJsonObject("data") ?: return@withContext emptyList()
+                val collectionsArray = data.getAsJsonArray("rootCollectionsOfTeam")
+                    ?: return@withContext emptyList()
+                collectionsArray.map { element ->
+                    val obj = element.asJsonObject
+                    HoppCollectionInfo(
+                        id = obj.get("id").asString,
+                        name = obj.get("title").asString
+                    )
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to list Hoppscotch collections", e)
+                emptyList()
+            }
+        }
+    }
+
+    suspend fun uploadCollection(collection: HoppCollection, teamId: String? = null): HoppUploadResult {
+        if (token.isBlank()) {
+            return HoppUploadResult(success = false, message = "No access token configured")
+        }
+        return withContext(Dispatchers.IO) {
+            try {
+                // Transform to personal collection format: move auth/headers/variables/etc.
+                // into a "data" sub-object, matching Hoppscotch's translateToPersonalCollectionFormat.
+                val transformed = translateToPersonalCollectionFormat(collection)
+                // Server expects a JSON array of CollectionFolder objects
+                val jsonArray = JsonArray()
+                jsonArray.add(transformed)
+                val collectionJson = gson.toJson(jsonArray)
+                val escapedJson = gson.toJson(collectionJson)
+
+                val mutation = if (teamId != null) {
+                    """mutation { importCollectionsFromJSON(
+                        teamID: "$teamId",
+                        jsonString: $escapedJson
+                    ) }"""
+                } else {
+                    """mutation { importUserCollectionsFromJSON(
+                        jsonString: $escapedJson,
+                        reqType: REST
+                    ) { exportedCollection collectionType } }"""
+                }
+
+                val response = executeGraphQL(mutation) ?: return@withContext HoppUploadResult(
+                    success = false,
+                    message = "Empty response from server"
+                )
+
+                if (response.has("errors")) {
+                    val errors = response.getAsJsonArray("errors")
+                    val message = errors?.firstOrNull()?.asJsonObject?.get("message")?.asString
+                        ?: "Unknown GraphQL error"
+                    HoppUploadResult(success = false, message = message)
+                } else {
+                    val data = response.getAsJsonObject("data")
+                    if (teamId != null) {
+                        // Team import returns Boolean
+                        val success = data?.get("importCollectionsFromJSON")?.asBoolean ?: false
+                        HoppUploadResult(
+                            success = success,
+                            message = if (success) "Collection uploaded to team successfully" else "Upload failed"
+                        )
+                    } else {
+                        // User import returns { exportedCollection, collectionType }
+                        val importResult = data?.getAsJsonObject("importUserCollectionsFromJSON")
+                        val collectionId = importResult?.get("exportedCollection")?.asString
+                        HoppUploadResult(
+                            success = true,
+                            message = "Collection uploaded successfully",
+                            collectionId = collectionId
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to upload Hoppscotch collection", e)
+                HoppUploadResult(success = false, message = e.message)
+            }
+        }
+    }
+
+    suspend fun updateCollection(collectionId: String, collection: HoppCollection): HoppUploadResult {
+        if (token.isBlank()) {
+            return HoppUploadResult(success = false, message = "No access token configured")
+        }
+
+        val uploadResult = uploadCollection(collection)
+        if (uploadResult.success && uploadResult.collectionId != null) {
+            deleteCollection(collectionId)
+            return uploadResult.copy(message = "Collection updated successfully (new ID: ${uploadResult.collectionId})")
+        }
+        return uploadResult
+    }
+
+    suspend fun deleteCollection(collectionId: String, teamId: String? = null): Boolean {
+        if (token.isBlank()) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                val mutation = if (teamId != null) {
+                    """mutation { deleteCollection(collectionID: "$collectionId") }"""
+                } else {
+                    """mutation { deleteUserCollection(id: "$collectionId") }"""
+                }
+                val response = executeGraphQL(mutation)
+                response != null && !response.has("errors")
+            } catch (e: Exception) {
+                LOG.warn("Failed to delete Hoppscotch collection", e)
+                false
+            }
+        }
+    }
+
+    private val isCloudInstance: Boolean
+        get() = isCloudServer(serverUrl)
+
+    private suspend fun executeGraphQL(query: String): JsonObject? {
+        val graphqlUrl = resolveGraphQLUrl(serverUrl, backendUrl)
+        val body = gson.toJson(mapOf("query" to query))
+
+        LOG.info("call:$graphqlUrl \nbody:$body")
+
+        val request = HttpRequest(
+            url = graphqlUrl,
+            method = "POST",
+            headers = listOf(
+                KeyValue("Content-Type", "application/json"),
+                KeyValue("Authorization", "Bearer $token")
+            ),
+            body = body
+        )
+
+        val response = httpClient.execute(request)
+
+        if (response.code == 401) {
+            LOG.warn("Hoppscotch API returned 401 Unauthorized")
+            throw HoppscotchAuthException("Authentication failed - token may be expired")
+        }
+
+        if (response.code == 405) {
+            LOG.warn("Hoppscotch API returned 405 Method Not Allowed - check endpoint URL")
+            return null
+        }
+
+        if (response.code != 200) {
+            LOG.warn("Hoppscotch API returned HTTP ${response.code}")
+            return null
+        }
+
+        return try {
+            gson.fromJson(response.body, JsonObject::class.java)
+        } catch (e: Exception) {
+            LOG.warn("Failed to parse Hoppscotch API response", e)
+            null
+        }
+    }
+
+    /**
+     * Transforms a [HoppCollection] into the "personal collection" format expected
+     * by Hoppscotch's `importUserCollectionsFromJSON` / `importCollectionsFromJSON` mutations.
+     *
+     * This mirrors the frontend's `translateToPersonalCollectionFormat`:
+     * - `auth`, `headers`, `variables`, `description`, `preRequestScript`, `testScript`
+     *   are moved into a `data` sub-object
+     * - `v`, `name`, `_ref_id`, `folders`, `requests` remain at the top level
+     * - `folders` are recursively transformed
+     */
+    private fun translateToPersonalCollectionFormat(collection: HoppCollection): JsonObject {
+        val obj = JsonObject()
+
+        obj.addProperty("v", collection.v)
+        obj.addProperty("name", collection.name)
+        obj.addProperty("_ref_id", collection._ref_id)
+
+        // Recursively transform folders
+        val foldersArray = JsonArray()
+        collection.folders.forEach { folder ->
+            foldersArray.add(translateToPersonalCollectionFormat(folder))
+        }
+        obj.add("folders", foldersArray)
+
+        // Requests stay at top level as-is
+        obj.add("requests", gson.toJsonTree(collection.requests))
+
+        // Move auth/headers/variables/description/scripts into "data" sub-object
+        val data = JsonObject()
+        data.add("auth", gson.toJsonTree(collection.auth))
+        data.add("headers", gson.toJsonTree(collection.headers))
+        data.add("variables", gson.toJsonTree(collection.variables))
+        data.addProperty("description", collection.description ?: "")
+        data.addProperty("preRequestScript", collection.preRequestScript)
+        data.addProperty("testScript", collection.testScript)
+        obj.add("data", data)
+
+        return obj
+    }
+
+    companion object : IdeaLog {
+        private const val DEFAULT_SERVER_URL = "https://hoppscotch.io"
+        private const val CLOUD_SERVER_HOST = "hoppscotch.io"
+        private const val CLOUD_API_BASE_URL = "https://api.hoppscotch.io"
+
+        /**
+         * Resolves the API base URL for a given Hoppscotch server URL.
+         *
+         * - For the cloud instance (`https://hoppscotch.io`), returns `https://api.hoppscotch.io`
+         * - For self-hosted instances with a configured backend URL, returns the backend URL
+         * - For self-hosted instances without a backend URL, returns the server URL
+         *
+         * The backend URL corresponds to Hoppscotch's `VITE_BACKEND_API_URL` env variable,
+         * e.g., `http://localhost:3170/v1` for a default self-hosted setup.
+         */
+        fun resolveApiBaseUrl(serverUrl: String, backendUrl: String? = null): String {
+            val normalized = serverUrl.trimEnd('/')
+            val host = try {
+                java.net.URI(normalized).host
+            } catch (e: Exception) {
+                normalized
+            }
+            if (host == CLOUD_SERVER_HOST) {
+                return CLOUD_API_BASE_URL
+            }
+            if (!backendUrl.isNullOrBlank()) {
+                return backendUrl.trimEnd('/')
+            }
+            return normalized
+        }
+
+        /**
+         * Resolves the REST API v1 base URL for a given Hoppscotch server URL.
+         *
+         * This corresponds to Hoppscotch's `VITE_BACKEND_API_URL` env variable:
+         * - Cloud: `https://api.hoppscotch.io/v1`
+         * - Self-hosted with backend URL: returns the backend URL as-is (already includes `/v1`)
+         * - Self-hosted without backend URL: `{serverUrl}/v1`
+         *
+         * Auth endpoints like `/auth/signin` and `/auth/verify` are under this base.
+         */
+        fun resolveApiV1BaseUrl(serverUrl: String, backendUrl: String? = null): String {
+            val apiBase = resolveApiBaseUrl(serverUrl, backendUrl)
+            // For cloud, resolveApiBaseUrl returns https://api.hoppscotch.io (no /v1)
+            // For self-hosted with backendUrl, it already includes /v1 (e.g., http://localhost:3170/v1)
+            // For self-hosted without backendUrl, it returns the server URL (no /v1)
+            if (isCloudServer(serverUrl)) {
+                return "$apiBase/v1"
+            }
+            if (!backendUrl.isNullOrBlank()) {
+                // Backend URL already includes /v1
+                return apiBase
+            }
+            return "$apiBase/v1"
+        }
+
+        /**
+         * Resolves the GraphQL endpoint URL.
+         *
+         * - Cloud: `https://api.hoppscotch.io/graphql`
+         * - Self-hosted with backend URL: `{backendUrl}/graphql`
+         * - Self-hosted without backend URL: `{serverUrl}/graphql`
+         *
+         * This matches the Hoppscotch frontend's `VITE_BACKEND_GQL_URL` default:
+         * `https://api.hoppscotch.io/graphql` for cloud,
+         * `http://localhost:3170/graphql` for self-hosted
+         */
+        fun resolveGraphQLUrl(serverUrl: String, backendUrl: String? = null): String {
+            val apiBase = resolveApiBaseUrl(serverUrl, backendUrl)
+            return "$apiBase/graphql"
+        }
+
+        fun isCloudServer(serverUrl: String): Boolean {
+            val normalized = serverUrl.trimEnd('/')
+            val host = try {
+                java.net.URI(normalized).host
+            } catch (e: Exception) {
+                normalized
+            }
+            return host == CLOUD_SERVER_HOST
+        }
+    }
+}
+
+/**
+ * A Hoppscotch team (workspace).
+ *
+ * @property id unique team identifier
+ * @property name display name of the team
+ */
+data class HoppTeam(
+    val id: String,
+    val name: String
+)
+
+/**
+ * Summary info for a Hoppscotch collection returned by list queries.
+ *
+ * @property id unique collection identifier
+ * @property name display name (title) of the collection
+ */
+data class HoppCollectionInfo(
+    val id: String,
+    val name: String
+)
+
+/**
+ * Result of a Hoppscotch collection upload or update operation.
+ *
+ * @property success whether the operation succeeded
+ * @property message human-readable result or error message
+ * @property collectionId the ID of the created collection (on success)
+ */
+data class HoppUploadResult(
+    val success: Boolean,
+    val message: String? = null,
+    val collectionId: String? = null
+)
+
+/**
+ * Thrown when the Hoppscotch API returns a 401 Unauthorized response.
+ *
+ * This indicates the access token has expired or is invalid.
+ * Callers should attempt token refresh via [HoppscotchAuthService.refreshToken]
+ * or prompt the user to re-authenticate.
+ *
+ * @param message description of the authentication failure
+ */
+class HoppscotchAuthException(message: String) : Exception(message)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchAuthService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchAuthService.kt
@@ -1,0 +1,876 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.application.ModalityState
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.swing
+import com.itangcent.easyapi.http.HttpClientProvider
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import com.google.gson.JsonObject
+
+/**
+ * Application-level service for Hoppscotch authentication.
+ *
+ * Manages the Hoppscotch login lifecycle:
+ * 1. **Login** — attempts JBCefBrowser-based login first (captures `access_token` and
+ *    `refresh_token` from cookies), falls back to manual token input when JCEF is unavailable
+ * 2. **Token refresh** — uses the stored `refresh_token` to obtain a new `access_token`
+ * 3. **Logout** — clears stored tokens
+ *
+ * Tokens are persisted in [SettingBinder] (project-level settings).
+ *
+ * @see HoppscotchLoginDialog for the JCEF browser-based login UI
+ */
+@Service(Service.Level.APP)
+class HoppscotchAuthService : IdeaLog {
+
+    fun isLoggedIn(settings: Settings): Boolean {
+        return !settings.hoppscotchToken.isNullOrBlank()
+    }
+
+    fun getServerUrl(settings: Settings): String {
+        return settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: DEFAULT_SERVER_URL
+    }
+
+    suspend fun login(project: Project, parent: java.awt.Component? = null): Boolean {
+        val jcefAvailable = isJcefAvailable()
+        return swing(ModalityState.any()) {
+            val choice = HoppscotchLoginMethodDialog.showDialog(project, parent, jcefAvailable)
+            when (choice) {
+                HoppscotchLoginMethodDialog.Method.MAGIC_LINK -> {
+                    closeSwingDialog()
+                    loginWithMagicLink(project, parent)
+                }
+                HoppscotchLoginMethodDialog.Method.BROWSER -> {
+                    closeSwingDialog()
+                    loginWithBrowser(project, parent)
+                }
+                HoppscotchLoginMethodDialog.Method.MANUAL_TOKEN -> {
+                    closeSwingDialog()
+                    loginWithManualToken(project)
+                }
+                null -> false
+            }
+        }
+    }
+
+    private suspend fun loginWithMagicLink(project: Project, parent: java.awt.Component? = null): Boolean {
+        // First check if the server supports email (magic link) auth
+        val providerCheck = checkAuthProviders(project)
+        if (providerCheck == AuthProviderCheckResult.NOT_SUPPORTED) {
+            swing(ModalityState.any()) {
+                Messages.showWarningDialog(
+                    project,
+                    "This Hoppscotch server does not support magic link (email) login. " +
+                        "Please use Browser Login or Manual Token instead.",
+                    "Magic Link Not Available"
+                )
+            }
+            return false
+        }
+        if (providerCheck == AuthProviderCheckResult.EMAIL_NOT_ENABLED) {
+            swing(ModalityState.any()) {
+                Messages.showWarningDialog(
+                    project,
+                    "Email login is not enabled on this Hoppscotch server. " +
+                        "Please contact your administrator or use another login method.",
+                    "Email Login Not Enabled"
+                )
+            }
+            return false
+        }
+
+        val isCloud = providerCheck == AuthProviderCheckResult.CLOUD
+
+        // For cloud, discover Firebase config
+        var firebaseConfig: FirebaseConfig? = null
+        if (isCloud) {
+            firebaseConfig = discoverFirebaseConfig(project)
+            if (firebaseConfig == null) {
+                // Fallback to hardcoded config for hoppscotch.io
+                firebaseConfig = FirebaseConfig(
+                    apiKey = "AIzaSyCMsFreESs58-hRxTtiqQrIcimh4i1wbsM",
+                    projectId = "postwoman-api",
+                    authDomain = "postwoman-api.firebaseapp.com"
+                )
+            }
+        }
+
+        return swing(ModalityState.any()) {
+            val dialog = if (parent != null) {
+                HoppscotchMagicLinkLoginDialog(project, parent, isCloud)
+            } else {
+                HoppscotchMagicLinkLoginDialog(project, isCloud = isCloud)
+            }
+
+            var deviceIdentifier: String? = null
+            var storedEmail: String? = null
+            val storedFirebaseConfig = firebaseConfig
+
+            dialog.onEmailSubmitted = { email ->
+                dialog.showSendingStep()
+                storedEmail = email
+                backgroundAsync {
+                    try {
+                        val result = if (isCloud && storedFirebaseConfig != null) {
+                            sendFirebaseMagicLink(project, email, storedFirebaseConfig)
+                        } else {
+                            sendMagicLinkRequest(project, email)
+                        }
+                        swing(ModalityState.any()) {
+                            if (result.success) {
+                                deviceIdentifier = result.deviceIdentifier
+                                dialog.showLinkInputStep(result.deviceIdentifier!!, email)
+                            } else {
+                                dialog.showEmailError(result.errorMessage ?: "Failed to send magic link. Please try again.")
+                            }
+                        }
+                    } catch (e: Exception) {
+                        LOG.warn("Magic link send failed", e)
+                        swing(ModalityState.any()) {
+                            dialog.showEmailError("Network error: ${e.message}. Please try again.")
+                        }
+                    }
+                }
+            }
+
+            dialog.onLinkSubmitted = fun(linkOrToken) {
+                dialog.isOKActionEnabled = false
+                val deviceId = deviceIdentifier
+                val email = storedEmail
+                if (deviceId == null) {
+                    dialog.showLinkError("Session expired. Please close and try again.")
+                    return
+                }
+                backgroundAsync {
+                    try {
+                        val result = if (isCloud && storedFirebaseConfig != null) {
+                            // For cloud Firebase: extract oobCode from the link URL
+                            val oobCode = extractOobCodeFromUrl(linkOrToken)
+                                ?: linkOrToken // fallback: treat input as raw oobCode
+                            verifyFirebaseMagicLink(
+                                project,
+                                email ?: "",
+                                oobCode,
+                                storedFirebaseConfig
+                            )
+                        } else {
+                            // For self-hosted: extract token from the link URL
+                            val token = extractTokenFromUrl(linkOrToken)
+                                ?: linkOrToken // fallback: treat input as raw token
+                            verifyMagicLink(project, deviceId, token)
+                        }
+                        swing(ModalityState.any()) {
+                            if (result.success) {
+                                saveTokens(result.accessToken, result.refreshToken, project)
+                                dialog.onLoginSuccess(result.accessToken, result.refreshToken)
+                            } else {
+                                dialog.showLinkError(result.errorMessage ?: "Verification failed. Please try again.")
+                            }
+                        }
+                    } catch (e: Exception) {
+                        LOG.warn("Magic link verification failed", e)
+                        swing(ModalityState.any()) {
+                            dialog.showLinkError("Network error: ${e.message}. Please try again.")
+                        }
+                    }
+                }
+            }
+
+            dialog.show()
+            val token = dialog.getAccessToken()
+            !token.isNullOrBlank()
+        }
+    }
+
+    /**
+     * Extracts the oobCode parameter from a Firebase magic link URL.
+     * Firebase magic links have the format: https://hoppscotch.io/enter?oobCode=XXX&...
+     */
+    private fun extractOobCodeFromUrl(url: String): String? {
+        val match = Regex("[?&]oobCode=([^&]+)").find(url)
+        return match?.groupValues?.get(1)
+    }
+
+    /**
+     * Extracts the token parameter from a self-hosted magic link URL.
+     * Self-hosted magic links have the format: https://example.com/enter?token=XXX&...
+     */
+    private fun extractTokenFromUrl(url: String): String? {
+        val match = Regex("[?&]token=([^&]+)").find(url)
+        return match?.groupValues?.get(1)
+    }
+
+    private fun backgroundAsync(block: suspend () -> Unit) {
+        GlobalScope.launch(Dispatchers.IO) {
+            try {
+                block()
+            } catch (e: Exception) {
+                LOG.warn("Background async error", e)
+            }
+        }
+    }
+
+    private fun closeSwingDialog() {
+        // No-op: used as a placeholder for swing context cleanup
+    }
+
+    internal suspend fun sendMagicLinkRequest(project: Project, email: String): MagicLinkSendResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val settingBinder = project.service<SettingBinder>()
+                val settings = settingBinder.read()
+                val serverUrl = getServerUrl(settings)
+                val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf("email" to email)
+                )
+                val request = HttpRequest(
+                    url = "$apiBaseUrl/auth/signin?origin=app",
+                    method = "POST",
+                    headers = listOf("Content-Type" to "application/json"),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val json = parseJson(response.body)
+                        val deviceId = json?.get("deviceIdentifier")?.asString
+                        if (!deviceId.isNullOrBlank()) {
+                            MagicLinkSendResult(success = true, deviceIdentifier = deviceId)
+                        } else {
+                            MagicLinkSendResult(success = false, errorMessage = "Unexpected response from server.")
+                        }
+                    }
+                    response.code == 400 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkSendResult(success = false, errorMessage = when (msg) {
+                            "INVALID_EMAIL" -> "Invalid email address. Please check and try again."
+                            else -> msg ?: "Bad request (HTTP 400)."
+                        })
+                    }
+                    response.code == 404 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkSendResult(success = false, errorMessage = when (msg) {
+                            "AUTH_PROVIDER_NOT_SPECIFIED" -> "Email login is not enabled on this Hoppscotch instance. Please use another login method."
+                            else -> "Magic link login is not available on this server (HTTP 404). The server may not support email authentication."
+                        })
+                    }
+                    else -> {
+                        MagicLinkSendResult(success = false, errorMessage = "Server error (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to send magic link", e)
+                MagicLinkSendResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    internal suspend fun verifyMagicLink(project: Project, deviceIdentifier: String, token: String): MagicLinkVerifyResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val settingBinder = project.service<SettingBinder>()
+                val settings = settingBinder.read()
+                val serverUrl = getServerUrl(settings)
+                val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf("deviceIdentifier" to deviceIdentifier, "token" to token)
+                )
+                val request = HttpRequest(
+                    url = "$apiBaseUrl/auth/verify",
+                    method = "POST",
+                    headers = listOf("Content-Type" to "application/json"),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val accessToken = extractTokenFromCookieHeader(response, "access_token")
+                        val refreshToken = extractTokenFromCookieHeader(response, "refresh_token")
+                        if (!accessToken.isNullOrBlank()) {
+                            MagicLinkVerifyResult(
+                                success = true,
+                                accessToken = accessToken,
+                                refreshToken = refreshToken
+                            )
+                        } else {
+                            MagicLinkVerifyResult(success = false, errorMessage = "Login succeeded but no access token was received.")
+                        }
+                    }
+                    response.code == 401 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkVerifyResult(success = false, errorMessage = when (msg) {
+                            "MAGIC_LINK_EXPIRED" -> "This magic link has expired. Please request a new one."
+                            else -> msg ?: "Unauthorized (HTTP 401)."
+                        })
+                    }
+                    response.code == 404 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkVerifyResult(success = false, errorMessage = when (msg) {
+                            "INVALID_MAGIC_LINK_DATA" -> "This magic link has already been used or is invalid. Please request a new one."
+                            else -> msg ?: "Not found (HTTP 404)."
+                        })
+                    }
+                    else -> {
+                        MagicLinkVerifyResult(success = false, errorMessage = "Verification failed (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to verify magic link", e)
+                MagicLinkVerifyResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    private fun parseJson(body: String?): JsonObject? {
+        if (body.isNullOrBlank()) return null
+        return try {
+            com.itangcent.easyapi.util.json.GsonUtils.GSON.fromJson(body, JsonObject::class.java)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    internal enum class AuthProviderCheckResult {
+        SUPPORTED,       // EMAIL provider is available (self-hosted backend)
+        EMAIL_NOT_ENABLED, // Server has auth but EMAIL is not in the providers list
+        NOT_SUPPORTED,   // Server doesn't have the auth providers endpoint (cloud instance — use Firebase)
+        CLOUD            // Cloud instance detected — use Firebase Identity Toolkit
+    }
+
+    /**
+     * Checks if the Hoppscotch server supports email (magic link) authentication.
+     * - For self-hosted: calls GET /v1/auth/providers to check available auth methods.
+     * - For cloud (hoppscotch.io): returns CLOUD to indicate Firebase should be used.
+     */
+    internal suspend fun checkAuthProviders(project: Project): AuthProviderCheckResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val settingBinder = project.service<SettingBinder>()
+                val settings = settingBinder.read()
+                val serverUrl = getServerUrl(settings)
+
+                // Check if this is the cloud instance
+                if (isCloudInstance(serverUrl)) {
+                    return@withContext AuthProviderCheckResult.CLOUD
+                }
+
+                val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val request = HttpRequest(
+                    url = "$apiBaseUrl/auth/providers",
+                    method = "GET"
+                )
+                val response = httpClient.execute(request)
+
+                if (response.code == 200) {
+                    val json = parseJson(response.body)
+                    val providers = json?.getAsJsonArray("providers")
+                    val hasEmail = providers?.any { it.isJsonPrimitive && it.asString == "EMAIL" } ?: false
+                    if (hasEmail) AuthProviderCheckResult.SUPPORTED else AuthProviderCheckResult.EMAIL_NOT_ENABLED
+                } else {
+                    // Auth providers endpoint doesn't exist — might be cloud
+                    if (isCloudInstance(serverUrl)) {
+                        AuthProviderCheckResult.CLOUD
+                    } else {
+                        AuthProviderCheckResult.NOT_SUPPORTED
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to check auth providers", e)
+                AuthProviderCheckResult.NOT_SUPPORTED
+            }
+        }
+    }
+
+    /**
+     * Checks if the given server URL points to the Hoppscotch cloud instance.
+     */
+    internal fun isCloudInstance(serverUrl: String): Boolean {
+        val host = try {
+            java.net.URL(serverUrl).host
+        } catch (e: Exception) {
+            serverUrl
+        }
+        return host.equals("hoppscotch.io", ignoreCase = true) ||
+                host.endsWith(".hoppscotch.io", ignoreCase = true)
+    }
+
+    /**
+     * Discovers the Firebase API key from the Hoppscotch cloud web app's JavaScript bundle.
+     * The key is public (embedded in client-side code) and is needed for the Identity Toolkit REST API.
+     */
+    internal suspend fun discoverFirebaseConfig(project: Project): FirebaseConfig? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                // Step 1: Fetch the main page to find the JS bundle URL
+                val pageRequest = HttpRequest(
+                    url = "https://hoppscotch.io",
+                    method = "GET"
+                )
+                val pageResponse = httpClient.execute(pageRequest)
+                if (pageResponse.code != 200) return@withContext null
+
+                val pageBody = pageResponse.body ?: return@withContext null
+                val jsBundlePattern = Regex("""src="(/assets/index-[^"]+\.js)"""")
+                val jsBundleMatch = jsBundlePattern.find(pageBody) ?: return@withContext null
+                val jsBundleUrl = "https://hoppscotch.io${jsBundleMatch.groupValues[1]}"
+
+                // Step 2: Fetch the JS bundle and extract Firebase config
+                val jsRequest = HttpRequest(
+                    url = jsBundleUrl,
+                    method = "GET"
+                )
+                val jsResponse = httpClient.execute(jsRequest)
+                if (jsResponse.code != 200) return@withContext null
+
+                val jsBody = jsResponse.body ?: return@withContext null
+
+                val apiKey = Regex("""apiKey:"([^"]+)"""").find(jsBody)?.groupValues?.get(1)
+                val projectId = Regex("""projectId:"([^"]+)"""").find(jsBody)?.groupValues?.get(1)
+                val authDomain = Regex("""authDomain:"([^"]+)"""").find(jsBody)?.groupValues?.get(1)
+
+                if (apiKey != null && projectId != null) {
+                    FirebaseConfig(apiKey = apiKey, projectId = projectId, authDomain = authDomain)
+                } else {
+                    null
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to discover Firebase config", e)
+                null
+            }
+        }
+    }
+
+    /**
+     * Sends a magic link email using the Firebase Identity Toolkit REST API.
+     * Used for the Hoppscotch cloud instance.
+     */
+    internal suspend fun sendFirebaseMagicLink(
+        project: Project,
+        email: String,
+        firebaseConfig: FirebaseConfig
+    ): MagicLinkSendResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf(
+                        "requestType" to "EMAIL_SIGNIN",
+                        "email" to email,
+                        "continueUrl" to "https://hoppscotch.io/enter"
+                    )
+                )
+                val request = HttpRequest(
+                    url = "https://identitytoolkit.googleapis.com/v1/accounts:sendOobCode?key=${firebaseConfig.apiKey}",
+                    method = "POST",
+                    headers = listOf(
+                        "Content-Type" to "application/json",
+                        "Referer" to "https://hoppscotch.io/",
+                        "Origin" to "https://hoppscotch.io"
+                    ),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val json = parseJson(response.body)
+                        val emailSent = json?.get("email")?.asString
+                        if (!emailSent.isNullOrBlank()) {
+                            MagicLinkSendResult(success = true, deviceIdentifier = "firebase:${firebaseConfig.apiKey}")
+                        } else {
+                            MagicLinkSendResult(success = false, errorMessage = "Unexpected response from Firebase.")
+                        }
+                    }
+                    response.code == 400 -> {
+                        val json = parseJson(response.body)
+                        val error = json?.getAsJsonObject("error")
+                        val message = error?.get("message")?.asString
+                        MagicLinkSendResult(success = false, errorMessage = when (message) {
+                            "EMAIL_NOT_FOUND" -> "No account found with this email address."
+                            "INVALID_EMAIL" -> "Invalid email address. Please check and try again."
+                            "TOO_MANY_ATTEMPTS_TRY_LATER" -> "Too many attempts. Please try again later."
+                            else -> message ?: "Bad request (HTTP 400)."
+                        })
+                    }
+                    else -> {
+                        MagicLinkSendResult(success = false, errorMessage = "Server error (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to send Firebase magic link", e)
+                MagicLinkSendResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Verifies a Firebase magic link using the Identity Toolkit REST API.
+     * The user provides the oobCode from the email link.
+     */
+    internal suspend fun verifyFirebaseMagicLink(
+        project: Project,
+        email: String,
+        oobCode: String,
+        firebaseConfig: FirebaseConfig
+    ): MagicLinkVerifyResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf(
+                        "email" to email,
+                        "oobCode" to oobCode
+                    )
+                )
+                val request = HttpRequest(
+                    url = "https://identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink?key=${firebaseConfig.apiKey}",
+                    method = "POST",
+                    headers = listOf(
+                        "Content-Type" to "application/json",
+                        "Referer" to "https://hoppscotch.io/",
+                        "Origin" to "https://hoppscotch.io"
+                    ),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val json = parseJson(response.body)
+                        val idToken = json?.get("idToken")?.asString
+                        val refreshToken = json?.get("refreshToken")?.asString
+                        if (!idToken.isNullOrBlank()) {
+                            MagicLinkVerifyResult(
+                                success = true,
+                                accessToken = idToken,
+                                refreshToken = refreshToken
+                            )
+                        } else {
+                            MagicLinkVerifyResult(success = false, errorMessage = "Login succeeded but no token was received.")
+                        }
+                    }
+                    response.code == 400 -> {
+                        val json = parseJson(response.body)
+                        val error = json?.getAsJsonObject("error")
+                        val message = error?.get("message")?.asString
+                        MagicLinkVerifyResult(success = false, errorMessage = when (message) {
+                            "INVALID_OOB_CODE" -> "This magic link has expired or already been used. Please request a new one."
+                            "EXPIRED_OOB_CODE" -> "This magic link has expired. Please request a new one."
+                            "INVALID_EMAIL" -> "The email doesn't match the magic link. Please use the same email you entered."
+                            else -> message ?: "Bad request (HTTP 400)."
+                        })
+                    }
+                    else -> {
+                        MagicLinkVerifyResult(success = false, errorMessage = "Verification failed (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to verify Firebase magic link", e)
+                MagicLinkVerifyResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Refreshes a Firebase ID token using the Secure Token REST API.
+     */
+    internal suspend fun refreshFirebaseToken(
+        project: Project,
+        firebaseRefreshToken: String,
+        firebaseConfig: FirebaseConfig
+    ): Pair<String?, String?>? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf(
+                        "grant_type" to "refresh_token",
+                        "refresh_token" to firebaseRefreshToken
+                    )
+                )
+                val request = HttpRequest(
+                    url = "https://securetoken.googleapis.com/v1/token?key=${firebaseConfig.apiKey}",
+                    method = "POST",
+                    headers = listOf(
+                        "Content-Type" to "application/json",
+                        "Referer" to "https://hoppscotch.io/",
+                        "Origin" to "https://hoppscotch.io"
+                    ),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                if (response.code == 200) {
+                    val json = parseJson(response.body)
+                    val idToken = json?.get("id_token")?.asString
+                    val newRefreshToken = json?.get("refresh_token")?.asString
+                    Pair(idToken, newRefreshToken)
+                } else {
+                    LOG.warn("Firebase token refresh failed: HTTP ${response.code}")
+                    null
+                }
+            } catch (e: Exception) {
+                LOG.warn("Firebase token refresh error", e)
+                null
+            }
+        }
+    }
+
+    /**
+     * Safely extracts a string value from a JSON field.
+     * Handles cases where the field is a JsonPrimitive string or a nested JsonObject
+     * (e.g., error responses like `{"message":{"message":"...","statusCode":404}}`).
+     */
+    private fun getJsonString(json: JsonObject?, field: String): String? {
+        val element = json?.get(field) ?: return null
+        return if (element.isJsonPrimitive) {
+            element.asString
+        } else if (element.isJsonObject) {
+            // Try to extract the inner "message" field from nested objects
+            val innerMsg = element.asJsonObject.get("message")
+            if (innerMsg != null && innerMsg.isJsonPrimitive) innerMsg.asString else element.toString()
+        } else {
+            element.toString()
+        }
+    }
+
+    private fun isJcefAvailable(): Boolean {
+        return try {
+            val jcefAppClass = Class.forName("com.intellij.ui.jcef.JBCefApp")
+            val isSupportedMethod = jcefAppClass.getMethod("isSupported")
+            isSupportedMethod.invoke(null) as Boolean
+        } catch (e: Throwable) {
+            LOG.info("JCEF not available, falling back to manual token input", e)
+            false
+        }
+    }
+
+    private suspend fun loginWithBrowser(project: Project, parent: java.awt.Component? = null): Boolean {
+        return swing(ModalityState.any()) {
+            try {
+                val dialog = if (parent != null) {
+                    HoppscotchLoginDialog(project, parent)
+                } else {
+                    HoppscotchLoginDialog(project)
+                }
+                dialog.show()
+                val token = dialog.getAccessToken()
+                val refreshToken = dialog.getRefreshToken()
+                if (!token.isNullOrBlank()) {
+                    saveTokens(token, refreshToken, project)
+                    true
+                } else {
+                    false
+                }
+            } catch (e: Exception) {
+                LOG.warn("Browser login failed, falling back to manual input", e)
+                false
+            }
+        }
+    }
+
+    private suspend fun loginWithManualToken(project: Project): Boolean {
+        return swing(ModalityState.any()) {
+            val token = Messages.showInputDialog(
+                project,
+                "Enter your Hoppscotch access token:\n" +
+                        "(You can find it in Hoppscotch > Settings > Access Tokens)",
+                "Hoppscotch Login",
+                Messages.getInformationIcon()
+            )
+            if (!token.isNullOrBlank()) {
+                saveTokens(token.trim(), null, project)
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    fun saveTokens(accessToken: String?, refreshToken: String?, project: Project) {
+        val settingBinder = project.service<SettingBinder>()
+        val settings = settingBinder.read()
+        settingBinder.save(
+            settings.copy(
+                hoppscotchToken = accessToken,
+                hoppscotchRefreshToken = refreshToken
+            )
+        )
+        LOG.info("Hoppscotch tokens saved")
+    }
+
+    suspend fun refreshToken(project: Project): Boolean {
+        val settingBinder = project.service<SettingBinder>()
+        val settings = settingBinder.read()
+        val storedRefreshToken = settings.hoppscotchRefreshToken
+
+        if (storedRefreshToken.isNullOrBlank()) {
+            LOG.info("No refresh token available, cannot refresh")
+            return false
+        }
+
+        val serverUrl = getServerUrl(settings)
+
+        // For cloud instances, use Firebase Secure Token API
+        if (isCloudInstance(serverUrl)) {
+            return refreshFirebaseTokenFlow(project, storedRefreshToken)
+        }
+
+        // For self-hosted instances, use backend refresh endpoint
+        return try {
+            val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+            val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+            val httpClient = com.itangcent.easyapi.http.HttpClientProvider.getInstance(project).getClient()
+            val request = com.itangcent.easyapi.http.HttpRequest(
+                url = "$apiBaseUrl/auth/refresh",
+                method = "GET",
+                headers = listOf(
+                    "Cookie" to "refresh_token=$storedRefreshToken"
+                )
+            )
+            val response = httpClient.execute(request)
+            if (response.code == 200) {
+                val newAccessToken = extractTokenFromCookieHeader(response, "access_token")
+                    ?: extractTokenFromResponseBody(response)
+                val newRefreshToken = extractTokenFromCookieHeader(response, "refresh_token")
+                if (!newAccessToken.isNullOrBlank()) {
+                    saveTokens(newAccessToken, newRefreshToken ?: storedRefreshToken, project)
+                    LOG.info("Hoppscotch token refreshed successfully")
+                    true
+                } else {
+                    LOG.warn("Token refresh response missing access_token")
+                    false
+                }
+            } else {
+                LOG.warn("Token refresh failed: HTTP ${response.code}")
+                false
+            }
+        } catch (e: Exception) {
+            LOG.warn("Token refresh error", e)
+            false
+        }
+    }
+
+    /**
+     * Refreshes a Firebase ID token for cloud instances.
+     */
+    private suspend fun refreshFirebaseTokenFlow(project: Project, firebaseRefreshToken: String): Boolean {
+        val firebaseConfig = discoverFirebaseConfig(project)
+            ?: FirebaseConfig(
+                apiKey = "AIzaSyCMsFreESs58-hRxTtiqQrIcimh4i1wbsM",
+                projectId = "postwoman-api",
+                authDomain = "postwoman-api.firebaseapp.com"
+            )
+        val result = refreshFirebaseToken(project, firebaseRefreshToken, firebaseConfig)
+        if (result != null) {
+            val newIdToken = result.first
+            val newRefreshToken = result.second
+            if (!newIdToken.isNullOrBlank()) {
+                saveTokens(newIdToken, newRefreshToken ?: firebaseRefreshToken, project)
+                LOG.info("Firebase token refreshed successfully")
+                return true
+            }
+        }
+        LOG.warn("Firebase token refresh failed")
+        return false
+    }
+
+    private fun extractTokenFromCookieHeader(
+        response: com.itangcent.easyapi.http.HttpResponse,
+        tokenName: String
+    ): String? {
+        val setCookieValues = response.headers["Set-Cookie"] ?: response.headers["set-cookie"] ?: return null
+        for (cookieValue in setCookieValues) {
+            if (cookieValue.startsWith("$tokenName=")) {
+                return cookieValue.substringAfter("$tokenName=").substringBefore(";")
+            }
+        }
+        return null
+    }
+
+    private fun extractTokenFromResponseBody(response: com.itangcent.easyapi.http.HttpResponse): String? {
+        if (response.body.isNullOrBlank()) return null
+        return try {
+            val json = com.itangcent.easyapi.util.json.GsonUtils.GSON.fromJson(
+                response.body, com.google.gson.JsonObject::class.java
+            )
+            json.get("access_token")?.asString
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun logout(project: Project) {
+        saveTokens(null, null, project)
+        LOG.info("Hoppscotch logged out")
+    }
+
+    companion object {
+        private const val DEFAULT_SERVER_URL = "https://hoppscotch.io"
+
+        fun getInstance(): HoppscotchAuthService =
+            com.intellij.openapi.application.ApplicationManager.getApplication().getService(HoppscotchAuthService::class.java)
+    }
+}
+
+private typealias Settings = com.itangcent.easyapi.settings.Settings
+
+/**
+ * Result of sending a magic link request.
+ */
+data class MagicLinkSendResult(
+    val success: Boolean,
+    val deviceIdentifier: String? = null,
+    val errorMessage: String? = null
+)
+
+/**
+ * Result of verifying a magic link.
+ */
+data class MagicLinkVerifyResult(
+    val success: Boolean,
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+    val errorMessage: String? = null
+)
+
+/**
+ * Firebase configuration for the Hoppscotch cloud instance.
+ * These values are public (embedded in the client-side JavaScript bundle).
+ */
+data class FirebaseConfig(
+    val apiKey: String,
+    val projectId: String,
+    val authDomain: String?
+)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchExportMetadata.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchExportMetadata.kt
@@ -1,0 +1,38 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.model.ExportMetadata
+import com.itangcent.easyapi.util.text.append
+
+/**
+ * Export metadata for Hoppscotch channel results.
+ *
+ * Carries information about the exported collection through the export pipeline.
+ * Two usage patterns:
+ * - **File export** — [collectionData] is populated with the [HoppCollection] object
+ *   (not serialized), and [formatDisplay] returns null (file path is shown instead)
+ * - **Cloud upload** — [collectionName], [workspaceName], and [collectionId] are populated,
+ *   and [formatDisplay] returns a "workspace/collection" display string
+ *
+ * @property collectionName the name of the exported collection
+ * @property collectionData the collection object (for file export mode)
+ * @property workspaceName the Hoppscotch workspace/team name (for cloud upload mode)
+ * @property collectionId the Hoppscotch collection ID (for cloud upload mode)
+ */
+data class HoppscotchExportMetadata(
+    val collectionName: String? = null,
+    val collectionData: HoppCollection? = null,
+    val workspaceName: String? = null,
+    val collectionId: String? = null
+) : ExportMetadata {
+    override fun formatDisplay(): String? {
+        if (collectionData != null) {
+            return null
+        }
+
+        val workspaceDisplay = workspaceName
+        val collectionDisplay = collectionName ?: collectionId
+
+        return workspaceDisplay.append(collectionDisplay, separator = "/")
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchFormatter.kt
@@ -1,0 +1,298 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.itangcent.easyapi.exporter.hoppscotch.model.*
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.exporter.model.isHttp
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+import com.itangcent.easyapi.rule.engine.RuleEngine
+import com.itangcent.easyapi.util.json.GsonUtils
+
+/**
+ * Options for customizing the Hoppscotch collection output.
+ *
+ * @property defaultHost the default host URL used when no `hopp.host` rule is defined
+ * @property appendTimestamp whether to append a timestamp to the collection name
+ */
+data class HoppscotchFormatOptions(
+    val defaultHost: String = "https://<<host>>",
+    val appendTimestamp: Boolean = true
+)
+
+/**
+ * Converts [ApiEndpoint]s into a Hoppscotch [HoppCollection].
+ *
+ * ## Conversion logic
+ * - Endpoints are grouped by folder name into nested [HoppCollection] sub-collections
+ * - Each endpoint becomes a [HoppRESTRequest] with method, URL, params, headers, and body
+ * - Request body format is determined by Content-Type: JSON, form-urlencoded, or multipart/form-data
+ * - Pre-request and test scripts are resolved from rule keys ([HoppscotchRuleKeys])
+ * - The host URL is resolved from `hopp.host` rule, falling back to [HoppscotchFormatOptions.defaultHost]
+ * - Collection-level scripts are aggregated from `hopp.collection.prerequest` / `hopp.collection.test` rules
+ *
+ * @param project the IntelliJ project (required for [RuleEngine] access)
+ * @param options formatting options
+ * @param systemTimeProvider injectable time source (for testing)
+ * @see HoppscotchChannel for the channel that uses this formatter
+ * @see HoppscotchRuleKeys for available rule keys
+ */
+class HoppscotchFormatter(
+    private val project: Project,
+    private val options: HoppscotchFormatOptions = HoppscotchFormatOptions(),
+    private val systemTimeProvider: () -> Long = { System.currentTimeMillis() }
+) {
+    private val ruleEngine: RuleEngine by lazy { RuleEngine.getInstance(project) }
+
+    suspend fun format(endpoints: List<ApiEndpoint>, moduleName: String): HoppCollection {
+        val httpEndpoints = endpoints.filter { it.isHttp }
+        val grouped = httpEndpoints.groupBy { it.folder ?: "" }
+
+        val folders = mutableListOf<HoppCollection>()
+        val rootRequests = mutableListOf<HoppRESTRequest>()
+
+        for ((folder, list) in grouped) {
+            val requests = list.map { toRequest(it) }
+            if (folder.isBlank()) {
+                rootRequests.addAll(requests)
+            } else {
+                folders.add(
+                    HoppCollection(
+                        name = folder,
+                        requests = requests
+                    )
+                )
+            }
+        }
+
+        val collectionPreRequest = resolveCollectionScript(
+            HoppscotchRuleKeys.COLLECTION_PREREQUEST,
+            HoppscotchRuleKeys.CLASS_PREREQUEST,
+            HoppscotchRuleKeys.PREREQUEST,
+            httpEndpoints
+        )
+        val collectionTest = resolveCollectionScript(
+            HoppscotchRuleKeys.COLLECTION_TEST,
+            HoppscotchRuleKeys.CLASS_TEST,
+            HoppscotchRuleKeys.TEST,
+            httpEndpoints
+        )
+
+        val collectionName = if (options.appendTimestamp) {
+            "$moduleName-${formatTimestamp(systemTimeProvider())}"
+        } else {
+            moduleName
+        }
+
+        return HoppCollection(
+            name = collectionName,
+            folders = folders,
+            requests = rootRequests,
+            preRequestScript = collectionPreRequest,
+            testScript = collectionTest
+        )
+    }
+
+    private suspend fun toRequest(endpoint: ApiEndpoint): HoppRESTRequest {
+        val meta = endpoint.httpMetadata
+            ?: throw IllegalArgumentException("HoppscotchFormatter only supports HTTP endpoints")
+
+        val host = resolveHost(endpoint)
+        val endpointUrl = buildEndpointUrl(meta, host)
+        val params = buildParams(meta)
+        val headers = buildHeaders(meta)
+        val body = buildBody(meta)
+        val preRequestScript = resolveScript(HoppscotchRuleKeys.PREREQUEST, endpoint)
+        val testScript = resolveScript(HoppscotchRuleKeys.TEST, endpoint)
+
+        fireEvent(endpoint)
+
+        return HoppRESTRequest(
+            name = endpoint.name ?: "${meta.method.name} ${meta.path}",
+            method = meta.method.name,
+            endpoint = endpointUrl,
+            params = params,
+            headers = headers,
+            body = body,
+            preRequestScript = preRequestScript,
+            testScript = testScript,
+            description = endpoint.description
+        )
+    }
+
+    private suspend fun resolveHost(endpoint: ApiEndpoint): String {
+        val psiClass = endpoint.sourceClass
+        val hostByRule = if (psiClass != null) {
+            ruleEngine.evaluate(HoppscotchRuleKeys.HOST, psiClass)
+        } else {
+            ruleEngine.evaluate(HoppscotchRuleKeys.HOST)
+        }
+        if (!hostByRule.isNullOrBlank()) {
+            return convertToHoppscotchVarSyntax(hostByRule)
+        }
+        return options.defaultHost
+    }
+
+    private fun convertToHoppscotchVarSyntax(value: String): String {
+        return value.trim()
+            .trim('`')
+            .replace("{{", "<<")
+            .replace("}}", ">>")
+    }
+
+    private fun buildEndpointUrl(meta: HttpMetadata, host: String): String {
+        val path = meta.path.trim().let { if (it.startsWith("/")) it else "/$it" }
+        return (host.trimEnd('/') + path)
+            .trim('`')
+            .replace("{{", "<<")
+            .replace("}}", ">>")
+    }
+
+    private fun buildParams(meta: HttpMetadata): List<HoppKeyValue> {
+        return meta.parameters
+            .filter { it.binding == ParameterBinding.Query || it.binding == ParameterBinding.Path }
+            .map { param ->
+                HoppKeyValue(
+                    key = param.name,
+                    value = param.example ?: param.defaultValue ?: "",
+                    active = true,
+                    description = param.description
+                )
+            }
+    }
+
+    private fun buildHeaders(meta: HttpMetadata): List<HoppKeyValue> {
+        return meta.headers.map { header ->
+            HoppKeyValue(
+                key = header.name,
+                value = header.value ?: header.example ?: "",
+                active = true,
+                description = header.description
+            )
+        }
+    }
+
+    private fun buildBody(meta: HttpMetadata): HoppRequestBody {
+        val contentType = meta.contentType?.lowercase().orEmpty()
+        val formParams = meta.parameters.filter { it.binding == ParameterBinding.Form }
+
+        if (contentType.contains("json")) {
+            val raw = when {
+                meta.body != null -> ObjectModelJsonConverter.toJson(meta.body)
+                else -> "{}"
+            }
+            return HoppRequestBody(
+                contentType = "application/json",
+                body = raw
+            )
+        }
+
+        if (contentType.contains("x-www-form-urlencoded")) {
+            return HoppRequestBody(
+                contentType = "application/x-www-form-urlencoded",
+                body = formParams.joinToString("&") {
+                    "${java.net.URLEncoder.encode(it.name, "UTF-8")}=${java.net.URLEncoder.encode(it.example ?: it.defaultValue ?: "", "UTF-8")}"
+                }
+            )
+        }
+
+        if (contentType.contains("multipart") || contentType.contains("form-data")) {
+            return HoppRequestBody(
+                contentType = "multipart/form-data",
+                body = formParams.map {
+                    HoppFormDataEntry(
+                        key = it.name,
+                        value = it.example ?: it.defaultValue ?: "",
+                        active = true,
+                        isFile = false
+                    )
+                }
+            )
+        }
+
+        if (meta.body != null) {
+            return HoppRequestBody(
+                contentType = "application/json",
+                body = ObjectModelJsonConverter.toJson(meta.body)
+            )
+        }
+
+        return HoppRequestBody()
+    }
+
+    private suspend fun resolveScript(ruleKey: com.itangcent.easyapi.rule.RuleKey.StringKey, endpoint: ApiEndpoint): String {
+        val scripts = mutableListOf<String>()
+
+        val psiMethod = endpoint.sourceMethod
+        if (psiMethod != null) {
+            ruleEngine.evaluate(ruleKey, psiMethod)
+                ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+        }
+
+        val psiClass = endpoint.sourceClass
+        if (psiClass != null) {
+            ruleEngine.evaluate(HoppscotchRuleKeys.CLASS_PREREQUEST.let {
+                if (ruleKey == HoppscotchRuleKeys.TEST) HoppscotchRuleKeys.CLASS_TEST else it
+            }, psiClass)
+                ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+        }
+
+        return scripts.flatMap { it.lines().filter { l -> l.isNotBlank() } }.joinToString("\n")
+    }
+
+    private suspend fun resolveCollectionScript(
+        collectionKey: com.itangcent.easyapi.rule.RuleKey.EventKey,
+        classKey: com.itangcent.easyapi.rule.RuleKey.StringKey,
+        methodKey: com.itangcent.easyapi.rule.RuleKey.StringKey,
+        endpoints: List<ApiEndpoint>
+    ): String {
+        val scripts = mutableListOf<String>()
+
+        ruleEngine.evaluate(collectionKey) { ctx ->
+            ctx.setExt("collection", endpoints)
+        }
+
+        for (endpoint in endpoints) {
+            val psiClass = endpoint.sourceClass
+            if (psiClass != null) {
+                ruleEngine.evaluate(classKey, psiClass)
+                    ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+            }
+            val psiMethod = endpoint.sourceMethod
+            if (psiMethod != null) {
+                ruleEngine.evaluate(methodKey, psiMethod)
+                    ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+            }
+        }
+
+        return scripts.flatMap { it.lines().filter { l -> l.isNotBlank() } }.joinToString("\n")
+    }
+
+    private suspend fun fireEvent(endpoint: ApiEndpoint) {
+        endpoint.sourceMethod?.let { element ->
+            ruleEngine.evaluate(HoppscotchRuleKeys.FORMAT_AFTER, element) { ctx ->
+                ctx.setExt("endpoint", endpoint)
+            }
+        }
+    }
+
+    companion object {
+        fun parsePath(path: String): List<String> {
+            return path.trim().trim('/').split("/")
+        }
+
+        private fun formatTimestamp(millis: Long): String {
+            val instant = java.time.Instant.ofEpochMilli(millis)
+            val formatter = java.time.format.DateTimeFormatter
+                .ofPattern("yyyyMMddHHmmss")
+                .withZone(java.time.ZoneId.systemDefault())
+            return formatter.format(instant)
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchLoginDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchLoginDialog.kt
@@ -1,0 +1,203 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import com.intellij.openapi.components.service
+import java.awt.BorderLayout
+import java.awt.Dimension
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Dialog for logging into Hoppscotch via an embedded JCEF browser.
+ *
+ * Opens the Hoppscotch login page in a JBCefBrowser and monitors cookies to capture
+ * the `access_token` and `refresh_token` once the user successfully authenticates.
+ *
+ * Uses reflection for all JCEF/CEF API calls to avoid compile-time dependencies on
+ * classes that may not be available on all platforms (e.g., headless Linux, older IDEs).
+ *
+ * If JCEF is not available ([JBCefApp.isSupported] returns false or the class is missing),
+ * a fallback panel is shown with instructions for manual token input.
+ *
+ * The OK button is disabled until an `access_token` cookie is captured.
+ *
+ * @param project the IntelliJ project context
+ * @see HoppscotchAuthService for the service that manages the login flow
+ */
+class HoppscotchLoginDialog(
+    private val project: Project,
+    parent: java.awt.Component? = null
+) : DialogWrapper(
+    parent ?: com.intellij.openapi.wm.WindowManager.getInstance().suggestParentWindow(project)!!,
+    parent != null
+), IdeaLog {
+
+    private var accessToken: String? = null
+    private var refreshToken: String? = null
+
+    private val settingBinder: SettingBinder by lazy { project.service<SettingBinder>() }
+
+    init {
+        title = "Login to Hoppscotch"
+        setOKButtonText("Sign In")
+        setCancelButtonText("Cancel")
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = JPanel(BorderLayout())
+        panel.preferredSize = Dimension(800, 600)
+
+        try {
+            val jbcEfBrowser = createJcefBrowser()
+            if (jbcEfBrowser != null) {
+                val getComponentMethod = jbcEfBrowser.javaClass.getMethod("getComponent")
+                val browserComponent = getComponentMethod.invoke(jbcEfBrowser) as JComponent
+                panel.add(browserComponent, BorderLayout.CENTER)
+                setupCookieMonitoring(jbcEfBrowser)
+            } else {
+                panel.add(createFallbackPanel(), BorderLayout.CENTER)
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to create JCEF browser", e)
+            panel.add(createFallbackPanel(), BorderLayout.CENTER)
+        }
+
+        return panel
+    }
+
+    private fun createJcefBrowser(): Any? {
+        return try {
+            val jbCefBrowserClass = Class.forName("com.intellij.ui.jcef.JBCefBrowser")
+            val builderClass = Class.forName("com.intellij.ui.jcef.JBCefBrowserBuilder")
+            val builder = builderClass.getDeclaredConstructor().newInstance()
+            val settings = settingBinder.read()
+            val serverUrl = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+            val setUrlMethod = builderClass.getMethod("setUrl", String::class.java)
+            setUrlMethod.invoke(builder, serverUrl)
+            val buildMethod = builderClass.getMethod("build")
+            buildMethod.invoke(builder)
+        } catch (e: Exception) {
+            LOG.info("Could not create JCEF browser", e)
+            null
+        }
+    }
+
+    private fun setupCookieMonitoring(browser: Any) {
+        try {
+            val timer = javax.swing.Timer(1000) {
+                try {
+                    val cookieManagerClass = Class.forName("org.cef.browser.CefCookieManager")
+                    val getGlobalMethod = cookieManagerClass.getMethod("getGlobalManager")
+                    val manager = getGlobalMethod.invoke(null)
+                    if (manager != null) {
+                        val visitAllCookiesMethod = manager.javaClass.getMethod(
+                            "visitAllCookies",
+                            Class.forName("org.cef.network.CefCookieVisitor")
+                        )
+                        val visitor = createCookieVisitor()
+                        visitAllCookiesMethod.invoke(manager, visitor)
+                    }
+                } catch (e: Exception) {
+                    LOG.info("Cookie monitoring error", e)
+                }
+            }
+            timer.start()
+
+            val window = window
+            window.addWindowListener(object : java.awt.event.WindowAdapter() {
+                override fun windowClosed(e: java.awt.event.WindowEvent?) {
+                    timer.stop()
+                }
+            })
+        } catch (e: Exception) {
+            LOG.warn("Failed to setup cookie monitoring", e)
+        }
+    }
+
+    private fun createCookieVisitor(): Any {
+        val visitorClass = Class.forName("org.cef.network.CefCookieVisitor")
+        val proxy = java.lang.reflect.Proxy.newProxyInstance(
+            visitorClass.classLoader,
+            arrayOf(visitorClass)
+        ) { _, method, args ->
+            if (method.name == "visit") {
+                val cookie = args?.get(0) ?: return@newProxyInstance true
+                try {
+                    val nameMethod = cookie.javaClass.getMethod("getName")
+                    val valueMethod = cookie.javaClass.getMethod("getValue")
+                    val domainMethod = cookie.javaClass.getMethod("getDomain")
+                    val cookieName = nameMethod.invoke(cookie) as? String
+                    val cookieValue = valueMethod.invoke(cookie) as? String
+                    val domain = domainMethod.invoke(cookie) as? String
+
+                    val settings = settingBinder.read()
+                    val serverUrl = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+                    val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                    val serverHost = java.net.URL(serverUrl).host
+                    val backendHost = backendUrl?.let { java.net.URL(it).host }
+                    val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(serverUrl, backendUrl)
+                    val apiHost = try {
+                        java.net.URL(apiBaseUrl).host
+                    } catch (_: Exception) {
+                        null
+                    }
+
+                    val isMatchingDomain = domain != null && (
+                            domain.contains(serverHost) ||
+                                    (backendHost != null && domain.contains(backendHost)) ||
+                                    (apiHost != null && domain.contains(apiHost))
+                            )
+
+                    if (cookieName == "access_token" && isMatchingDomain) {
+                        accessToken = cookieValue
+                    }
+                    if (cookieName == "refresh_token" && isMatchingDomain) {
+                        refreshToken = cookieValue
+                    }
+                    if (accessToken != null) {
+                        LOG.info("Hoppscotch access token captured from browser")
+                    }
+                } catch (e: Exception) {
+                    LOG.info("Cookie parsing error", e)
+                }
+                args?.get(1) as? Boolean ?: true
+            } else {
+                null
+            }
+        }
+        return proxy
+    }
+
+    private fun createFallbackPanel(): JComponent {
+        val panel = JPanel(BorderLayout())
+        val label = javax.swing.JLabel(
+            "<html><body style='padding: 20px'>" +
+                    "<h2>Browser Login Not Available</h2>" +
+                    "<p>JCEF (Java Chromium Embedded Framework) is not available on this platform.</p>" +
+                    "<p>Please log in manually:</p>" +
+                    "<ol>" +
+                    "<li>Open <a href='https://hoppscotch.io'>hoppscotch.io</a> in your browser</li>" +
+                    "<li>Go to Settings &gt; Access Tokens</li>" +
+                    "<li>Create a new token and paste it in the settings</li>" +
+                    "</ol>" +
+                    "</body></html>"
+        )
+        panel.add(label, BorderLayout.CENTER)
+        return panel
+    }
+
+    override fun doOKAction() {
+        if (accessToken.isNullOrBlank()) {
+            setTitle("Login to Hoppscotch — Waiting for login...")
+            return
+        }
+        super.doOKAction()
+    }
+
+    fun getAccessToken(): String? = accessToken
+    fun getRefreshToken(): String? = refreshToken
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchLoginMethodDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchLoginMethodDialog.kt
@@ -1,0 +1,94 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.itangcent.easyapi.logging.IdeaLog
+import java.awt.BorderLayout
+import java.awt.Component
+import javax.swing.*
+
+/**
+ * Dialog for selecting a Hoppscotch login method.
+ *
+ * Presents three options:
+ * 1. **Magic Link (Recommended)** — email-based passwordless login
+ * 2. **Browser Login** — JCEF browser-based login (disabled when JCEF unavailable)
+ * 3. **Manual Token** — manual access token input
+ *
+ * @param project the IntelliJ project context
+ * @param jcefAvailable whether JCEF browser is available on this platform
+ * @see HoppscotchAuthService.login
+ */
+class HoppscotchLoginMethodDialog(
+    private val project: Project,
+    parent: Component?,
+    private val jcefAvailable: Boolean
+) : DialogWrapper(
+    parent ?: com.intellij.openapi.wm.WindowManager.getInstance().suggestParentWindow(project)!!,
+    parent != null
+), IdeaLog {
+
+    enum class Method { MAGIC_LINK, BROWSER, MANUAL_TOKEN }
+
+    private val buttonGroup = ButtonGroup()
+    private val magicLinkRadio = JRadioButton("Magic Link (Recommended)", true)
+    private val browserRadio = JRadioButton("Browser Login")
+    private val manualTokenRadio = JRadioButton("Manual Token")
+
+    init {
+        title = "Login to Hoppscotch"
+        setOKButtonText("Continue")
+        setCancelButtonText("Cancel")
+
+        buttonGroup.add(magicLinkRadio)
+        buttonGroup.add(browserRadio)
+        buttonGroup.add(manualTokenRadio)
+
+        magicLinkRadio.toolTipText = "Email-based passwordless login (supports both Cloud and Self-hosted)"
+
+        if (!jcefAvailable) {
+            browserRadio.isEnabled = false
+            browserRadio.toolTipText = "JCEF browser is not available on this platform"
+        }
+
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = JPanel()
+        panel.layout = BoxLayout(panel, BoxLayout.Y_AXIS)
+
+        panel.add(JLabel("Choose a login method:"))
+        panel.add(Box.createVerticalStrut(10))
+        panel.add(magicLinkRadio)
+        panel.add(Box.createVerticalStrut(5))
+        panel.add(browserRadio)
+        panel.add(Box.createVerticalStrut(5))
+        panel.add(manualTokenRadio)
+
+        return panel
+    }
+
+    fun getSelectedMethod(): Method {
+        return when {
+            magicLinkRadio.isSelected -> Method.MAGIC_LINK
+            browserRadio.isSelected -> Method.BROWSER
+            manualTokenRadio.isSelected -> Method.MANUAL_TOKEN
+            else -> Method.MAGIC_LINK
+        }
+    }
+
+    companion object {
+        /**
+         * Shows the login method selection dialog and returns the chosen method,
+         * or null if the user cancelled.
+         */
+        fun showDialog(project: Project, parent: Component?, jcefAvailable: Boolean): Method? {
+            val dialog = HoppscotchLoginMethodDialog(project, parent, jcefAvailable)
+            if (dialog.showAndGet()) {
+                return dialog.getSelectedMethod()
+            }
+            return null
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchMagicLinkLoginDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchMagicLinkLoginDialog.kt
@@ -1,0 +1,252 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import com.intellij.openapi.components.service
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.Dimension
+import javax.swing.*
+
+/**
+ * Multi-step dialog for Hoppscotch Magic Link authentication.
+ *
+ * Guides the user through three steps:
+ * 1. **EMAIL_INPUT** — Enter email address
+ * 2. **SENDING_LINK** — Progress indicator while sending the magic link request
+ * 3. **LINK_INPUT** — Paste the magic link URL from the email
+ *
+ * Supports both self-hosted and cloud (Firebase) authentication:
+ * - Self-hosted: magic link contains a `token` parameter
+ * - Cloud (Firebase): magic link contains an `oobCode` parameter
+ *
+ * On success, [getAccessToken] and [getRefreshToken] return the extracted tokens.
+ *
+ * @param project the IntelliJ project context
+ * @param isCloud whether this is a cloud (Firebase) login or self-hosted
+ * @see HoppscotchAuthService.loginWithMagicLink
+ */
+class HoppscotchMagicLinkLoginDialog(
+    private val project: Project,
+    parent: java.awt.Component? = null,
+    private val isCloud: Boolean = false
+) : DialogWrapper(
+    parent ?: com.intellij.openapi.wm.WindowManager.getInstance().suggestParentWindow(project)!!,
+    parent != null
+), IdeaLog {
+
+    private enum class Step { EMAIL_INPUT, SENDING_LINK, LINK_INPUT }
+
+    private var currentStep = Step.EMAIL_INPUT
+
+    private val emailField = JTextField().apply { columns = 30 }
+    private val linkUrlField = JTextField().apply { columns = 50 }
+    private val emailLabel = JLabel("Email address:")
+    private val statusLabel = JLabel(" ")
+    private val progressLabel = JLabel("Sending magic link...")
+
+    private var accessToken: String? = null
+    private var refreshToken: String? = null
+    private var deviceIdentifier: String? = null
+    private var userEmail: String? = null
+
+    private val cardLayout = CardLayout()
+    private val cardPanel = JPanel(cardLayout)
+
+    init {
+        title = "Login to Hoppscotch — Magic Link"
+        setOKButtonText("Send Magic Link")
+        setCancelButtonText("Cancel")
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        // Step 1: Email input
+        val emailPanel = JPanel().apply {
+            layout = BorderLayout()
+            add(JPanel(BorderLayout()).apply {
+                add(emailLabel, BorderLayout.WEST)
+                add(emailField, BorderLayout.CENTER)
+            }, BorderLayout.NORTH)
+            add(statusLabel, BorderLayout.SOUTH)
+        }
+
+        // Step 2: Sending link progress
+        val sendingPanel = JPanel().apply {
+            layout = BorderLayout()
+            add(progressLabel, BorderLayout.CENTER)
+        }
+
+        // Step 3: Link URL input
+        val linkPanel = JPanel().apply {
+            layout = BorderLayout()
+            val infoLabel = JLabel()
+            add(infoLabel, BorderLayout.NORTH)
+            add(JPanel(BorderLayout()).apply {
+                add(JLabel("Magic link URL:"), BorderLayout.WEST)
+                add(linkUrlField, BorderLayout.CENTER)
+            }, BorderLayout.CENTER)
+            add(statusLabel, BorderLayout.SOUTH)
+        }
+
+        cardPanel.add(emailPanel, Step.EMAIL_INPUT.name)
+        cardPanel.add(sendingPanel, Step.SENDING_LINK.name)
+        cardPanel.add(linkPanel, Step.LINK_INPUT.name)
+
+        val panel = JPanel(BorderLayout())
+        panel.preferredSize = Dimension(500, 150)
+        panel.add(cardPanel, BorderLayout.CENTER)
+        return panel
+    }
+
+    /**
+     * Transitions to the "sending link" step.
+     * Called by [HoppscotchAuthService] after the user submits their email.
+     */
+    fun showSendingStep() {
+        currentStep = Step.SENDING_LINK
+        cardLayout.show(cardPanel, Step.SENDING_LINK.name)
+        isOKActionEnabled = false
+    }
+
+    /**
+     * Transitions to the "link input" step after the magic link was sent successfully.
+     *
+     * @param deviceIdentifier the device identifier from the signin response
+     * @param email the email address the magic link was sent to
+     */
+    fun showLinkInputStep(deviceIdentifier: String, email: String) {
+        this.deviceIdentifier = deviceIdentifier
+        this.userEmail = email
+        currentStep = Step.LINK_INPUT
+        cardLayout.show(cardPanel, Step.LINK_INPUT.name)
+        setOKButtonText("Sign In")
+        isOKActionEnabled = true
+        statusLabel.text = " "
+    }
+
+    /**
+     * Shows an error and returns to the email input step.
+     *
+     * @param message the error message to display
+     */
+    fun showEmailError(message: String) {
+        currentStep = Step.EMAIL_INPUT
+        cardLayout.show(cardPanel, Step.EMAIL_INPUT.name)
+        setOKButtonText("Send Magic Link")
+        isOKActionEnabled = true
+        statusLabel.text = message
+    }
+
+    /**
+     * Shows an error on the link input step.
+     *
+     * @param message the error message to display
+     */
+    fun showLinkError(message: String) {
+        statusLabel.text = message
+        isOKActionEnabled = true
+    }
+
+    /**
+     * Called when login succeeds — stores tokens and closes the dialog.
+     */
+    fun onLoginSuccess(accessToken: String?, refreshToken: String?) {
+        this.accessToken = accessToken
+        this.refreshToken = refreshToken
+        close(OK_EXIT_CODE)
+    }
+
+    fun getAccessToken(): String? = accessToken
+    fun getRefreshToken(): String? = refreshToken
+    fun getDeviceIdentifier(): String? = deviceIdentifier
+    fun getEmail(): String = emailField.text.trim()
+    fun getLinkUrl(): String = linkUrlField.text.trim()
+
+    override fun doOKAction() {
+        when (currentStep) {
+            Step.EMAIL_INPUT -> {
+                val email = emailField.text.trim()
+                if (email.isBlank()) {
+                    statusLabel.text = "Please enter your email address."
+                    return
+                }
+                if (!isValidEmail(email)) {
+                    statusLabel.text = "Please enter a valid email address."
+                    return
+                }
+                // Notify the service to send the magic link
+                onEmailSubmitted?.invoke(email)
+            }
+            Step.LINK_INPUT -> {
+                val url = linkUrlField.text.trim()
+                if (url.isBlank()) {
+                    statusLabel.text = "Please paste the magic link URL from your email."
+                    return
+                }
+                // Validate the URL contains the expected parameter
+                val hasValidParam = if (isCloud) {
+                    extractOobCodeFromUrl(url) != null
+                } else {
+                    extractTokenFromUrl(url) != null
+                }
+                if (!hasValidParam) {
+                    if (isCloud) {
+                        statusLabel.text = "Invalid magic link URL. Please paste the full URL from the email (should contain oobCode parameter)."
+                    } else {
+                        statusLabel.text = "Invalid magic link URL. Please paste the full URL from the email (should contain token parameter)."
+                    }
+                    return
+                }
+                // Pass the full URL to the service, which will extract the appropriate parameter
+                onLinkSubmitted?.invoke(url)
+            }
+            Step.SENDING_LINK -> {
+                // No action during sending
+            }
+        }
+    }
+
+    /**
+     * Callback invoked when the user submits their email.
+     * Set by [HoppscotchAuthService] to handle the API call.
+     */
+    var onEmailSubmitted: ((String) -> Unit)? = null
+
+    /**
+     * Callback invoked when the user submits the magic link URL.
+     * Set by [HoppscotchAuthService] to handle the verification API call.
+     * The parameter is the full URL from the email.
+     */
+    var onLinkSubmitted: ((String) -> Unit)? = null
+
+    companion object {
+        private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
+
+        fun isValidEmail(email: String): Boolean = EMAIL_REGEX.matches(email)
+
+        /**
+         * Extracts the `token` query parameter from a self-hosted magic link URL.
+         *
+         * @param url the full URL from the email, e.g. "https://example.com/enter?token=abc123"
+         * @return the token value, or null if not found
+         */
+        fun extractTokenFromUrl(url: String): String? {
+            val match = Regex("[?&]token=([^&]+)").find(url)
+            return match?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+        }
+
+        /**
+         * Extracts the `oobCode` query parameter from a Firebase magic link URL.
+         *
+         * @param url the full URL from the email, e.g. "https://hoppscotch.io/enter?oobCode=XXX&..."
+         * @return the oobCode value, or null if not found
+         */
+        fun extractOobCodeFromUrl(url: String): String? {
+            val match = Regex("[?&]oobCode=([^&]+)").find(url)
+            return match?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchRuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchRuleKeys.kt
@@ -1,0 +1,34 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.itangcent.easyapi.rule.RuleKeys
+
+/**
+ * Aliases for Hoppscotch-specific rule keys defined in [RuleKeys].
+ *
+ * These rule keys allow users to customize Hoppscotch export behavior via
+ * the rule engine (e.g., in `.easy.api.yml` files):
+ *
+ * | Rule Key | Purpose |
+ * |----------|---------|
+ * | `hopp.prerequest` | Pre-request script for a method |
+ * | `hopp.class.prerequest` | Pre-request script for all methods in a class |
+ * | `hopp.collection.prerequest` | Pre-request script for the entire collection |
+ * | `hopp.test` | Test script for a method |
+ * | `hopp.class.test` | Test script for all methods in a class |
+ * | `hopp.collection.test` | Test script for the entire collection |
+ * | `hopp.host` | Base URL override for endpoints |
+ * | `hopp.format.after` | Post-format hook |
+ *
+ * @see RuleKeys for the canonical key definitions
+ * @see HoppscotchFormatter for how these keys are resolved
+ */
+object HoppscotchRuleKeys {
+    val PREREQUEST = RuleKeys.HOPP_PREREQUEST
+    val CLASS_PREREQUEST = RuleKeys.HOPP_CLASS_PREREQUEST
+    val COLLECTION_PREREQUEST = RuleKeys.HOPP_COLLECTION_PREREQUEST
+    val TEST = RuleKeys.HOPP_TEST
+    val CLASS_TEST = RuleKeys.HOPP_CLASS_TEST
+    val COLLECTION_TEST = RuleKeys.HOPP_COLLECTION_TEST
+    val HOST = RuleKeys.HOPP_HOST
+    val FORMAT_AFTER = RuleKeys.HOPP_FORMAT_AFTER
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/model/HoppscotchModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/hoppscotch/model/HoppscotchModels.kt
@@ -1,0 +1,200 @@
+package com.itangcent.easyapi.exporter.hoppscotch.model
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+
+/**
+ * Represents a Hoppscotch collection (schema v12).
+ *
+ * Collections can be nested: top-level collections contain folders (sub-collections)
+ * and requests. Each collection may define pre-request scripts, test scripts,
+ * collection variables, auth, and headers.
+ *
+ * @property v schema version (always 12 for collections, as Int per Hoppscotch spec)
+ * @property name display name of the collection
+ * @property folders nested sub-collections (used as folder grouping)
+ * @property requests REST requests at this level
+ * @property auth authentication configuration for this collection
+ * @property headers headers applied to all requests in this collection
+ * @property variables collection-level variables
+ * @property description optional description
+ * @property preRequestScript pre-request script (HoppScript / JavaScript)
+ * @property testScript test script (HoppScript / JavaScript)
+ */
+data class HoppCollection(
+    val v: Int = 12,
+    val name: String,
+    val _ref_id: String = generateUniqueRefId("coll"),
+    val folders: List<HoppCollection> = emptyList(),
+    val requests: List<HoppRESTRequest> = emptyList(),
+    val auth: HoppAuth = HoppAuth(),
+    val headers: List<HoppKeyValue> = emptyList(),
+    val variables: List<HoppCollectionVariable> = emptyList(),
+    val description: String? = null,
+    val preRequestScript: String = "",
+    val testScript: String = ""
+)
+
+/**
+ * Represents a Hoppscotch REST request (schema v17).
+ *
+ * @property v schema version (always "17" for requests, as String per Hoppscotch spec)
+ * @property name display name of the request
+ * @property method HTTP method (GET, POST, PUT, DELETE, etc.)
+ * @property endpoint full URL (may include Hoppscotch variables like `{{host}}`)
+ * @property params query and path parameters
+ * @property headers request headers
+ * @property auth request-level authentication override
+ * @property body request body (JSON, form-data, etc.)
+ * @property preRequestScript pre-request script for this request
+ * @property testScript test script for this request
+ * @property requestVariables request-scoped variables
+ * @property responses saved response examples
+ * @property description optional description
+ */
+data class HoppRESTRequest(
+    val v: String = "17",
+    val name: String,
+    val method: String,
+    val endpoint: String,
+    val _ref_id: String = generateUniqueRefId("req"),
+    val params: List<HoppKeyValue> = emptyList(),
+    val headers: List<HoppKeyValue> = emptyList(),
+    val auth: HoppAuth = HoppAuth(),
+    val body: HoppRequestBody = HoppRequestBody(),
+    val preRequestScript: String = "",
+    val testScript: String = "",
+    val requestVariables: List<HoppRequestVariable> = emptyList(),
+    val responses: Map<String, Any?> = emptyMap(),
+    val description: String? = null
+)
+
+/**
+ * A key-value pair used for parameters, headers, and other name-value entries.
+ *
+ * @property key the parameter/header name
+ * @property value the parameter/header value
+ * @property active whether this entry is enabled
+ * @property description optional description
+ */
+data class HoppKeyValue(
+    val key: String,
+    val value: String = "",
+    val active: Boolean = true,
+    val description: String? = null
+)
+
+/**
+ * Authentication configuration for a Hoppscotch request or collection.
+ *
+ * @property authType authentication type (e.g., "inherit", "bearer", "basic", "oauth2", "api-key", "none")
+ * @property authActive whether authentication is enabled
+ */
+data class HoppAuth(
+    val authType: String = "inherit",
+    val authActive: Boolean = true
+)
+
+/**
+ * Request body configuration.
+ *
+ * The [contentType] determines how [body] is interpreted:
+ * - `"application/json"` → [body] is a JSON string
+ * - `"application/x-www-form-urlencoded"` → [body] is a Map of key-value pairs
+ * - `"multipart/form-data"` → [body] is a List of [HoppFormDataEntry]
+ * - `null` → no body
+ *
+ * Null fields are serialized via `serializeNulls()` in [hoppscotchGson] to match
+ * Hoppscotch's expected schema.
+ *
+ * @property contentType the Content-Type header value, or null for no body
+ * @property body the body content (type depends on contentType)
+ */
+data class HoppRequestBody(
+    val contentType: String? = null,
+    val body: Any? = null
+)
+
+/**
+ * A collection-level variable in Hoppscotch.
+ *
+ * Collection variables are accessible to all requests within the collection
+ * via the `<<key>>` syntax.
+ *
+ * @property key variable name
+ * @property initialValue default value (used when first creating the variable)
+ * @property currentValue active value (used during request execution)
+ * @property secret whether this variable contains sensitive data
+ */
+data class HoppCollectionVariable(
+    val key: String,
+    val initialValue: String = "",
+    val currentValue: String = "",
+    val secret: Boolean = false
+)
+
+/**
+ * A request-scoped variable in Hoppscotch.
+ *
+ * @property key variable name
+ * @property value variable value
+ * @property active whether this variable is enabled
+ */
+data class HoppRequestVariable(
+    val key: String,
+    val value: String = "",
+    val active: Boolean = true
+)
+
+/**
+ * A form-data entry for multipart/form-data request bodies.
+ *
+ * Matches Hoppscotch's FormDataKeyValue Zod schema:
+ * - `key` and `active` are always present
+ * - `contentType` is optional
+ * - `isFile` determines whether `value` is a file reference or a plain string
+ * - When `isFile` is false, `value` is a string
+ *
+ * @property key field name
+ * @property value field value (string when isFile is false)
+ * @property active whether this entry is enabled
+ * @property isFile whether this entry represents a file upload
+ * @property contentType optional content type for this entry
+ */
+data class HoppFormDataEntry(
+    val key: String,
+    val value: String = "",
+    val active: Boolean = true,
+    val isFile: Boolean = false,
+    val contentType: String? = null
+)
+
+/**
+ * Creates a Gson instance configured for Hoppscotch JSON serialization.
+ *
+ * Key configuration:
+ * - `serializeNulls()` — ensures null fields in [HoppRequestBody] are included
+ *   (required by Hoppscotch's schema)
+ * - Optional pretty printing for file export readability
+ *
+ * @param prettyPrint whether to enable pretty-printed JSON output
+ * @return a configured Gson instance
+ */
+fun hoppscotchGson(prettyPrint: Boolean = true): Gson {
+    val builder = GsonBuilder()
+    if (prettyPrint) {
+        builder.setPrettyPrinting()
+    }
+    builder.serializeNulls()
+    return builder.create()
+}
+
+fun generateUniqueRefId(prefix: String = ""): String {
+    val timestamp = System.currentTimeMillis().toString(36)
+    val uuid = java.util.UUID.randomUUID().toString()
+    return if (prefix.isNotEmpty()) {
+        "${prefix}_${timestamp}_${uuid}"
+    } else {
+        "${timestamp}_${uuid}"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ide/dialog/ExportDialogPreferences.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/dialog/ExportDialogPreferences.kt
@@ -22,7 +22,9 @@ data class ExportDialogPreferences(
     val lastPostmanWorkspaceId: String? = null,
     val lastPostmanWorkspaceName: String? = null,
     val lastPostmanCollectionId: String? = null,
-    val lastPostmanCollectionName: String? = null
+    val lastPostmanCollectionName: String? = null,
+    val lastHoppscotchCollectionId: String? = null,
+    val lastHoppscotchCollectionName: String? = null
 )
 
 /**

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
@@ -102,6 +102,19 @@ object RuleKeys {
     val POSTMAN_HOST = RuleKey.string("postman.host")
     val POSTMAN_FORMAT_AFTER = RuleKey.event("postman.format.after", EventRuleMode.THROW_IN_ERROR)
 
+    // ── Hoppscotch rules ──────────────────────────────────────────
+    val HOPP_PREREQUEST = RuleKey.string("hopp.prerequest", StringRuleMode.MERGE)
+    val HOPP_CLASS_PREREQUEST =
+        RuleKey.string("hopp.class.prerequest", StringRuleMode.MERGE, aliases = listOf("class.hopp.prerequest"))
+    val HOPP_COLLECTION_PREREQUEST =
+        RuleKey.event("hopp.collection.prerequest", aliases = listOf("collection.hopp.prerequest"))
+    val HOPP_TEST = RuleKey.string("hopp.test", StringRuleMode.MERGE)
+    val HOPP_CLASS_TEST =
+        RuleKey.string("hopp.class.test", StringRuleMode.MERGE, aliases = listOf("class.hopp.test"))
+    val HOPP_COLLECTION_TEST = RuleKey.event("hopp.collection.test", aliases = listOf("collection.hopp.test"))
+    val HOPP_HOST = RuleKey.string("hopp.host")
+    val HOPP_FORMAT_AFTER = RuleKey.event("hopp.format.after", EventRuleMode.THROW_IN_ERROR)
+
     // ── Enum rules ────────────────────────────────────────────────
     val ENUM_USE_CUSTOM = RuleKey.string("enum.use.custom")
     val CONSTANT_FIELD_IGNORE = RuleKey.boolean("constant.field.ignore")

--- a/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
@@ -57,7 +57,11 @@ data class Settings(
     override var concurrentScanEnabled: Boolean = false,
     override var gutterIconEnabled: Boolean = true,
     override var projectEnvironments: String = "",
-    override var globalEnvironments: String = ""
+    override var globalEnvironments: String = "",
+    override var hoppscotchToken: String? = null,
+    override var hoppscotchServerUrl: String? = "https://hoppscotch.io",
+    override var hoppscotchBackendUrl: String? = null,
+    override var hoppscotchRefreshToken: String? = null
 ) : ProjectSettingsSupport, ApplicationSettingsSupport {
 
     companion object {
@@ -109,6 +113,10 @@ data class Settings(
         if (gutterIconEnabled != other.gutterIconEnabled) return false
         if (projectEnvironments != other.projectEnvironments) return false
         if (globalEnvironments != other.globalEnvironments) return false
+        if (hoppscotchToken != other.hoppscotchToken) return false
+        if (hoppscotchServerUrl != other.hoppscotchServerUrl) return false
+        if (hoppscotchBackendUrl != other.hoppscotchBackendUrl) return false
+        if (hoppscotchRefreshToken != other.hoppscotchRefreshToken) return false
 
         return true
     }
@@ -151,6 +159,10 @@ data class Settings(
         result = 31 * result + gutterIconEnabled.hashCode()
         result = 31 * result + projectEnvironments.hashCode()
         result = 31 * result + globalEnvironments.hashCode()
+        result = 31 * result + (hoppscotchToken?.hashCode() ?: 0)
+        result = 31 * result + (hoppscotchServerUrl?.hashCode() ?: 0)
+        result = 31 * result + (hoppscotchBackendUrl?.hashCode() ?: 0)
+        result = 31 * result + (hoppscotchRefreshToken?.hashCode() ?: 0)
         return result
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -57,7 +57,11 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         override var grpcRepositories: Array<String> = emptyArray(),
         override var concurrentScanEnabled: Boolean = false,
         override var gutterIconEnabled: Boolean = true,
-        override var globalEnvironments: String = ""
+        override var globalEnvironments: String = "",
+        override var hoppscotchToken: String? = null,
+        override var hoppscotchServerUrl: String? = "https://hoppscotch.io",
+        override var hoppscotchBackendUrl: String? = null,
+        override var hoppscotchRefreshToken: String? = null
     ) : ApplicationSettingsSupport {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -97,6 +101,10 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             if (concurrentScanEnabled != other.concurrentScanEnabled) return false
             if (gutterIconEnabled != other.gutterIconEnabled) return false
             if (globalEnvironments != other.globalEnvironments) return false
+            if (hoppscotchToken != other.hoppscotchToken) return false
+            if (hoppscotchServerUrl != other.hoppscotchServerUrl) return false
+            if (hoppscotchBackendUrl != other.hoppscotchBackendUrl) return false
+            if (hoppscotchRefreshToken != other.hoppscotchRefreshToken) return false
 
             return true
         }
@@ -134,6 +142,10 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             result = 31 * result + concurrentScanEnabled.hashCode()
             result = 31 * result + gutterIconEnabled.hashCode()
             result = 31 * result + globalEnvironments.hashCode()
+            result = 31 * result + (hoppscotchToken?.hashCode() ?: 0)
+            result = 31 * result + (hoppscotchServerUrl?.hashCode() ?: 0)
+            result = 31 * result + (hoppscotchBackendUrl?.hashCode() ?: 0)
+            result = 31 * result + (hoppscotchRefreshToken?.hashCode() ?: 0)
             return result
         }
     }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
@@ -69,6 +69,10 @@ interface ApplicationSettingsSupport {
     /** When true, show gutter icon on API methods for opening in API Dashboard */
     var gutterIconEnabled: Boolean
     var globalEnvironments: String
+    var hoppscotchToken: String?
+    var hoppscotchServerUrl: String?
+    var hoppscotchBackendUrl: String?
+    var hoppscotchRefreshToken: String?
 
     fun copyTo(newSetting: ApplicationSettingsSupport) {
         newSetting.postmanToken = this.postmanToken
@@ -103,6 +107,10 @@ interface ApplicationSettingsSupport {
         newSetting.concurrentScanEnabled = this.concurrentScanEnabled
         newSetting.gutterIconEnabled = this.gutterIconEnabled
         newSetting.globalEnvironments = this.globalEnvironments
+        newSetting.hoppscotchToken = this.hoppscotchToken
+        newSetting.hoppscotchServerUrl = this.hoppscotchServerUrl
+        newSetting.hoppscotchBackendUrl = this.hoppscotchBackendUrl
+        newSetting.hoppscotchRefreshToken = this.hoppscotchRefreshToken
     }
 }
 

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/EasyApiSettingsConfigurable.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/EasyApiSettingsConfigurable.kt
@@ -25,6 +25,7 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
     private val builtInPanel = BuiltInConfigPanel()
     private val otherPanel = OtherSettingsPanel()
     private val grpcPanel = GrpcSettingsPanel(project)
+    private val hoppscotchPanel = HoppscotchSettingsPanel(project)
     private val environmentPanel = EnvironmentSettingsPanel(project)
 
     companion object {
@@ -43,6 +44,7 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         const val TAB_BUILT_IN = "Built-in"
         const val TAB_OTHER = "Other"
         const val TAB_GRPC = "gRPC"
+        const val TAB_HOPPSCOTCH = "Hoppscotch (Beta)"
         const val TAB_ENVIRONMENT = "Environments"
     }
 
@@ -67,6 +69,7 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
                 t.addTab(TAB_BUILT_IN, builtInPanel.component)
                 t.addTab(TAB_OTHER, otherPanel.component)
                 t.addTab(TAB_GRPC, wrapNorth(grpcPanel.component))
+                t.addTab(TAB_HOPPSCOTCH, wrapNorth(hoppscotchPanel.component))
                 t.addTab(TAB_ENVIRONMENT, environmentPanel.component)
             }
             panel!!.add(tabs, BorderLayout.CENTER)
@@ -111,7 +114,7 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         val settings = settingBinder.read()
         return listOf(
             generalPanel, postmanPanel, httpPanel,
-            intelligentPanel, extensionPanel, remotePanel, builtInPanel, otherPanel, grpcPanel, environmentPanel
+            intelligentPanel, extensionPanel, remotePanel, builtInPanel, otherPanel, grpcPanel, hoppscotchPanel, environmentPanel
         ).any { it.isModified(settings) }
     }
 
@@ -129,6 +132,7 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         builtInPanel.applyTo(settings)
         otherPanel.applyTo(settings)
         grpcPanel.applyTo(settings)
+        hoppscotchPanel.applyTo(settings)
         environmentPanel.applyTo(settings)
         settingBinder.save(settings)
     }
@@ -147,6 +151,7 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         builtInPanel.resetFrom(settings)
         otherPanel.resetFrom(settings)
         grpcPanel.resetFrom(settings)
+        hoppscotchPanel.resetFrom(settings)
         environmentPanel.resetFrom(settings)
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -1081,3 +1081,127 @@ private fun createTitledPanel(title: String, components: List<JComponent>): JPan
         add(inner, BorderLayout.CENTER)
     }
 }
+
+class HoppscotchSettingsPanel(private val project: com.intellij.openapi.project.Project) : SettingsPanel {
+    private val serverUrlField = JBTextField().apply {
+        text = "https://hoppscotch.io"
+        columns = 40
+        toolTipText = "Hoppscotch server URL (use custom URL for self-hosted instances)"
+    }
+    private val backendUrlField = JBTextField().apply {
+        columns = 40
+        toolTipText = "Backend API URL for self-hosted instances (e.g., http://localhost:3170/v1). Leave empty for cloud (hoppscotch.io)."
+    }
+    private val loginButton = JButton("Login to Hoppscotch (Beta)").apply {
+        toolTipText = "Open browser to login to Hoppscotch and capture access token (Beta feature)"
+    }
+    private val tokenStatusLabel = JLabel("Not logged in").apply {
+        foreground = UIUtil.getInactiveTextColor()
+    }
+    private val logoutButton = JButton("Logout").apply {
+        toolTipText = "Clear stored Hoppscotch access token"
+        isEnabled = false
+    }
+    private val manualTokenField = JBPasswordField().apply {
+        columns = 40
+        toolTipText = "Manually enter Hoppscotch access token (fallback when browser login is not available)"
+    }
+
+    init {
+        loginButton.addActionListener { performLogin() }
+        logoutButton.addActionListener { performLogout() }
+    }
+
+    private fun performLogin() {
+        loginButton.isEnabled = false
+        loginButton.text = "Logging in..."
+        val parentWindow = javax.swing.SwingUtilities.getWindowAncestor(loginButton)
+        thread {
+            try {
+                val authService = com.itangcent.easyapi.exporter.hoppscotch.HoppscotchAuthService.getInstance()
+                val success = kotlinx.coroutines.runBlocking { authService.login(project, parentWindow) }
+                SwingUtilities.invokeLater {
+                    if (success) {
+                        updateTokenStatus()
+                        Messages.showInfoMessage(project, "Successfully logged in to Hoppscotch!", "Login Success")
+                    } else {
+                        Messages.showWarningDialog(project, "Login was cancelled or failed.", "Login Failed")
+                    }
+                    loginButton.isEnabled = true
+                    loginButton.text = "Login to Hoppscotch (Beta)"
+                }
+            } catch (e: Exception) {
+                SwingUtilities.invokeLater {
+                    Messages.showErrorDialog(project, "Login failed: ${e.message}", "Login Error")
+                    loginButton.isEnabled = true
+                    loginButton.text = "Login to Hoppscotch (Beta)"
+                }
+            }
+        }
+    }
+
+    private fun performLogout() {
+        val authService = com.itangcent.easyapi.exporter.hoppscotch.HoppscotchAuthService.getInstance()
+        authService.logout(project)
+        updateTokenStatus()
+        Messages.showInfoMessage(project, "Logged out of Hoppscotch.", "Logout")
+    }
+
+    private fun updateTokenStatus() {
+        val settingBinder = com.itangcent.easyapi.settings.SettingBinder.getInstance(project)
+        val settings = settingBinder.read()
+        val token = settings.hoppscotchToken
+        if (token.isNullOrBlank()) {
+            tokenStatusLabel.text = "Not logged in"
+            tokenStatusLabel.foreground = UIUtil.getInactiveTextColor()
+            logoutButton.isEnabled = false
+        } else {
+            tokenStatusLabel.text = "Logged in (token: ${token.take(8)}...)"
+            tokenStatusLabel.foreground = java.awt.Color(java.awt.Color.green.darker().rgb)
+            logoutButton.isEnabled = true
+        }
+    }
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addLabeledComponent("Server URL:", serverUrlField)
+        .addLabeledComponent("Backend URL (self-hosted only):", backendUrlField)
+        .addComponent(createLoginPanel())
+        .addLabeledComponent("Manual Token (fallback):", manualTokenField)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    private fun createLoginPanel(): JPanel {
+        return JPanel(BorderLayout(8, 0)).apply {
+            add(JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply {
+                add(loginButton)
+                add(logoutButton)
+            }, BorderLayout.WEST)
+            add(tokenStatusLabel, BorderLayout.CENTER)
+        }
+    }
+
+    override fun resetFrom(settings: Settings?) {
+        serverUrlField.text = settings?.hoppscotchServerUrl ?: "https://hoppscotch.io"
+        backendUrlField.text = settings?.hoppscotchBackendUrl ?: ""
+        manualTokenField.text = settings?.hoppscotchToken ?: ""
+        updateTokenStatus()
+    }
+
+    override fun applyTo(settings: Settings) {
+        settings.hoppscotchServerUrl = serverUrlField.text.takeIf { it.isNotBlank() }
+        settings.hoppscotchBackendUrl = backendUrlField.text.takeIf { it.isNotBlank() }
+        val manualToken = String(manualTokenField.password).takeIf { it.isNotBlank() }
+        if (manualToken != null && settings.hoppscotchToken.isNullOrBlank()) {
+            settings.hoppscotchToken = manualToken
+        }
+    }
+
+    override fun isModified(settings: Settings?): Boolean {
+        val s = settings ?: return false
+        return serverUrlField.text != (s.hoppscotchServerUrl ?: "https://hoppscotch.io") ||
+                backendUrlField.text != (s.hoppscotchBackendUrl ?: "") ||
+                (String(manualTokenField.password).takeIf { it.isNotBlank() } != s.hoppscotchToken && s.hoppscotchToken.isNullOrBlank())
+    }
+
+    companion object : IdeaLog
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,6 +35,7 @@
         <apiChannel implementation="com.itangcent.easyapi.exporter.channel.postman.PostmanChannel"/>
         <apiChannel implementation="com.itangcent.easyapi.exporter.channel.curl.CurlChannel"/>
         <apiChannel implementation="com.itangcent.easyapi.exporter.channel.httpclient.HttpClientChannel"/>
+        <apiChannel implementation="com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchChannel"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/main/resources/pluginDescription.html
+++ b/src/main/resources/pluginDescription.html
@@ -4,7 +4,7 @@
 <a href="https://github.com/tangcent/easy-api/issues">Issues</a> |
 <br/>
 <br/>
-<b>Export API to Postman / Markdown / Curl / HttpClient</b>
+<b>Export API to Postman / Hoppscotch (Beta) / Markdown / Curl / HttpClient</b>
 <br/>
 <ul>
     <li>Parse API documents from Javadoc, KDoc &amp; ScalaDoc</li>
@@ -17,7 +17,7 @@
 <ol>
     <li>Right-click on a controller file, class, or method in the editor or project view</li>
     <li>Select <b>Export API</b> from the context menu</li>
-    <li>Choose the target channel (Postman / Markdown / Curl / HttpClient)</li>
+    <li>Choose the target channel (Postman / Hoppscotch (Beta) / Markdown / Curl / HttpClient)</li>
     <li>The APIs will be exported automatically</li>
 </ol>
 <br/>

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/ChannelConfigTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/ChannelConfigTest.kt
@@ -120,10 +120,12 @@ class ChannelConfigTest {
             is ChannelConfig.Empty -> "empty"
             is ChannelConfig.FileConfig -> "file:${config.fileName}"
             is ChannelConfig.PostmanConfig -> "postman:${config.collectionName}"
+            is ChannelConfig.HoppscotchConfig -> "hoppscotch:${config.collectionName}"
         }
 
         assertEquals("empty", describe(ChannelConfig.Empty))
         assertEquals("file:api.md", describe(ChannelConfig.FileConfig(fileName = "api.md")))
         assertEquals("postman:MyAPI", describe(ChannelConfig.PostmanConfig(collectionName = "MyAPI")))
+        assertEquals("hoppscotch:MyAPI", describe(ChannelConfig.HoppscotchConfig(collectionName = "MyAPI")))
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannelTest.kt
@@ -1,0 +1,62 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.ApiChannel
+import com.itangcent.easyapi.exporter.channel.ApiChannelRegistry
+import com.itangcent.easyapi.exporter.hoppscotch.HoppscotchExportMetadata
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppRESTRequest
+import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+
+class HoppscotchChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var channel: HoppscotchChannel
+
+    override fun setUp() {
+        super.setUp()
+        channel = HoppscotchChannel()
+    }
+
+    fun testChannelProperties() {
+        assertEquals("hoppscotch", channel.id)
+        assertEquals("Hoppscotch (Beta)", channel.displayName)
+        assertFalse(channel.supportsGrpc)
+        assertTrue(channel.exposeAsAction)
+        assertEquals("Export to Hoppscotch (Beta)", channel.actionText)
+    }
+
+    fun testChannelRegistered() {
+        val registry = ApiChannelRegistry.getInstance(project)
+        val channels = registry.getAvailableChannels(emptyList())
+        val hoppscotchChannel = channels.find { it.id == "hoppscotch" }
+        assertNotNull("Hoppscotch channel should be registered", hoppscotchChannel)
+        assertEquals("Hoppscotch (Beta)", hoppscotchChannel!!.displayName)
+    }
+
+    fun testCreateOptionsPanelReturnsNonNull() {
+        val panel = channel.createOptionsPanel(project)
+        assertNotNull("Options panel should not be null", panel)
+    }
+
+    fun testCountRequests() {
+        val collection = HoppCollection(
+            name = "Root",
+            requests = listOf(
+                HoppRESTRequest(name = "R1", method = "GET", endpoint = "/r1"),
+                HoppRESTRequest(name = "R2", method = "POST", endpoint = "/r2")
+            ),
+            folders = listOf(
+                HoppCollection(
+                    name = "Sub",
+                    requests = listOf(
+                        HoppRESTRequest(name = "R3", method = "PUT", endpoint = "/r3")
+                    )
+                )
+            )
+        )
+        val method = HoppscotchChannel::class.java.getDeclaredMethod("countRequests", HoppCollection::class.java)
+        method.isAccessible = true
+        val count = method.invoke(channel, collection) as Int
+        assertEquals(3, count)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchApiClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchApiClientTest.kt
@@ -1,0 +1,367 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.google.gson.JsonObject
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppRESTRequest
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.HttpResponse
+import com.itangcent.easyapi.util.json.GsonUtils
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class HoppscotchApiClientTest {
+
+    private lateinit var mockHttpClient: MockHttpClient
+    private lateinit var client: HoppscotchApiClient
+
+    @Before
+    fun setUp() {
+        mockHttpClient = MockHttpClient()
+        client = HoppscotchApiClient(
+            token = "test-token-123",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+    }
+
+    @Test
+    fun `testConnection returns true for valid response`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        assertTrue(client.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false for error response`() = runBlocking {
+        val errors = """{"errors":[{"message":"Unauthorized"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errors)
+        assertFalse(client.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        assertFalse(blankTokenClient.testConnection())
+    }
+
+    @Test
+    fun `listTeams returns teams from valid response`() = runBlocking {
+        val teamsData = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team1", "name" to "Team A"),
+                mapOf("id" to "team2", "name" to "Team B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData)
+        val teams = client.listTeams()
+        assertEquals(2, teams.size)
+        assertEquals("team1", teams[0].id)
+        assertEquals("Team A", teams[0].name)
+        assertEquals("team2", teams[1].id)
+        assertEquals("Team B", teams[1].name)
+    }
+
+    @Test
+    fun `listTeams returns empty for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        assertTrue(blankTokenClient.listTeams().isEmpty())
+    }
+
+    @Test
+    fun `listCollections returns collections from valid response`() = runBlocking {
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col1", "title" to "Collection A"),
+                mapOf("id" to "col2", "title" to "Collection B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+        val collections = client.listCollections()
+        assertEquals(2, collections.size)
+        assertEquals("col1", collections[0].id)
+        assertEquals("Collection A", collections[0].name)
+    }
+
+    @Test
+    fun `listCollections with teamId includes teamID in query`() = runBlocking {
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(emptyList<Map<String, String>>()))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+        client.listCollections(teamId = "team1")
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertTrue(lastRequest!!.body!!.contains("teamID"))
+    }
+
+    @Test
+    fun `uploadCollection returns success for valid response`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "new-col-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+        val collection = HoppCollection(
+            name = "Test Collection",
+            requests = listOf(HoppRESTRequest(name = "GET /api", method = "GET", endpoint = "/api"))
+        )
+        val result = client.uploadCollection(collection)
+        assertTrue(result.success)
+        assertEquals("new-col-1", result.collectionId)
+    }
+
+    @Test
+    fun `uploadCollection with teamId uses importCollectionsFromJSON`() = runBlocking {
+        val importData = JsonObject().apply {
+            addProperty("importCollectionsFromJSON", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+        val collection = HoppCollection(name = "Team Collection")
+        val result = client.uploadCollection(collection, teamId = "team1")
+        assertTrue(result.success)
+        assertNull(result.collectionId) // Team import returns Boolean, no collection ID
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertTrue(lastRequest!!.body!!.contains("importCollectionsFromJSON"))
+        assertTrue(lastRequest.body!!.contains("teamID"))
+    }
+
+    @Test
+    fun `uploadCollection returns failure for GraphQL errors`() = runBlocking {
+        val errorBody = """{"errors":[{"message":"Collection name already exists"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errorBody)
+        val collection = HoppCollection(name = "Test")
+        val result = client.uploadCollection(collection)
+        assertFalse(result.success)
+        assertEquals("Collection name already exists", result.message)
+    }
+
+    @Test
+    fun `uploadCollection returns failure for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        val collection = HoppCollection(name = "Test")
+        val result = blankTokenClient.uploadCollection(collection)
+        assertFalse(result.success)
+        assertEquals("No access token configured", result.message)
+    }
+
+    @Test
+    fun `updateCollection creates new then deletes old`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "new-col-2")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(importData))
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(deleteData))
+
+        val collection = HoppCollection(name = "Updated")
+        val result = client.updateCollection("old-col-1", collection)
+        assertTrue(result.success)
+        assertEquals("new-col-2", result.collectionId)
+        assertTrue(result.message!!.contains("updated successfully"))
+    }
+
+    @Test
+    fun `deleteCollection returns true for valid response`() = runBlocking {
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(deleteData)
+        assertTrue(client.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `deleteCollection with teamId uses deleteCollection mutation`() = runBlocking {
+        val deleteData = JsonObject().apply {
+            addProperty("deleteCollection", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(deleteData)
+        assertTrue(client.deleteCollection("col-1", teamId = "team1"))
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertTrue(lastRequest!!.body!!.contains("deleteCollection"))
+        assertTrue(lastRequest.body!!.contains("collectionID"))
+    }
+
+    @Test
+    fun `deleteCollection returns false for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        assertFalse(blankTokenClient.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `request includes Bearer token in Authorization header`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        client.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        val authHeader = lastRequest!!.headers.find { it.first == "Authorization" }
+        assertNotNull(authHeader)
+        assertEquals("Bearer test-token-123", authHeader!!.second)
+    }
+
+    @Test
+    fun `request includes Content-Type json header`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        client.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        val contentTypeHeader = lastRequest!!.headers.find { it.first == "Content-Type" }
+        assertNotNull(contentTypeHeader)
+        assertEquals("application/json", contentTypeHeader!!.second)
+    }
+
+    @Test
+    fun `401 response returns false from testConnection`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 401, body = "Unauthorized")
+        assertFalse(client.testConnection())
+    }
+
+    @Test
+    fun `401 response makes listTeams return empty list`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 401, body = "Unauthorized")
+        val result = client.listTeams()
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `non-200 response returns null gracefully`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 500, body = "Internal Server Error")
+        val result = client.listTeams()
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `HoppscotchAuthException is an Exception with message`() {
+        val exception = HoppscotchAuthException("Token expired")
+        assertTrue(exception is Exception)
+        assertEquals("Token expired", exception.message)
+    }
+
+    @Test
+    fun `custom server URL uses api graphql path`() = runBlocking {
+        val customClient = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://custom.hoppscotch.example",
+            httpClient = mockHttpClient
+        )
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        customClient.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertEquals("https://custom.hoppscotch.example/graphql", lastRequest!!.url)
+    }
+
+    @Test
+    fun `cloud server URL resolves to api hoppscotch io`() = runBlocking {
+        val cloudClient = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://hoppscotch.io",
+            httpClient = mockHttpClient
+        )
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        cloudClient.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertEquals("https://api.hoppscotch.io/graphql", lastRequest!!.url)
+    }
+
+    @Test
+    fun `resolveApiBaseUrl returns api hoppscotch io for cloud`() {
+        assertEquals(
+            "https://api.hoppscotch.io",
+            HoppscotchApiClient.resolveApiBaseUrl("https://hoppscotch.io")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl returns same URL for self-hosted`() {
+        assertEquals(
+            "https://custom.example.com",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com")
+        )
+    }
+
+    @Test
+    fun `isCloudServer returns true for hoppscotch io`() {
+        assertTrue(HoppscotchApiClient.isCloudServer("https://hoppscotch.io"))
+    }
+
+    @Test
+    fun `isCloudServer returns false for custom server`() {
+        assertFalse(HoppscotchApiClient.isCloudServer("https://custom.example.com"))
+    }
+
+    private fun graphqlResponse(data: JsonObject): HttpResponse {
+        val wrapper = JsonObject().apply { add("data", data) }
+        return HttpResponse(code = 200, body = GsonUtils.GSON.toJson(wrapper))
+    }
+
+    class MockHttpClient : HttpClient {
+        var nextResponse: HttpResponse = HttpResponse(code = 200, body = "{}")
+        var responseQueue: ArrayDeque<HttpResponse> = ArrayDeque()
+        var lastRequest: HttpRequest? = null
+
+        override suspend fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            return if (responseQueue.isNotEmpty()) responseQueue.removeFirst() else nextResponse
+        }
+
+        override fun close() {}
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchAuthServiceLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchAuthServiceLogicTest.kt
@@ -1,0 +1,104 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.itangcent.easyapi.settings.Settings
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoppscotchAuthServiceLogicTest {
+
+    private val defaultServerUrl = "https://hoppscotch.io"
+
+    @Test
+    fun `isLoggedIn returns true when token is present`() {
+        val settings = Settings(hoppscotchToken = "valid-token")
+        assertTrue(!settings.hoppscotchToken.isNullOrBlank())
+    }
+
+    @Test
+    fun `isLoggedIn returns false when token is null`() {
+        val settings = Settings(hoppscotchToken = null)
+        assertFalse(!settings.hoppscotchToken.isNullOrBlank())
+    }
+
+    @Test
+    fun `isLoggedIn returns false when token is blank`() {
+        val settings = Settings(hoppscotchToken = "")
+        assertFalse(!settings.hoppscotchToken.isNullOrBlank())
+    }
+
+    @Test
+    fun `isLoggedIn returns false when token is whitespace`() {
+        val settings = Settings(hoppscotchToken = "   ")
+        assertFalse(!settings.hoppscotchToken.isNullOrBlank())
+    }
+
+    @Test
+    fun `getServerUrl returns custom URL when set`() {
+        val settings = Settings(hoppscotchServerUrl = "https://custom.hoppscotch.io")
+        val result = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://custom.hoppscotch.io", result)
+    }
+
+    @Test
+    fun `getServerUrl returns default URL when null`() {
+        val settings = Settings(hoppscotchServerUrl = null)
+        val result = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://hoppscotch.io", result)
+    }
+
+    @Test
+    fun `getServerUrl returns default URL when blank`() {
+        val settings = Settings(hoppscotchServerUrl = "")
+        val result = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://hoppscotch.io", result)
+    }
+
+    @Test
+    fun `getServerUrl returns default URL when whitespace`() {
+        val settings = Settings(hoppscotchServerUrl = "   ")
+        val result = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://hoppscotch.io", result)
+    }
+
+    @Test
+    fun `isJcefAvailable gracefully handles JCEF unavailability`() {
+        val result = try {
+            val jcefAppClass = Class.forName("com.intellij.ui.jcef.JBCefApp")
+            val isSupportedMethod = jcefAppClass.getMethod("isSupported")
+            isSupportedMethod.invoke(null) as Boolean
+        } catch (e: Throwable) {
+            false
+        }
+        assertNotNull("JCEF check should not throw uncaught exceptions", result)
+    }
+
+    @Test
+    fun `custom server URL constructs correct GraphQL endpoint`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(customUrl)
+        val graphqlUrl = "$apiBaseUrl/api/graphql"
+        assertEquals("https://custom.hoppscotch.example/api/graphql", graphqlUrl)
+    }
+
+    @Test
+    fun `default server URL constructs correct GraphQL endpoint`() {
+        val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(defaultServerUrl)
+        val graphqlUrl = "$apiBaseUrl/graphql"
+        assertEquals("https://api.hoppscotch.io/graphql", graphqlUrl)
+    }
+
+    @Test
+    fun `custom server URL constructs correct auth login URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val loginUrl = "$customUrl/auth/login"
+        assertEquals("https://custom.hoppscotch.example/auth/login", loginUrl)
+    }
+
+    @Test
+    fun `custom server URL constructs correct token refresh URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(customUrl)
+        val refreshUrl = "$apiBaseUrl/api/auth/token/refresh"
+        assertEquals("https://custom.hoppscotch.example/api/auth/token/refresh", refreshUrl)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchCloudUploadTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchCloudUploadTest.kt
@@ -1,0 +1,192 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppRESTRequest
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.HttpResponse
+import com.itangcent.easyapi.util.json.GsonUtils
+import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class HoppscotchCloudUploadTest {
+
+    private lateinit var mockHttpClient: MockHttpClient
+    private lateinit var client: HoppscotchApiClient
+    private lateinit var cachedClient: CachedHoppscotchApiClient
+
+    @Before
+    fun setUp() {
+        mockHttpClient = MockHttpClient()
+        client = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        cachedClient = client.asCached()
+    }
+
+    @Test
+    fun `asCached extension creates CachedHoppscotchApiClient`() {
+        val cached = HoppscotchApiClient("t", "u", httpClient = mockHttpClient).asCached()
+        assertNotNull(cached)
+        assertTrue(cached is CachedHoppscotchApiClient)
+    }
+
+    @Test
+    fun `full upload flow - create new collection`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-new-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val collection = HoppCollection(
+            name = "My API",
+            requests = listOf(
+                HoppRESTRequest(name = "GET /users", method = "GET", endpoint = "/users"),
+                HoppRESTRequest(name = "POST /users", method = "POST", endpoint = "/users")
+            )
+        )
+        val result = cachedClient.uploadCollection(collection)
+        assertTrue(result.success)
+        assertEquals("col-new-1", result.collectionId)
+    }
+
+    @Test
+    fun `full upload flow - update existing collection`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-new-2")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(importData))
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(deleteData))
+
+        val collection = HoppCollection(name = "My API v2")
+        val result = cachedClient.updateCollection("col-old-1", collection)
+        assertTrue(result.success)
+        assertEquals("col-new-2", result.collectionId)
+        assertTrue(result.message!!.contains("updated successfully"))
+    }
+
+    @Test
+    fun `cached client delegates upload to underlying client`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val collection = HoppCollection(name = "Test")
+        val result = cachedClient.uploadCollection(collection)
+        assertTrue(result.success)
+    }
+
+    @Test
+    fun `cached client delegates delete to underlying client`() = runBlocking {
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(deleteData)
+        assertTrue(cachedClient.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `cached client delegates testConnection to underlying client`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        assertTrue(cachedClient.testConnection())
+    }
+
+    @Test
+    fun `HoppscotchConfig stores collection update info`() {
+        val config = ChannelConfig.HoppscotchConfig(
+            collectionId = "col-1",
+            collectionName = "My Collection",
+            isUpdate = true
+        )
+        assertEquals("col-1", config.collectionId)
+        assertEquals("My Collection", config.collectionName)
+        assertTrue(config.isUpdate)
+    }
+
+    @Test
+    fun `HoppscotchConfig defaults to create mode`() {
+        val config = ChannelConfig.HoppscotchConfig()
+        assertNull(config.collectionId)
+        assertNull(config.collectionName)
+        assertFalse(config.isUpdate)
+    }
+
+    @Test
+    fun `upload with teamId uses importCollectionsFromJSON`() = runBlocking {
+        val importData = JsonObject().apply {
+            addProperty("importCollectionsFromJSON", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val collection = HoppCollection(name = "Team Collection")
+        val result = cachedClient.uploadCollection(collection, teamId = "team-1")
+        assertTrue(result.success)
+
+        val lastBody = mockHttpClient.lastRequest?.body
+        assertNotNull(lastBody)
+        assertTrue(lastBody!!.contains("importCollectionsFromJSON"))
+        assertTrue(lastBody.contains("teamID"))
+    }
+
+    @Test
+    fun `upload failure does not delete old collection during update`() = runBlocking {
+        val errorBody = """{"errors":[{"message":"Server error"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errorBody)
+
+        val collection = HoppCollection(name = "Failed Upload")
+        val result = client.updateCollection("old-col-1", collection)
+        assertFalse(result.success)
+    }
+
+    @Test
+    fun `HoppUploadResult copy preserves fields`() {
+        val original = HoppUploadResult(success = true, message = "OK", collectionId = "col-1")
+        val copied = original.copy(message = "Updated successfully (new ID: col-1)")
+        assertTrue(copied.success)
+        assertEquals("Updated successfully (new ID: col-1)", copied.message)
+        assertEquals("col-1", copied.collectionId)
+    }
+
+    private fun graphqlResponse(data: JsonObject): HttpResponse {
+        val wrapper = JsonObject().apply { add("data", data) }
+        return HttpResponse(code = 200, body = GsonUtils.GSON.toJson(wrapper))
+    }
+
+    class MockHttpClient : HttpClient {
+        var nextResponse: HttpResponse = HttpResponse(code = 200, body = "{}")
+        var responseQueue: ArrayDeque<HttpResponse> = ArrayDeque()
+        var lastRequest: HttpRequest? = null
+
+        override suspend fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            return if (responseQueue.isNotEmpty()) responseQueue.removeFirst() else nextResponse
+        }
+
+        override fun close() {}
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchExportMetadataTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchExportMetadataTest.kt
@@ -1,0 +1,58 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import com.itangcent.easyapi.exporter.hoppscotch.model.HoppCollection
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoppscotchExportMetadataTest {
+
+    @Test
+    fun testFormatDisplayWithWorkspaceAndCollectionNames() {
+        val metadata = HoppscotchExportMetadata(
+            workspaceName = "My Workspace",
+            collectionName = "My Collection"
+        )
+        assertEquals("My Workspace/My Collection", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithWorkspaceNameOnly() {
+        val metadata = HoppscotchExportMetadata(workspaceName = "My Workspace")
+        assertEquals("My Workspace", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithCollectionNameOnly() {
+        val metadata = HoppscotchExportMetadata(collectionName = "My Collection")
+        assertEquals("My Collection", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithCollectionIdFallback() {
+        val metadata = HoppscotchExportMetadata(collectionId = "col-456")
+        assertEquals("col-456", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithNullData() {
+        val metadata = HoppscotchExportMetadata()
+        assertEquals("", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayReturnsNullWhenCollectionDataPresent() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "Test",
+            collectionData = HoppCollection(name = "Test")
+        )
+        assertNull(metadata.formatDisplay())
+    }
+
+    @Test
+    fun testCopy() {
+        val metadata = HoppscotchExportMetadata(workspaceName = "Test")
+        val copy = metadata.copy(collectionName = "New Collection")
+        assertEquals("Test", copy.workspaceName)
+        assertEquals("New Collection", copy.collectionName)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchMagicLinkLoginDialogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/HoppscotchMagicLinkLoginDialogTest.kt
@@ -1,0 +1,206 @@
+package com.itangcent.easyapi.exporter.hoppscotch
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoppscotchMagicLinkLoginDialogTest {
+
+    // --- Email validation tests ---
+
+    @Test
+    fun `isValidEmail accepts standard email`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("user@example.com"))
+    }
+
+    @Test
+    fun `isValidEmail accepts email with subdomain`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("user@mail.example.com"))
+    }
+
+    @Test
+    fun `isValidEmail accepts email with plus sign`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("user+tag@example.com"))
+    }
+
+    @Test
+    fun `isValidEmail accepts email with dots in local part`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("first.last@example.com"))
+    }
+
+    @Test
+    fun `isValidEmail rejects empty string`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail(""))
+    }
+
+    @Test
+    fun `isValidEmail rejects string without at sign`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("userexample.com"))
+    }
+
+    @Test
+    fun `isValidEmail rejects string without domain`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("user@"))
+    }
+
+    @Test
+    fun `isValidEmail rejects string without TLD`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("user@example"))
+    }
+
+    @Test
+    fun `isValidEmail rejects string with spaces`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("user @example.com"))
+    }
+
+    // --- Token extraction from URL tests ---
+
+    @Test
+    fun `extractTokenFromUrl extracts token from standard magic link URL`() {
+        val url = "https://hoppscotch.io/enter?token=abc123def456"
+        assertEquals("abc123def456", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl extracts token from self-hosted URL`() {
+        val url = "https://custom.example.com/enter?token=xyz789"
+        assertEquals("xyz789", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl extracts token from URL with multiple query params`() {
+        val url = "https://hoppscotch.io/enter?foo=bar&token=abc123&baz=qux"
+        assertEquals("abc123", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for URL without token param`() {
+        val url = "https://hoppscotch.io/enter?foo=bar"
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for URL without query string`() {
+        val url = "https://hoppscotch.io/enter"
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for empty string`() {
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(""))
+    }
+
+    @Test
+    fun `extractTokenFromUrl falls back to regex for partial URL strings`() {
+        // The regex should find token= even in a partial URL string
+        val url = "enter?token=abc123"
+        assertEquals("abc123", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for string without query marker`() {
+        // No ? or & before token=, so it shouldn't match
+        val url = "not a url but token=abc123 is here"
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for URL with empty token value`() {
+        val url = "https://hoppscotch.io/enter?token="
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl handles token with special characters`() {
+        val url = "https://hoppscotch.io/enter?token=abc-123_xyz.ABC"
+        assertEquals("abc-123_xyz.ABC", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    // --- Magic link API URL construction tests ---
+
+    @Test
+    fun `cloud instance constructs correct signin URL`() {
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl("https://hoppscotch.io")
+        val signinUrl = "$apiBaseUrl/auth/signin?origin=app"
+        assertEquals("https://api.hoppscotch.io/v1/auth/signin?origin=app", signinUrl)
+    }
+
+    @Test
+    fun `cloud instance constructs correct verify URL`() {
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl("https://hoppscotch.io")
+        val verifyUrl = "$apiBaseUrl/auth/verify"
+        assertEquals("https://api.hoppscotch.io/v1/auth/verify", verifyUrl)
+    }
+
+    @Test
+    fun `self-hosted instance constructs correct signin URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(customUrl)
+        val signinUrl = "$apiBaseUrl/auth/signin?origin=app"
+        assertEquals("https://custom.hoppscotch.example/v1/auth/signin?origin=app", signinUrl)
+    }
+
+    @Test
+    fun `self-hosted with backend URL constructs correct signin URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val backendUrl = "http://localhost:3170/v1"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(customUrl, backendUrl)
+        val signinUrl = "$apiBaseUrl/auth/signin?origin=app"
+        assertEquals("http://localhost:3170/v1/auth/signin?origin=app", signinUrl)
+    }
+
+    // --- MagicLinkSendResult tests ---
+
+    @Test
+    fun `MagicLinkSendResult success case`() {
+        val result = MagicLinkSendResult(success = true, deviceIdentifier = "abc123")
+        assertTrue(result.success)
+        assertEquals("abc123", result.deviceIdentifier)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkSendResult failure case`() {
+        val result = MagicLinkSendResult(success = false, errorMessage = "Network error")
+        assertFalse(result.success)
+        assertNull(result.deviceIdentifier)
+        assertEquals("Network error", result.errorMessage)
+    }
+
+    // --- MagicLinkVerifyResult tests ---
+
+    @Test
+    fun `MagicLinkVerifyResult success case`() {
+        val result = MagicLinkVerifyResult(
+            success = true,
+            accessToken = "access123",
+            refreshToken = "refresh456"
+        )
+        assertTrue(result.success)
+        assertEquals("access123", result.accessToken)
+        assertEquals("refresh456", result.refreshToken)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkVerifyResult failure with expired link`() {
+        val result = MagicLinkVerifyResult(
+            success = false,
+            errorMessage = "This magic link has expired. Please request a new one."
+        )
+        assertFalse(result.success)
+        assertNull(result.accessToken)
+        assertNull(result.refreshToken)
+        assertEquals("This magic link has expired. Please request a new one.", result.errorMessage)
+    }
+
+    // --- HoppscotchLoginMethodDialog.Method tests ---
+
+    @Test
+    fun `Method enum has all three values`() {
+        val methods = HoppscotchLoginMethodDialog.Method.values()
+        assertEquals(3, methods.size)
+        assertTrue(methods.contains(HoppscotchLoginMethodDialog.Method.MAGIC_LINK))
+        assertTrue(methods.contains(HoppscotchLoginMethodDialog.Method.BROWSER))
+        assertTrue(methods.contains(HoppscotchLoginMethodDialog.Method.MANUAL_TOKEN))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/model/HoppscotchModelsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/hoppscotch/model/HoppscotchModelsTest.kt
@@ -1,0 +1,326 @@
+package com.itangcent.easyapi.exporter.hoppscotch.model
+
+import com.google.gson.JsonObject
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoppCollectionTest {
+
+    @Test
+    fun testHoppCollectionCreation() {
+        val collection = HoppCollection(name = "Test API")
+        assertEquals(12, collection.v)
+        assertEquals("Test API", collection.name)
+        assertTrue(collection.folders.isEmpty())
+        assertTrue(collection.requests.isEmpty())
+        assertEquals("inherit", collection.auth.authType)
+        assertTrue(collection.headers.isEmpty())
+        assertTrue(collection.variables.isEmpty())
+        assertNull(collection.description)
+        assertEquals("", collection.preRequestScript)
+        assertEquals("", collection.testScript)
+    }
+
+    @Test
+    fun testHoppCollectionWithFoldersAndRequests() {
+        val request = HoppRESTRequest(name = "Get Users", method = "GET", endpoint = "/users")
+        val folder = HoppCollection(name = "Users", requests = listOf(request))
+        val collection = HoppCollection(name = "API", folders = listOf(folder), requests = listOf(request))
+        assertEquals(1, collection.folders.size)
+        assertEquals(1, collection.requests.size)
+        assertEquals("Users", collection.folders[0].name)
+    }
+
+    @Test
+    fun testHoppCollectionEquality() {
+        val refId = generateUniqueRefId("coll")
+        val c1 = HoppCollection(name = "API", _ref_id = refId)
+        val c2 = HoppCollection(name = "API", _ref_id = refId)
+        assertEquals(c1, c2)
+    }
+
+    @Test
+    fun testHoppCollectionCopy() {
+        val original = HoppCollection(name = "API")
+        val copy = original.copy(name = "New API")
+        assertEquals("New API", copy.name)
+        assertEquals("API", original.name)
+    }
+}
+
+class HoppRESTRequestTest {
+
+    @Test
+    fun testHoppRESTRequestCreation() {
+        val request = HoppRESTRequest(
+            name = "Create User",
+            method = "POST",
+            endpoint = "/users",
+            params = listOf(HoppKeyValue("id", "1")),
+            headers = listOf(HoppKeyValue("Content-Type", "application/json")),
+            body = HoppRequestBody(contentType = "application/json", body = "{}"),
+            preRequestScript = "pw.console.log('pre')",
+            testScript = "pw.expect(pw.response.status).toBe(200)",
+            description = "Creates a new user"
+        )
+        assertEquals("17", request.v)
+        assertEquals("Create User", request.name)
+        assertEquals("POST", request.method)
+        assertEquals("/users", request.endpoint)
+        assertEquals(1, request.params.size)
+        assertEquals(1, request.headers.size)
+        assertEquals("application/json", request.body.contentType)
+        assertEquals("pw.console.log('pre')", request.preRequestScript)
+        assertEquals("pw.expect(pw.response.status).toBe(200)", request.testScript)
+        assertEquals("Creates a new user", request.description)
+    }
+
+    @Test
+    fun testHoppRESTRequestWithDefaults() {
+        val request = HoppRESTRequest(name = "Test", method = "GET", endpoint = "/test")
+        assertEquals("17", request.v)
+        assertTrue(request.params.isEmpty())
+        assertTrue(request.headers.isEmpty())
+        assertEquals("inherit", request.auth.authType)
+        assertNull(request.body.contentType)
+        assertNull(request.body.body)
+        assertEquals("", request.preRequestScript)
+        assertEquals("", request.testScript)
+        assertTrue(request.requestVariables.isEmpty())
+        assertTrue(request.responses.isEmpty())
+        assertNull(request.description)
+    }
+}
+
+class HoppKeyValueTest {
+
+    @Test
+    fun testHoppKeyValueCreation() {
+        val kv = HoppKeyValue(key = "Authorization", value = "Bearer token", active = true, description = "Auth header")
+        assertEquals("Authorization", kv.key)
+        assertEquals("Bearer token", kv.value)
+        assertTrue(kv.active)
+        assertEquals("Auth header", kv.description)
+    }
+
+    @Test
+    fun testHoppKeyValueWithDefaults() {
+        val kv = HoppKeyValue(key = "Content-Type")
+        assertEquals("Content-Type", kv.key)
+        assertEquals("", kv.value)
+        assertTrue(kv.active)
+        assertNull(kv.description)
+    }
+}
+
+class HoppAuthTest {
+
+    @Test
+    fun testHoppAuthDefaults() {
+        val auth = HoppAuth()
+        assertEquals("inherit", auth.authType)
+        assertTrue(auth.authActive)
+    }
+
+    @Test
+    fun testHoppAuthBearer() {
+        val auth = HoppAuth(authType = "bearer", authActive = true)
+        assertEquals("bearer", auth.authType)
+        assertTrue(auth.authActive)
+    }
+}
+
+class HoppRequestBodyTest {
+
+    @Test
+    fun testHoppRequestBodyDefaults() {
+        val body = HoppRequestBody()
+        assertNull(body.contentType)
+        assertNull(body.body)
+    }
+
+    @Test
+    fun testHoppRequestBodyJson() {
+        val body = HoppRequestBody(contentType = "application/json", body = "{\"name\":\"test\"}")
+        assertEquals("application/json", body.contentType)
+        assertEquals("{\"name\":\"test\"}", body.body)
+    }
+
+    @Test
+    fun testHoppRequestBodyFormData() {
+        val entries = listOf(HoppFormDataEntry(key = "file", value = "test.txt"))
+        val body = HoppRequestBody(contentType = "multipart/form-data", body = entries)
+        assertEquals("multipart/form-data", body.contentType)
+        assertNotNull(body.body)
+    }
+}
+
+class HoppCollectionVariableTest {
+
+    @Test
+    fun testHoppCollectionVariableCreation() {
+        val variable = HoppCollectionVariable(
+            key = "baseUrl",
+            initialValue = "http://localhost:8080",
+            currentValue = "http://localhost:8080"
+        )
+        assertEquals("baseUrl", variable.key)
+        assertEquals("http://localhost:8080", variable.initialValue)
+        assertEquals("http://localhost:8080", variable.currentValue)
+        assertFalse(variable.secret)
+    }
+}
+
+class HoppRequestVariableTest {
+
+    @Test
+    fun testHoppRequestVariableCreation() {
+        val variable = HoppRequestVariable(key = "token", value = "abc123", active = true)
+        assertEquals("token", variable.key)
+        assertEquals("abc123", variable.value)
+        assertTrue(variable.active)
+    }
+}
+
+class HoppFormDataEntryTest {
+
+    @Test
+    fun testHoppFormDataEntryCreation() {
+        val entry = HoppFormDataEntry(key = "avatar", value = "photo.jpg", active = true, isFile = false)
+        assertEquals("avatar", entry.key)
+        assertEquals("photo.jpg", entry.value)
+        assertTrue(entry.active)
+        assertFalse(entry.isFile)
+    }
+
+    @Test
+    fun testHoppFormDataEntryWithDefaults() {
+        val entry = HoppFormDataEntry(key = "file")
+        assertEquals("file", entry.key)
+        assertEquals("", entry.value)
+        assertTrue(entry.active)
+        assertFalse(entry.isFile)
+        assertNull(entry.contentType)
+    }
+
+    @Test
+    fun testHoppFormDataEntryWithContentType() {
+        val entry = HoppFormDataEntry(key = "data", value = "content", active = true, isFile = false, contentType = "text/plain")
+        assertEquals("data", entry.key)
+        assertEquals("content", entry.value)
+        assertEquals("text/plain", entry.contentType)
+    }
+}
+
+class HoppscotchGsonTest {
+
+    @Test
+    fun testHoppscotchGsonPrettyPrint() {
+        val gson = hoppscotchGson(prettyPrint = true)
+        val collection = HoppCollection(name = "Test")
+        val json = gson.toJson(collection)
+        assertTrue(json.contains("\n"))
+        assertTrue(json.contains("\"v\""))
+        assertTrue(json.contains("\"name\""))
+    }
+
+    @Test
+    fun testHoppscotchGsonNoPrettyPrint() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val collection = HoppCollection(name = "Test")
+        val json = gson.toJson(collection)
+        assertFalse(json.contains("\n"))
+    }
+
+    @Test
+    fun testHoppscotchGsonSerializeNulls() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val body = HoppRequestBody()
+        val json = gson.toJson(body)
+        val obj = gson.fromJson(json, JsonObject::class.java)
+        assertTrue(obj.has("contentType"))
+        assertTrue(obj.has("body"))
+        assertTrue(obj.get("contentType").isJsonNull)
+        assertTrue(obj.get("body").isJsonNull)
+    }
+
+    @Test
+    fun testHoppscotchGsonCollectionVersionIsInt() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val collection = HoppCollection(name = "Test")
+        val json = gson.toJson(collection)
+        val obj = gson.fromJson(json, JsonObject::class.java)
+        assertTrue(obj.get("v").isJsonPrimitive)
+        assertTrue(obj.get("v").asJsonPrimitive.isNumber)
+        assertEquals(12, obj.get("v").asInt)
+    }
+
+    @Test
+    fun testHoppscotchGsonRequestVersionIsString() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val request = HoppRESTRequest(name = "Test", method = "GET", endpoint = "/test")
+        val json = gson.toJson(request)
+        val obj = gson.fromJson(json, JsonObject::class.java)
+        assertTrue(obj.get("v").isJsonPrimitive)
+        assertTrue(obj.get("v").asJsonPrimitive.isString)
+        assertEquals("17", obj.get("v").asString)
+    }
+
+    @Test
+    fun testResponsesSerializedAsObject() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val request = HoppRESTRequest(name = "Test", method = "GET", endpoint = "/test")
+        val json = gson.toJson(request)
+        val obj = gson.fromJson(json, JsonObject::class.java)
+        assertTrue(obj.get("responses").isJsonObject)
+        assertEquals(0, obj.getAsJsonObject("responses").size())
+    }
+
+    @Test
+    fun testRefIdFormat() {
+        val collRefId = generateUniqueRefId("coll")
+        val reqRefId = generateUniqueRefId("req")
+        assertTrue(collRefId.startsWith("coll_"))
+        assertTrue(reqRefId.startsWith("req_"))
+    }
+
+    @Test
+    fun testFullCollectionSerialization() {
+        val gson = hoppscotchGson(prettyPrint = true)
+        val collection = HoppCollection(
+            name = "My API",
+            folders = listOf(
+                HoppCollection(
+                    name = "Users",
+                    requests = listOf(
+                        HoppRESTRequest(
+                            name = "Get Users",
+                            method = "GET",
+                            endpoint = "https://{{host}}/users",
+                            params = listOf(HoppKeyValue("page", "1")),
+                            headers = listOf(HoppKeyValue("Accept", "application/json")),
+                            body = HoppRequestBody()
+                        )
+                    )
+                )
+            ),
+            variables = listOf(
+                HoppCollectionVariable(key = "host", initialValue = "localhost:8080", currentValue = "localhost:8080")
+            ),
+            preRequestScript = "pw.console.log('pre')",
+            testScript = "pw.expect(pw.response.status).toBe(200)"
+        )
+        val json = gson.toJson(collection)
+        val obj = gson.fromJson(json, JsonObject::class.java)
+
+        assertEquals(12, obj.get("v").asInt)
+        assertEquals("My API", obj.get("name").asString)
+        assertEquals(1, obj.getAsJsonArray("folders").size())
+        assertEquals(0, obj.getAsJsonArray("requests").size())
+        val folder = obj.getAsJsonArray("folders")[0].asJsonObject
+        assertEquals(1, folder.getAsJsonArray("requests").size())
+        assertEquals("pw.console.log('pre')", obj.get("preRequestScript").asString)
+        assertEquals("pw.expect(pw.response.status).toBe(200)", obj.get("testScript").asString)
+        assertEquals(1, obj.getAsJsonArray("variables").size())
+    }
+}


### PR DESCRIPTION
Implement Hoppscotch export channel with file export and cloud upload. Includes GraphQL API client with caching, multi-method authentication (magic link, browser, manual token), Hoppscotch collection formatter (schema v12/v17), rule engine integration, and settings panel. Mark as beta in UI labels and README.