### PR TITLE
refactor: restructure settings modules, rename Intelligent tab, group panel sections

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
@@ -15,7 +15,7 @@ import com.itangcent.easyapi.psi.model.ObjectModelUtils
 import com.itangcent.easyapi.psi.type.PrimitiveKind
 import com.itangcent.easyapi.psi.type.ResolvedType
 import com.itangcent.easyapi.psi.type.TypeResolver
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.settings
 
 /**
@@ -40,7 +40,7 @@ import com.itangcent.easyapi.settings.settings
  */
 class EndpointBuilder(private val project: Project) {
 
-    private val settings get() = project.settings<IntelligentSettings>()
+    private val settings get() = project.settings<ParsingOutputSettings>()
     private val docHelper: DocHelper by lazy { UnifiedDocHelper.getInstance(project) }
     private val metadataResolver: DocMetadataResolver get() = DocMetadataResolver.getInstance(project)
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -24,7 +24,7 @@ import com.itangcent.easyapi.psi.type.SpecialTypeHandler
 import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.text.PathVariablePattern
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
@@ -350,7 +350,7 @@ class SpringMvcClassExporter(
     private suspend fun expandFormParameter(
         resolvedParamType: ResolvedType
     ): List<ApiParameter> {
-        val formExpanded = project.settings<IntelligentSettings>().formExpanded
+        val formExpanded = project.settings<ParsingOutputSettings>().formExpanded
         if (!formExpanded) {
             return emptyList()
         }
@@ -360,7 +360,7 @@ class SpringMvcClassExporter(
     private suspend fun expandQueryParameter(
         resolvedParamType: ResolvedType
     ): List<ApiParameter> {
-        val queryExpanded = project.settings<IntelligentSettings>().queryExpanded
+        val queryExpanded = project.settings<ParsingOutputSettings>().queryExpanded
         if (!queryExpanded) {
             return emptyList()
         }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/EnumValueResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/EnumValueResolver.kt
@@ -12,7 +12,7 @@ import com.itangcent.easyapi.psi.model.FieldOption
 import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.module.GeneralSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.settings
 
 /**
@@ -121,7 +121,7 @@ class EnumValueResolver(private val project: Project) : IdeaLog {
      */
     private fun readAutoInferEnabled(): Boolean =
         runCatching {
-            project.settings<GeneralSettings>().enumFieldAutoInferEnabled
+            project.settings<ParsingOutputSettings>().enumFieldAutoInferEnabled
         }.getOrNull() ?: false
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
@@ -16,7 +16,7 @@ import com.itangcent.easyapi.exporter.model.PathSelector
 import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.json.GsonUtils
 import com.itangcent.easyapi.util.text.appendWithDedup
@@ -98,7 +98,7 @@ class DocMetadataResolver internal constructor(
 ) : com.itangcent.easyapi.logging.IdeaLog {
     private val engine: RuleEngine get() = RuleEngine.getInstance(project)
     private val docHelper: DocHelper get() = UnifiedDocHelper.getInstance(project)
-    private val settings get() = project.settings<IntelligentSettings>()
+    private val settings get() = project.settings<ParsingOutputSettings>()
 
     companion object {
         fun getInstance(project: Project): DocMetadataResolver = project.service()

--- a/src/main/kotlin/com/itangcent/easyapi/script/env/EnvironmentService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/script/env/EnvironmentService.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.settings.module.EnvironmentSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
 import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.json.GsonUtils
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -174,7 +173,6 @@ class EnvironmentService(private val project: Project) : com.itangcent.easyapi.l
      */
     private fun loadEnvironmentData(): EnvironmentData {
         val envSettings = project.settings<EnvironmentSettings>()
-        val intelSettings = project.settings<IntelligentSettings>()
         val projectEnvJson = envSettings.projectEnvironments
         val projectData = if (projectEnvJson.isNotBlank()) {
             runCatching { GsonUtils.fromJson<EnvironmentData>(projectEnvJson) }
@@ -182,7 +180,7 @@ class EnvironmentService(private val project: Project) : com.itangcent.easyapi.l
                 .getOrNull()
         } else null
 
-        val globalEnvJson = intelSettings.globalEnvironments
+        val globalEnvJson = envSettings.globalEnvironments
         val globalData = if (globalEnvJson.isNotBlank()) {
             runCatching { GsonUtils.fromJson<EnvironmentData>(globalEnvJson) }
                 .onFailure { LOG.warn("EnvironmentService: failed to parse global environments JSON", it) }
@@ -210,7 +208,6 @@ class EnvironmentService(private val project: Project) : com.itangcent.easyapi.l
      */
     private fun persistEnvironmentData(data: EnvironmentData) {
         val envSettings = project.settings<EnvironmentSettings>()
-        val intelSettings = project.settings<IntelligentSettings>()
         val projectEnvs = data.environments.filter { it.scope == EnvironmentScope.PROJECT }
         val globalEnvs = data.environments.filter { it.scope == EnvironmentScope.GLOBAL }
 
@@ -221,16 +218,14 @@ class EnvironmentService(private val project: Project) : com.itangcent.easyapi.l
             ))
         } else ""
 
-        intelSettings.globalEnvironments = if (globalEnvs.isNotEmpty()) {
+        envSettings.globalEnvironments = if (globalEnvs.isNotEmpty()) {
             GsonUtils.toJson(EnvironmentData(
                 environments = globalEnvs,
                 activeEnvironmentName = if (data.activeEnvironmentName in globalEnvs.map { it.name }) data.activeEnvironmentName else null
             ))
         } else ""
 
-        val modularBinder = SettingBinder.getInstance(project)
-        modularBinder.save(envSettings)
-        modularBinder.save(intelSettings)
+        SettingBinder.getInstance(project).save(envSettings)
     }
 
     companion object {

--- a/src/main/kotlin/com/itangcent/easyapi/settings/migration/SettingsMigrationActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/migration/SettingsMigrationActivity.kt
@@ -24,6 +24,8 @@ import com.itangcent.easyapi.util.json.GsonUtils
  * Version history:
  * - v1: migrated legacy state to per-module `*SettingsState` components (now deleted).
  * - v2: re-migrates legacy state into the unified map-backed state components.
+ * - v3: `enumFieldAutoInferEnabled` moved GeneralSettings -> ParsingOutputSettings;
+ *   `globalEnvironments` moved ParsingOutputSettings -> EnvironmentSettings (APP scope).
  *
  * Special handling:
  * - `postmanToken` duplication: prefer the non-empty value between APP/PROJ copies; write to APP only.
@@ -33,7 +35,7 @@ import com.itangcent.easyapi.util.json.GsonUtils
 class SettingsMigrationActivity : StartupActivity {
 
     companion object {
-        private const val MIGRATION_VERSION = 2
+        private const val MIGRATION_VERSION = 3
     }
 
     override fun runActivity(project: Project) {
@@ -79,7 +81,6 @@ class SettingsMigrationActivity : StartupActivity {
         appState.setValue(generalKey, "concurrentScanEnabled", legacy.concurrentScanEnabled.toString())
         appState.setValue(generalKey, "gutterIconEnabled", legacy.gutterIconEnabled.toString())
         appState.setValue(generalKey, "switchNotice", legacy.switchNotice.toString())
-        appState.setValue(generalKey, "enumFieldAutoInferEnabled", legacy.enumFieldAutoInferEnabled.toString())
         appState.setValue(generalKey, "logLevel", legacy.logLevel.toString())
         appState.setValue(generalKey, "outputDemo", legacy.outputDemo.toString())
         appState.setValue(generalKey, "outputCharset", legacy.outputCharset)
@@ -90,14 +91,18 @@ class SettingsMigrationActivity : StartupActivity {
         appState.setValue(httpKey, "unsafeSsl", legacy.unsafeSsl.toString())
         appState.setValue(httpKey, "httpClient", legacy.httpClient)
 
-        // IntelligentSettings
-        val intelligentKey = IntelligentSettings::class.qualifiedName!!
-        appState.setValue(intelligentKey, "inferReturnMain", legacy.inferReturnMain.toString())
-        appState.setValue(intelligentKey, "enableUrlTemplating", legacy.enableUrlTemplating.toString())
-        appState.setValue(intelligentKey, "queryExpanded", legacy.queryExpanded.toString())
-        appState.setValue(intelligentKey, "formExpanded", legacy.formExpanded.toString())
-        appState.setValue(intelligentKey, "pathMulti", legacy.pathMulti)
-        appState.setValue(intelligentKey, "globalEnvironments", legacy.globalEnvironments)
+        // ParsingOutputSettings (includes enumFieldAutoInferEnabled moved from GeneralSettings in v3)
+        val parsingOutputKey = ParsingOutputSettings::class.qualifiedName!!
+        appState.setValue(parsingOutputKey, "inferReturnMain", legacy.inferReturnMain.toString())
+        appState.setValue(parsingOutputKey, "enableUrlTemplating", legacy.enableUrlTemplating.toString())
+        appState.setValue(parsingOutputKey, "queryExpanded", legacy.queryExpanded.toString())
+        appState.setValue(parsingOutputKey, "formExpanded", legacy.formExpanded.toString())
+        appState.setValue(parsingOutputKey, "pathMulti", legacy.pathMulti)
+        appState.setValue(parsingOutputKey, "enumFieldAutoInferEnabled", legacy.enumFieldAutoInferEnabled.toString())
+
+        // EnvironmentSettings (APP field — globalEnvironments moved here from ParsingOutputSettings in v3)
+        val envAppKey = EnvironmentSettings::class.qualifiedName!!
+        appState.setValue(envAppKey, "globalEnvironments", legacy.globalEnvironments)
 
         // GrpcSettings
         val grpcKey = GrpcSettings::class.qualifiedName!!
@@ -148,7 +153,7 @@ class SettingsMigrationActivity : StartupActivity {
         projState.setValue(ruleFileKey, "projectRemoteConfig", legacy.remoteConfig)
         projState.setValue(ruleFileKey, "recommendConfig", legacy.recommendConfig)
 
-        // EnvironmentSettings
+        // EnvironmentSettings (PROJ fields — same module key as APP, scope-routed by the binder)
         val envKey = EnvironmentSettings::class.qualifiedName!!
         projState.setValue(envKey, "projectEnvironments", legacy.projectEnvironments)
         projState.setValue(envKey, "disabledAutoRuleFiles", GsonUtils.toJson(legacy.disabledAutoRuleFiles))

--- a/src/main/kotlin/com/itangcent/easyapi/settings/module/EnvironmentSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/module/EnvironmentSettings.kt
@@ -5,11 +5,22 @@ import com.itangcent.easyapi.settings.Settings
 import com.itangcent.easyapi.settings.StorageScope
 
 /**
- * Environment settings: project environments, disabled auto rule files.
+ * Environment settings: project environments, disabled auto rule files,
+ * and global (cross-project) environments.
  *
- * Persisted at PROJECT scope via the unified [com.itangcent.easyapi.settings.state.UnifiedProjectSettingsState].
+ * Mixed-scope module:
+ * - APP field: `globalEnvironments`
+ * - PROJ fields: `projectEnvironments`, `disabledAutoRuleFiles`
+ *
+ * Persisted via the unified state components
+ * ([com.itangcent.easyapi.settings.state.UnifiedAppSettingsState] /
+ * [com.itangcent.easyapi.settings.state.UnifiedProjectSettingsState]).
  */
 data class EnvironmentSettings(
+    // ---- APPLICATION scope ----
+    @StorageScope(Scope.APPLICATION) var globalEnvironments: String = "",
+
+    // ---- PROJECT scope ----
     @StorageScope(Scope.PROJECT) var projectEnvironments: String = "",
     @StorageScope(Scope.PROJECT) var disabledAutoRuleFiles: Array<String> = emptyArray()
 ) : Settings {
@@ -17,13 +28,15 @@ data class EnvironmentSettings(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         other as EnvironmentSettings
+        if (globalEnvironments != other.globalEnvironments) return false
         if (projectEnvironments != other.projectEnvironments) return false
         if (!disabledAutoRuleFiles.contentEquals(other.disabledAutoRuleFiles)) return false
         return true
     }
 
     override fun hashCode(): Int {
-        var result = projectEnvironments.hashCode()
+        var result = globalEnvironments.hashCode()
+        result = 31 * result + projectEnvironments.hashCode()
         result = 31 * result + disabledAutoRuleFiles.contentHashCode()
         return result
     }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/module/GeneralSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/module/GeneralSettings.kt
@@ -19,7 +19,6 @@ data class GeneralSettings(
     @StorageScope(Scope.APPLICATION) var concurrentScanEnabled: Boolean = false,
     @StorageScope(Scope.APPLICATION) var gutterIconEnabled: Boolean = true,
     @StorageScope(Scope.APPLICATION) var switchNotice: Boolean = true,
-    @StorageScope(Scope.APPLICATION) var enumFieldAutoInferEnabled: Boolean = false,
     @StorageScope(Scope.APPLICATION) var logLevel: Int = 100,
     @StorageScope(Scope.APPLICATION) var outputDemo: Boolean = true,
     @StorageScope(Scope.APPLICATION) var outputCharset: String = "UTF-8"

--- a/src/main/kotlin/com/itangcent/easyapi/settings/module/ParsingOutputSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/module/ParsingOutputSettings.kt
@@ -5,18 +5,18 @@ import com.itangcent.easyapi.settings.Settings
 import com.itangcent.easyapi.settings.StorageScope
 
 /**
- * Intelligent inference settings: return-type inference, URL templating,
- * expanded query/form panels, path multi, global environments.
+ * Parsing & output settings: return-type inference, enum-field inference,
+ * URL templating, expanded query/form panels, path multi.
  *
- * Tab-aligned with the "Intelligent" settings tab.
+ * Tab-aligned with the "Parsing & Output" settings tab.
  *
  * Persisted at APPLICATION scope via the unified [com.itangcent.easyapi.settings.state.UnifiedAppSettingsState].
  */
-data class IntelligentSettings(
+data class ParsingOutputSettings(
     @StorageScope(Scope.APPLICATION) var inferReturnMain: Boolean = true,
     @StorageScope(Scope.APPLICATION) var enableUrlTemplating: Boolean = true,
     @StorageScope(Scope.APPLICATION) var queryExpanded: Boolean = true,
     @StorageScope(Scope.APPLICATION) var formExpanded: Boolean = true,
     @StorageScope(Scope.APPLICATION) var pathMulti: String = "ALL",
-    @StorageScope(Scope.APPLICATION) var globalEnvironments: String = ""
+    @StorageScope(Scope.APPLICATION) var enumFieldAutoInferEnabled: Boolean = false
 ) : Settings

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/EasyApiSettingsConfigurable.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/EasyApiSettingsConfigurable.kt
@@ -1,7 +1,6 @@
 package com.itangcent.easyapi.settings.ui
 
 import com.intellij.openapi.options.Configurable
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.itangcent.easyapi.exporter.channel.ChannelRegistry
 import com.itangcent.easyapi.settings.SettingBinder
@@ -11,7 +10,7 @@ import com.itangcent.easyapi.settings.module.EnvironmentSettings
 import com.itangcent.easyapi.settings.module.GeneralSettings
 import com.itangcent.easyapi.settings.module.GrpcSettings
 import com.itangcent.easyapi.settings.module.HttpSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.module.RuleFileSettings
 import java.awt.BorderLayout
 import javax.swing.JComponent
@@ -25,10 +24,9 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
 
     private val generalPanel = GeneralSettingsPanel(project)
     private val httpPanel = HttpSettingsPanel()
-    private val intelligentPanel = IntelligentSettingsPanel()
+    private val parsingOutputPanel = ParsingOutputSettingsPanel()
     private val extensionPanel = ExtensionConfigPanel()
     private val aiPanel = AiSettingsPanel()
-    private val otherPanel = OtherSettingsPanel(project)
     private val grpcPanel = GrpcSettingsPanel(project)
     private val environmentPanel = EnvironmentSettingsPanel(project)
 
@@ -58,11 +56,10 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         const val TAB_GENERAL = "General"
         const val TAB_POSTMAN = "Postman"
         const val TAB_HTTP = "HTTP"
-        const val TAB_INTELLIGENT = "Intelligent"
+        const val TAB_PARSING_OUTPUT = "Parsing & Output"
         const val TAB_EXTENSIONS = "Extensions"
         const val TAB_RULES = "Rules"
         const val TAB_AI = "AI"
-        const val TAB_OTHER = "Other"
         const val TAB_GRPC = "gRPC"
         const val TAB_ENVIRONMENT = "Environments"
     }
@@ -82,10 +79,9 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
             tabs = JTabbedPane().also { t ->
                 t.addTab(TAB_GENERAL, wrapNorth(generalPanel.component))
                 t.addTab(TAB_HTTP, wrapNorth(httpPanel.component))
-                t.addTab(TAB_INTELLIGENT, wrapNorth(intelligentPanel.component))
+                t.addTab(TAB_PARSING_OUTPUT, wrapNorth(parsingOutputPanel.component))
                 t.addTab(TAB_EXTENSIONS, extensionPanel.component)
                 t.addTab(TAB_AI, wrapNorth(aiPanel.component))
-                t.addTab(TAB_OTHER, wrapNorth(otherPanel.component))
                 t.addTab(TAB_GRPC, wrapNorth(grpcPanel.component))
                 t.addTab(TAB_ENVIRONMENT, environmentPanel.component)
 
@@ -148,20 +144,17 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         val binder = SettingBinder.getInstance(project)
         val general = binder.read(GeneralSettings::class)
         val grpc = binder.read(GrpcSettings::class)
-        val intelligent = binder.read(IntelligentSettings::class)
+        val parsingOutput = binder.read(ParsingOutputSettings::class)
         val environment = binder.read(EnvironmentSettings::class)
 
         return generalPanel.isModified(general) ||
             generalPanel.isRepositoriesModified(grpc) ||
             httpPanel.isModified(binder.read(HttpSettings::class)) ||
-            intelligentPanel.isModified(intelligent) ||
-            intelligentPanel.isEnumFieldModified(general) ||
+            parsingOutputPanel.isModified(parsingOutput) ||
             extensionPanel.isModified(binder.read(RuleFileSettings::class)) ||
             aiPanel.isModified(binder.read(AiSettings::class)) ||
-            otherPanel.isModified(null) ||
             grpcPanel.isModified(grpc) ||
             environmentPanel.isModified(environment) ||
-            environmentPanel.isGlobalEnvsModified(intelligent) ||
             channelPanels.any { entry -> isChannelModified(binder, entry) }
     }
 
@@ -182,14 +175,11 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         generalPanel.applyRepositoriesTo(grpc)
         grpcPanel.applyTo(grpc)
 
-        val intelligent = binder.read(IntelligentSettings::class)
-        intelligentPanel.applyTo(intelligent)
-        environmentPanel.applyGlobalEnvsTo(intelligent)
+        val parsingOutput = binder.read(ParsingOutputSettings::class)
+        parsingOutputPanel.applyTo(parsingOutput)
 
         val environment = binder.read(EnvironmentSettings::class)
         environmentPanel.applyTo(environment)
-
-        intelligentPanel.applyEnumFieldTo(general)
 
         val http = binder.read(HttpSettings::class)
         httpPanel.applyTo(http)
@@ -200,15 +190,13 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         val ai = binder.read(AiSettings::class)
         aiPanel.applyTo(ai)
 
-        // self-contained panels (no-op applyTo)
-        otherPanel.applyTo(noopModule)
         // Channel panels: read their own typed module, apply, then persist.
         channelPanels.forEach { entry -> applyChannel(binder, entry) }
 
         // persist all modules
         binder.save(general)
         binder.save(grpc)
-        binder.save(intelligent)
+        binder.save(parsingOutput)
         binder.save(environment)
         binder.save(http)
         binder.save(ruleFile)
@@ -256,21 +244,17 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         generalPanel.resetFrom(general)
         generalPanel.resetRepositoriesFrom(binder.read(GrpcSettings::class))
 
-        val intelligent = binder.read(IntelligentSettings::class)
-        intelligentPanel.resetFrom(intelligent)
-        intelligentPanel.resetEnumFieldFrom(general)
+        val parsingOutput = binder.read(ParsingOutputSettings::class)
+        parsingOutputPanel.resetFrom(parsingOutput)
 
         val environment = binder.read(EnvironmentSettings::class)
         environmentPanel.resetFrom(environment)
-        environmentPanel.resetGlobalEnvsFrom(intelligent)
 
         httpPanel.resetFrom(binder.read(HttpSettings::class))
         extensionPanel.resetFrom(binder.read(RuleFileSettings::class))
         aiPanel.resetFrom(binder.read(AiSettings::class))
         grpcPanel.resetFrom(binder.read(GrpcSettings::class))
 
-        // self-contained panels (no-op resetFrom)
-        otherPanel.resetFrom(null)
         @Suppress("UNCHECKED_CAST")
         channelPanels.forEach { entry ->
             val type = entry.settingsType
@@ -345,13 +329,6 @@ abstract class BaseEasyApiChildConfigurable<T : Settings>(
     }
 }
 
-class EasyApiExtensionConfigurable(project: com.intellij.openapi.project.Project) :
-    BaseEasyApiChildConfigurable<RuleFileSettings>("Extensions", { ExtensionConfigPanel() }) {
-    init { this.project = project }
-    override fun readSettings(): RuleFileSettings? = modularBinder?.read(RuleFileSettings::class)
-    override fun saveSettings(settings: RuleFileSettings) { modularBinder?.save(settings) }
-}
-
 class EasyApiRulesConfigurable(project: com.intellij.openapi.project.Project) :
     BaseEasyApiChildConfigurable<RuleFileSettings>("Rules", { RulesTabPanel(project) }) {
     init { this.project = project }
@@ -379,8 +356,8 @@ class EasyApiRulesConfigurable(project: com.intellij.openapi.project.Project) :
     }
 }
 
-class EasyApiOtherConfigurable(project: com.intellij.openapi.project.Project) :
-    BaseEasyApiChildConfigurable<Settings>("Other", { OtherSettingsPanel(project) }) {
+class EasyApiBackupConfigurable(project: com.intellij.openapi.project.Project) :
+    BaseEasyApiChildConfigurable<Settings>("Backup", { BackupSettingsPanel(project) }) {
     init { this.project = project }
     override fun readSettings(): Settings? = object : Settings {}
     override fun saveSettings(settings: Settings) { /* no-op: self-contained panel */ }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/EnvironmentSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/EnvironmentSettingsPanel.kt
@@ -11,7 +11,6 @@ import com.itangcent.easyapi.script.env.Environment
 import com.itangcent.easyapi.script.env.EnvironmentData
 import com.itangcent.easyapi.script.env.EnvironmentScope
 import com.itangcent.easyapi.settings.module.EnvironmentSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
 import com.itangcent.easyapi.util.json.GsonUtils
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -70,14 +69,9 @@ class EnvironmentSettingsPanel(private val project: Project) : SettingsPanel<Env
         val scopeColumn = envTable.columnModel.getColumn(1)
         scopeColumn.cellEditor = DefaultCellEditor(JComboBox(arrayOf("Project", "Global")))
 
-        val envPanel = JPanel(BorderLayout()).apply {
-            border = BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
-                "Environments",
-                TitledBorder.LEFT,
-                TitledBorder.TOP
-            )
-            val toolbarDecorator = ToolbarDecorator.createDecorator(envTable)
+        val envPanel = SettingsUiKit.titledPanel(
+            "Environments",
+            ToolbarDecorator.createDecorator(envTable)
                 .setAddAction {
                     showAddEnvironmentDialog()
                 }
@@ -95,8 +89,8 @@ class EnvironmentSettingsPanel(private val project: Project) : SettingsPanel<Env
                     }
                 }
                 .disableUpDownActions()
-            add(toolbarDecorator.createPanel(), BorderLayout.CENTER)
-        }
+                .createPanel()
+        )
 
         component = FormBuilder.createFormBuilder()
             .addComponentFillVertically(envPanel, 0)
@@ -229,15 +223,8 @@ class EnvironmentSettingsPanel(private val project: Project) : SettingsPanel<Env
                 ))
             }
         }
-    }
 
-    /**
-     * Resets the global environments table from [IntelligentSettings.globalEnvironments].
-     * Called separately by the configurable because `globalEnvironments` belongs
-     * to [IntelligentSettings], not [EnvironmentSettings].
-     */
-    fun resetGlobalEnvsFrom(intelligentSettings: IntelligentSettings?) {
-        val globalEnvJson = intelligentSettings?.globalEnvironments
+        val globalEnvJson = settings?.globalEnvironments
         if (!globalEnvJson.isNullOrBlank()) {
             val data = runCatching { GsonUtils.fromJson<EnvironmentData>(globalEnvJson) }
                 .onFailure { LOG.warn("EnvironmentSettingsPanel: failed to parse global environments JSON", it) }
@@ -254,23 +241,15 @@ class EnvironmentSettingsPanel(private val project: Project) : SettingsPanel<Env
 
     override fun applyTo(settings: EnvironmentSettings) {
         val projectEnvs = envTableModel.items.filter { it.scope == EnvironmentScope.PROJECT }
+        val globalEnvs = envTableModel.items.filter { it.scope == EnvironmentScope.GLOBAL }
 
         settings.projectEnvironments = if (projectEnvs.isNotEmpty()) {
             GsonUtils.toJson(EnvironmentData(
                 environments = projectEnvs.map { Environment(it.name, it.scope, it.variables) }
             ))
         } else ""
-    }
 
-    /**
-     * Applies the global environments to [IntelligentSettings.globalEnvironments].
-     * Called separately by the configurable because `globalEnvironments` belongs
-     * to [IntelligentSettings], not [EnvironmentSettings].
-     */
-    fun applyGlobalEnvsTo(intelligentSettings: IntelligentSettings) {
-        val globalEnvs = envTableModel.items.filter { it.scope == EnvironmentScope.GLOBAL }
-
-        intelligentSettings.globalEnvironments = if (globalEnvs.isNotEmpty()) {
+        settings.globalEnvironments = if (globalEnvs.isNotEmpty()) {
             GsonUtils.toJson(EnvironmentData(
                 environments = globalEnvs.map { Environment(it.name, it.scope, it.variables) }
             ))
@@ -280,6 +259,7 @@ class EnvironmentSettingsPanel(private val project: Project) : SettingsPanel<Env
     override fun isModified(settings: EnvironmentSettings?): Boolean {
         val s = settings ?: return false
         val currentProjectEnvs = envTableModel.items.filter { it.scope == EnvironmentScope.PROJECT }
+        val currentGlobalEnvs = envTableModel.items.filter { it.scope == EnvironmentScope.GLOBAL }
 
         val currentProjectJson = if (currentProjectEnvs.isNotEmpty()) {
             GsonUtils.toJson(EnvironmentData(
@@ -287,25 +267,14 @@ class EnvironmentSettingsPanel(private val project: Project) : SettingsPanel<Env
             ))
         } else ""
 
-        return currentProjectJson != s.projectEnvironments
-    }
-
-    /**
-     * Checks if the global environments have been modified relative to
-     * [IntelligentSettings.globalEnvironments].
-     * Called separately by the configurable because `globalEnvironments` belongs
-     * to [IntelligentSettings], not [EnvironmentSettings].
-     */
-    fun isGlobalEnvsModified(intelligentSettings: IntelligentSettings?): Boolean {
-        val currentGlobalEnvs = envTableModel.items.filter { it.scope == EnvironmentScope.GLOBAL }
-
         val currentGlobalJson = if (currentGlobalEnvs.isNotEmpty()) {
             GsonUtils.toJson(EnvironmentData(
                 environments = currentGlobalEnvs.map { Environment(it.name, it.scope, it.variables) }
             ))
         } else ""
 
-        return currentGlobalJson != (intelligentSettings?.globalEnvironments ?: "")
+        return currentProjectJson != s.projectEnvironments ||
+            currentGlobalJson != (s.globalEnvironments ?: "")
     }
 
     private data class EnvironmentRow(

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/GrpcSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/GrpcSettingsPanel.kt
@@ -16,7 +16,6 @@ import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GridLayout
 import javax.swing.*
-import javax.swing.border.TitledBorder
 
 class GrpcSettingsPanel(private val project: com.intellij.openapi.project.Project) : SettingsPanel<GrpcSettings> {
 
@@ -90,14 +89,9 @@ class GrpcSettingsPanel(private val project: com.intellij.openapi.project.Projec
         artifactTable.columnModel.getColumn(1).preferredWidth = 150
         artifactTable.columnModel.getColumn(2).preferredWidth = 60
 
-        val artifactPanel = JPanel(BorderLayout()).apply {
-            border = BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
-                "Runtime Packages",
-                TitledBorder.LEFT,
-                TitledBorder.TOP
-            )
-            val toolbarDecorator = ToolbarDecorator.createDecorator(artifactTable)
+        val artifactPanel = SettingsUiKit.titledPanel(
+            "Runtime Packages",
+            ToolbarDecorator.createDecorator(artifactTable)
                 .setAddAction {
                     showAddArtifactDialog()
                 }
@@ -115,17 +109,12 @@ class GrpcSettingsPanel(private val project: com.intellij.openapi.project.Projec
                     }
                 }
                 .disableUpDownActions()
-            add(toolbarDecorator.createPanel(), BorderLayout.CENTER)
-        }
+                .createPanel()
+        )
 
-        val additionalJarsPanel = JPanel(BorderLayout()).apply {
-            border = BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
-                "Additional JARs",
-                TitledBorder.LEFT,
-                TitledBorder.TOP
-            )
-            val toolbarDecorator = ToolbarDecorator.createDecorator(additionalJarsList)
+        val additionalJarsPanel = SettingsUiKit.titledPanel(
+            "Additional JARs",
+            ToolbarDecorator.createDecorator(additionalJarsList)
                 .setAddAction {
                     showAddJarDialog()
                 }
@@ -136,28 +125,25 @@ class GrpcSettingsPanel(private val project: com.intellij.openapi.project.Projec
                     }
                 }
                 .disableUpDownActions()
-            add(toolbarDecorator.createPanel(), BorderLayout.CENTER)
-        }
+                .createPanel()
+        )
 
         runtimePackagesPanel = JPanel(GridLayout(0, 1, 0, 8)).apply {
             add(artifactPanel)
             add(additionalJarsPanel)
         }
 
-        val grpcRuntimePanel = JPanel(BorderLayout()).apply {
-            border = BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
-                "gRPC Runtime",
-                TitledBorder.LEFT,
-                TitledBorder.TOP
-            )
-            val callRow = JPanel(GridLayout(1, 2, 8, 0)).apply {
-                add(grpcCallEnabledCheckbox)
-                add(autoDetectButton)
-            }
-            add(callRow, BorderLayout.NORTH)
-            add(runtimePackagesPanel, BorderLayout.CENTER)
+        val callRow = JPanel(GridLayout(1, 2, 8, 0)).apply {
+            add(grpcCallEnabledCheckbox)
+            add(autoDetectButton)
         }
+        val grpcRuntimePanel = SettingsUiKit.titledPanel(
+            "gRPC Runtime",
+            JPanel(BorderLayout()).apply {
+                add(callRow, BorderLayout.NORTH)
+                add(runtimePackagesPanel, BorderLayout.CENTER)
+            }
+        )
 
         component = FormBuilder.createFormBuilder()
             .addComponent(grpcEnableCheckbox)

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -49,7 +49,7 @@ import com.itangcent.easyapi.settings.module.EnvironmentSettings
 import com.itangcent.easyapi.settings.module.GeneralSettings
 import com.itangcent.easyapi.settings.module.GrpcSettings
 import com.itangcent.easyapi.settings.module.HttpSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.module.RuleFileSettings
 import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.settings.update
@@ -58,7 +58,6 @@ import com.google.gson.JsonParser
 import java.awt.*
 import java.io.File
 import javax.swing.*
-import javax.swing.border.TitledBorder
 import kotlin.concurrent.thread
 
 /**
@@ -234,33 +233,25 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
     }
 
     private fun createRepositoryPanel(): JPanel {
-        return JPanel(BorderLayout()).apply {
-            border = BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
-                "Repositories",
-                TitledBorder.LEFT,
-                TitledBorder.TOP
-            )
-            val toolbarDecorator = ToolbarDecorator.createDecorator(repositoryTable)
-                .setAddAction {
-                    showAddRepositoryDialog()
+        val toolbarDecorator = ToolbarDecorator.createDecorator(repositoryTable)
+            .setAddAction {
+                showAddRepositoryDialog()
+            }
+            .setRemoveAction {
+                val selected = repositoryTable.selectedRow
+                if (selected >= 0) {
+                    repositoryTableModel.removeRow(selected)
                 }
-                .setRemoveAction {
-                    val selected = repositoryTable.selectedRow
-                    if (selected >= 0) {
-                        repositoryTableModel.removeRow(selected)
-                    }
+            }
+            .setEditAction {
+                val selected = repositoryTable.selectedRow
+                if (selected >= 0) {
+                    val config = repositoryTableModel.getItem(selected)
+                    showEditRepositoryDialog(config)
                 }
-                .setEditAction {
-                    val selected = repositoryTable.selectedRow
-                    if (selected >= 0) {
-                        val config = repositoryTableModel.getItem(selected)
-                        showEditRepositoryDialog(config)
-                    }
-                }
-                .disableUpDownActions()
-            add(toolbarDecorator.createPanel(), BorderLayout.CENTER)
-        }
+            }
+            .disableUpDownActions()
+        return SettingsUiKit.titledPanel("Repositories", toolbarDecorator.createPanel())
     }
 
     private fun showAddRepositoryDialog() {
@@ -393,20 +384,42 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
 
     override val component: JComponent = FormBuilder.createFormBuilder()
         .addComponent(
-            createTitledPanel(
+            SettingsUiKit.titledPanel(
                 "Framework Support", listOf(
                     feignEnable, jaxrsEnable, actuatorEnable
                 )
             )
         )
-        .addComponent(autoScanEnabled)
-        .addComponent(concurrentScanEnabled)
-        .addComponent(gutterIconEnabled)
-        .addComponent(switchNotice)
-        .addLabeledComponent("Log Level:", logLevelCombo)
-        .addLabeledComponent("Output Charset:", outputCharsetCombo)
-        .addComponent(outputDemoCheckBox)
-        .addComponent(createTitledPanel("Cache Management", listOf(cachePanel)))
+        .addComponent(
+            SettingsUiKit.titledPanel(
+                "Scanning", listOf(
+                    autoScanEnabled, concurrentScanEnabled
+                )
+            )
+        )
+        .addComponent(
+            SettingsUiKit.titledPanel(
+                "Editor", listOf(
+                    gutterIconEnabled, switchNotice
+                )
+            )
+        )
+        .addComponent(
+            SettingsUiKit.titledPanel(
+                "Output", listOf(
+                    SettingsUiKit.labeledRow("Output Charset:", outputCharsetCombo),
+                    outputDemoCheckBox
+                )
+            )
+        )
+        .addComponent(
+            SettingsUiKit.titledPanel(
+                "Diagnostics", listOf(
+                    SettingsUiKit.labeledRow("Log Level:", logLevelCombo)
+                )
+            )
+        )
+        .addComponent(SettingsUiKit.titledPanel("Cache Management", cachePanel))
         .addComponent(createRepositoryPanel())
         .addComponentFillVertically(JPanel(), 0)
         .panel
@@ -543,7 +556,7 @@ class HttpSettingsPanel : SettingsPanel<HttpSettings> {
     }
 }
 
-class IntelligentSettingsPanel : SettingsPanel<IntelligentSettings> {
+class ParsingOutputSettingsPanel : SettingsPanel<ParsingOutputSettings> {
     private val queryExpanded = JBCheckBox("Query expanded", true).apply {
         toolTipText = "Expand query parameters into individual fields in the exported API documentation"
     }
@@ -567,66 +580,50 @@ class IntelligentSettingsPanel : SettingsPanel<IntelligentSettings> {
         }
 
     override val component: JComponent = FormBuilder.createFormBuilder()
-        .addComponent(queryExpanded)
-        .addComponent(formExpanded)
-        .addComponent(inferReturnMain)
-        .addComponent(enableUrlTemplating)
+        .addComponent(
+            SettingsUiKit.titledPanel(
+                "Inference", listOf(
+                    inferReturnMain, enumFieldAutoInferEnabled
+                )
+            )
+        )
+        .addComponent(
+            SettingsUiKit.titledPanel(
+                "Output Format", listOf(
+                    queryExpanded, formExpanded, enableUrlTemplating
+                )
+            )
+        )
         .addLabeledComponent("Path multi-select strategy:", pathMultiCombo)
-        .addComponent(enumFieldAutoInferEnabled)
         .addComponentFillVertically(JPanel(), 0)
         .panel
 
-    override fun resetFrom(settings: IntelligentSettings?) {
+    override fun resetFrom(settings: ParsingOutputSettings?) {
         queryExpanded.isSelected = settings?.queryExpanded ?: true
         formExpanded.isSelected = settings?.formExpanded ?: true
         inferReturnMain.isSelected = settings?.inferReturnMain ?: true
         enableUrlTemplating.isSelected = settings?.enableUrlTemplating ?: true
         pathMultiCombo.selectedItem = settings?.pathMulti ?: "ALL"
+        enumFieldAutoInferEnabled.isSelected = settings?.enumFieldAutoInferEnabled ?: false
     }
 
-    /**
-     * Resets the `enumFieldAutoInferEnabled` checkbox from [GeneralSettings].
-     * Called separately by the configurable because `enumFieldAutoInferEnabled`
-     * belongs to [GeneralSettings], not [IntelligentSettings].
-     */
-    fun resetEnumFieldFrom(generalSettings: GeneralSettings?) {
-        enumFieldAutoInferEnabled.isSelected = generalSettings?.enumFieldAutoInferEnabled ?: false
-    }
-
-    override fun applyTo(settings: IntelligentSettings) {
+    override fun applyTo(settings: ParsingOutputSettings) {
         settings.queryExpanded = queryExpanded.isSelected
         settings.formExpanded = formExpanded.isSelected
         settings.inferReturnMain = inferReturnMain.isSelected
         settings.enableUrlTemplating = enableUrlTemplating.isSelected
         settings.pathMulti = pathMultiCombo.selectedItem?.toString() ?: "ALL"
+        settings.enumFieldAutoInferEnabled = enumFieldAutoInferEnabled.isSelected
     }
 
-    /**
-     * Applies the `enumFieldAutoInferEnabled` checkbox to [GeneralSettings].
-     * Called separately by the configurable because `enumFieldAutoInferEnabled`
-     * belongs to [GeneralSettings], not [IntelligentSettings].
-     */
-    fun applyEnumFieldTo(generalSettings: GeneralSettings) {
-        generalSettings.enumFieldAutoInferEnabled = enumFieldAutoInferEnabled.isSelected
-    }
-
-    override fun isModified(settings: IntelligentSettings?): Boolean {
+    override fun isModified(settings: ParsingOutputSettings?): Boolean {
         val s = settings ?: return false
         return queryExpanded.isSelected != s.queryExpanded ||
                 formExpanded.isSelected != s.formExpanded ||
                 inferReturnMain.isSelected != s.inferReturnMain ||
                 enableUrlTemplating.isSelected != s.enableUrlTemplating ||
-                pathMultiCombo.selectedItem?.toString() != s.pathMulti
-    }
-
-    /**
-     * Checks if the `enumFieldAutoInferEnabled` checkbox has been modified
-     * relative to [GeneralSettings.enumFieldAutoInferEnabled].
-     * Called separately by the configurable because `enumFieldAutoInferEnabled`
-     * belongs to [GeneralSettings], not [IntelligentSettings].
-     */
-    fun isEnumFieldModified(generalSettings: GeneralSettings?): Boolean {
-        return enumFieldAutoInferEnabled.isSelected != (generalSettings?.enumFieldAutoInferEnabled ?: false)
+                pathMultiCombo.selectedItem?.toString() != s.pathMulti ||
+                enumFieldAutoInferEnabled.isSelected != s.enumFieldAutoInferEnabled
     }
 }
 
@@ -934,15 +931,15 @@ class AiAssistantSection : SettingsPanel<AiSettings> {
 
     override val component: JComponent = FormBuilder.createFormBuilder()
         .addComponent(
-            createTitledPanel(
+            SettingsUiKit.titledPanel(
                 "AI Assistant", listOf(
-            compactRow("Provider:", providerCombo),
-            compactRow("Base URL:", baseUrlField),
-            compactRow("API Key:", apiKeyField, revealApiKeyButton),
-            compactRow("Model:", modelField),
-            compactRow("Request Timeout (sec):", timeoutSpinner),
-            compactRow("Max Requests:", maxAgentStepsSpinner),
-            compactRow("Context Window:", contextWindowCombo),
+            SettingsUiKit.labeledRow("Provider:", providerCombo),
+            SettingsUiKit.labeledRow("Base URL:", baseUrlField),
+            SettingsUiKit.labeledRow("API Key:", apiKeyField, revealApiKeyButton),
+            SettingsUiKit.labeledRow("Model:", modelField),
+            SettingsUiKit.labeledRow("Request Timeout (sec):", timeoutSpinner),
+            SettingsUiKit.labeledRow("Max Requests:", maxAgentStepsSpinner),
+            SettingsUiKit.labeledRow("Context Window:", contextWindowCombo),
             JPanel(FlowLayout(FlowLayout.LEFT, 6, 2)).apply {
                 add(testConnectionButton)
                 add(autoDetectButton)
@@ -1288,18 +1285,6 @@ class AiAssistantSection : SettingsPanel<AiSettings> {
         return false
     }
 
-    private fun compactRow(label: String, field: JComponent, vararg extras: JComponent): JComponent {
-        val panel = JPanel(FlowLayout(FlowLayout.LEFT, 6, 2))
-        if (label.isNotEmpty()) {
-            val l = JLabel(label)
-            l.preferredSize = Dimension(150, l.preferredSize.height)
-            panel.add(l)
-        }
-        panel.add(field)
-        extras.forEach { panel.add(it) }
-        return panel
-    }
-
     /**
      * Updates the inline status label. [ok] = true → neutral/positive
      * colour; false → error colour.
@@ -1400,7 +1385,7 @@ class AiAssistantSection : SettingsPanel<AiSettings> {
     }
 }
 
-class OtherSettingsPanel(private val project: com.intellij.openapi.project.Project) : SettingsPanel<Settings> {
+class BackupSettingsPanel(private val project: com.intellij.openapi.project.Project) : SettingsPanel<Settings> {
     private val importButton = JButton("Import Settings")
     private val exportButton = JButton("Export Settings")
 
@@ -1489,7 +1474,6 @@ class OtherSettingsPanel(private val project: com.intellij.openapi.project.Proje
             obj.get("concurrentScanEnabled")?.asBoolean?.let { concurrentScanEnabled = it }
             obj.get("gutterIconEnabled")?.asBoolean?.let { gutterIconEnabled = it }
             obj.get("switchNotice")?.asBoolean?.let { switchNotice = it }
-            obj.get("enumFieldAutoInferEnabled")?.asBoolean?.let { enumFieldAutoInferEnabled = it }
             obj.get("logLevel")?.asInt?.let { logLevel = it }
             obj.get("outputDemo")?.asBoolean?.let { outputDemo = it }
             obj.get("outputCharset")?.asString?.let { outputCharset = it }
@@ -1501,12 +1485,16 @@ class OtherSettingsPanel(private val project: com.intellij.openapi.project.Proje
             obj.get("httpClient")?.asString?.let { httpClient = it }
         }
 
-        binder.update(com.itangcent.easyapi.settings.module.IntelligentSettings::class) {
+        binder.update(com.itangcent.easyapi.settings.module.ParsingOutputSettings::class) {
             obj.get("queryExpanded")?.asBoolean?.let { queryExpanded = it }
             obj.get("formExpanded")?.asBoolean?.let { formExpanded = it }
             obj.get("inferReturnMain")?.asBoolean?.let { inferReturnMain = it }
             obj.get("enableUrlTemplating")?.asBoolean?.let { enableUrlTemplating = it }
             obj.get("pathMulti")?.asString?.let { pathMulti = it }
+            obj.get("enumFieldAutoInferEnabled")?.asBoolean?.let { enumFieldAutoInferEnabled = it }
+        }
+
+        binder.update(com.itangcent.easyapi.settings.module.EnvironmentSettings::class) {
             obj.get("globalEnvironments")?.asString?.let { globalEnvironments = it }
         }
 
@@ -1547,7 +1535,6 @@ class OtherSettingsPanel(private val project: com.intellij.openapi.project.Proje
         obj.addProperty("concurrentScanEnabled", general.concurrentScanEnabled)
         obj.addProperty("gutterIconEnabled", general.gutterIconEnabled)
         obj.addProperty("switchNotice", general.switchNotice)
-        obj.addProperty("enumFieldAutoInferEnabled", general.enumFieldAutoInferEnabled)
         obj.addProperty("logLevel", general.logLevel)
         obj.addProperty("outputDemo", general.outputDemo)
         obj.addProperty("outputCharset", general.outputCharset)
@@ -1557,13 +1544,16 @@ class OtherSettingsPanel(private val project: com.intellij.openapi.project.Proje
         obj.addProperty("unsafeSsl", http.unsafeSsl)
         obj.addProperty("httpClient", http.httpClient)
 
-        val intelligent = binder.read(com.itangcent.easyapi.settings.module.IntelligentSettings::class)
-        obj.addProperty("queryExpanded", intelligent.queryExpanded)
-        obj.addProperty("formExpanded", intelligent.formExpanded)
-        obj.addProperty("inferReturnMain", intelligent.inferReturnMain)
-        obj.addProperty("enableUrlTemplating", intelligent.enableUrlTemplating)
-        obj.addProperty("pathMulti", intelligent.pathMulti)
-        obj.addProperty("globalEnvironments", intelligent.globalEnvironments)
+        val parsingOutput = binder.read(com.itangcent.easyapi.settings.module.ParsingOutputSettings::class)
+        obj.addProperty("queryExpanded", parsingOutput.queryExpanded)
+        obj.addProperty("formExpanded", parsingOutput.formExpanded)
+        obj.addProperty("inferReturnMain", parsingOutput.inferReturnMain)
+        obj.addProperty("enableUrlTemplating", parsingOutput.enableUrlTemplating)
+        obj.addProperty("pathMulti", parsingOutput.pathMulti)
+        obj.addProperty("enumFieldAutoInferEnabled", parsingOutput.enumFieldAutoInferEnabled)
+
+        val environment = binder.read(com.itangcent.easyapi.settings.module.EnvironmentSettings::class)
+        obj.addProperty("globalEnvironments", environment.globalEnvironments)
 
         val ruleFile = binder.read(com.itangcent.easyapi.settings.module.RuleFileSettings::class)
         obj.addProperty("extensionConfigs", ruleFile.extensionConfigs)
@@ -1582,19 +1572,5 @@ class OtherSettingsPanel(private val project: com.intellij.openapi.project.Proje
         obj.addProperty("postmanJson5FormatType", postman.postmanJson5FormatType)
 
         return GsonUtils.toJson(obj)
-    }
-}
-
-private fun createTitledPanel(title: String, components: List<JComponent>): JPanel {
-    return JPanel(BorderLayout()).apply {
-        border = BorderFactory.createTitledBorder(
-            BorderFactory.createEtchedBorder(),
-            title,
-            TitledBorder.LEFT,
-            TitledBorder.TOP
-        )
-        val inner = JPanel(GridLayout(0, 1, 0, 2))
-        components.forEach { inner.add(it) }
-        add(inner, BorderLayout.CENTER)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsUiKit.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsUiKit.kt
@@ -1,0 +1,72 @@
+package com.itangcent.easyapi.settings.ui
+
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.GridLayout
+import javax.swing.BorderFactory
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.border.TitledBorder
+
+/**
+ * Shared UI builders for settings panels.
+ *
+ * Centralizes the `TitledBorder` panel pattern used across [SettingsPanel]
+ * implementations (gRPC, Environments, General, Parsing & Output, AI) so the
+ * styling stays consistent and panels stop re-inlining the same boilerplate.
+ */
+internal object SettingsUiKit {
+
+    /**
+     * A panel with an etched [TitledBorder] and a vertical stack of components.
+     */
+    fun titledPanel(title: String, components: List<JComponent>): JPanel {
+        return JPanel(BorderLayout()).apply {
+            border = BorderFactory.createTitledBorder(
+                BorderFactory.createEtchedBorder(),
+                title,
+                TitledBorder.LEFT,
+                TitledBorder.TOP
+            )
+            val inner = JPanel(GridLayout(0, 1, 0, 2))
+            components.forEach { inner.add(it) }
+            add(inner, BorderLayout.CENTER)
+        }
+    }
+
+    /**
+     * A titled panel wrapping a single arbitrary component (used when the inner
+     * layout is not a simple vertical stack — e.g. a table + toolbar, or a
+     * composite sub-panel).
+     */
+    fun titledPanel(title: String, component: JComponent): JPanel {
+        return JPanel(BorderLayout()).apply {
+            border = BorderFactory.createTitledBorder(
+                BorderFactory.createEtchedBorder(),
+                title,
+                TitledBorder.LEFT,
+                TitledBorder.TOP
+            )
+            add(component, BorderLayout.CENTER)
+        }
+    }
+
+    /**
+     * A left-aligned label + field row. The label is given a fixed width so
+     * multiple rows line up. [extras] (e.g. an eye-toggle button) are appended
+     * after the field.
+     */
+    fun labeledRow(label: String, field: JComponent, vararg extras: JComponent): JComponent {
+        val panel = JPanel(FlowLayout(FlowLayout.LEFT, 6, 2))
+        if (label.isNotEmpty()) {
+            val l = JLabel(label)
+            l.preferredSize = Dimension(150, l.preferredSize.height)
+            panel.add(l)
+        }
+        panel.add(field)
+        extras.forEach { panel.add(it) }
+        return panel
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -92,9 +92,9 @@
                              instance="com.itangcent.easyapi.settings.ui.EasyApiRulesConfigurable"
                              weight="10"/>
         <projectConfigurable groupId="easyapi.settings.EasyApiConfigurable"
-                             displayName="Other"
-                             id="easyapi.settings.EasyApiConfigurable.Other"
-                             instance="com.itangcent.easyapi.settings.ui.EasyApiOtherConfigurable"/>
+                             displayName="Backup"
+                             id="easyapi.settings.EasyApiConfigurable.Backup"
+                             instance="com.itangcent.easyapi.settings.ui.EasyApiBackupConfigurable"/>
         <toolWindow
                 id="API Dashboard"
                 icon="AllIcons.Toolwindows.WebToolWindow"

--- a/src/test/kotlin/com/itangcent/easyapi/psi/ComprehensiveEnumCasesTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/ComprehensiveEnumCasesTest.kt
@@ -2,7 +2,7 @@ package com.itangcent.easyapi.psi
 
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
-import com.itangcent.easyapi.settings.module.GeneralSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.update
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
@@ -200,7 +200,7 @@ enum.use.custom=groovy:```
         override fun setUp() {
             super.setUp()
             // Enable auto-infer so class-only @see can auto-match by type.
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = true
             }
             SUPPORTING_FILE_PATHS.forEach { loadFile(it) }
@@ -235,7 +235,7 @@ enum.use.custom=groovy:```
                 throw AssumptionViolatedException("Kotlin plugin not available")
             }
             // Enable auto-infer so class-only @see can auto-match by type.
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = true
             }
             SUPPORTING_FILE_PATHS.forEach { loadFile(it) }

--- a/src/test/kotlin/com/itangcent/easyapi/psi/EnumResolutionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/EnumResolutionTest.kt
@@ -2,7 +2,7 @@ package com.itangcent.easyapi.psi
 
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
-import com.itangcent.easyapi.settings.module.GeneralSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.update
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
@@ -535,7 +535,7 @@ class EnumResolutionTest {
         override fun setUp() {
             super.setUp()
             // Auto-match by type is only performed in INTELLIGENT mode (issue #1383).
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = true
             }
         }
@@ -784,7 +784,7 @@ class EnumResolutionTest {
 
         override fun setUp() {
             super.setUp()
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = true
             }
         }
@@ -852,7 +852,7 @@ class EnumResolutionTest {
 
         override fun setUp() {
             super.setUp()
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = false
             }
         }
@@ -898,7 +898,7 @@ class EnumResolutionTest {
 
         override fun setUp() {
             super.setUp()
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = false
             }
         }
@@ -938,7 +938,7 @@ class EnumResolutionTest {
 
         override fun setUp() {
             super.setUp()
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = true
             }
         }
@@ -1004,7 +1004,7 @@ class EnumResolutionTest {
         }
 
         fun testSimpleEnumUsesConstantNamesInIntelligentMode() = runBlocking {
-            settingBinder.update(GeneralSettings::class) {
+            settingBinder.update(ParsingOutputSettings::class) {
                 enumFieldAutoInferEnabled = true
             }
             myFixture.addFileToProject("constant/SimpleStatus.java", SIMPLE_STATUS_ENUM.trimIndent())

--- a/src/test/kotlin/com/itangcent/easyapi/script/env/EnvironmentServicePlatformTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/script/env/EnvironmentServicePlatformTest.kt
@@ -2,7 +2,7 @@ package com.itangcent.easyapi.script.env
 
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.settings.module.EnvironmentSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 class EnvironmentServicePlatformTest : EasyApiLightCodeInsightFixtureTestCase() {
@@ -14,7 +14,7 @@ class EnvironmentServicePlatformTest : EasyApiLightCodeInsightFixtureTestCase() 
         // Initialize settings with empty environments
         val settingBinder = SettingBinder.getInstance(project)
         settingBinder.save(EnvironmentSettings())
-        settingBinder.save(IntelligentSettings())
+        settingBinder.save(ParsingOutputSettings())
         service = EnvironmentService(project)
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
@@ -1,7 +1,9 @@
 package com.itangcent.easyapi.settings
 
+import com.itangcent.easyapi.settings.module.EnvironmentSettings
 import com.itangcent.easyapi.settings.module.GeneralSettings
 import com.itangcent.easyapi.settings.module.HttpSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.state.ApplicationSettingsState
 import org.junit.Assert.*
 import org.junit.Test
@@ -75,8 +77,8 @@ class SettingsDefaultsTest {
     }
 
     @Test
-    fun `test GeneralSettings default enumFieldAutoInferEnabled is false`() {
-        val settings = GeneralSettings()
+    fun `test ParsingOutputSettings default enumFieldAutoInferEnabled is false`() {
+        val settings = ParsingOutputSettings()
         assertFalse(
             "Default enumFieldAutoInferEnabled should be false",
             settings.enumFieldAutoInferEnabled
@@ -93,13 +95,34 @@ class SettingsDefaultsTest {
     }
 
     @Test
-    fun `test GeneralSettings and ApplicationSettingsState have matching enumFieldAutoInferEnabled defaults`() {
-        val settings = GeneralSettings()
+    fun `test ParsingOutputSettings and ApplicationSettingsState have matching enumFieldAutoInferEnabled defaults`() {
+        val settings = ParsingOutputSettings()
         val appState = ApplicationSettingsState.State()
         assertEquals(
-            "enumFieldAutoInferEnabled defaults should match between GeneralSettings and ApplicationSettingsState",
+            "enumFieldAutoInferEnabled defaults should match between ParsingOutputSettings and ApplicationSettingsState",
             settings.enumFieldAutoInferEnabled,
             appState.enumFieldAutoInferEnabled
+        )
+    }
+
+    @Test
+    fun `test EnvironmentSettings default globalEnvironments is empty`() {
+        val settings = EnvironmentSettings()
+        assertEquals(
+            "Default globalEnvironments should be empty",
+            "",
+            settings.globalEnvironments
+        )
+    }
+
+    @Test
+    fun `test EnvironmentSettings and ApplicationSettingsState have matching globalEnvironments defaults`() {
+        val settings = EnvironmentSettings()
+        val appState = ApplicationSettingsState.State()
+        assertEquals(
+            "globalEnvironments defaults should match between EnvironmentSettings and ApplicationSettingsState",
+            settings.globalEnvironments,
+            appState.globalEnvironments
         )
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/EasyApiSettingsConfigurableTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/EasyApiSettingsConfigurableTest.kt
@@ -65,11 +65,10 @@ class EasyApiSettingsConfigurableTest : EasyApiLightCodeInsightFixtureTestCase()
         assertEquals("TAB_GENERAL should be 'General'", "General", EasyApiSettingsConfigurable.TAB_GENERAL)
         assertEquals("TAB_POSTMAN should be 'Postman'", "Postman", EasyApiSettingsConfigurable.TAB_POSTMAN)
         assertEquals("TAB_HTTP should be 'HTTP'", "HTTP", EasyApiSettingsConfigurable.TAB_HTTP)
-        assertEquals("TAB_INTELLIGENT should be 'Intelligent'", "Intelligent", EasyApiSettingsConfigurable.TAB_INTELLIGENT)
+        assertEquals("TAB_PARSING_OUTPUT should be 'Parsing & Output'", "Parsing & Output", EasyApiSettingsConfigurable.TAB_PARSING_OUTPUT)
         assertEquals("TAB_EXTENSIONS should be 'Extensions'", "Extensions", EasyApiSettingsConfigurable.TAB_EXTENSIONS)
         assertEquals("TAB_RULES should be 'Rules'", "Rules", EasyApiSettingsConfigurable.TAB_RULES)
         assertEquals("TAB_AI should be 'AI'", "AI", EasyApiSettingsConfigurable.TAB_AI)
-        assertEquals("TAB_OTHER should be 'Other'", "Other", EasyApiSettingsConfigurable.TAB_OTHER)
         assertEquals("TAB_GRPC should be 'gRPC'", "gRPC", EasyApiSettingsConfigurable.TAB_GRPC)
     }
 
@@ -81,7 +80,7 @@ class EasyApiSettingsConfigurableTest : EasyApiLightCodeInsightFixtureTestCase()
         configurable.createComponent()
         val tabs = configurable.tabsForTest()
         // Rules is no longer an inner tab of the main
-        // EasyApi page — it lives only as the child node beside "Other"
+        // EasyApi page — it lives only as the child node beside "Backup"
         // (EasyApiRulesConfigurable).
         assertFalse(
             "Rules tab must NOT be present in the main tabbed pane; got: $tabs",
@@ -91,6 +90,12 @@ class EasyApiSettingsConfigurableTest : EasyApiLightCodeInsightFixtureTestCase()
             "Built-in tab should be absent (replaced by Rules in 3.0); got: $tabs",
             tabs.any { it.equals("Built-in", ignoreCase = true) ||
                        it.equals("BuiltIn", ignoreCase = true) }
+        )
+        // Backup lives only as the child node (EasyApiBackupConfigurable),
+        // never as an inner tab — guards against re-duplication.
+        assertFalse(
+            "Backup tab must NOT be present in the main tabbed pane; got: $tabs",
+            tabs.any { it.equals("Backup", ignoreCase = true) }
         )
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/EnhancedSettingsPanelsLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/EnhancedSettingsPanelsLogicTest.kt
@@ -1,7 +1,6 @@
 package com.itangcent.easyapi.settings.ui
 
 import com.itangcent.easyapi.settings.module.EnvironmentSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
 import com.itangcent.easyapi.util.json.GsonUtils
 import org.junit.Assert.*
 import org.junit.Test
@@ -88,9 +87,8 @@ class EnvironmentSettingsPanelLogicTest {
     @Test
     fun testSettings_environmentDefaults() {
         val envSettings = EnvironmentSettings()
-        val intelSettings = IntelligentSettings()
         assertEquals("", envSettings.projectEnvironments)
-        assertEquals("", intelSettings.globalEnvironments)
+        assertEquals("", envSettings.globalEnvironments)
     }
 
     @Test
@@ -101,10 +99,12 @@ class EnvironmentSettingsPanelLogicTest {
         val globalEnvJson = GsonUtils.toJson(
             mapOf("environments" to listOf(mapOf("name" to "prod", "variables" to mapOf("URL" to "https://prod.example.com"))))
         )
-        val envSettings = EnvironmentSettings(projectEnvironments = projectEnvJson)
-        val intelSettings = IntelligentSettings(globalEnvironments = globalEnvJson)
+        val envSettings = EnvironmentSettings(
+            projectEnvironments = projectEnvJson,
+            globalEnvironments = globalEnvJson
+        )
         assertTrue(envSettings.projectEnvironments.isNotBlank())
-        assertTrue(intelSettings.globalEnvironments.isNotBlank())
+        assertTrue(envSettings.globalEnvironments.isNotBlank())
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/EnvironmentSettingsPanelPlatformTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/EnvironmentSettingsPanelPlatformTest.kt
@@ -1,7 +1,6 @@
 package com.itangcent.easyapi.settings.ui
 
 import com.itangcent.easyapi.settings.module.EnvironmentSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.util.json.GsonUtils
 
@@ -16,17 +15,13 @@ class EnvironmentSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestC
 
     fun testResetFromAndApplyToDefaultSettings() {
         val envSettings = EnvironmentSettings()
-        val globalEnvSettings = IntelligentSettings()
         panel.resetFrom(envSettings)
-        panel.resetGlobalEnvsFrom(globalEnvSettings)
 
         val target = EnvironmentSettings()
-        val globalTarget = IntelligentSettings()
         panel.applyTo(target)
-        panel.applyGlobalEnvsTo(globalTarget)
 
         assertEquals("", target.projectEnvironments)
-        assertEquals("", globalTarget.globalEnvironments)
+        assertEquals("", target.globalEnvironments)
     }
 
     fun testResetFromWithProjectEnvironments() {
@@ -52,14 +47,13 @@ class EnvironmentSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestC
                 mapOf("name" to "prod", "scope" to "GLOBAL", "variables" to mapOf("URL" to "https://prod.example.com"))
             ))
         )
-        val globalEnvSettings = IntelligentSettings().apply {
+        val settings = EnvironmentSettings().apply {
             this.globalEnvironments = globalEnvJson
         }
-        panel.resetFrom(EnvironmentSettings())
-        panel.resetGlobalEnvsFrom(globalEnvSettings)
+        panel.resetFrom(settings)
 
-        val target = IntelligentSettings()
-        panel.applyGlobalEnvsTo(target)
+        val target = EnvironmentSettings()
+        panel.applyTo(target)
 
         assertTrue(target.globalEnvironments.isNotBlank())
     }
@@ -75,37 +69,27 @@ class EnvironmentSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestC
     fun testResetFromEmptyEnvironments() {
         val envSettings = EnvironmentSettings().apply {
             projectEnvironments = ""
-        }
-        val globalEnvSettings = IntelligentSettings().apply {
             globalEnvironments = ""
         }
         panel.resetFrom(envSettings)
-        panel.resetGlobalEnvsFrom(globalEnvSettings)
 
         val target = EnvironmentSettings()
-        val globalTarget = IntelligentSettings()
         panel.applyTo(target)
-        panel.applyGlobalEnvsTo(globalTarget)
 
         assertEquals("", target.projectEnvironments)
-        assertEquals("", globalTarget.globalEnvironments)
+        assertEquals("", target.globalEnvironments)
     }
 
     fun testResetFromMalformedJson() {
         val envSettings = EnvironmentSettings().apply {
             projectEnvironments = "not-valid-json"
-        }
-        val globalEnvSettings = IntelligentSettings().apply {
             globalEnvironments = "also-not-valid"
         }
         panel.resetFrom(envSettings)
-        panel.resetGlobalEnvsFrom(globalEnvSettings)
         // Should not throw, just ignore malformed JSON
 
         val target = EnvironmentSettings()
-        val globalTarget = IntelligentSettings()
         panel.applyTo(target)
-        panel.applyGlobalEnvsTo(globalTarget)
         // Should produce empty environments
     }
 
@@ -125,21 +109,16 @@ class EnvironmentSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestC
                 mapOf("name" to "prod", "scope" to "GLOBAL", "variables" to mapOf("URL" to "https://prod.example.com"))
             ))
         )
-        val envSettings = EnvironmentSettings().apply {
+        val settings = EnvironmentSettings().apply {
             this.projectEnvironments = projectEnvJson
-        }
-        val globalEnvSettings = IntelligentSettings().apply {
             this.globalEnvironments = globalEnvJson
         }
-        panel.resetFrom(envSettings)
-        panel.resetGlobalEnvsFrom(globalEnvSettings)
+        panel.resetFrom(settings)
 
         val target = EnvironmentSettings()
-        val globalTarget = IntelligentSettings()
         panel.applyTo(target)
-        panel.applyGlobalEnvsTo(globalTarget)
 
         assertTrue(target.projectEnvironments.isNotBlank())
-        assertTrue(globalTarget.globalEnvironments.isNotBlank())
+        assertTrue(target.globalEnvironments.isNotBlank())
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsCoverageTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsCoverageTest.kt
@@ -3,7 +3,7 @@ package com.itangcent.easyapi.settings.ui
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.extension.ExtensionConfigRegistry
 import com.itangcent.easyapi.settings.module.GeneralSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.module.RuleFileSettings
 import org.junit.Assert.*
 import org.junit.Test
@@ -14,7 +14,7 @@ import org.mockito.kotlin.mock
  * tested without the IntelliJ Platform test framework.
  *
  * Tests use plain JUnit (no LightCodeInsightFixtureTestCase). The only
- * IntelliJ-specific seam is a Mockito-mocked [Project] for [OtherSettingsPanel],
+ * IntelliJ-specific seam is a Mockito-mocked [Project] for [BackupSettingsPanel],
  * whose no-op methods never touch the project.
  *
  * Existing coverage in SettingsPanelsLogicTest / SettingsPanelsParityTest /
@@ -23,64 +23,70 @@ import org.mockito.kotlin.mock
 class SettingsPanelsCoverageTest {
 
     // =====================================================================
-    // IntelligentSettingsPanel — enum field null handling + round-trip
+    // ParsingOutputSettingsPanel — enum field null handling + round-trip
     // =====================================================================
 
     @Test
-    fun testIntelligentSettingsPanel_resetEnumFieldFrom_nullSettings() {
-        val panel = IntelligentSettingsPanel()
-        panel.resetEnumFieldFrom(null)
-        // null → checkbox defaults to false; default GeneralSettings also has false
-        assertFalse(panel.isEnumFieldModified(GeneralSettings()))
+    fun testParsingOutputSettingsPanel_resetFromNull_enumFieldDefault() {
+        val panel = ParsingOutputSettingsPanel()
+        panel.resetFrom(null)
+        // null → enum checkbox defaults to false; default ParsingOutputSettings also has false
+        assertFalse(panel.isModified(ParsingOutputSettings()))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_isEnumFieldModified_nullSettings() {
-        val panel = IntelligentSettingsPanel()
-        panel.resetEnumFieldFrom(GeneralSettings().apply { enumFieldAutoInferEnabled = true })
-        // checkbox is true; null settings treated as false → modified
-        assertTrue(panel.isEnumFieldModified(null))
-    }
+    fun testParsingOutputSettingsPanel_enumFieldRoundTrip_disabled() {
+        val source = ParsingOutputSettings().apply { enumFieldAutoInferEnabled = false }
+        val panel = ParsingOutputSettingsPanel()
+        panel.resetFrom(source)
+        assertFalse(panel.isModified(source))
 
-    @Test
-    fun testIntelligentSettingsPanel_enumFieldRoundTrip_disabled() {
-        val source = GeneralSettings().apply { enumFieldAutoInferEnabled = false }
-        val panel = IntelligentSettingsPanel()
-        panel.resetEnumFieldFrom(source)
-        assertFalse(panel.isEnumFieldModified(source))
-
-        val target = GeneralSettings().apply { enumFieldAutoInferEnabled = true }
-        panel.applyEnumFieldTo(target)
+        val target = ParsingOutputSettings().apply { enumFieldAutoInferEnabled = true }
+        panel.applyTo(target)
         assertFalse(target.enumFieldAutoInferEnabled)
     }
 
     @Test
-    fun testIntelligentSettingsPanel_resetFromNull_doesNotThrow() {
-        val panel = IntelligentSettingsPanel()
+    fun testParsingOutputSettingsPanel_enumFieldRoundTrip_enabled() {
+        val source = ParsingOutputSettings().apply { enumFieldAutoInferEnabled = true }
+        val panel = ParsingOutputSettingsPanel()
+        panel.resetFrom(source)
+        assertFalse(panel.isModified(source))
+
+        val target = ParsingOutputSettings().apply { enumFieldAutoInferEnabled = false }
+        panel.applyTo(target)
+        assertTrue(target.enumFieldAutoInferEnabled)
+    }
+
+    @Test
+    fun testParsingOutputSettingsPanel_resetFromNull_doesNotThrow() {
+        val panel = ParsingOutputSettingsPanel()
         panel.resetFrom(null)
         // After resetFrom(null), isModified(null) returns false
         assertFalse(panel.isModified(null))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_fullRoundTrip_allFieldsNonDefault() {
-        val source = IntelligentSettings().apply {
+    fun testParsingOutputSettingsPanel_fullRoundTrip_allFieldsNonDefault() {
+        val source = ParsingOutputSettings().apply {
             queryExpanded = false
             formExpanded = false
             inferReturnMain = false
             enableUrlTemplating = false
             pathMulti = "LAST"
+            enumFieldAutoInferEnabled = true
         }
-        val panel = IntelligentSettingsPanel()
+        val panel = ParsingOutputSettingsPanel()
         panel.resetFrom(source)
         assertFalse(panel.isModified(source))
 
-        val target = IntelligentSettings().apply {
+        val target = ParsingOutputSettings().apply {
             queryExpanded = true
             formExpanded = true
             inferReturnMain = true
             enableUrlTemplating = true
             pathMulti = "ALL"
+            enumFieldAutoInferEnabled = false
         }
         panel.applyTo(target)
 
@@ -89,19 +95,21 @@ class SettingsPanelsCoverageTest {
         assertEquals(source.inferReturnMain, target.inferReturnMain)
         assertEquals(source.enableUrlTemplating, target.enableUrlTemplating)
         assertEquals(source.pathMulti, target.pathMulti)
+        assertEquals(source.enumFieldAutoInferEnabled, target.enumFieldAutoInferEnabled)
     }
 
     @Test
-    fun testIntelligentSettingsPanel_fullRoundTrip_defaultSettings() {
-        val source = IntelligentSettings()
-        val panel = IntelligentSettingsPanel()
+    fun testParsingOutputSettingsPanel_fullRoundTrip_defaultSettings() {
+        val source = ParsingOutputSettings()
+        val panel = ParsingOutputSettingsPanel()
         panel.resetFrom(source)
         assertFalse(panel.isModified(source))
 
-        val target = IntelligentSettings().apply {
+        val target = ParsingOutputSettings().apply {
             queryExpanded = false
             formExpanded = false
             pathMulti = "FIRST"
+            enumFieldAutoInferEnabled = true
         }
         panel.applyTo(target)
 
@@ -110,6 +118,7 @@ class SettingsPanelsCoverageTest {
         assertEquals(source.inferReturnMain, target.inferReturnMain)
         assertEquals(source.enableUrlTemplating, target.enableUrlTemplating)
         assertEquals(source.pathMulti, target.pathMulti)
+        assertEquals(source.enumFieldAutoInferEnabled, target.enumFieldAutoInferEnabled)
     }
 
     // =====================================================================
@@ -330,49 +339,49 @@ class SettingsPanelsCoverageTest {
     }
 
     // =====================================================================
-    // OtherSettingsPanel — no-op methods (requires Project, mocked)
+    // BackupSettingsPanel — no-op methods (requires Project, mocked)
     // =====================================================================
 
     @Test
-    fun testOtherSettingsPanel_componentNotNull() {
+    fun testBackupSettingsPanel_componentNotNull() {
         val project: Project = mock()
-        val panel = OtherSettingsPanel(project)
+        val panel = BackupSettingsPanel(project)
         assertNotNull(panel.component)
     }
 
     @Test
-    fun testOtherSettingsPanel_resetFrom_doesNotThrow() {
+    fun testBackupSettingsPanel_resetFrom_doesNotThrow() {
         val project: Project = mock()
-        val panel = OtherSettingsPanel(project)
+        val panel = BackupSettingsPanel(project)
         panel.resetFrom(GeneralSettings())
     }
 
     @Test
-    fun testOtherSettingsPanel_resetFromNull_doesNotThrow() {
+    fun testBackupSettingsPanel_resetFromNull_doesNotThrow() {
         val project: Project = mock()
-        val panel = OtherSettingsPanel(project)
+        val panel = BackupSettingsPanel(project)
         panel.resetFrom(null)
     }
 
     @Test
-    fun testOtherSettingsPanel_applyTo_doesNotThrow() {
+    fun testBackupSettingsPanel_applyTo_doesNotThrow() {
         val project: Project = mock()
-        val panel = OtherSettingsPanel(project)
+        val panel = BackupSettingsPanel(project)
         val settings = GeneralSettings()
         panel.applyTo(settings)
     }
 
     @Test
-    fun testOtherSettingsPanel_isModified_nullSettings_returnsFalse() {
+    fun testBackupSettingsPanel_isModified_nullSettings_returnsFalse() {
         val project: Project = mock()
-        val panel = OtherSettingsPanel(project)
+        val panel = BackupSettingsPanel(project)
         assertFalse(panel.isModified(null))
     }
 
     @Test
-    fun testOtherSettingsPanel_isModified_returnsFalse() {
+    fun testBackupSettingsPanel_isModified_returnsFalse() {
         val project: Project = mock()
-        val panel = OtherSettingsPanel(project)
+        val panel = BackupSettingsPanel(project)
         assertFalse(panel.isModified(GeneralSettings()))
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsLogicTest.kt
@@ -2,7 +2,7 @@ package com.itangcent.easyapi.settings.ui
 
 import com.itangcent.easyapi.settings.HttpClientType
 import com.itangcent.easyapi.settings.module.HttpSettings
-import com.itangcent.easyapi.settings.module.IntelligentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.module.RuleFileSettings
 import org.junit.Assert.*
 import org.junit.Test
@@ -119,20 +119,20 @@ class HttpSettingsPanelLogicTest {
     }
 }
 
-class IntelligentSettingsPanelLogicTest {
+class ParsingOutputSettingsPanelLogicTest {
 
     @Test
-    fun testIntelligentSettingsPanel_resetFromDefault_notModified() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings()
+    fun testParsingOutputSettingsPanel_resetFromDefault_notModified() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings()
         panel.resetFrom(settings)
         assertFalse(panel.isModified(settings))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_resetFromCustom_notModified() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings().apply {
+    fun testParsingOutputSettingsPanel_resetFromCustom_notModified() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings().apply {
             queryExpanded = false
             formExpanded = false
             inferReturnMain = false
@@ -144,12 +144,12 @@ class IntelligentSettingsPanelLogicTest {
     }
 
     @Test
-    fun testIntelligentSettingsPanel_applyTo_defaultSettings() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings()
+    fun testParsingOutputSettingsPanel_applyTo_defaultSettings() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings()
         panel.resetFrom(settings)
 
-        val target = IntelligentSettings()
+        val target = ParsingOutputSettings()
         panel.applyTo(target)
 
         assertTrue(target.queryExpanded)
@@ -160,9 +160,9 @@ class IntelligentSettingsPanelLogicTest {
     }
 
     @Test
-    fun testIntelligentSettingsPanel_applyTo_customSettings() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings().apply {
+    fun testParsingOutputSettingsPanel_applyTo_customSettings() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings().apply {
             queryExpanded = false
             formExpanded = false
             inferReturnMain = false
@@ -171,7 +171,7 @@ class IntelligentSettingsPanelLogicTest {
         }
         panel.resetFrom(settings)
 
-        val target = IntelligentSettings()
+        val target = ParsingOutputSettings()
         panel.applyTo(target)
 
         assertFalse(target.queryExpanded)
@@ -182,69 +182,69 @@ class IntelligentSettingsPanelLogicTest {
     }
 
     @Test
-    fun testIntelligentSettingsPanel_isModified_nullSettings() {
-        val panel = IntelligentSettingsPanel()
+    fun testParsingOutputSettingsPanel_isModified_nullSettings() {
+        val panel = ParsingOutputSettingsPanel()
         assertFalse(panel.isModified(null))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_isModified_differentQueryExpanded() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings().apply { queryExpanded = true }
+    fun testParsingOutputSettingsPanel_isModified_differentQueryExpanded() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings().apply { queryExpanded = true }
         panel.resetFrom(settings)
 
-        val differentSettings = IntelligentSettings().apply { queryExpanded = false }
+        val differentSettings = ParsingOutputSettings().apply { queryExpanded = false }
         panel.resetFrom(differentSettings)
         assertTrue(panel.isModified(settings))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_isModified_differentFormExpanded() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings().apply { formExpanded = true }
+    fun testParsingOutputSettingsPanel_isModified_differentFormExpanded() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings().apply { formExpanded = true }
         panel.resetFrom(settings)
 
-        val differentSettings = IntelligentSettings().apply { formExpanded = false }
+        val differentSettings = ParsingOutputSettings().apply { formExpanded = false }
         panel.resetFrom(differentSettings)
         assertTrue(panel.isModified(settings))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_isModified_differentInferReturnMain() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings().apply { inferReturnMain = true }
+    fun testParsingOutputSettingsPanel_isModified_differentInferReturnMain() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings().apply { inferReturnMain = true }
         panel.resetFrom(settings)
 
-        val differentSettings = IntelligentSettings().apply { inferReturnMain = false }
+        val differentSettings = ParsingOutputSettings().apply { inferReturnMain = false }
         panel.resetFrom(differentSettings)
         assertTrue(panel.isModified(settings))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_isModified_differentEnableUrlTemplating() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings().apply { enableUrlTemplating = true }
+    fun testParsingOutputSettingsPanel_isModified_differentEnableUrlTemplating() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings().apply { enableUrlTemplating = true }
         panel.resetFrom(settings)
 
-        val differentSettings = IntelligentSettings().apply { enableUrlTemplating = false }
+        val differentSettings = ParsingOutputSettings().apply { enableUrlTemplating = false }
         panel.resetFrom(differentSettings)
         assertTrue(panel.isModified(settings))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_isModified_differentPathMulti() {
-        val panel = IntelligentSettingsPanel()
-        val settings = IntelligentSettings().apply { pathMulti = "ALL" }
+    fun testParsingOutputSettingsPanel_isModified_differentPathMulti() {
+        val panel = ParsingOutputSettingsPanel()
+        val settings = ParsingOutputSettings().apply { pathMulti = "ALL" }
         panel.resetFrom(settings)
 
-        val differentSettings = IntelligentSettings().apply { pathMulti = "FIRST" }
+        val differentSettings = ParsingOutputSettings().apply { pathMulti = "FIRST" }
         panel.resetFrom(differentSettings)
         assertTrue(panel.isModified(settings))
     }
 
     @Test
-    fun testIntelligentSettingsPanel_componentNotNull() {
-        val panel = IntelligentSettingsPanel()
+    fun testParsingOutputSettingsPanel_componentNotNull() {
+        val panel = ParsingOutputSettingsPanel()
         assertNotNull(panel.component)
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsParityTest.kt
@@ -2,7 +2,7 @@ package com.itangcent.easyapi.settings.ui
 
 import com.itangcent.easyapi.settings.module.AiSettings
 import com.itangcent.easyapi.settings.module.EnvironmentSettings
-import com.itangcent.easyapi.settings.module.GeneralSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
 import com.itangcent.easyapi.settings.module.RuleFileSettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -40,27 +40,27 @@ class SettingsPanelsParityTest {
     // the IntelliJ Application).
 
     @Test
-    fun testIntelligentPanelEnumFieldAutoInferEnabledRoundTrip() {
-        val settings = GeneralSettings().apply {
+    fun testParsingOutputPanelEnumFieldAutoInferEnabledRoundTrip() {
+        val settings = ParsingOutputSettings().apply {
             enumFieldAutoInferEnabled = true
         }
-        val panel = IntelligentSettingsPanel()
-        panel.resetEnumFieldFrom(settings)
-        assertFalse(panel.isEnumFieldModified(settings))
-        panel.applyEnumFieldTo(settings)
+        val panel = ParsingOutputSettingsPanel()
+        panel.resetFrom(settings)
+        assertFalse(panel.isModified(settings))
+        panel.applyTo(settings)
         assertEquals(true, settings.enumFieldAutoInferEnabled)
     }
 
     @Test
-    fun testIntelligentPanelEnumFieldAutoInferEnabledChangeDetected() {
-        val settings = GeneralSettings().apply {
+    fun testParsingOutputPanelEnumFieldAutoInferEnabledChangeDetected() {
+        val settings = ParsingOutputSettings().apply {
             enumFieldAutoInferEnabled = false
         }
-        val panel = IntelligentSettingsPanel()
-        panel.resetEnumFieldFrom(settings)
-        assertFalse(panel.isEnumFieldModified(settings))
+        val panel = ParsingOutputSettingsPanel()
+        panel.resetFrom(settings)
+        assertFalse(panel.isModified(settings))
         settings.enumFieldAutoInferEnabled = true
-        assertTrue(panel.isEnumFieldModified(settings))
+        assertTrue(panel.isModified(settings))
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
@@ -63,7 +63,7 @@ import java.io.InputStreamReader
  * ```kotlin
  * override fun setUp() {
  *     super.setUp()
- *     SettingBinder.getInstance(project).update(IntelligentSettings::class) {
+ *     SettingBinder.getInstance(project).update(ParsingOutputSettings::class) {
  *         enableUrlTemplating = false
  *     }
  * }
@@ -72,7 +72,7 @@ import java.io.InputStreamReader
  * **2. Update settings in test method (applies only to that specific test):**
  * ```kotlin
  * fun testSomething() {
- *     SettingBinder.getInstance(project).update(IntelligentSettings::class) {
+ *     SettingBinder.getInstance(project).update(ParsingOutputSettings::class) {
  *         enableUrlTemplating = false
  *     }
  *     // test code


### PR DESCRIPTION
## Summary

Resolves long-standing structural smells in the settings UI and consolidates duplicated `TitledBorder` boilerplate. Backwards-compatible: existing users migrate from `ApplicationSettingsState`/`ProjectSettingsState` on next startup (no unified-state release has shipped yet).

### 1. Field moves (eliminate cross-module leaks)

Two settings were stored in a different module from the panel that edited them, requiring bespoke cross-module shims:

- **`enumFieldAutoInferEnabled`**: `GeneralSettings` → `ParsingOutputSettings`. It's enum *inference*, lives in the Parsing & Output panel, but was stored in `GeneralSettings` via `resetEnumFieldFrom` / `applyEnumFieldTo` / `isEnumFieldModified` shims. Folded into the standard `resetFrom`/`applyTo`/`isModified` flow; shims deleted.
- **`globalEnvironments`**: `IntelligentSettings` → `EnvironmentSettings`. Edited in the Environments tab but parked in `IntelligentSettings` because `EnvironmentSettings` was PROJECT-only. `EnvironmentSettings` is now mixed APP+PROJ scope (modeled on `RuleFileSettings`). The panel's `resetGlobalEnvsFrom` / `applyGlobalEnvsTo` / `isGlobalEnvsModified` shims are deleted; `EnvironmentService` now touches only `EnvironmentSettings`.

### 2. Migration

`SettingsMigrationActivity`: `MIGRATION_VERSION` 2 → 3. Both fields are written to their new module keys. Legacy `ApplicationSettingsState`/`ProjectSettingsState` retained as the migration source. Orphaned unified-state keys are harmless (never read).

### 3. Class & tab rename

- `IntelligentSettings` → `ParsingOutputSettings` (file renamed via `git mv`, history preserved). The old name described only one of six fields.
- Tab label **"Intelligent"** → **"Parsing & Output"**; **"Other"** → **"Backup"**.
- Module FQN is the persistence key, but no release has shipped the unified-state code yet, so every user migrates from legacy state directly to the new key — no orphans.

### 4. Panel layout restructuring

- New shared helper **`SettingsUiKit`** (`titledPanel` / `labeledRow`) consolidates the `TitledBorder` boilerplate that was inlined 3× in `GrpcSettingsPanel`, 1× in `EnvironmentSettingsPanel`, 2× in `GeneralSettingsPanel`.
- **`GeneralSettingsPanel`**: flat list of 11 controls + 2 trailing titled boxes → **6 titled groups** in concept order: Framework Support, Scanning, Editor, Output, Diagnostics, Cache Management. Log Level moved out of the Output cluster into its own Diagnostics group.
- **`ParsingOutputSettingsPanel`**: 6 interleaved toggles → **two titled groups** (`Inference`, `Output Format`) matching the new tab name. Path Multi stays as a labeled row outside.
- `GrpcSettingsPanel` / `EnvironmentSettingsPanel` / `createRepositoryPanel`: inlined `TitledBorder` blocks replaced with `SettingsUiKit.titledPanel`.
- Removed private `createTitledPanel` and `AiAssistantSection.compactRow` in favor of `SettingsUiKit`.

## Test plan

- [x] `./gradlew compileKotlin compileTestKotlin` — clean
- [x] `./gradlew test --tests "com.itangcent.easyapi.settings.*"` — pass
- [x] `./gradlew test --tests "*EnvironmentService*"` — pass
- [x] `./gradlew test --tests "*Case2_SeeWithAutoMatch*" --tests "*Case1_IntelligentMode*" --tests "*Case2_IntelligentModeAutoMatch*" --tests "*ComprehensiveEnumCasesTest*"` — pass (the cases that exercise `enumFieldAutoInferEnabled = true`)
- [ ] Manual spot-check in `runIde`: confirm General tab shows 6 titled groups, Parsing & Output shows 2, Backup renamed, enum checkbox persists, global environments editor persists across restart.

## Out of scope (deferred Tier 3)

- Tooltip wording cleanup (several tooltips restate the label).
- Moving `outputDemo` out of `GeneralSettings` into a Markdown-exporter module.
- Dropping dead `TAB_RULES` / `TAB_POSTMAN` constants.
- Grouping Feign/JAX-RS/Actuator under a "Frameworks" header (they're already in a titled group).
- Note: `EnumValueResolver`'s unrelated `INTELLIGENT` mode concept (`Source.INTELLIGENT_SINGLE`, etc.) intentionally **not** renamed — that's enum-resolution domain vocabulary from issue #1383, unrelated to the settings class.
