### PR TITLE
feat: refactor BodyView to carry ObjectModel with render helpers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize line endings to LF across all platforms.
+#
+# Without this, Windows checkouts default to core.autocrlf=true and LF in the
+# index is converted to CRLF on disk. That breaks byte-for-byte parity tests
+# (e.g. MarkdownTemplateParityTest) whose rendered output uses literal "\n".
+# Force LF so checkouts are identical on Linux, macOS, and Windows.
+* text=auto eol=lf
+
+# Binary files — never normalize.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.icns binary
+*.pdf  binary
+*.zip  binary
+*.jar  binary
+*.class binary

--- a/.skills/write-test-case/SKILL.md
+++ b/.skills/write-test-case/SKILL.md
@@ -166,6 +166,37 @@ class MyFormatterTest : EasyApiLightCodeInsightFixtureTestCase() {
 
 ---
 
+### ⚠️ Cross-platform line endings — the golden-file parity trap
+
+**The pitfall.** Code under test typically emits literal `\n`, but a golden file
+checked out on a Windows CI runner (default `core.autocrlf=true`) becomes `\r\n`
+on disk. A byte-for-byte `assertEquals` then fails on Windows only — passing on
+Linux/macOS, hiding the bug until a Windows CI run.
+
+**Always read golden/expected resources through the test framework**, never via
+`File.readText()` / `Paths.readText()`. Two helpers, both in
+`com.itangcent.easyapi.testFramework`:
+
+| Helper | When to use | Normalization |
+|---|---|---|
+| `ResultLoader.load()` / `load("name")` | Snapshot/golden test where trailing whitespace doesn't matter (default choice) | CRLF→LF + `trimEnd()` |
+| `ResourceLoader.read("/path/in/resources")` | Same, when you control the resource path explicitly | CRLF→LF + `trimEnd()` |
+| `ResourceLoader.readRaw("/path/in/resources")` | **Byte-for-byte parity gate** where trailing whitespace MUST be preserved (e.g. `MarkdownTemplateParityTest`) | CRLF→LF only |
+
+Both `read` and `readRaw` collapse CRLF→LF; the difference is whether trailing
+whitespace is trimmed. Use `readRaw` only when the test's contract is strict
+byte equality — for everything else, prefer `ResultLoader`/`read`.
+
+**When writing a new parity/golden test, ask:** "Does my `actual` value carry
+meaningful trailing whitespace?" If yes → `ResourceLoader.readRaw`. If no →
+`ResultLoader.load` (which already calls `ResourceLoader.read`).
+
+The repo also ships a `.gitattributes` forcing `eol=lf` for text files, so
+golden files committed with LF stay LF on Windows checkouts. Do not weaken this.
+
+
+---
+
 ### Pattern D — Action Test
 **When:** Testing an `AnAction` subclass.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,7 @@ Tests use JUnit 4 + Mockito/Mockito-Kotlin + the IntelliJ Platform Test Framewor
 - Run tests: `./gradlew test`
 - Base classes: `EasyApiLightCodeInsightFixtureTestCase` (PSI/Project-aware), plain JUnit for pure utilities
 - Mocking: `mockito-kotlin`
+- **Cross-platform golden-file rule:** Never read expected-output resources with `File.readText()`. Use `ResultLoader.load()` (trailing-trimmed) or `ResourceLoader.readRaw()` (strict byte parity) — both collapse CRLF→LF so snapshot tests pass on Windows CI where `core.autocrlf` may convert the on-disk golden. `.gitattributes` enforces `eol=lf`; do not weaken it.
 
 ## Skills
 

--- a/docs/knowledge-base/settings-guide.md
+++ b/docs/knowledge-base/settings-guide.md
@@ -19,6 +19,7 @@ This guide documents every setting in **Settings → EasyApi**. Settings are org
 9. [Hoppscotch (Beta)](#hoppscotch-beta)
 10. [Other](#other)
 11. [Environments](#environments)
+12. [Markdown Template Reference](#markdown-template-reference)
 
 ---
 
@@ -33,7 +34,6 @@ Framework recognition and output formatting.
 | Enable Actuator | `false` | Recognize Spring Boot Actuator endpoints | `actuatorEnable` |
 | Auto Scan Enabled | `true` | Automatically scan the project for API endpoints | `autoScanEnabled` |
 | Concurrent Scan | `false` | Use parallel scanning for faster discovery | `concurrentScanEnabled` |
-| Output Demo | `true` | Include demo/example values in exports | `outputDemo` |
 | Output Charset | `UTF-8` | Character encoding for exported files | `outputCharset` |
 | Log Level | `100` (SILENT) | Console verbosity. Lower = more verbose. `100`=SILENT, `40`=ERROR, `30`=WARN, `20`=INFO, `10`=DEBUG, `0`=TRACE | `logLevel` |
 | Gutter Icon | `true` | Show gutter icons for API endpoints in the editor | `gutterIconEnabled` |
@@ -224,3 +224,127 @@ Environment variable management for export and script execution.
 |-------|---------|--------|----------|
 | Project Environments | *(empty)* | Project-scoped environment definitions (JSON) | `projectEnvironments` |
 | Global Environments | *(empty)* | Application-scoped environment definitions (JSON) | `globalEnvironments` |
+
+---
+
+## Markdown Template Reference
+
+Custom Markdown export templates (`.md.tpl` files in `src/main/resources/markdown/templates/`) use a Handlebars-like syntax. This section documents the body-view API introduced in the BodyView refactor.
+
+### BodyView API
+
+Each HTTP/gRPC body or response is exposed as a `BodyView` object with:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `model` | `ObjectModel` | The structured body model (Object, Array, Single, or MapModel). |
+| `fields` | `List<FieldView>` | Pre-flattened field list for table/list rendering. |
+
+**Method calls** (evaluated lazily at render time):
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `body.asDemo()` | `String` | Plain JSON demo string (no code fence). |
+| `body.asJson()` | `String` | Alias of `asDemo()` — byte-identical output. |
+| `body.asJson5()` | `String` | JSON5 demo with inline comments (field descriptions). |
+
+### FieldView fields
+
+Each entry in `body.fields` exposes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Field name (empty for primitive bodies). |
+| `type` | `String` | Type label (e.g. `"string"`, `"object[]"`, `"map"`). |
+| `desc` | `String` | Description = comment + options joined with `<br>`. |
+| `required` | `Boolean` | Whether the field is required. |
+| `defaultValue` | `String?` | Default value (empty string if null). |
+| `depth` | `Int` | Nesting depth (0 = top-level). |
+| `indent` | `String` | Pre-computed indent prefix (`&ensp;&ensp;`×depth + `&#124;─`). Use raw interpolation `{{{f.indent}}}` to preserve HTML entities. |
+| `hasChildren` | `Boolean` | Whether the field has nested children. |
+| `childrenCount` | `Int` | Number of direct children. |
+| `structuralKind` | `String` | One of `OBJECT`, `ARRAY`, `MAP`, `PRIMITIVE`. |
+
+### Body variant behavior
+
+| Body type | `fields` content |
+|-----------|-----------------|
+| Object | One `FieldView` per top-level field; nested fields at depth > 0. |
+| Array<Object> | `[0]` item fields at depth 1. |
+| Primitive (Single) | One synthetic field: `name=""`, `type=model.type`, `desc=""`. |
+| Map | Two synthetic fields: `key` + `value`, both `structuralKind=MAP`. |
+| Recursive | Finite — cycle-safe via `ObjectModelVisitTracker` (max 2 visits per object identity). |
+
+### Recipe: table rendering
+
+```handlebars
+{{#if api.http.body}}
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
+{{/each}}
+
+**Request Demo:**
+
+```json
+{{{api.http.body.asDemo()}}}
+```
+{{/if}}
+```
+
+> **Note:** Use `{{{f.indent}}}` (triple braces, raw) for the indent prefix so HTML entities like `&ensp;` survive unescaped. Use `{{f.name}}` (double braces) for the name so it gets markdown-escaped.
+
+### Recipe: list rendering
+
+```handlebars
+{{#each api.http.body.fields as f}}
+{{{f.indent}}}{{f.name}} ({{f.type}}) — {{f.desc}}
+{{/each}}
+```
+
+### Recipe: JSON5 demo with comments
+
+```handlebars
+```json5
+{{{api.http.body.asJson5()}}}
+```
+```
+
+### Breaking change: migration from `body.rows` / `body.demo`
+
+**Removed** (v3.0 BodyView refactor):
+- `body.rows` — replaced by `body.fields`
+- `body.demo` — replaced by `body.asDemo()`
+
+**Before (old):**
+```handlebars
+{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{/each}}
+{{#if api.http.body.demo}}
+```json
+{{{api.http.body.demo}}}
+```
+{{/if}}
+```
+
+**After (new):**
+```handlebars
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
+{{/each}}
+```json
+{{{api.http.body.asDemo()}}}
+```
+```
+
+Key differences:
+1. `r.name` (which included the indent prefix) is split into `{{{f.indent}}}` (raw) + `{{f.name}}` (escaped).
+2. `body.demo` (a pre-computed string) is now `body.asDemo()` (a method call, evaluated lazily).
+3. The `{{#if body.demo}}` conditional is removed — the demo is always present when a body exists.
+
+### Engine v1 limitations
+
+- **No chained method calls:** `body.asJson5().trim()` renders empty + an info log. Only a single method call per expression is supported.
+- **No template recursion:** `{{#each}}` does not support recursive partials.
+- **`meta.*` is always built-in:** `meta.date(...)`, `meta.time(...)` always resolve to built-in functions, never to model fields.

--- a/skills/easy-api-assistant/docs/settings-guide.md
+++ b/skills/easy-api-assistant/docs/settings-guide.md
@@ -19,6 +19,7 @@ This guide documents every setting in **Settings → EasyApi**. Settings are org
 9. [Hoppscotch (Beta)](#hoppscotch-beta)
 10. [Other](#other)
 11. [Environments](#environments)
+12. [Markdown Template Reference](#markdown-template-reference)
 
 ---
 
@@ -33,7 +34,6 @@ Framework recognition and output formatting.
 | Enable Actuator | `false` | Recognize Spring Boot Actuator endpoints | `actuatorEnable` |
 | Auto Scan Enabled | `true` | Automatically scan the project for API endpoints | `autoScanEnabled` |
 | Concurrent Scan | `false` | Use parallel scanning for faster discovery | `concurrentScanEnabled` |
-| Output Demo | `true` | Include demo/example values in exports | `outputDemo` |
 | Output Charset | `UTF-8` | Character encoding for exported files | `outputCharset` |
 | Log Level | `100` (SILENT) | Console verbosity. Lower = more verbose. `100`=SILENT, `40`=ERROR, `30`=WARN, `20`=INFO, `10`=DEBUG, `0`=TRACE | `logLevel` |
 | Gutter Icon | `true` | Show gutter icons for API endpoints in the editor | `gutterIconEnabled` |
@@ -224,3 +224,127 @@ Environment variable management for export and script execution.
 |-------|---------|--------|----------|
 | Project Environments | *(empty)* | Project-scoped environment definitions (JSON) | `projectEnvironments` |
 | Global Environments | *(empty)* | Application-scoped environment definitions (JSON) | `globalEnvironments` |
+
+---
+
+## Markdown Template Reference
+
+Custom Markdown export templates (`.md.tpl` files in `src/main/resources/markdown/templates/`) use a Handlebars-like syntax. This section documents the body-view API introduced in the BodyView refactor.
+
+### BodyView API
+
+Each HTTP/gRPC body or response is exposed as a `BodyView` object with:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `model` | `ObjectModel` | The structured body model (Object, Array, Single, or MapModel). |
+| `fields` | `List<FieldView>` | Pre-flattened field list for table/list rendering. |
+
+**Method calls** (evaluated lazily at render time):
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `body.asDemo()` | `String` | Plain JSON demo string (no code fence). |
+| `body.asJson()` | `String` | Alias of `asDemo()` — byte-identical output. |
+| `body.asJson5()` | `String` | JSON5 demo with inline comments (field descriptions). |
+
+### FieldView fields
+
+Each entry in `body.fields` exposes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Field name (empty for primitive bodies). |
+| `type` | `String` | Type label (e.g. `"string"`, `"object[]"`, `"map"`). |
+| `desc` | `String` | Description = comment + options joined with `<br>`. |
+| `required` | `Boolean` | Whether the field is required. |
+| `defaultValue` | `String?` | Default value (empty string if null). |
+| `depth` | `Int` | Nesting depth (0 = top-level). |
+| `indent` | `String` | Pre-computed indent prefix (`&ensp;&ensp;`×depth + `&#124;─`). Use raw interpolation `{{{f.indent}}}` to preserve HTML entities. |
+| `hasChildren` | `Boolean` | Whether the field has nested children. |
+| `childrenCount` | `Int` | Number of direct children. |
+| `structuralKind` | `String` | One of `OBJECT`, `ARRAY`, `MAP`, `PRIMITIVE`. |
+
+### Body variant behavior
+
+| Body type | `fields` content |
+|-----------|-----------------|
+| Object | One `FieldView` per top-level field; nested fields at depth > 0. |
+| Array<Object> | `[0]` item fields at depth 1. |
+| Primitive (Single) | One synthetic field: `name=""`, `type=model.type`, `desc=""`. |
+| Map | Two synthetic fields: `key` + `value`, both `structuralKind=MAP`. |
+| Recursive | Finite — cycle-safe via `ObjectModelVisitTracker` (max 2 visits per object identity). |
+
+### Recipe: table rendering
+
+```handlebars
+{{#if api.http.body}}
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
+{{/each}}
+
+**Request Demo:**
+
+```json
+{{{api.http.body.asDemo()}}}
+```
+{{/if}}
+```
+
+> **Note:** Use `{{{f.indent}}}` (triple braces, raw) for the indent prefix so HTML entities like `&ensp;` survive unescaped. Use `{{f.name}}` (double braces) for the name so it gets markdown-escaped.
+
+### Recipe: list rendering
+
+```handlebars
+{{#each api.http.body.fields as f}}
+{{{f.indent}}}{{f.name}} ({{f.type}}) — {{f.desc}}
+{{/each}}
+```
+
+### Recipe: JSON5 demo with comments
+
+```handlebars
+```json5
+{{{api.http.body.asJson5()}}}
+```
+```
+
+### Breaking change: migration from `body.rows` / `body.demo`
+
+**Removed** (v3.0 BodyView refactor):
+- `body.rows` — replaced by `body.fields`
+- `body.demo` — replaced by `body.asDemo()`
+
+**Before (old):**
+```handlebars
+{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{/each}}
+{{#if api.http.body.demo}}
+```json
+{{{api.http.body.demo}}}
+```
+{{/if}}
+```
+
+**After (new):**
+```handlebars
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
+{{/each}}
+```json
+{{{api.http.body.asDemo()}}}
+```
+```
+
+Key differences:
+1. `r.name` (which included the indent prefix) is split into `{{{f.indent}}}` (raw) + `{{f.name}}` (escaped).
+2. `body.demo` (a pre-computed string) is now `body.asDemo()` (a method call, evaluated lazily).
+3. The `{{#if body.demo}}` conditional is removed — the demo is always present when a body exists.
+
+### Engine v1 limitations
+
+- **No chained method calls:** `body.asJson5().trim()` renders empty + an info log. Only a single method call per expression is supported.
+- **No template recursion:** `{{#each}}` does not support recursive partials.
+- **`meta.*` is always built-in:** `meta.date(...)`, `meta.time(...)` always resolve to built-in functions, never to model fields.

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/DefaultMarkdownFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/DefaultMarkdownFormatter.kt
@@ -11,21 +11,20 @@ import com.itangcent.easyapi.exporter.model.ApiEndpoint
  *
  * Delegates to [MarkdownTemplateRenderer] with the bundled default template
  * (`default.md.tpl`). The default template reproduces the legacy string-concatenation
- * output byte-for-byte (proven by [MarkdownTemplateParityTest]), so this class is now
- * a thin wrapper that preserves the public API ([outputDemo] flag + `suspend format`).
+ * output byte-for-byte (proven by [MarkdownTemplateParityTest]).
+ *
+ * The model builder always populates [com.itangcent.easyapi.exporter.channel.markdown.template.BodyView.model]
+ * and `fields`; whether demos are rendered is decided solely by the template's
+ * `{{#if body}}` + `{{{body.asDemo()}}}` blocks — the formatter itself has no demo toggle.
  *
  * The default template does not reference any `meta.*` built-ins, so the
  * [RenderContext] values are irrelevant to the output — [RenderContext.production]
  * is used with placeholder project/plugin names.
- *
- * @param outputDemo Whether to include JSON demo examples in the output
  */
-class DefaultMarkdownFormatter(
-    private val outputDemo: Boolean = true
-) : MarkdownFormatter {
+class DefaultMarkdownFormatter : MarkdownFormatter {
 
     override suspend fun format(endpoints: List<ApiEndpoint>, moduleName: String): String {
-        val model = TemplateModelBuilder.build(endpoints, outputDemo, moduleName)
+        val model = TemplateModelBuilder.build(endpoints, moduleName)
         val ctx = RenderContext.production(projectName = "", pluginVersion = "")
         val template = DefaultMarkdownTemplate.get()
         return MarkdownTemplateRenderer.render(template, model, ctx)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/MarkdownChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/MarkdownChannel.kt
@@ -123,7 +123,7 @@ class MarkdownChannel : Channel, IdeaLog {
 
         LOG.info("Markdown template resolved from tier: ${resolved.source}")
 
-        val model = TemplateModelBuilder.build(context.endpointsToExport, outputDemo = true, "API Documentation")
+        val model = TemplateModelBuilder.build(context.endpointsToExport, "API Documentation")
         val ctx = RenderContext.production(projectName = project.name ?: "", pluginVersion = "")
         val content = MarkdownTemplateRenderer.renderWithFallback(resolved.templateText, model, ctx)
         return ExportResult.Success(

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngine.kt
@@ -212,6 +212,12 @@ object TemplateEngine : IdeaLog {
         class Helper(val name: String, val args: List<Expr>) : Expr()
         class BuiltinCall(val name: String, val rawArg: String?) : Expr()
         class Literal(val value: Any) : Expr()
+        /**
+         * A method call on a receiver: `receiver.name(args)`. v1 supports no-arg methods
+         * (`body.asJson5()`); the [args] node is forward-compatible. Chained calls
+         * (`a.b().c()`) are NOT supported — see [parseExpr].
+         */
+        class MethodCall(val receiver: Expr, val name: String, val args: List<Expr>) : Expr()
     }
 
     private class Parser(private val tokens: List<Token>) {
@@ -287,9 +293,34 @@ object TemplateEngine : IdeaLog {
 
         private fun parseExpr(content: String): Expr {
             val trimmed = content.trim()
-            // Builtin call form: NAME(...) or meta.NAME(...)
+
+            // Chained-call v1 boundary (review finding F14): if the expression contains
+            // a ')' followed by a '.', it's a chained method call (e.g. `a.b().c()`) which
+            // v1 does not support. Log once at parse time and render empty.
+            if (hasChainedMethodCall(trimmed)) {
+                LOG.info("Chained method calls are not supported in v1: $trimmed")
+                return Expr.Literal("")
+            }
+
+            // Method-call form: receiver.name(args) — with meta.* carve-out (review finding F4).
+            // Recognized when the expression contains '(' and ends in ')', AND there is a '.'
+            // before the first '(' whose preceding segment is NOT exactly 'meta' (preserving
+            // today's meta.date(...)/meta.time(...)/meta.unknownThing(...) → BuiltinCall behavior).
             val parenIdx = trimmed.indexOf('(')
             if (parenIdx != -1 && trimmed.endsWith(")")) {
+                val lastDotBeforeParen = trimmed.lastIndexOf('.', parenIdx - 1)
+                if (lastDotBeforeParen != -1) {
+                    val receiverPart = trimmed.substring(0, lastDotBeforeParen)
+                    val methodName = trimmed.substring(lastDotBeforeParen + 1, parenIdx).trim()
+                    // meta.* carve-out: 'meta.<name>(...)' stays a BuiltinCall.
+                    if (receiverPart != "meta") {
+                        val rawArgs = trimmed.substring(parenIdx + 1, trimmed.length - 1)
+                        val args = if (rawArgs.isBlank()) emptyList()
+                            else rawArgs.split(',').map { parseSingleExpr(it.trim()) }
+                        return Expr.MethodCall(parseSingleExpr(receiverPart), methodName, args)
+                    }
+                }
+                // Fall through to existing BuiltinCall logic (covers meta.* and bare foo(...)).
                 var name = trimmed.substring(0, parenIdx).trim()
                 val rawArg = trimmed.substring(parenIdx + 1, trimmed.length - 1)
                 if (name.startsWith("meta.")) name = name.substring(5)
@@ -303,6 +334,33 @@ object TemplateEngine : IdeaLog {
                 return Expr.Helper(name, args)
             }
             return parseSingleExpr(trimmed)
+        }
+
+        /**
+         * Detects chained method calls: a `)` followed (after optional whitespace) by a `.`.
+         * Catches `a.b().c()`, `meta.date('yyyy').foo()`, etc. String literals (`'...'`) are
+         * skipped so a `)` inside a string doesn't trigger a false positive.
+         */
+        private fun hasChainedMethodCall(s: String): Boolean {
+            var inString = false
+            var i = 0
+            while (i < s.length) {
+                val c = s[i]
+                if (inString) {
+                    if (c == '\'') inString = false
+                } else {
+                    when (c) {
+                        '\'' -> inString = true
+                        ')' -> {
+                            var j = i + 1
+                            while (j < s.length && s[j].isWhitespace()) j++
+                            if (j < s.length && s[j] == '.') return true
+                        }
+                    }
+                }
+                i++
+            }
+            return false
         }
 
         private fun parseSingleExpr(s: String): Expr {
@@ -388,6 +446,37 @@ object TemplateEngine : IdeaLog {
             is Expr.Path -> evalPath(expr.segments)
             is Expr.BuiltinCall -> TemplateBuiltins.resolve(expr.name, ctx, expr.rawArg)
             is Expr.Helper -> evalHelper(expr.name, expr.args)
+            is Expr.MethodCall -> evalMethodCall(expr)
+        }
+
+        private fun evalMethodCall(expr: Expr.MethodCall): Any? {
+            val target = evalExpr(expr.receiver) ?: return null
+            val argValues = expr.args.map { evalExpr(it) }
+            return invokeMethod(target, expr.name, argValues)
+        }
+
+        /**
+         * Dispatches a method call `target.name(args)` (review finding F7).
+         *
+         * - `BodyView` receiver: `asDemo`/`asJson` → `BodyView.asDemo()` (alias); `asJson5` → `asJson5()`;
+         *   unknown name → null + `info` log.
+         * - Any other receiver type → null + `info` log "Unknown method '<name>' on <receiverType>".
+         */
+        private fun invokeMethod(target: Any, name: String, args: List<Any?>): Any? {
+            return when (target) {
+                is BodyView -> when (name) {
+                    "asDemo", "asJson" -> target.asDemo()
+                    "asJson5" -> target.asJson5()
+                    else -> {
+                        LOG.info("Unknown method '$name' on BodyView")
+                        null
+                    }
+                }
+                else -> {
+                    LOG.info("Unknown method '$name' on ${target::class.simpleName}")
+                    null
+                }
+            }
         }
 
         private fun evalHelper(name: String, args: List<Expr>): Any? {
@@ -539,14 +628,21 @@ object TemplateEngine : IdeaLog {
                 else -> null
             }
             is BodyView -> when (name) {
-                "rows" -> target.rows
-                "demo" -> target.demo
+                "model" -> target.model
+                "fields" -> target.fields
                 else -> null
             }
-            is Row -> when (name) {
+            is FieldView -> when (name) {
                 "name" -> target.name
                 "type" -> target.type
                 "desc" -> target.desc
+                "required" -> target.required
+                "defaultValue" -> target.defaultValue
+                "depth" -> target.depth
+                "indent" -> target.indent
+                "hasChildren" -> target.hasChildren
+                "childrenCount" -> target.childrenCount
+                "structuralKind" -> target.structuralKind.name
                 else -> null
             }
             else -> null

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModel.kt
@@ -1,5 +1,8 @@
 package com.itangcent.easyapi.exporter.channel.markdown.template
 
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+
 /**
  * The Template Model — the versioned data contract between the plugin and user-authored
  * Markdown templates. Plain data classes with no behavior and no PSI/VFS access.
@@ -98,25 +101,73 @@ data class Header(
 /**
  * A request/response body.
  *
- * - [rows] is the **flat**, cycle-safe list of table rows (the indent prefix is already
- *   applied to [Row.name]); the recursive [com.itangcent.easyapi.psi.model.ObjectModel] tree
- *   is flattened by [TemplateModelBuilder] using [com.itangcent.easyapi.psi.model.ObjectModelVisitTracker]
- *   (cycle-safe by object identity, not depth-capped).
- * - [demo] is the pre-rendered JSON demo text **without** the code fence, or `null` when
- *   the body is null **or** when demos are disabled
- *   (`DefaultMarkdownFormatter(outputDemo = false)`). The `outputDemo` flag is an input to
- *   the model build, not a template variable — the builder sets `demo = null` for every
- *   body when demos are off, so the template's `{{#if ...demo}}` guards suppress the blocks
- *   unchanged .
+ * - [model] is the structured [ObjectModel] tree (the source of truth for a body).
+ *   It is **not** directly iterated by templates — the engine has no recursion and
+ *   [ObjectModel] is a sealed class not in `getFieldByName`. It is exposed for
+ *   method-call rendering (`asDemo()` / `asJson()` / `asJson5()`) and for future
+ *   expansion (e.g. partials / macros when added).
+ * - [fields] is the **flat, cycle-safe** list of [FieldView]s the template iterates
+ *   over for table/list rendering. The recursive `ObjectModel` tree is flattened by
+ *   [TemplateModelBuilder] using [com.itangcent.easyapi.psi.model.ObjectModelVisitTracker]
+ *   (cycle-safe by object identity, not depth-capped). Each [FieldView] carries a
+ *   pre-computed [FieldView.indent] so templates can render indented tables without
+ *   arithmetic.
+ *
+ * The three method-call targets — [asDemo], [asJson], [asJson5] — are evaluated
+ * lazily at render time (NOT pre-computed in the builder). `asJson` is sugar for
+ * `asDemo` (D5 — byte-identical output). All three return strings **without** a
+ * markdown code fence; the template owns the fence.
+ *
+ * **Breaking change (D4):** replaces the legacy `BodyView(rows, demo)` shape.
+ * Migration: `body.rows` → `{{#each body.fields as f}}…{{/each}}` with `{{{f.indent}}}{{f.name}}`;
+ * `body.demo` → `{{{body.asDemo()}}}` (or `asJson5()` for JSON5).
  */
 data class BodyView(
-    val rows: List<Row>,
-    val demo: String?,
+    /** The structured body. FR-1. */
+    val model: ObjectModel,
+    /** Cycle-safe, pre-flattened, with depth+indent. FR-3/FR-4. */
+    val fields: List<FieldView>,
+) {
+    /** Plain JSON, no fence. Always non-empty when called on a non-null BodyView. */
+    fun asDemo(): String = ObjectModelJsonConverter.toJson(model)
+
+    /** Byte-identical to [asDemo] (D5 — asDemo is sugar for asJson). */
+    fun asJson(): String = asDemo()
+
+    /** JSON5 with comments, no fence. */
+    fun asJson5(): String = ObjectModelJsonConverter.toJson5(model)
+}
+
+/**
+ * A single row in a body's flattened [fields] list. Replaces the legacy `Row` —
+ * splitting `name`/`indent`/`depth`/`structuralKind` lets the same data drive both
+ * table and list renderings, and lets templates branch on structure
+ * (`{{#if f.hasChildren}}`).
+ *
+ * For synthetic rows produced for non-`Object` top-level bodies (Single/MapModel),
+ * the non-name/non-type/non-structuralKind fields default to: `desc=""`,
+ * `required=false`, `defaultValue=null`, `hasChildren=false`, `childrenCount=0` —
+ * matching the legacy `flattenInto` byte-for-byte (review finding F10).
+ */
+data class FieldView(
+    /** Leaf name (no indent prefix). Indent is separate. */
+    val name: String,
+    /** Formatted type, e.g. "string", "User[]", "object". */
+    val type: String,
+    /** Comment + options joined with "<br>" (parity with legacy). */
+    val desc: String,
+    val required: Boolean,
+    val defaultValue: String?,
+    /** 0 = top-level. */
+    val depth: Int,
+    /** Pre-computed: "" at depth 0; else "&ensp;&ensp;"×depth + "&#124;─". */
+    val indent: String,
+    /** For `{{#if f.hasChildren}}` branching. */
+    val hasChildren: Boolean,
+    val childrenCount: Int,
+    /** OBJECT / ARRAY / MAP / PRIMITIVE — lets templates branch on body shape. */
+    val structuralKind: FieldStructuralKind,
 )
 
-/** A single row in a body table. [name] may include the indent HTML entity prefix. */
-data class Row(
-    val name: String,
-    val type: String,
-    val desc: String,
-)
+/** Structural classification of a [FieldView], for `{{#if}}` branching in templates. */
+enum class FieldStructuralKind { OBJECT, ARRAY, MAP, PRIMITIVE }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilder.kt
@@ -6,21 +6,22 @@ import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.ParameterBinding
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
-import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
 import com.itangcent.easyapi.psi.model.ObjectModelVisitTracker
 
 /**
  * Builds the pure-data [TemplateModel] from already-resolved [ApiEndpoint]s.
  *
  * Pure function: no PSI/VFS access, no side effects. Walks the recursive
- * [ObjectModel] bodies into a flat, cycle-safe list of [Row]s using
- * [ObjectModelVisitTracker] (cycle-safe by object identity, not depth-capped),
- * and pre-renders the JSON `demo` via [ObjectModelJsonConverter.toJson].
+ * [ObjectModel] bodies into a flat, cycle-safe list of [FieldView]s using
+ * [ObjectModelVisitTracker] (cycle-safe by object identity, not depth-capped).
  *
  * The body-flattening logic is ported from the legacy `DefaultMarkdownFormatter`
  * (`formatObjectModelRecursive` / `formatFieldRow` / `formatArrayItemRecursive` /
  * `buildFieldDescription` / `formatType`) so the default template can reproduce the old
  * output byte-for-byte (the parity gate — [MarkdownTemplateParityTest]).
+ *
+ * The JSON demo is **not** pre-rendered here — `BodyView.asDemo()`/`asJson()`/`asJson5()`
+ * are evaluated lazily at render time. See [BodyView] (D5).
  *
  * @see TemplateModel
  */
@@ -28,18 +29,15 @@ object TemplateModelBuilder {
 
     /**
      * @param endpoints the endpoints to render, already resolved (no PSI reads happen here).
-     * @param outputDemo when `false`, every [BodyView.demo] is set to `null` so the template's
-     *   `{{#if ...demo}}` guards suppress the blocks unchanged .
      * @param moduleName the document title passed to `MarkdownChannel.export`.
      */
     fun build(
         endpoints: List<ApiEndpoint>,
-        outputDemo: Boolean,
         moduleName: String,
     ): TemplateModel {
         val groups = endpoints
             .groupBy { it.folder ?: "" }
-            .map { (folder, list) -> Group(folder = folder, endpoints = list.map { it.toView(outputDemo) }) }
+            .map { (folder, list) -> Group(folder = folder, endpoints = list.map { it.toView() }) }
         return TemplateModel(
             moduleName = moduleName,
             groups = groups,
@@ -49,7 +47,7 @@ object TemplateModelBuilder {
 
     // ---- Endpoint → view ----
 
-    private fun ApiEndpoint.toView(outputDemo: Boolean): Endpoint {
+    private fun ApiEndpoint.toView(): Endpoint {
         val meta = metadata
         // Mirror DefaultMarkdownFormatter: `ep.description?.takeIf { it.isNotBlank() }`
         // so whitespace-only descriptions are treated as absent (parity gate).
@@ -61,7 +59,7 @@ object TemplateModelBuilder {
                 protocol = meta.protocol,
                 path = meta.path,
                 method = meta.method.name,
-                http = meta.toHttpView(outputDemo),
+                http = meta.toHttpView(),
                 grpc = null,
             )
             is GrpcMetadata -> Endpoint(
@@ -71,18 +69,18 @@ object TemplateModelBuilder {
                 path = meta.path,
                 method = meta.path.substringAfterLast('/'),
                 http = null,
-                grpc = meta.toGrpcView(outputDemo),
+                grpc = meta.toGrpcView(),
             )
         }
     }
 
-    private fun HttpMetadata.toHttpView(outputDemo: Boolean): HttpView {
+    private fun HttpMetadata.toHttpView(): HttpView {
         val pathParams = parameters.filter { it.binding == ParameterBinding.Path }.map { it.toParam() }
         val queryParams = parameters.filter { it.binding == ParameterBinding.Query }.map { it.toParam() }
         val formParams = parameters.filter { it.binding == ParameterBinding.Form }.map { it.toParam() }
         val headers = headers.map { it.toHeader() }
-        val body = body?.toBodyView(outputDemo)
-        val response = responseBody?.toBodyView(outputDemo)
+        val body = body?.toBodyView()
+        val response = responseBody?.toBodyView()
         val hasRequestContent = pathParams.isNotEmpty() ||
             queryParams.isNotEmpty() ||
             formParams.isNotEmpty() ||
@@ -99,14 +97,14 @@ object TemplateModelBuilder {
         )
     }
 
-    private fun GrpcMetadata.toGrpcView(outputDemo: Boolean): GrpcView {
+    private fun GrpcMetadata.toGrpcView(): GrpcView {
         return GrpcView(
             serviceName = serviceName,
             methodName = path.substringAfterLast('/'),
             streamingType = streamingType.name,
             fullPath = path,
-            body = body?.toBodyView(outputDemo),
-            response = responseBody?.toBodyView(outputDemo),
+            body = body?.toBodyView(),
+            response = responseBody?.toBodyView(),
         )
     }
 
@@ -126,17 +124,22 @@ object TemplateModelBuilder {
     )
 
     // ---- Body flattening (ported from DefaultMarkdownFormatter) ----
+    //
+    // Produces a flat, cycle-safe list of [FieldView]s. The indent string and desc format
+    // match the legacy `Row` byte-for-byte (parity gate — review findings F5, F6):
+    //  - depth 0: indent = ""
+    //  - depth N>0: indent = "&ensp;&ensp;"×N + "&#124;─"
+    //  - desc = comment + options joined with "<br>"
 
-    private fun ObjectModel.toBodyView(outputDemo: Boolean): BodyView {
-        val rows = mutableListOf<Row>()
+    private fun ObjectModel.toBodyView(): BodyView {
+        val fields = mutableListOf<FieldView>()
         val tracker = ObjectModelVisitTracker()
-        flattenInto(rows, this, depth = 0, tracker = tracker)
-        val demo = if (outputDemo) ObjectModelJsonConverter.toJson(this) else null
-        return BodyView(rows = rows, demo = demo)
+        flattenFieldsInto(fields, this, depth = 0, tracker = tracker)
+        return BodyView(model = this, fields = fields)
     }
 
-    private fun flattenInto(
-        rows: MutableList<Row>,
+    private fun flattenFieldsInto(
+        fields: MutableList<FieldView>,
         model: ObjectModel,
         depth: Int,
         tracker: ObjectModelVisitTracker,
@@ -146,27 +149,64 @@ object TemplateModelBuilder {
                 if (!tracker.tryEnter(model)) return
                 try {
                     for ((fieldName, fieldModel) in model.fields) {
-                        appendFieldRow(rows, fieldName, fieldModel, depth, tracker)
+                        appendFieldView(fields, fieldName, fieldModel, depth, tracker)
                     }
                 } finally {
                     tracker.exit(model)
                 }
             }
             is ObjectModel.Array -> {
-                flattenArrayItemInto(rows, model.item, prefix = "[0]", depth = depth, tracker = tracker)
+                flattenArrayItemIntoFields(fields, model.item, prefix = "[0]", depth = depth, tracker = tracker)
             }
             is ObjectModel.Single -> {
-                rows += Row(name = "", type = model.type, desc = "")
+                // Parity (review finding F5): one synthetic row, name="" matching legacy
+                // `Row(name="", type=model.type, desc="")` byte-for-byte.
+                fields += FieldView(
+                    name = "",
+                    type = model.type,
+                    desc = "",
+                    required = false,
+                    defaultValue = null,
+                    depth = 0,
+                    indent = "",
+                    hasChildren = false,
+                    childrenCount = 0,
+                    structuralKind = FieldStructuralKind.PRIMITIVE,
+                )
             }
             is ObjectModel.MapModel -> {
-                rows += Row(name = "key", type = formatType(model.keyType), desc = "")
-                rows += Row(name = "value", type = formatType(model.valueType), desc = "")
+                // Parity (review finding F6): two synthetic rows (key + value), matching
+                // legacy `Row(name="key", type=formatType(keyType), desc="")` + value byte-for-byte.
+                fields += FieldView(
+                    name = "key",
+                    type = formatType(model.keyType),
+                    desc = "",
+                    required = false,
+                    defaultValue = null,
+                    depth = 0,
+                    indent = "",
+                    hasChildren = false,
+                    childrenCount = 0,
+                    structuralKind = FieldStructuralKind.MAP,
+                )
+                fields += FieldView(
+                    name = "value",
+                    type = formatType(model.valueType),
+                    desc = "",
+                    required = false,
+                    defaultValue = null,
+                    depth = 0,
+                    indent = "",
+                    hasChildren = false,
+                    childrenCount = 0,
+                    structuralKind = FieldStructuralKind.MAP,
+                )
             }
         }
     }
 
-    private fun appendFieldRow(
-        rows: MutableList<Row>,
+    private fun appendFieldView(
+        fields: MutableList<FieldView>,
         fieldName: String,
         fieldModel: FieldModel,
         depth: Int,
@@ -175,14 +215,28 @@ object TemplateModelBuilder {
         val indent = if (depth > 0) "&ensp;&ensp;".repeat(depth) + "&#124;─" else ""
         val type = formatType(fieldModel.model)
         val desc = buildFieldDescription(fieldModel)
-        rows += Row(name = "$indent$fieldName", type = type, desc = desc)
+        val structuralKind = structuralKindOf(fieldModel.model)
+        val (hasChildren, childrenCount) = childrenInfo(fieldModel.model, tracker)
+
+        fields += FieldView(
+            name = fieldName,
+            type = type,
+            desc = desc,
+            required = false,
+            defaultValue = null,
+            depth = depth,
+            indent = indent,
+            hasChildren = hasChildren,
+            childrenCount = childrenCount,
+            structuralKind = structuralKind,
+        )
 
         when (val nested = fieldModel.model) {
             is ObjectModel.Object -> {
                 if (tracker.tryEnter(nested)) {
                     try {
                         for ((nestedName, nestedField) in nested.fields) {
-                            appendFieldRow(rows, nestedName, nestedField, depth + 1, tracker)
+                            appendFieldView(fields, nestedName, nestedField, depth + 1, tracker)
                         }
                     } finally {
                         tracker.exit(nested)
@@ -195,7 +249,7 @@ object TemplateModelBuilder {
                         if (tracker.tryEnter(item)) {
                             try {
                                 for ((nestedName, nestedField) in item.fields) {
-                                    appendFieldRow(rows, nestedName, nestedField, depth + 1, tracker)
+                                    appendFieldView(fields, nestedName, nestedField, depth + 1, tracker)
                                 }
                             } finally {
                                 tracker.exit(item)
@@ -209,8 +263,8 @@ object TemplateModelBuilder {
         }
     }
 
-    private fun flattenArrayItemInto(
-        rows: MutableList<Row>,
+    private fun flattenArrayItemIntoFields(
+        fields: MutableList<FieldView>,
         item: ObjectModel,
         prefix: String,
         depth: Int,
@@ -221,22 +275,86 @@ object TemplateModelBuilder {
                 if (!tracker.tryEnter(item)) return
                 try {
                     for ((fieldName, fieldModel) in item.fields) {
-                        appendFieldRow(rows, "$prefix.$fieldName", fieldModel, depth, tracker)
+                        appendFieldView(fields, "$prefix.$fieldName", fieldModel, depth, tracker)
                     }
                 } finally {
                     tracker.exit(item)
                 }
             }
             is ObjectModel.Array -> {
-                flattenArrayItemInto(rows, item.item, "$prefix[0]", depth, tracker)
+                flattenArrayItemIntoFields(fields, item.item, "$prefix[0]", depth, tracker)
             }
             is ObjectModel.Single -> {
-                rows += Row(name = prefix, type = "${item.type}[]", desc = "")
+                fields += FieldView(
+                    name = prefix,
+                    type = "${item.type}[]",
+                    desc = "",
+                    required = false,
+                    defaultValue = null,
+                    depth = depth,
+                    indent = if (depth > 0) "&ensp;&ensp;".repeat(depth) + "&#124;─" else "",
+                    hasChildren = false,
+                    childrenCount = 0,
+                    structuralKind = FieldStructuralKind.PRIMITIVE,
+                )
             }
             is ObjectModel.MapModel -> {
-                rows += Row(name = "$prefix.key", type = formatType(item.keyType), desc = "")
-                rows += Row(name = "$prefix.value", type = formatType(item.valueType), desc = "")
+                fields += FieldView(
+                    name = "$prefix.key",
+                    type = formatType(item.keyType),
+                    desc = "",
+                    required = false,
+                    defaultValue = null,
+                    depth = depth,
+                    indent = if (depth > 0) "&ensp;&ensp;".repeat(depth) + "&#124;─" else "",
+                    hasChildren = false,
+                    childrenCount = 0,
+                    structuralKind = FieldStructuralKind.MAP,
+                )
+                fields += FieldView(
+                    name = "$prefix.value",
+                    type = formatType(item.valueType),
+                    desc = "",
+                    required = false,
+                    defaultValue = null,
+                    depth = depth,
+                    indent = if (depth > 0) "&ensp;&ensp;".repeat(depth) + "&#124;─" else "",
+                    hasChildren = false,
+                    childrenCount = 0,
+                    structuralKind = FieldStructuralKind.MAP,
+                )
             }
+        }
+    }
+
+    /** Returns the structural kind of a model for [FieldView.structuralKind]. */
+    private fun structuralKindOf(model: ObjectModel): FieldStructuralKind = when (model) {
+        is ObjectModel.Object -> FieldStructuralKind.OBJECT
+        is ObjectModel.Array -> FieldStructuralKind.ARRAY
+        is ObjectModel.MapModel -> FieldStructuralKind.MAP
+        is ObjectModel.Single -> FieldStructuralKind.PRIMITIVE
+    }
+
+    /**
+     * Returns `(hasChildren, childrenCount)` for a field's model. `hasChildren` is true
+     * when the model is an Object/Array<Object>/MapModel that would produce nested rows
+     * (subject to cycle-safety). `childrenCount` is the immediate child count (0 for
+     * primitives or cycle-blocked nodes).
+     */
+    private fun childrenInfo(model: ObjectModel, tracker: ObjectModelVisitTracker): Pair<Boolean, Int> {
+        return when (model) {
+            is ObjectModel.Object -> {
+                if (tracker.canEnter(model)) true to model.fields.size
+                else false to 0
+            }
+            is ObjectModel.Array -> {
+                when (val item = model.item) {
+                    is ObjectModel.Object -> if (tracker.canEnter(item)) true to item.fields.size else false to 0
+                    else -> false to 0
+                }
+            }
+            is ObjectModel.MapModel -> true to 2
+            is ObjectModel.Single -> false to 0
         }
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModelVisitTracker.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModelVisitTracker.kt
@@ -35,6 +35,16 @@ class ObjectModelVisitTracker {
         return true
     }
 
+    /**
+     * Returns `true` if [tryEnter] would succeed for [model] right now, **without**
+     * incrementing the visit count. Used by callers that need to pre-compute
+     * `hasChildren` metadata for a [FieldView] before deciding whether to recurse.
+     */
+    fun canEnter(model: ObjectModel.Object): Boolean {
+        val count = counts.getOrDefault(model, 0)
+        return count < ObjectModel.DEFAULT_MAX_VISITS
+    }
+
     /** Must be called once for every successful [tryEnter]. */
     fun exit(model: ObjectModel.Object) {
         val count = counts.getOrDefault(model, 0)

--- a/src/main/kotlin/com/itangcent/easyapi/settings/migration/SettingsMigrationActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/migration/SettingsMigrationActivity.kt
@@ -82,7 +82,6 @@ class SettingsMigrationActivity : StartupActivity {
         appState.setValue(generalKey, "gutterIconEnabled", legacy.gutterIconEnabled.toString())
         appState.setValue(generalKey, "switchNotice", legacy.switchNotice.toString())
         appState.setValue(generalKey, "logLevel", legacy.logLevel.toString())
-        appState.setValue(generalKey, "outputDemo", legacy.outputDemo.toString())
         appState.setValue(generalKey, "outputCharset", legacy.outputCharset)
 
         // HttpSettings

--- a/src/main/kotlin/com/itangcent/easyapi/settings/module/GeneralSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/module/GeneralSettings.kt
@@ -20,6 +20,5 @@ data class GeneralSettings(
     @StorageScope(Scope.APPLICATION) var gutterIconEnabled: Boolean = true,
     @StorageScope(Scope.APPLICATION) var switchNotice: Boolean = true,
     @StorageScope(Scope.APPLICATION) var logLevel: Int = 100,
-    @StorageScope(Scope.APPLICATION) var outputDemo: Boolean = true,
     @StorageScope(Scope.APPLICATION) var outputCharset: String = "UTF-8"
 ) : Settings

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -57,7 +57,6 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         var httpClient: String = HttpClientType.APACHE.value,
         var extensionConfigs: String = ExtensionConfigRegistry.codesToString(ExtensionConfigRegistry.defaultCodes()),
         var logLevel: Int = 100, // SILENT — console off by default
-        var outputDemo: Boolean = true,
         var outputCharset: String = "UTF-8",
         var builtInConfig: String? = null,
         var remoteConfig: Array<String> = emptyArray(),
@@ -99,7 +98,6 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             if (httpTimeOut != other.httpTimeOut) return false
             if (unsafeSsl != other.unsafeSsl) return false
             if (logLevel != other.logLevel) return false
-            if (outputDemo != other.outputDemo) return false
             if (postmanToken != other.postmanToken) return false
             if (postmanJson5FormatType != other.postmanJson5FormatType) return false
             if (httpClient != other.httpClient) return false
@@ -143,7 +141,6 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             result = 31 * result + httpTimeOut
             result = 31 * result + unsafeSsl.hashCode()
             result = 31 * result + logLevel
-            result = 31 * result + outputDemo.hashCode()
             result = 31 * result + (postmanToken?.hashCode() ?: 0)
             result = 31 * result + postmanJson5FormatType.hashCode()
             result = 31 * result + httpClient.hashCode()
@@ -190,7 +187,6 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             target.httpClient = httpClient
             target.extensionConfigs = extensionConfigs
             target.logLevel = logLevel
-            target.outputDemo = outputDemo
             target.outputCharset = outputCharset
             target.builtInConfig = builtInConfig
             target.remoteConfig = remoteConfig

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -131,9 +131,6 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
 
     private val logLevelCombo = ComboBox(CommonSettingsHelper.VerbosityLevel.values())
     private val outputCharsetCombo = ComboBox(arrayOf("UTF-8", "GBK", "ISO-8859-1"))
-    private val outputDemoCheckBox = JBCheckBox("Output demo in markdown", true).apply {
-        toolTipText = "Include example/demo values in generated markdown documentation"
-    }
 
     private val projectCacheSizeLabel = JBLabel("0 B")
     private val globalCacheSizeLabel = JBLabel("0 B")
@@ -407,8 +404,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         .addComponent(
             SettingsUiKit.titledPanel(
                 "Output", listOf(
-                    SettingsUiKit.labeledRow("Output Charset:", outputCharsetCombo),
-                    outputDemoCheckBox
+                    SettingsUiKit.labeledRow("Output Charset:", outputCharsetCombo)
                 )
             )
         )
@@ -434,7 +430,6 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         switchNotice.isSelected = settings?.switchNotice ?: true
         logLevelCombo.selectedItem = CommonSettingsHelper.VerbosityLevel.toLevel(settings?.logLevel ?: 0)
         outputCharsetCombo.selectedItem = settings?.outputCharset ?: "UTF-8"
-        outputDemoCheckBox.isSelected = settings?.outputDemo ?: true
         refreshCacheSizes()
     }
 
@@ -462,7 +457,6 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         settings.switchNotice = switchNotice.isSelected
         settings.logLevel = (logLevelCombo.selectedItem as? CommonSettingsHelper.VerbosityLevel)?.level ?: 0
         settings.outputCharset = outputCharsetCombo.selectedItem?.toString() ?: "UTF-8"
-        settings.outputDemo = outputDemoCheckBox.isSelected
     }
 
     /**
@@ -485,8 +479,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
                 gutterIconEnabled.isSelected != s.gutterIconEnabled ||
                 switchNotice.isSelected != s.switchNotice ||
                 (logLevelCombo.selectedItem as? CommonSettingsHelper.VerbosityLevel)?.level != s.logLevel ||
-                outputCharsetCombo.selectedItem?.toString() != s.outputCharset ||
-                outputDemoCheckBox.isSelected != s.outputDemo
+                outputCharsetCombo.selectedItem?.toString() != s.outputCharset
     }
 
     /**
@@ -1475,7 +1468,6 @@ class BackupSettingsPanel(private val project: com.intellij.openapi.project.Proj
             obj.get("gutterIconEnabled")?.asBoolean?.let { gutterIconEnabled = it }
             obj.get("switchNotice")?.asBoolean?.let { switchNotice = it }
             obj.get("logLevel")?.asInt?.let { logLevel = it }
-            obj.get("outputDemo")?.asBoolean?.let { outputDemo = it }
             obj.get("outputCharset")?.asString?.let { outputCharset = it }
         }
 
@@ -1536,7 +1528,6 @@ class BackupSettingsPanel(private val project: com.intellij.openapi.project.Proj
         obj.addProperty("gutterIconEnabled", general.gutterIconEnabled)
         obj.addProperty("switchNotice", general.switchNotice)
         obj.addProperty("logLevel", general.logLevel)
-        obj.addProperty("outputDemo", general.outputDemo)
         obj.addProperty("outputCharset", general.outputCharset)
 
         val http = binder.read(com.itangcent.easyapi.settings.module.HttpSettings::class)

--- a/src/main/resources/docs/knowledge-base/settings-guide.md
+++ b/src/main/resources/docs/knowledge-base/settings-guide.md
@@ -19,6 +19,7 @@ This guide documents every setting in **Settings → EasyApi**. Settings are org
 9. [Hoppscotch (Beta)](#hoppscotch-beta)
 10. [Other](#other)
 11. [Environments](#environments)
+12. [Markdown Template Reference](#markdown-template-reference)
 
 ---
 
@@ -33,7 +34,6 @@ Framework recognition and output formatting.
 | Enable Actuator | `false` | Recognize Spring Boot Actuator endpoints | `actuatorEnable` |
 | Auto Scan Enabled | `true` | Automatically scan the project for API endpoints | `autoScanEnabled` |
 | Concurrent Scan | `false` | Use parallel scanning for faster discovery | `concurrentScanEnabled` |
-| Output Demo | `true` | Include demo/example values in exports | `outputDemo` |
 | Output Charset | `UTF-8` | Character encoding for exported files | `outputCharset` |
 | Log Level | `100` (SILENT) | Console verbosity. Lower = more verbose. `100`=SILENT, `40`=ERROR, `30`=WARN, `20`=INFO, `10`=DEBUG, `0`=TRACE | `logLevel` |
 | Gutter Icon | `true` | Show gutter icons for API endpoints in the editor | `gutterIconEnabled` |
@@ -224,3 +224,127 @@ Environment variable management for export and script execution.
 |-------|---------|--------|----------|
 | Project Environments | *(empty)* | Project-scoped environment definitions (JSON) | `projectEnvironments` |
 | Global Environments | *(empty)* | Application-scoped environment definitions (JSON) | `globalEnvironments` |
+
+---
+
+## Markdown Template Reference
+
+Custom Markdown export templates (`.md.tpl` files in `src/main/resources/markdown/templates/`) use a Handlebars-like syntax. This section documents the body-view API introduced in the BodyView refactor.
+
+### BodyView API
+
+Each HTTP/gRPC body or response is exposed as a `BodyView` object with:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `model` | `ObjectModel` | The structured body model (Object, Array, Single, or MapModel). |
+| `fields` | `List<FieldView>` | Pre-flattened field list for table/list rendering. |
+
+**Method calls** (evaluated lazily at render time):
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `body.asDemo()` | `String` | Plain JSON demo string (no code fence). |
+| `body.asJson()` | `String` | Alias of `asDemo()` — byte-identical output. |
+| `body.asJson5()` | `String` | JSON5 demo with inline comments (field descriptions). |
+
+### FieldView fields
+
+Each entry in `body.fields` exposes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Field name (empty for primitive bodies). |
+| `type` | `String` | Type label (e.g. `"string"`, `"object[]"`, `"map"`). |
+| `desc` | `String` | Description = comment + options joined with `<br>`. |
+| `required` | `Boolean` | Whether the field is required. |
+| `defaultValue` | `String?` | Default value (empty string if null). |
+| `depth` | `Int` | Nesting depth (0 = top-level). |
+| `indent` | `String` | Pre-computed indent prefix (`&ensp;&ensp;`×depth + `&#124;─`). Use raw interpolation `{{{f.indent}}}` to preserve HTML entities. |
+| `hasChildren` | `Boolean` | Whether the field has nested children. |
+| `childrenCount` | `Int` | Number of direct children. |
+| `structuralKind` | `String` | One of `OBJECT`, `ARRAY`, `MAP`, `PRIMITIVE`. |
+
+### Body variant behavior
+
+| Body type | `fields` content |
+|-----------|-----------------|
+| Object | One `FieldView` per top-level field; nested fields at depth > 0. |
+| Array<Object> | `[0]` item fields at depth 1. |
+| Primitive (Single) | One synthetic field: `name=""`, `type=model.type`, `desc=""`. |
+| Map | Two synthetic fields: `key` + `value`, both `structuralKind=MAP`. |
+| Recursive | Finite — cycle-safe via `ObjectModelVisitTracker` (max 2 visits per object identity). |
+
+### Recipe: table rendering
+
+```handlebars
+{{#if api.http.body}}
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
+{{/each}}
+
+**Request Demo:**
+
+```json
+{{{api.http.body.asDemo()}}}
+```
+{{/if}}
+```
+
+> **Note:** Use `{{{f.indent}}}` (triple braces, raw) for the indent prefix so HTML entities like `&ensp;` survive unescaped. Use `{{f.name}}` (double braces) for the name so it gets markdown-escaped.
+
+### Recipe: list rendering
+
+```handlebars
+{{#each api.http.body.fields as f}}
+{{{f.indent}}}{{f.name}} ({{f.type}}) — {{f.desc}}
+{{/each}}
+```
+
+### Recipe: JSON5 demo with comments
+
+```handlebars
+```json5
+{{{api.http.body.asJson5()}}}
+```
+```
+
+### Breaking change: migration from `body.rows` / `body.demo`
+
+**Removed** (v3.0 BodyView refactor):
+- `body.rows` — replaced by `body.fields`
+- `body.demo` — replaced by `body.asDemo()`
+
+**Before (old):**
+```handlebars
+{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{/each}}
+{{#if api.http.body.demo}}
+```json
+{{{api.http.body.demo}}}
+```
+{{/if}}
+```
+
+**After (new):**
+```handlebars
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
+{{/each}}
+```json
+{{{api.http.body.asDemo()}}}
+```
+```
+
+Key differences:
+1. `r.name` (which included the indent prefix) is split into `{{{f.indent}}}` (raw) + `{{f.name}}` (escaped).
+2. `body.demo` (a pre-computed string) is now `body.asDemo()` (a method call, evaluated lazily).
+3. The `{{#if body.demo}}` conditional is removed — the demo is always present when a body exists.
+
+### Engine v1 limitations
+
+- **No chained method calls:** `body.asJson5().trim()` renders empty + an info log. Only a single method call per expression is supported.
+- **No template recursion:** `{{#each}}` does not support recursive partials.
+- **`meta.*` is always built-in:** `meta.date(...)`, `meta.time(...)` always resolve to built-in functions, never to model fields.

--- a/src/main/resources/markdown/templates/ar.md.tpl
+++ b/src/main/resources/markdown/templates/ar.md.tpl
@@ -53,17 +53,15 @@
 
 | الاسم | النوع | الوصف |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **مثال الطلب:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | الاسم | النوع | الوصف |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **مثال الاستجابة:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | الاسم | النوع | الوصف |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **مثال الطلب:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > الاستجابة
 
@@ -131,14 +125,12 @@
 
 | الاسم | النوع | الوصف |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **مثال الاستجابة:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/de.md.tpl
+++ b/src/main/resources/markdown/templates/de.md.tpl
@@ -53,17 +53,15 @@
 
 | Name | Typ | Beschreibung |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Anfrage-Beispiel:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | Name | Typ | Beschreibung |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Antwort-Beispiel:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | Name | Typ | Beschreibung |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Anfrage-Beispiel:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > ANTWORT
 
@@ -131,14 +125,12 @@
 
 | Name | Typ | Beschreibung |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Antwort-Beispiel:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/default.md.tpl
+++ b/src/main/resources/markdown/templates/default.md.tpl
@@ -53,17 +53,15 @@
 
 | name | type | desc |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Request Demo:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | name | type | desc |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Response Demo:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | name | type | desc |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Request Demo:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > RESPONSE
 
@@ -131,14 +125,12 @@
 
 | name | type | desc |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Response Demo:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/es.md.tpl
+++ b/src/main/resources/markdown/templates/es.md.tpl
@@ -53,17 +53,15 @@
 
 | nombre | tipo | descripción |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Ejemplo de Solicitud:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | nombre | tipo | descripción |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Ejemplo de Respuesta:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | nombre | tipo | descripción |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Ejemplo de Solicitud:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > RESPUESTA
 
@@ -131,14 +125,12 @@
 
 | nombre | tipo | descripción |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Ejemplo de Respuesta:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/fr.md.tpl
+++ b/src/main/resources/markdown/templates/fr.md.tpl
@@ -53,17 +53,15 @@
 
 | nom | type | description |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Exemple de Requête :**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | nom | type | description |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Exemple de Réponse :**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | nom | type | description |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Exemple de Requête :**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > RÉPONSE
 
@@ -131,14 +125,12 @@
 
 | nom | type | description |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Exemple de Réponse :**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/hi.md.tpl
+++ b/src/main/resources/markdown/templates/hi.md.tpl
@@ -53,17 +53,15 @@
 
 | नाम | प्रकार | विवरण |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **अनुरोध उदाहरण:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | नाम | प्रकार | विवरण |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **प्रतिक्रिया उदाहरण:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | नाम | प्रकार | विवरण |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **अनुरोध उदाहरण:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > प्रतिक्रिया
 
@@ -131,14 +125,12 @@
 
 | नाम | प्रकार | विवरण |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **प्रतिक्रिया उदाहरण:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/id.md.tpl
+++ b/src/main/resources/markdown/templates/id.md.tpl
@@ -53,17 +53,15 @@
 
 | nama | tipe | deskripsi |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Contoh Permintaan:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | nama | tipe | deskripsi |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Contoh Tanggapan:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | nama | tipe | deskripsi |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Contoh Permintaan:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > TANGGAPAN
 
@@ -131,14 +125,12 @@
 
 | nama | tipe | deskripsi |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Contoh Tanggapan:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/it.md.tpl
+++ b/src/main/resources/markdown/templates/it.md.tpl
@@ -53,17 +53,15 @@
 
 | nome | tipo | descrizione |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Esempio di Richiesta:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | nome | tipo | descrizione |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Esempio di Risposta:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | nome | tipo | descrizione |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Esempio di Richiesta:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > RISPOSTA
 
@@ -131,14 +125,12 @@
 
 | nome | tipo | descrizione |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Esempio di Risposta:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/ja.md.tpl
+++ b/src/main/resources/markdown/templates/ja.md.tpl
@@ -53,17 +53,15 @@
 
 | パラメータ名 | タイプ | 説明 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **リクエスト例：**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | パラメータ名 | タイプ | 説明 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **レスポンス例：**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | パラメータ名 | タイプ | 説明 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **リクエスト例：**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > レスポンス
 
@@ -131,14 +125,12 @@
 
 | パラメータ名 | タイプ | 説明 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **レスポンス例：**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/ko.md.tpl
+++ b/src/main/resources/markdown/templates/ko.md.tpl
@@ -53,17 +53,15 @@
 
 | 매개변수명 | 타입 | 설명 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **요청 예시:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | 매개변수명 | 타입 | 설명 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **응답 예시:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | 매개변수명 | 타입 | 설명 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **요청 예시:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > 응답
 
@@ -131,14 +125,12 @@
 
 | 매개변수명 | 타입 | 설명 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **응답 예시:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/nl.md.tpl
+++ b/src/main/resources/markdown/templates/nl.md.tpl
@@ -53,17 +53,15 @@
 
 | naam | type | beschrijving |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Verzoekvoorbeeld:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | naam | type | beschrijving |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Antwoordvoorbeeld:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | naam | type | beschrijving |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Verzoekvoorbeeld:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > ANTWOORD
 
@@ -131,14 +125,12 @@
 
 | naam | type | beschrijving |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Antwoordvoorbeeld:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/pl.md.tpl
+++ b/src/main/resources/markdown/templates/pl.md.tpl
@@ -53,17 +53,15 @@
 
 | nazwa | typ | opis |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Przykład żądania:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | nazwa | typ | opis |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Przykład odpowiedzi:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | nazwa | typ | opis |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Przykład żądania:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > ODPOWIEDŹ
 
@@ -131,14 +125,12 @@
 
 | nazwa | typ | opis |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Przykład odpowiedzi:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/pt-BR.md.tpl
+++ b/src/main/resources/markdown/templates/pt-BR.md.tpl
@@ -53,17 +53,15 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Exemplo de Solicitação:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Exemplo de Resposta:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Exemplo de Solicitação:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > RESPOSTA
 
@@ -131,14 +125,12 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Exemplo de Resposta:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/pt.md.tpl
+++ b/src/main/resources/markdown/templates/pt.md.tpl
@@ -53,17 +53,15 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Exemplo de Solicitação:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Exemplo de Resposta:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Exemplo de Solicitação:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > RESPOSTA
 
@@ -131,14 +125,12 @@
 
 | nome | tipo | descrição |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Exemplo de Resposta:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/ru.md.tpl
+++ b/src/main/resources/markdown/templates/ru.md.tpl
@@ -53,17 +53,15 @@
 
 | имя | тип | описание |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Пример запроса:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | имя | тип | описание |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Пример ответа:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | имя | тип | описание |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Пример запроса:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > ОТВЕТ
 
@@ -131,14 +125,12 @@
 
 | имя | тип | описание |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Пример ответа:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/th.md.tpl
+++ b/src/main/resources/markdown/templates/th.md.tpl
@@ -53,17 +53,15 @@
 
 | ชื่อ | ประเภท | คำอธิบาย |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **ตัวอย่างคำขอ:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | ชื่อ | ประเภท | คำอธิบาย |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **ตัวอย่างการตอบกลับ:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | ชื่อ | ประเภท | คำอธิบาย |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **ตัวอย่างคำขอ:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > การตอบกลับ
 
@@ -131,14 +125,12 @@
 
 | ชื่อ | ประเภท | คำอธิบาย |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **ตัวอย่างการตอบกลับ:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/tr.md.tpl
+++ b/src/main/resources/markdown/templates/tr.md.tpl
@@ -53,17 +53,15 @@
 
 | ad | tür | açıklama |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **İstek Örneği:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | ad | tür | açıklama |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Yanıt Örneği:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | ad | tür | açıklama |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **İstek Örneği:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > YANIT
 
@@ -131,14 +125,12 @@
 
 | ad | tür | açıklama |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Yanıt Örneği:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/uk.md.tpl
+++ b/src/main/resources/markdown/templates/uk.md.tpl
@@ -53,17 +53,15 @@
 
 | назва | тип | опис |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Приклад запиту:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | назва | тип | опис |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Приклад відповіді:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | назва | тип | опис |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Приклад запиту:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > ВІДПОВІДЬ
 
@@ -131,14 +125,12 @@
 
 | назва | тип | опис |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Приклад відповіді:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/vi.md.tpl
+++ b/src/main/resources/markdown/templates/vi.md.tpl
@@ -53,17 +53,15 @@
 
 | tên | loại | mô tả |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **Mẫu yêu cầu:**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | tên | loại | mô tả |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **Mẫu phản hồi:**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | tên | loại | mô tả |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **Mẫu yêu cầu:**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > PHẢN HỒI
 
@@ -131,14 +125,12 @@
 
 | tên | loại | mô tả |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **Mẫu phản hồi:**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/zh-CN.md.tpl
+++ b/src/main/resources/markdown/templates/zh-CN.md.tpl
@@ -53,17 +53,15 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **请求示例：**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **响应示例：**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **请求示例：**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > 响应信息
 
@@ -131,14 +125,12 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **响应示例：**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/zh-TW.md.tpl
+++ b/src/main/resources/markdown/templates/zh-TW.md.tpl
@@ -53,17 +53,15 @@
 
 | 參數名 | 類型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **請求範例：**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | 參數名 | 類型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **回應範例：**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | 參數名 | 類型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **請求範例：**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > 回應資訊
 
@@ -131,14 +125,12 @@
 
 | 參數名 | 類型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **回應範例：**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/main/resources/markdown/templates/zh.md.tpl
+++ b/src/main/resources/markdown/templates/zh.md.tpl
@@ -53,17 +53,15 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.body.demo}}
 
 **请求示例：**
 
 ```json
-{{{api.http.body.demo}}}
+{{{api.http.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.http.hasRequestContent}}{{else}}
+{{/if}}{{#if api.http.hasRequestContent}}{{else}}
 
 {{/if}}
 {{#if api.http.response}}
@@ -74,17 +72,15 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.http.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.http.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.http.response.demo}}
 
 **响应示例：**
 
 ```json
-{{{api.http.response.demo}}}
+{{{api.http.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{#if api.grpc}}
+{{/if}}{{/if}}{{#if api.grpc}}
 
 ---
 ### {{#if api.name}}{{{api.name}}}{{else}}{{{api.path}}}{{/if}}
@@ -113,17 +109,15 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.body.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.body.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.body.demo}}
 
 **请求示例：**
 
 ```json
-{{{api.grpc.body.demo}}}
+{{{api.grpc.body.asDemo()}}}
 ```
-{{/if}}{{/if}}{{#if api.grpc.response}}
+{{/if}}{{#if api.grpc.response}}
 
 > 响应信息
 
@@ -131,14 +125,12 @@
 
 | 参数名 | 类型 | 描述 |
 | ------------ | ------------ | ------------ |
-{{#each api.grpc.response.rows as r}}| {{r.name}} | {{r.type}} | {{r.desc}} |
+{{#each api.grpc.response.fields as f}}| {{{f.indent}}}{{f.name}} | {{f.type}} | {{f.desc}} |
 {{/each}}
-
-{{#if api.grpc.response.demo}}
 
 **响应示例：**
 
 ```json
-{{{api.grpc.response.demo}}}
+{{{api.grpc.response.asDemo()}}}
 ```
-{{/if}}{{/if}}{{/if}}{{/each}}{{/each}}
+{{/if}}{{/if}}{{/each}}{{/each}}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/DefaultMarkdownFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/DefaultMarkdownFormatterTest.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 
 class DefaultMarkdownFormatterTest {
 
-    private val formatter = DefaultMarkdownFormatter(outputDemo = true)
+    private val formatter = DefaultMarkdownFormatter()
 
     @Test
     fun testFormatSimpleEndpoint() = runBlocking {
@@ -541,33 +541,6 @@ class DefaultMarkdownFormatterTest {
         val markdown = formatter.format(listOf(endpoint), "gRPC API")
 
         assertTrue(markdown.contains("**Streaming:** BIDIRECTIONAL"))
-    }
-
-    // ==================== No-demo mode ====================
-
-    @Test
-    fun testFormatNoDemoMode() = runBlocking {
-        val noDemoFormatter = DefaultMarkdownFormatter(outputDemo = false)
-        val bodyModel = ObjectModel.Object(
-            mapOf(
-                "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name")
-            )
-        )
-
-        val endpoint = ApiEndpoint(
-            name = "Create User",
-            metadata = httpMetadata(
-                path = "/api/users",
-                method = HttpMethod.POST,
-                body = bodyModel,
-                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
-            )
-        )
-
-        val markdown = noDemoFormatter.format(listOf(endpoint), "User API")
-
-        assertTrue(markdown.contains("**Request Body:**"))
-        assertFalse(markdown.contains("**Request Demo:**"))
     }
 
     // ==================== Endpoint without name ====================

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/MarkdownTemplateParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/MarkdownTemplateParityTest.kt
@@ -17,31 +17,32 @@ import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.FieldOption
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
-import kotlinx.coroutines.runBlocking
+import com.itangcent.easyapi.testFramework.ResourceLoader
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
 /**
- * The load-bearing parity gate .
+ * The load-bearing parity gate.
  *
- * Asserts **full-string** `assertEquals` that the default template rendered via
- * [MarkdownTemplateRenderer] reproduces [DefaultMarkdownFormatter] output byte-for-byte,
- * for every shape exercised by [DefaultMarkdownFormatterTest].
+ * Asserts that the default template rendered via [MarkdownTemplateRenderer]
+ * matches a **static committed golden file** byte-for-byte. The golden is
+ * captured at `src/test/resources/com/itangcent/easyapi/exporter/channel/markdown/MarkdownTemplateParityTest.expected.md`.
  *
- * The default template does not reference any `meta.*` built-ins (it must stay byte-identical
- * to the legacy formatter), so the [RenderContext] values are irrelevant to the output — fixed
- * values are used for determinism only.
+ * To regenerate the golden (deliberate, reviewed change):
+ *   `./gradlew test --tests *.MarkdownTemplateParityTest -Dupdate.golden=true`
+ *
+ * The fixture matrix covers: object/array/primitive/map/recursive bodies,
+ * gRPC (all streaming types), params (path/query/header/form), field options,
+ * descriptions, folders, and edge cases (no name, blank description).
  *
  * Pure JUnit: no `Project`, no PSI/VFS.
  */
 class MarkdownTemplateParityTest {
-
-    private val oldFormatter = DefaultMarkdownFormatter(outputDemo = true)
-    private val oldNoDemoFormatter = DefaultMarkdownFormatter(outputDemo = false)
 
     private val ctx = RenderContext(
         clock = Clock.fixed(Instant.parse("2026-03-15T10:30:45Z"), ZoneId.of("UTC")),
@@ -53,36 +54,19 @@ class MarkdownTemplateParityTest {
 
     private val defaultTemplate = DefaultMarkdownTemplate.get()
 
-    /**
-     * Runs both the old formatter and the new template renderer on the same input and
-     * asserts byte-for-byte equality.
-     */
-    private fun assertParity(
-        endpoints: List<ApiEndpoint>,
-        moduleName: String,
-        outputDemo: Boolean = true,
-    ) {
-        val expected = runBlocking {
-            (if (outputDemo) oldFormatter else oldNoDemoFormatter).format(endpoints, moduleName)
-        }
-        assertTrue("Sanity: old formatter must produce non-empty output", expected.isNotEmpty())
-
-        val model = TemplateModelBuilder.build(endpoints, outputDemo, moduleName)
-        val actual = MarkdownTemplateRenderer.render(defaultTemplate, model, ctx)
-
-        assertEquals(
-            "Parity mismatch (moduleName=$moduleName outputDemo=$outputDemo)",
-            expected,
-            actual,
-        )
+    companion object {
+        private const val GOLDEN_RESOURCE =
+            "/com/itangcent/easyapi/exporter/channel/markdown/MarkdownTemplateParityTest.expected.md"
+        private const val GOLDEN_PATH =
+            "src/test/resources/com/itangcent/easyapi/exporter/channel/markdown/MarkdownTemplateParityTest.expected.md"
     }
 
-    // ---------- HTTP: basic, params, headers, form ----------
-
-    @Test
-    fun testSimpleEndpoint() {
-        val endpoint = ApiEndpoint(
+    /** The comprehensive fixture matrix — mirrors the shapes from DefaultMarkdownFormatterTest. */
+    private fun comprehensiveEndpoints(): List<ApiEndpoint> = listOf(
+        // --- HTTP: basic GET with path param ---
+        ApiEndpoint(
             name = "Get User",
+            folder = "Users",
             metadata = httpMetadata(
                 path = "/api/users/{id}",
                 method = HttpMethod.GET,
@@ -90,351 +74,214 @@ class MarkdownTemplateParityTest {
                     ApiParameter(name = "id", binding = ParameterBinding.Path, required = true, description = "User ID")
                 )
             )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testEndpointWithDescription() {
-        val endpoint = ApiEndpoint(
-            name = "Get User",
-            description = "Retrieve user information by ID",
+        ),
+        // --- HTTP: POST with object request body + nested object response ---
+        ApiEndpoint(
+            name = "Create User",
+            folder = "Users",
             metadata = httpMetadata(
-                path = "/api/users/{id}",
-                method = HttpMethod.GET
+                path = "/api/users",
+                method = HttpMethod.POST,
+                body = ObjectModel.Object(
+                    mapOf(
+                        "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name"),
+                        "age" to FieldModel(ObjectModel.single(JsonType.INT), comment = "user age")
+                    )
+                ),
+                responseBody = ObjectModel.Object(
+                    mapOf(
+                        "code" to FieldModel(ObjectModel.single(JsonType.INT), comment = "response code"),
+                        "msg" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "message"),
+                        "data" to FieldModel(
+                            ObjectModel.Object(
+                                mapOf(
+                                    "id" to FieldModel(ObjectModel.single(JsonType.LONG), comment = "user id"),
+                                    "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name")
+                                )
+                            ),
+                            comment = "response data"
+                        )
+                    )
+                ),
+                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
             )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testEndpointWithQueryParameters() {
-        val endpoint = ApiEndpoint(
+        ),
+        // --- HTTP: array response body ---
+        ApiEndpoint(
             name = "List Users",
+            folder = "Users",
             metadata = httpMetadata(
                 path = "/api/users",
                 method = HttpMethod.GET,
                 parameters = listOf(
                     ApiParameter(name = "page", binding = ParameterBinding.Query, required = false, description = "Page number"),
                     ApiParameter(name = "size", binding = ParameterBinding.Query, required = false, description = "Page size")
+                ),
+                responseBody = ObjectModel.Object(
+                    mapOf(
+                        "code" to FieldModel(ObjectModel.single(JsonType.INT)),
+                        "data" to FieldModel(
+                            ObjectModel.array(
+                                ObjectModel.Object(
+                                    mapOf(
+                                        "id" to FieldModel(ObjectModel.single(JsonType.LONG)),
+                                        "name" to FieldModel(ObjectModel.single(JsonType.STRING))
+                                    )
+                                )
+                            ),
+                            comment = "user list"
+                        )
+                    )
                 )
             )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testEndpointWithHeaders() {
-        val endpoint = ApiEndpoint(
-            name = "Create User",
+        ),
+        // --- HTTP: primitive (Single) body ---
+        ApiEndpoint(
+            name = "Echo String",
+            folder = "Misc",
             metadata = httpMetadata(
-                path = "/api/users",
+                path = "/api/echo/string",
                 method = HttpMethod.POST,
-                headers = listOf(
-                    ApiHeader(name = "Content-Type", value = "application/json"),
-                    ApiHeader(name = "Authorization", value = "Bearer token", required = true)
-                )
-            )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testEndpointWithFolders() {
-        val endpoints = listOf(
-            ApiEndpoint(
-                name = "Get User",
-                folder = "Users",
-                metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
-            ),
-            ApiEndpoint(
-                name = "Create User",
-                folder = "Users",
-                metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)
-            ),
-            ApiEndpoint(
-                name = "Get Order",
-                folder = "Orders",
-                metadata = httpMetadata(path = "/api/orders/{id}", method = HttpMethod.GET)
-            )
-        )
-        assertParity(endpoints, "API")
-    }
-
-    @Test
-    fun testEndpointWithRequestBody() {
-        val bodyModel = ObjectModel.Object(
-            mapOf(
-                "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name"),
-                "age" to FieldModel(ObjectModel.single(JsonType.INT), comment = "user age")
-            )
-        )
-        val endpoint = ApiEndpoint(
-            name = "Create User",
-            metadata = httpMetadata(
-                path = "/api/users",
-                method = HttpMethod.POST,
-                body = bodyModel,
+                body = ObjectModel.single(JsonType.STRING),
                 headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
             )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testEndpointWithResponseBody() {
-        val responseModel = ObjectModel.Object(
-            mapOf(
-                "code" to FieldModel(ObjectModel.single(JsonType.INT), comment = "response code"),
-                "msg" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "message"),
-                "data" to FieldModel(
-                    ObjectModel.Object(
-                        mapOf(
-                            "id" to FieldModel(ObjectModel.single(JsonType.LONG), comment = "user id"),
-                            "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name")
+        ),
+        // --- HTTP: map body ---
+        ApiEndpoint(
+            name = "Update Metadata",
+            folder = "Misc",
+            metadata = httpMetadata(
+                path = "/api/resources/{id}/metadata",
+                method = HttpMethod.PUT,
+                parameters = listOf(
+                    ApiParameter(name = "id", binding = ParameterBinding.Path, required = true, description = "Resource ID")
+                ),
+                body = ObjectModel.Object(
+                    mapOf(
+                        "metadata" to FieldModel(
+                            ObjectModel.MapModel(
+                                keyType = ObjectModel.single(JsonType.STRING),
+                                valueType = ObjectModel.single(JsonType.INT)
+                            ),
+                            comment = "key-value metadata"
                         )
-                    ),
-                    comment = "response data"
-                )
+                    )
+                ),
+                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
             )
-        )
-        val endpoint = ApiEndpoint(
-            name = "Get User",
+        ),
+        // --- HTTP: array of primitives body ---
+        ApiEndpoint(
+            name = "Create Post",
+            folder = "Misc",
             metadata = httpMetadata(
-                path = "/api/users/{id}",
-                method = HttpMethod.GET,
-                responseBody = responseModel
+                path = "/api/posts",
+                method = HttpMethod.POST,
+                body = ObjectModel.Object(
+                    mapOf(
+                        "tags" to FieldModel(ObjectModel.array(ObjectModel.single(JsonType.STRING)), comment = "tag list")
+                    )
+                ),
+                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
             )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testEndpointWithArrayResponseBody() {
-        val itemModel = ObjectModel.Object(
-            mapOf(
-                "id" to FieldModel(ObjectModel.single(JsonType.LONG)),
-                "name" to FieldModel(ObjectModel.single(JsonType.STRING))
-            )
-        )
-        val responseModel = ObjectModel.Object(
-            mapOf(
-                "code" to FieldModel(ObjectModel.single(JsonType.INT)),
-                "data" to FieldModel(ObjectModel.array(itemModel), comment = "user list")
-            )
-        )
-        val endpoint = ApiEndpoint(
-            name = "List Users",
+        ),
+        // --- HTTP: field options ---
+        ApiEndpoint(
+            name = "Update Status",
+            folder = "Misc",
             metadata = httpMetadata(
-                path = "/api/users",
-                method = HttpMethod.GET,
-                responseBody = responseModel
+                path = "/api/status",
+                method = HttpMethod.PUT,
+                body = ObjectModel.Object(
+                    mapOf(
+                        "status" to FieldModel(
+                            ObjectModel.single(JsonType.STRING),
+                            comment = "status",
+                            options = listOf(
+                                FieldOption(value = "active", desc = "Active user"),
+                                FieldOption(value = "inactive", desc = "Inactive user")
+                            )
+                        )
+                    )
+                ),
+                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
             )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testEndpointWithNoResponseBody() {
-        val endpoint = ApiEndpoint(
-            name = "Delete User",
-            metadata = httpMetadata(
-                path = "/api/users/{id}",
-                method = HttpMethod.DELETE
-            )
-        )
-        assertParity(listOf(endpoint), "User API")
-    }
-
-    @Test
-    fun testMultipleEndpoints() {
-        val endpoints = listOf(
-            ApiEndpoint(name = "Get User", metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)),
-            ApiEndpoint(name = "Create User", metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST)),
-            ApiEndpoint(name = "Update User", metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.PUT)),
-            ApiEndpoint(name = "Delete User", metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.DELETE))
-        )
-        assertParity(endpoints, "User API")
-    }
-
-    @Test
-    fun testEndpointWithFormParams() {
-        val endpoint = ApiEndpoint(
+        ),
+        // --- HTTP: form params ---
+        ApiEndpoint(
             name = "Upload File",
+            folder = "Misc",
             metadata = httpMetadata(
                 path = "/api/upload",
                 method = HttpMethod.POST,
                 parameters = listOf(
                     ApiParameter(name = "file", type = ParameterType.FILE, binding = ParameterBinding.Form, required = true, description = "File to upload"),
                     ApiParameter(name = "description", binding = ParameterBinding.Form, required = false, description = "File description")
+                ),
+                headers = listOf(ApiHeader(name = "Content-Type", value = "multipart/form-data"))
+            )
+        ),
+        // --- HTTP: DELETE with no response body ---
+        ApiEndpoint(
+            name = "Delete User",
+            folder = "Users",
+            metadata = httpMetadata(
+                path = "/api/users/{id}",
+                method = HttpMethod.DELETE
+            )
+        ),
+        // --- HTTP: endpoint with description ---
+        ApiEndpoint(
+            name = "Get Profile",
+            folder = "Misc",
+            description = "Retrieve the current user's profile information",
+            metadata = httpMetadata(
+                path = "/api/profile",
+                method = HttpMethod.GET
+            )
+        ),
+        // --- HTTP: recursive (cycle) body ---
+        run {
+            val fields = mutableMapOf<String, FieldModel>()
+            val treeNode = ObjectModel.Object(fields)
+            fields["name"] = FieldModel(ObjectModel.single(JsonType.STRING), comment = "node name")
+            fields["children"] = FieldModel(ObjectModel.array(treeNode), comment = "child nodes")
+            ApiEndpoint(
+                name = "Get Tree",
+                folder = "Misc",
+                metadata = httpMetadata(
+                    path = "/api/tree",
+                    method = HttpMethod.GET,
+                    responseBody = treeNode
                 )
             )
-        )
-        assertParity(listOf(endpoint), "Upload API")
-    }
-
-    // ---------- Cycle safety ----------
-
-    @Test
-    fun testCircularReference() {
-        val fields = mutableMapOf<String, FieldModel>()
-        val treeNode = ObjectModel.Object(fields)
-        fields["name"] = FieldModel(ObjectModel.single(JsonType.STRING), comment = "node name")
-        fields["children"] = FieldModel(ObjectModel.array(treeNode), comment = "child nodes")
-
-        val endpoint = ApiEndpoint(
-            name = "Get Tree",
-            metadata = httpMetadata(
-                path = "/api/tree",
-                method = HttpMethod.GET,
-                responseBody = treeNode
-            )
-        )
-        assertParity(listOf(endpoint), "Tree API")
-    }
-
-    @Test
-    fun testDirectCircularReference() {
-        val fields = mutableMapOf<String, FieldModel>()
-        val selfRef = ObjectModel.Object(fields)
-        fields["id"] = FieldModel(ObjectModel.single(JsonType.INT), comment = "id")
-        fields["parent"] = FieldModel(selfRef, comment = "parent reference")
-
-        val endpoint = ApiEndpoint(
-            name = "Get Node",
-            metadata = httpMetadata(
-                path = "/api/node",
-                method = HttpMethod.GET,
-                responseBody = selfRef
-            )
-        )
-        assertParity(listOf(endpoint), "Node API")
-    }
-
-    @Test
-    fun testMutualCircularReference() {
-        val fieldsA = mutableMapOf<String, FieldModel>()
-        val fieldsB = mutableMapOf<String, FieldModel>()
-        val objectA = ObjectModel.Object(fieldsA)
-        val objectB = ObjectModel.Object(fieldsB)
-        fieldsA["name"] = FieldModel(ObjectModel.single(JsonType.STRING))
-        fieldsA["refB"] = FieldModel(objectB, comment = "reference to B")
-        fieldsB["value"] = FieldModel(ObjectModel.single(JsonType.INT))
-        fieldsB["refA"] = FieldModel(objectA, comment = "reference to A")
-
-        val endpoint = ApiEndpoint(
-            name = "Get Mutual",
-            metadata = httpMetadata(
-                path = "/api/mutual",
-                method = HttpMethod.GET,
-                responseBody = objectA
-            )
-        )
-        assertParity(listOf(endpoint), "Mutual API")
-    }
-
-    @Test
-    fun testNonCircularDeepNesting() {
-        val inner = ObjectModel.Object(
-            mapOf("value" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "inner value"))
-        )
-        val middle = ObjectModel.Object(
-            mapOf("inner" to FieldModel(inner, comment = "inner object"))
-        )
-        val outer = ObjectModel.Object(
-            mapOf("middle" to FieldModel(middle, comment = "middle object"))
-        )
-
-        val endpoint = ApiEndpoint(
-            name = "Get Nested",
-            metadata = httpMetadata(
-                path = "/api/nested",
-                method = HttpMethod.GET,
-                responseBody = outer
-            )
-        )
-        assertParity(listOf(endpoint), "Nested API")
-    }
-
-    // ---------- gRPC ----------
-
-    @Test
-    fun testGrpcEndpoint() {
-        val endpoint = ApiEndpoint(
+        },
+        // --- gRPC: unary with body + response ---
+        ApiEndpoint(
             name = "GetUser",
-            metadata = GrpcMetadata(
-                path = "/user.UserService/GetUser",
-                serviceName = "UserService",
-                methodName = "GetUser",
-                packageName = "user",
-                streamingType = GrpcStreamingType.UNARY
-            )
-        )
-        assertParity(listOf(endpoint), "gRPC API")
-    }
-
-    @Test
-    fun testGrpcEndpointWithDescription() {
-        val endpoint = ApiEndpoint(
-            name = "GetUser",
-            description = "Retrieves a user by ID",
-            metadata = GrpcMetadata(
-                path = "/user.UserService/GetUser",
-                serviceName = "UserService",
-                methodName = "GetUser",
-                packageName = "user",
-                streamingType = GrpcStreamingType.UNARY
-            )
-        )
-        assertParity(listOf(endpoint), "gRPC API")
-    }
-
-    @Test
-    fun testGrpcEndpointWithRequestBody() {
-        val bodyModel = ObjectModel.Object(
-            mapOf(
-                "user_id" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user ID")
-            )
-        )
-        val endpoint = ApiEndpoint(
-            name = "GetUser",
+            folder = "gRPC",
             metadata = GrpcMetadata(
                 path = "/user.UserService/GetUser",
                 serviceName = "UserService",
                 methodName = "GetUser",
                 packageName = "user",
                 streamingType = GrpcStreamingType.UNARY,
-                body = bodyModel
+                body = ObjectModel.Object(
+                    mapOf(
+                        "user_id" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user ID")
+                    )
+                ),
+                responseBody = ObjectModel.Object(
+                    mapOf(
+                        "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name")
+                    )
+                )
             )
-        )
-        assertParity(listOf(endpoint), "gRPC API")
-    }
-
-    @Test
-    fun testGrpcEndpointWithResponseBody() {
-        val responseModel = ObjectModel.Object(
-            mapOf(
-                "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name")
-            )
-        )
-        val endpoint = ApiEndpoint(
-            name = "GetUser",
-            metadata = GrpcMetadata(
-                path = "/user.UserService/GetUser",
-                serviceName = "UserService",
-                methodName = "GetUser",
-                packageName = "user",
-                streamingType = GrpcStreamingType.UNARY,
-                responseBody = responseModel
-            )
-        )
-        assertParity(listOf(endpoint), "gRPC API")
-    }
-
-    @Test
-    fun testGrpcServerStreaming() {
-        val endpoint = ApiEndpoint(
+        ),
+        // --- gRPC: server streaming ---
+        ApiEndpoint(
             name = "ListUsers",
+            folder = "gRPC",
             metadata = GrpcMetadata(
                 path = "/user.UserService/ListUsers",
                 serviceName = "UserService",
@@ -442,14 +289,11 @@ class MarkdownTemplateParityTest {
                 packageName = "user",
                 streamingType = GrpcStreamingType.SERVER_STREAMING
             )
-        )
-        assertParity(listOf(endpoint), "gRPC API")
-    }
-
-    @Test
-    fun testGrpcBidiStreaming() {
-        val endpoint = ApiEndpoint(
+        ),
+        // --- gRPC: bidi streaming ---
+        ApiEndpoint(
             name = "Chat",
+            folder = "gRPC",
             metadata = GrpcMetadata(
                 path = "/chat.ChatService/Chat",
                 serviceName = "ChatService",
@@ -457,164 +301,45 @@ class MarkdownTemplateParityTest {
                 packageName = "chat",
                 streamingType = GrpcStreamingType.BIDIRECTIONAL
             )
-        )
-        assertParity(listOf(endpoint), "gRPC API")
-    }
-
-    // ---------- No-demo mode ----------
-
-    @Test
-    fun testNoDemoMode() {
-        val bodyModel = ObjectModel.Object(
-            mapOf(
-                "name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name")
-            )
-        )
-        val endpoint = ApiEndpoint(
-            name = "Create User",
+        ),
+        // --- HTTP: endpoint without name (edge case) ---
+        ApiEndpoint(
+            folder = "Misc",
             metadata = httpMetadata(
-                path = "/api/users",
-                method = HttpMethod.POST,
-                body = bodyModel,
-                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
-            )
-        )
-        assertParity(listOf(endpoint), "User API", outputDemo = false)
-    }
-
-    // ---------- Edge cases ----------
-
-    @Test
-    fun testEndpointWithoutName() {
-        val endpoint = ApiEndpoint(
-            metadata = httpMetadata(
-                path = "/api/users",
+                path = "/api/webhook",
                 method = HttpMethod.POST
             )
-        )
-        assertParity(listOf(endpoint), "API")
-    }
+        ),
+    )
 
     @Test
-    fun testEndpointWithBlankDescription() {
-        val endpoint = ApiEndpoint(
-            name = "Get User",
-            description = "   ",
-            metadata = httpMetadata(
-                path = "/api/users/{id}",
-                method = HttpMethod.GET
-            )
-        )
-        assertParity(listOf(endpoint), "API")
-    }
+    fun testDefaultTemplateMatchesGolden() {
+        val endpoints = comprehensiveEndpoints()
+        val model = TemplateModelBuilder.build(endpoints, moduleName = "Test API")
+        val actual = MarkdownTemplateRenderer.render(defaultTemplate, model, ctx)
 
-    @Test
-    fun testEndpointWithAllParamTypes() {
-        val endpoint = ApiEndpoint(
-            name = "Update User",
-            metadata = httpMetadata(
-                path = "/api/users/{id}",
-                method = HttpMethod.PUT,
-                parameters = listOf(
-                    ApiParameter(name = "id", binding = ParameterBinding.Path, required = true, description = "User ID"),
-                    ApiParameter(name = "page", binding = ParameterBinding.Query, required = false, description = "Page number"),
-                    ApiParameter(name = "X-Token", binding = ParameterBinding.Header, required = true, description = "Auth token"),
-                    ApiParameter(name = "avatar", type = ParameterType.FILE, binding = ParameterBinding.Form, required = false, description = "Avatar file")
-                ),
-                headers = listOf(
-                    ApiHeader(name = "Content-Type", value = "multipart/form-data")
-                )
-            )
-        )
-        assertParity(listOf(endpoint), "API")
-    }
+        assertTrue("Rendered output must be non-empty", actual.isNotEmpty())
 
-    @Test
-    fun testMixedHttpAndGrpcEndpoints() {
-        val endpoints = listOf(
-            ApiEndpoint(
-                name = "Get User",
-                metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
-            ),
-            ApiEndpoint(
-                name = "GetUserGrpc",
-                metadata = GrpcMetadata(
-                    path = "/user.UserService/GetUser",
-                    serviceName = "UserService",
-                    methodName = "GetUser",
-                    packageName = "user",
-                    streamingType = GrpcStreamingType.UNARY
-                )
-            )
-        )
-        assertParity(endpoints, "Mixed API")
-    }
+        val goldenFile = File(GOLDEN_PATH)
+        val updateGolden = System.getProperty("update.golden") != null ||
+            System.getenv("UPDATE_GOLDEN") != null
 
-    @Test
-    fun testEndpointWithMapBody() {
-        val mapModel = ObjectModel.MapModel(
-            keyType = ObjectModel.single(JsonType.STRING),
-            valueType = ObjectModel.single(JsonType.INT)
-        )
-        val bodyModel = ObjectModel.Object(
-            mapOf(
-                "metadata" to FieldModel(mapModel, comment = "key-value metadata")
-            )
-        )
-        val endpoint = ApiEndpoint(
-            name = "Create Resource",
-            metadata = httpMetadata(
-                path = "/api/resources",
-                method = HttpMethod.POST,
-                body = bodyModel,
-                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
-            )
-        )
-        assertParity(listOf(endpoint), "API")
-    }
+        if (updateGolden || !goldenFile.exists()) {
+            goldenFile.parentFile.mkdirs()
+            goldenFile.writeText(actual)
+            println("Golden written at $GOLDEN_PATH (${actual.length} chars)")
+            return
+        }
 
-    @Test
-    fun testEndpointWithArrayOfPrimitives() {
-        val bodyModel = ObjectModel.Object(
-            mapOf(
-                "tags" to FieldModel(ObjectModel.array(ObjectModel.single(JsonType.STRING)), comment = "tag list")
-            )
+        // The renderer emits LF (`\n`) on every platform; the golden is committed
+        // with LF. readRaw collapses CRLF→LF so the parity gate is stable on
+        // Windows checkouts (where git autocrlf may convert the on-disk golden).
+        val expected = ResourceLoader.readRaw(GOLDEN_RESOURCE)
+        assertEquals(
+            "Default template output must match the committed golden byte-for-byte. " +
+                "If this is an intentional change, run with -Dupdate.golden=true to update.",
+            expected,
+            actual,
         )
-        val endpoint = ApiEndpoint(
-            name = "Create Post",
-            metadata = httpMetadata(
-                path = "/api/posts",
-                method = HttpMethod.POST,
-                body = bodyModel,
-                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
-            )
-        )
-        assertParity(listOf(endpoint), "API")
-    }
-
-    @Test
-    fun testEndpointWithFieldOptions() {
-        val bodyModel = ObjectModel.Object(
-            mapOf(
-                "status" to FieldModel(
-                    ObjectModel.single(JsonType.STRING),
-                    comment = "status",
-                    options = listOf(
-                        FieldOption(value = "active", desc = "Active user"),
-                        FieldOption(value = "inactive", desc = "Inactive user")
-                    )
-                )
-            )
-        )
-        val endpoint = ApiEndpoint(
-            name = "Update Status",
-            metadata = httpMetadata(
-                path = "/api/status",
-                method = HttpMethod.PUT,
-                body = bodyModel,
-                headers = listOf(ApiHeader(name = "Content-Type", value = "application/json"))
-            )
-        )
-        assertParity(listOf(endpoint), "API")
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngineMethodCallTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngineMethodCallTest.kt
@@ -1,0 +1,293 @@
+package com.itangcent.easyapi.exporter.channel.markdown.template
+
+import com.itangcent.easyapi.psi.model.FieldModel
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+import com.itangcent.easyapi.psi.type.JsonType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Engine-level contract for method-call syntax (`body.asDemo()`, `body.asJson()`, `body.asJson5()`),
+ * the `meta.*` carve-out (review finding F4), the chained-call v1 boundary (F14), and the
+ * non-BodyView receiver fallback (F7).
+ *
+ * Pure JUnit — no `Project`, no PSI/VFS.
+ */
+class TemplateEngineMethodCallTest {
+
+    private val fixedInstant: Instant = Instant.parse("2026-03-15T10:30:45Z")
+    private val zone: ZoneId = ZoneId.of("UTC")
+    private val fixedClock: Clock = Clock.fixed(fixedInstant, zone)
+
+    private val ctx: RenderContext = RenderContext(
+        clock = fixedClock,
+        zone = zone,
+        username = "test-user",
+        projectName = "test-project",
+        pluginVersion = "1.2.3",
+    )
+
+    private val emptyModel: TemplateModel = TemplateModel(
+        moduleName = "TestAPI",
+        groups = emptyList(),
+        endpointCount = 0,
+    )
+
+    /** Builds a model with one HTTP endpoint whose body is a simple Object {name: string}. */
+    private fun modelWithBody(bodyModel: ObjectModel): TemplateModel {
+        val body = BodyView(
+            model = bodyModel,
+            fields = listOf(
+                FieldView(
+                    name = "name",
+                    type = "string",
+                    desc = "user name",
+                    required = false,
+                    defaultValue = null,
+                    depth = 0,
+                    indent = "",
+                    hasChildren = false,
+                    childrenCount = 0,
+                    structuralKind = FieldStructuralKind.PRIMITIVE,
+                ),
+            ),
+        )
+        val endpoint = Endpoint(
+            name = "Create User",
+            description = null,
+            protocol = "HTTP",
+            path = "/api/users",
+            method = "POST",
+            http = HttpView(
+                pathParams = emptyList(),
+                queryParams = emptyList(),
+                formParams = emptyList(),
+                headers = emptyList(),
+                body = body,
+                response = null,
+                hasRequestContent = true,
+            ),
+            grpc = null,
+        )
+        return TemplateModel(
+            moduleName = "TestAPI",
+            groups = listOf(Group(folder = "Users", endpoints = listOf(endpoint))),
+            endpointCount = 1,
+        )
+    }
+
+    private val simpleBodyModel: ObjectModel = ObjectModel.Object(
+        mapOf("name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name"))
+    )
+
+    private val modelWithSimpleBody: TemplateModel = modelWithBody(simpleBodyModel)
+
+    private val expectedJson: String = ObjectModelJsonConverter.toJson(simpleBodyModel)
+    private val expectedJson5: String = ObjectModelJsonConverter.toJson5(simpleBodyModel)
+
+    // ---------- asDemo / asJson / asJson5 ----------
+
+    @Test
+    fun testAsDemoResolvesBodyAndReturnsJson() {
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asDemo()}}}{{/each}}{{/each}}"
+        assertEquals(expectedJson, TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    @Test
+    fun testAsJsonReturnsJson() {
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asJson()}}}{{/each}}{{/each}}"
+        assertEquals(expectedJson, TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    @Test
+    fun testAsJson5ReturnsJson5() {
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asJson5()}}}{{/each}}{{/each}}"
+        assertEquals(expectedJson5, TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    @Test
+    fun testAsJson5DiffersFromAsDemoWhenCommentsPresent() {
+        // The body has a comment "user name" — toJson5 should embed it, toJson should not.
+        assertNotEquals(expectedJson, expectedJson5)
+        assertTrue("JSON5 should contain the comment", expectedJson5.contains("user name"))
+    }
+
+    @Test
+    fun testAsDemoEqualsAsJson() {
+        // F9 / FR-9: asDemo and asJson return byte-identical strings for the same BodyView.
+        val template1 = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asDemo()}}}{{/each}}{{/each}}"
+        val template2 = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asJson()}}}{{/each}}{{/each}}"
+        assertEquals(
+            TemplateEngine.render(template1, modelWithSimpleBody, ctx),
+            TemplateEngine.render(template2, modelWithSimpleBody, ctx),
+        )
+    }
+
+    // ---------- Raw form is not escaped ----------
+
+    @Test
+    fun testMethodCallInRawFormIsNotEscaped() {
+        // {{{...}}} must NOT html-escape the JSON output (would corrupt quotes/braces).
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asDemo()}}}{{/each}}{{/each}}"
+        val rendered = TemplateEngine.render(template, modelWithSimpleBody, ctx)
+        // JSON contains `"` and `{` `}` — they must survive unescaped.
+        assertTrue("rendered should contain {", rendered.contains("{"))
+        assertTrue("rendered should contain }", rendered.contains("}"))
+        assertTrue("rendered should contain \"", rendered.contains("\""))
+    }
+
+    @Test
+    fun testMethodCallInEscapedFormIsEscaped() {
+        // {{...}} (non-raw) MUST html-escape — pipes and newlines. JSON has neither by default,
+        // but the contract is that {{...}} runs through MarkdownEscapeUtils.escape.
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{api.http.body.asDemo()}}{{/each}}{{/each}}"
+        val rendered = TemplateEngine.render(template, modelWithSimpleBody, ctx)
+        // The escaped form should still render the JSON (no pipe/newline to escape here),
+        // so it equals the raw form for this particular body. We assert it's non-empty.
+        assertTrue("escaped form should render non-empty", rendered.isNotEmpty())
+    }
+
+    // ---------- Null receiver ----------
+
+    @Test
+    fun testMethodCallOnNullReceiverRendersEmpty() {
+        // Body is null → receiver resolves to null → renders empty, no throw, no log.
+        val endpoint = Endpoint(
+            name = "Get",
+            description = null,
+            protocol = "HTTP",
+            path = "/api/x",
+            method = "GET",
+            http = HttpView(
+                pathParams = emptyList(),
+                queryParams = emptyList(),
+                formParams = emptyList(),
+                headers = emptyList(),
+                body = null,
+                response = null,
+                hasRequestContent = false,
+            ),
+            grpc = null,
+        )
+        val model = TemplateModel(
+            moduleName = "M",
+            groups = listOf(Group(folder = "", endpoints = listOf(endpoint))),
+            endpointCount = 1,
+        )
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asDemo()}}}{{/each}}{{/each}}"
+        assertEquals("", TemplateEngine.render(template, model, ctx))
+    }
+
+    // ---------- Unknown method on BodyView ----------
+
+    @Test
+    fun testUnknownMethodOnBodyViewRendersEmpty() {
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.unknownMethod()}}}{{/each}}{{/each}}"
+        assertEquals("", TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    // ---------- Non-BodyView receiver (F7) ----------
+
+    @Test
+    fun testMethodCallOnNonBodyViewReceiverRendersEmpty() {
+        // api.path is a String receiver. Calling asJson5() on it → empty + info log.
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.path.asJson5()}}}{{/each}}{{/each}}"
+        assertEquals("", TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    // ---------- meta.* no-regression (F4) ----------
+
+    @Test
+    fun testMetaDateStillParsesAsBuiltinCall() {
+        // meta.date('yyyy') must continue to resolve as a BuiltinCall, not a MethodCall.
+        assertEquals("2026", TemplateEngine.render("{{meta.date(yyyy)}}", emptyModel, ctx))
+    }
+
+    @Test
+    fun testMetaTimeStillParsesAsBuiltinCall() {
+        assertEquals("10:30:45", TemplateEngine.render("{{meta.time(HH:mm:ss)}}", emptyModel, ctx))
+    }
+
+    @Test
+    fun testMetaUnknownThingStillParsesAsBuiltinCall() {
+        // meta.unknownThing('x') — not a registered builtin → empty, but parses as BuiltinCall.
+        assertEquals("", TemplateEngine.render("{{meta.unknownThing('x')}}", emptyModel, ctx))
+    }
+
+    @Test
+    fun testBareDateStillParsesAsBuiltinCall() {
+        // Bare date('yyyy') (no dot) — BuiltinCall.
+        assertEquals("2026", TemplateEngine.render("{{date(yyyy)}}", emptyModel, ctx))
+    }
+
+    @Test
+    fun testMetaDateNoParensStillBuiltinCall() {
+        assertEquals("2026-03-15", TemplateEngine.render("{{meta.date}}", emptyModel, ctx))
+    }
+
+    // ---------- Chained-call v1 boundary (F14) ----------
+
+    @Test
+    fun testChainedMethodCallRendersEmpty() {
+        // api.http.body.asJson5().trim() — v1 does not support chained calls.
+        // Renders empty + info log "Chained method calls are not supported in v1".
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.asJson5().trim()}}}{{/each}}{{/each}}"
+        assertEquals("", TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    @Test
+    fun testChainedCallOnMetaDateRendersEmpty() {
+        // meta.date('yyyy').foo() — also a chained call; v1 does not support.
+        assertEquals("", TemplateEngine.render("{{meta.date('yyyy').foo()}}", emptyModel, ctx))
+    }
+
+    // ---------- No-regression: helpers, dotted paths, if, each ----------
+
+    @Test
+    fun testDottedPathStillResolves() {
+        // api.path (no parens) — Path, not MethodCall.
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.path}}}{{/each}}{{/each}}"
+        assertEquals("/api/users", TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    @Test
+    fun testIfBlockStillWorks() {
+        val template = "{{#if moduleName}}yes{{else}}no{{/if}}"
+        assertEquals("yes", TemplateEngine.render(template, emptyModel, ctx))
+    }
+
+    @Test
+    fun testEachBlockStillWorks() {
+        val template = "{{#each groups as g}}{{g.folder}}|{{/each}}"
+        assertEquals("Users|", TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+
+    @Test
+    fun testJsonDemoHelperStillWorks() {
+        // {{jsonDemo body.model}} — helper form, takes ObjectModel directly.
+        // Uses raw {{{...}}} because jsonDemo's output contains newlines (fence + JSON).
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{jsonDemo api.http.body.model}}}{{/each}}{{/each}}"
+        val rendered = TemplateEngine.render(template, modelWithSimpleBody, ctx)
+        // jsonDemo wraps in ```json\n...\n```
+        assertTrue("jsonDemo should open fence", rendered.startsWith("```json\n"))
+        assertTrue("jsonDemo should close fence", rendered.endsWith("\n```"))
+        assertTrue("jsonDemo should contain the JSON", rendered.contains("\"name\""))
+    }
+
+    // ---------- Direct body.asDemo() (body is loop context) ----------
+
+    @Test
+    fun testAsDemoCalledOnLoopContextBody() {
+        // Inside {{#each api.http.body.fields as f}}, `body` is NOT in scope.
+        // But if we use `api.http.body` explicitly, it works.
+        // Uses raw {{{...}}} because asDemo()'s JSON output contains newlines.
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}body={{{api.http.body.asDemo()}}}{{/each}}{{/each}}"
+        assertEquals("body=$expectedJson", TemplateEngine.render(template, modelWithSimpleBody, ctx))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngineTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngineTest.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.exporter.channel.markdown.template
 
+import com.itangcent.easyapi.psi.model.ObjectModel
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.Clock
@@ -100,8 +101,20 @@ class TemplateEngineTest {
 
     @Test
     fun testRawInterpolationPreservesHtmlEntities() {
-        // Used for the indent prefix `&ensp;&ensp;&#124;─` in body rows.
-        val row = Row(name = "&ensp;&ensp;&#124;─id", type = "string", desc = "")
+        // Used for the indent prefix `&ensp;&ensp;&#124;─` in body fields.
+        val field = FieldView(
+            name = "id",
+            type = "string",
+            desc = "",
+            required = false,
+            defaultValue = null,
+            depth = 1,
+            indent = "&ensp;&ensp;&#124;─",
+            hasChildren = false,
+            childrenCount = 0,
+            structuralKind = FieldStructuralKind.PRIMITIVE,
+        )
+        val bodyModel = ObjectModel.Object(mapOf("id" to com.itangcent.easyapi.psi.model.FieldModel(ObjectModel.single(com.itangcent.easyapi.psi.type.JsonType.STRING), comment = "user id")))
         val endpoint = Endpoint(
             name = "x",
             description = null,
@@ -113,7 +126,7 @@ class TemplateEngineTest {
                 queryParams = emptyList(),
                 formParams = emptyList(),
                 headers = emptyList(),
-                body = BodyView(rows = listOf(row), demo = null),
+                body = BodyView(model = bodyModel, fields = listOf(field)),
                 response = null,
                 hasRequestContent = true,
             ),
@@ -124,9 +137,9 @@ class TemplateEngineTest {
             groups = listOf(Group(folder = "", endpoints = listOf(endpoint))),
             endpointCount = 1,
         )
-        // Raw interpolation of the row name should preserve the entities verbatim.
-        // Path: groups[0].endpoints[0].http.body.rows[0].name — reached via loop aliases.
-        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.body.rows[0].name}}}{{/each}}{{/each}}"
+        // Raw interpolation of the field indent should preserve the entities verbatim.
+        // Path: groups[0].endpoints[0].http.body.fields[0].indent — reached via loop aliases.
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{#each api.http.body.fields as f}}{{{f.indent}}}{{f.name}}{{/each}}{{/each}}{{/each}}"
         assertEquals(
             "&ensp;&ensp;&#124;─id",
             TemplateEngine.render(template, model, ctx),

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilderTest.kt
@@ -45,7 +45,7 @@ class TemplateModelBuilderTest {
             )
         )
 
-        val model = TemplateModelBuilder.build(endpoints, outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(endpoints, moduleName = "API")
 
         assertEquals("API", model.moduleName)
         assertEquals(2, model.endpointCount)
@@ -62,7 +62,7 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
 
         assertEquals(1, model.groups.size)
         assertEquals("", model.groups[0].folder)
@@ -77,7 +77,7 @@ class TemplateModelBuilderTest {
             ApiEndpoint(name = "B2", folder = "B", metadata = httpMetadata(path = "/b2", method = HttpMethod.GET))
         )
 
-        val model = TemplateModelBuilder.build(endpoints, outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(endpoints, moduleName = "API")
 
         // groupBy preserves first-appearance order of keys
         assertEquals(listOf("B", "A"), model.groups.map { it.folder })
@@ -99,7 +99,7 @@ class TemplateModelBuilderTest {
             )
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val http = model.groups[0].endpoints[0].http!!
 
         assertEquals("HTTP", model.groups[0].endpoints[0].protocol)
@@ -120,7 +120,7 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/nothing", method = HttpMethod.GET)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val http = model.groups[0].endpoints[0].http!!
 
         assertTrue(http.pathParams.isEmpty())
@@ -147,7 +147,7 @@ class TemplateModelBuilderTest {
             )
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val http = model.groups[0].endpoints[0].http!!
 
         assertEquals(listOf("page"), http.queryParams.map { it.name })
@@ -171,14 +171,14 @@ class TemplateModelBuilderTest {
             )
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val p = model.groups[0].endpoints[0].http!!.pathParams[0]
 
         assertEquals("", p.defaultValue)
         assertEquals("", p.description)
     }
 
-    // ---- Body: rows, demo, outputDemo ----
+    // ---- Body: fields, asDemo ----
 
     @Test
     fun testBodyRowsSimpleObject() {
@@ -193,16 +193,18 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST, body = body)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val bodyView = model.groups[0].endpoints[0].http!!.body!!
 
-        assertEquals(2, bodyView.rows.size)
-        assertEquals("name", bodyView.rows[0].name)
-        assertEquals("string", bodyView.rows[0].type)
-        assertEquals("user name", bodyView.rows[0].desc)
-        assertEquals("age", bodyView.rows[1].name)
-        assertEquals("int", bodyView.rows[1].type)
-        assertEquals("user age", bodyView.rows[1].desc)
+        assertEquals(2, bodyView.fields.size)
+        assertEquals("name", bodyView.fields[0].name)
+        assertEquals("string", bodyView.fields[0].type)
+        assertEquals("user name", bodyView.fields[0].desc)
+        assertEquals("age", bodyView.fields[1].name)
+        assertEquals("int", bodyView.fields[1].type)
+        assertEquals("user age", bodyView.fields[1].desc)
+        // model is the original ObjectModel (FR-1)
+        assertSame(body, bodyView.model)
     }
 
     @Test
@@ -218,17 +220,21 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET, responseBody = body)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val bodyView = model.groups[0].endpoints[0].http!!.response!!
 
-        // top-level row has no indent
-        assertEquals("data", bodyView.rows[0].name)
-        assertEquals("object", bodyView.rows[0].type)
-        assertEquals("response data", bodyView.rows[0].desc)
-        // nested row has the indent prefix
-        assertEquals("&ensp;&ensp;&#124;─id", bodyView.rows[1].name)
-        assertEquals("long", bodyView.rows[1].type)
-        assertEquals("user id", bodyView.rows[1].desc)
+        // top-level field has no indent
+        assertEquals("data", bodyView.fields[0].name)
+        assertEquals("", bodyView.fields[0].indent)
+        assertEquals(0, bodyView.fields[0].depth)
+        assertEquals("object", bodyView.fields[0].type)
+        assertEquals("response data", bodyView.fields[0].desc)
+        // nested field has the indent prefix (separate from name)
+        assertEquals("id", bodyView.fields[1].name)
+        assertEquals("&ensp;&ensp;&#124;─", bodyView.fields[1].indent)
+        assertEquals(1, bodyView.fields[1].depth)
+        assertEquals("long", bodyView.fields[1].type)
+        assertEquals("user id", bodyView.fields[1].desc)
     }
 
     @Test
@@ -247,12 +253,13 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/users", method = HttpMethod.GET, responseBody = body)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
-        val row = model.groups[0].endpoints[0].http!!.response!!.rows[0]
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val field = model.groups[0].endpoints[0].http!!.response!!.fields[0]
 
-        assertEquals("data", row.name)
-        assertEquals("object[]", row.type)
-        assertEquals("user list", row.desc)
+        assertEquals("data", field.name)
+        assertEquals("object[]", field.type)
+        assertEquals("user list", field.desc)
+        assertEquals(FieldStructuralKind.ARRAY, field.structuralKind)
     }
 
     @Test
@@ -265,30 +272,15 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST, body = body)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
-        val demo = model.groups[0].endpoints[0].http!!.body!!.demo
-
-        assertNotNull("demo must be present when outputDemo=true", demo)
-        assertEquals(ObjectModelJsonConverter.toJson(body), demo)
-    }
-
-    @Test
-    fun testBodyDemoNullWhenOutputDemoFalse() {
-        val body = ObjectModel.Object(
-            mapOf("name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name"))
-        )
-        val endpoint = ApiEndpoint(
-            name = "Create User",
-            metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST, body = body)
-        )
-
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = false, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val bodyView = model.groups[0].endpoints[0].http!!.body!!
 
-        // rows still present
-        assertEquals(1, bodyView.rows.size)
-        // demo suppressed 
-        assertNull("demo must be null when outputDemo=false", bodyView.demo)
+        // asDemo() is evaluated lazily; equals ObjectModelJsonConverter.toJson(body)
+        assertEquals(ObjectModelJsonConverter.toJson(body), bodyView.asDemo())
+        // asJson is an alias of asDemo (D5 / FR-9)
+        assertEquals(bodyView.asDemo(), bodyView.asJson())
+        // asJson5 is JSON5 with comments
+        assertEquals(ObjectModelJsonConverter.toJson5(body), bodyView.asJson5())
     }
 
     @Test
@@ -298,21 +290,85 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.DELETE)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
 
         assertNull(model.groups[0].endpoints[0].http!!.response)
     }
 
     @Test
-    fun testBodyDemoNullWhenBodyAbsent() {
+    fun testBodyNullWhenBodyAbsent() {
         val endpoint = ApiEndpoint(
             name = "Get User",
             metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
 
         assertNull(model.groups[0].endpoints[0].http!!.body)
+    }
+
+    // ---- Primitive body (Single) — parity with legacy Row(name="", type=model.type, desc="") ----
+
+    @Test
+    fun testPrimitiveBodyProducesOneSyntheticField() {
+        // Review finding F5: Single body → one FieldView with name="", type=model.type, desc="",
+        // structuralKind=PRIMITIVE, depth=0, indent="" — byte-identical to legacy Row.
+        val body = ObjectModel.single(JsonType.STRING)
+        val endpoint = ApiEndpoint(
+            name = "Echo",
+            metadata = httpMetadata(path = "/api/echo", method = HttpMethod.POST, body = body)
+        )
+
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val bodyView = model.groups[0].endpoints[0].http!!.body!!
+
+        assertEquals(1, bodyView.fields.size)
+        val field = bodyView.fields[0]
+        assertEquals("", field.name)
+        assertEquals("string", field.type)
+        assertEquals("", field.desc)
+        assertEquals("", field.indent)
+        assertEquals(0, field.depth)
+        assertFalse(field.required)
+        assertNull(field.defaultValue)
+        assertFalse(field.hasChildren)
+        assertEquals(0, field.childrenCount)
+        assertEquals(FieldStructuralKind.PRIMITIVE, field.structuralKind)
+    }
+
+    // ---- Map body (MapModel) — parity with legacy two rows (key + value) ----
+
+    @Test
+    fun testMapBodyProducesTwoSyntheticFields() {
+        // Review finding F6: MapModel body → two FieldViews at depth 0:
+        // {name="key", type=formatType(keyType), structuralKind=MAP} and {name="value", ...}.
+        val body = ObjectModel.MapModel(
+            keyType = ObjectModel.single(JsonType.STRING),
+            valueType = ObjectModel.single(JsonType.INT),
+        )
+        val endpoint = ApiEndpoint(
+            name = "MapResource",
+            metadata = httpMetadata(path = "/api/map", method = HttpMethod.POST, body = body)
+        )
+
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val bodyView = model.groups[0].endpoints[0].http!!.body!!
+
+        assertEquals(2, bodyView.fields.size)
+        val keyField = bodyView.fields[0]
+        assertEquals("key", keyField.name)
+        assertEquals("string", keyField.type)
+        assertEquals("", keyField.desc)
+        assertEquals("", keyField.indent)
+        assertEquals(0, keyField.depth)
+        assertEquals(FieldStructuralKind.MAP, keyField.structuralKind)
+        val valueField = bodyView.fields[1]
+        assertEquals("value", valueField.name)
+        assertEquals("int", valueField.type)
+        assertEquals("", valueField.desc)
+        assertEquals("", valueField.indent)
+        assertEquals(0, valueField.depth)
+        assertEquals(FieldStructuralKind.MAP, valueField.structuralKind)
     }
 
     // ---- Cycle safety ----
@@ -331,13 +387,13 @@ class TemplateModelBuilderTest {
         )
 
         // Must not stack-overflow
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
-        val rows = model.groups[0].endpoints[0].http!!.response!!.rows
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val fieldsList = model.groups[0].endpoints[0].http!!.response!!.fields
 
-        assertTrue("top-level name row present", rows.any { it.name == "name" })
-        assertTrue("top-level children row present", rows.any { it.name == "children" })
-        // At least one nested row exists (DEFAULT_MAX_VISITS=2 allows one expansion)
-        assertTrue("a nested row with indent prefix present", rows.any { it.name.startsWith("&ensp;&ensp;&#124;─") })
+        assertTrue("top-level name row present", fieldsList.any { it.name == "name" })
+        assertTrue("top-level children row present", fieldsList.any { it.name == "children" })
+        // At least one nested field exists (DEFAULT_MAX_VISITS=2 allows one expansion)
+        assertTrue("a nested field with indent prefix present", fieldsList.any { it.depth > 0 && it.indent.startsWith("&ensp;&ensp;") })
     }
 
     @Test
@@ -353,11 +409,11 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/node", method = HttpMethod.GET, responseBody = selfRef)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
-        val rows = model.groups[0].endpoints[0].http!!.response!!.rows
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val fieldsList = model.groups[0].endpoints[0].http!!.response!!.fields
 
-        assertTrue(rows.any { it.name == "id" })
-        assertTrue(rows.any { it.name == "parent" })
+        assertTrue(fieldsList.any { it.name == "id" })
+        assertTrue(fieldsList.any { it.name == "parent" })
     }
 
     @Test
@@ -377,11 +433,11 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/mutual", method = HttpMethod.GET, responseBody = objectA)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
-        val rows = model.groups[0].endpoints[0].http!!.response!!.rows
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val fieldsList = model.groups[0].endpoints[0].http!!.response!!.fields
 
-        assertTrue(rows.any { it.name == "name" })
-        assertTrue(rows.any { it.name == "refB" })
+        assertTrue(fieldsList.any { it.name == "name" })
+        assertTrue(fieldsList.any { it.name == "refB" })
     }
 
     @Test
@@ -400,12 +456,12 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/nested", method = HttpMethod.GET, responseBody = outer)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
-        val rows = model.groups[0].endpoints[0].http!!.response!!.rows
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val fieldsList = model.groups[0].endpoints[0].http!!.response!!.fields
 
-        assertTrue("middle row present", rows.any { it.name == "middle" })
-        assertTrue("inner row present (depth 1)", rows.any { it.name == "&ensp;&ensp;&#124;─inner" })
-        assertTrue("value row present (depth 2)", rows.any { it.name == "&ensp;&ensp;&ensp;&ensp;&#124;─value" })
+        assertTrue("middle row present", fieldsList.any { it.name == "middle" && it.depth == 0 })
+        assertTrue("inner row present (depth 1)", fieldsList.any { it.name == "inner" && it.depth == 1 && it.indent == "&ensp;&ensp;&#124;─" })
+        assertTrue("value row present (depth 2)", fieldsList.any { it.name == "value" && it.depth == 2 && it.indent == "&ensp;&ensp;&ensp;&ensp;&#124;─" })
     }
 
     // ---- gRPC view ----
@@ -423,7 +479,7 @@ class TemplateModelBuilderTest {
             )
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "gRPC API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "gRPC API")
         val ep = model.groups[0].endpoints[0]
 
         assertEquals("gRPC", ep.protocol)
@@ -454,7 +510,7 @@ class TemplateModelBuilderTest {
             )
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
 
         assertEquals("SERVER_STREAMING", model.groups[0].endpoints[0].grpc!!.streamingType)
     }
@@ -476,13 +532,14 @@ class TemplateModelBuilderTest {
             )
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
         val grpc = model.groups[0].endpoints[0].grpc!!
 
         assertNotNull(grpc.body)
-        assertEquals(1, grpc.body!!.rows.size)
-        assertEquals("user_id", grpc.body!!.rows[0].name)
-        assertNotNull("demo present when outputDemo=true", grpc.body!!.demo)
+        assertEquals(1, grpc.body!!.fields.size)
+        assertEquals("user_id", grpc.body!!.fields[0].name)
+        // asDemo() is the lazy JSON render
+        assertEquals(ObjectModelJsonConverter.toJson(body), grpc.body!!.asDemo())
     }
 
     // ---- Field description (options) ----
@@ -506,8 +563,8 @@ class TemplateModelBuilderTest {
             metadata = httpMetadata(path = "/api/users", method = HttpMethod.POST, body = body)
         )
 
-        val model = TemplateModelBuilder.build(listOf(endpoint), outputDemo = true, moduleName = "API")
-        val desc = model.groups[0].endpoints[0].http!!.body!!.rows[0].desc
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val desc = model.groups[0].endpoints[0].http!!.body!!.fields[0].desc
 
         // Mirrors DefaultMarkdownFormatter.buildFieldDescription:
         // "<comment><br><value1 :desc1><br><value2>"

--- a/src/test/kotlin/com/itangcent/easyapi/integration/EndToEndExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/integration/EndToEndExportTest.kt
@@ -81,7 +81,7 @@ class EndToEndExportTest : EasyApiLightCodeInsightFixtureTestCase() {
         val endpoints = springMvcExporter.export(psiClass!!)
         assertTrue("Should export at least one endpoint", endpoints.isNotEmpty())
 
-        val formatter = DefaultMarkdownFormatter(outputDemo = true)
+        val formatter = DefaultMarkdownFormatter()
         val markdown = formatter.format(endpoints, "User API")
 
         assertTrue("Markdown should contain title", markdown.contains("# User API"))

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
@@ -30,7 +30,6 @@ class ApplicationSettingsStateTest {
         assertFalse(s.unsafeSsl)
         assertEquals(HttpClientType.APACHE.value, s.httpClient)
         assertEquals(100, s.logLevel) // SILENT — console off by default
-        assertTrue(s.outputDemo)
         assertEquals("UTF-8", s.outputCharset)
         assertNull(s.builtInConfig)
         assertArrayEquals(emptyArray(), s.remoteConfig)

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/GeneralSettingsPanelLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/GeneralSettingsPanelLogicTest.kt
@@ -97,7 +97,6 @@ class GeneralSettingsPanelLogicTest {
         assertTrue(settings.switchNotice)
         assertEquals(100, settings.logLevel)
         assertEquals("UTF-8", settings.outputCharset)
-        assertTrue(settings.outputDemo)
     }
 
     @Test
@@ -111,8 +110,7 @@ class GeneralSettingsPanelLogicTest {
             gutterIconEnabled = false,
             switchNotice = false,
             logLevel = 40,
-            outputCharset = "GBK",
-            outputDemo = false
+            outputCharset = "GBK"
         )
         assertTrue(settings.feignEnable)
         assertFalse(settings.jaxrsEnable)
@@ -123,7 +121,6 @@ class GeneralSettingsPanelLogicTest {
         assertFalse(settings.switchNotice)
         assertEquals(40, settings.logLevel)
         assertEquals("GBK", settings.outputCharset)
-        assertFalse(settings.outputDemo)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/GeneralSettingsPanelPlatformTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/GeneralSettingsPanelPlatformTest.kt
@@ -30,7 +30,6 @@ class GeneralSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestCase(
             actuatorEnable = true
             logLevel = 40
             outputCharset = "GBK"
-            outputDemo = false
         }
         panel.resetFrom(settings)
 
@@ -42,7 +41,6 @@ class GeneralSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestCase(
         assertTrue(target.actuatorEnable)
         assertEquals(40, target.logLevel)
         assertEquals("GBK", target.outputCharset)
-        assertFalse(target.outputDemo)
     }
 
     fun testIsModifiedNullSettings() {
@@ -64,7 +62,6 @@ class GeneralSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestCase(
             switchNotice = false
             logLevel = 100
             outputCharset = "ISO-8859-1"
-            outputDemo = false
         }
         panel.resetFrom(modified)
 
@@ -80,7 +77,6 @@ class GeneralSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestCase(
         assertFalse(target.switchNotice)
         assertEquals(100, target.logLevel)
         assertEquals("ISO-8859-1", target.outputCharset)
-        assertFalse(target.outputDemo)
     }
 
     fun testResetFromNullDoesNotThrow() {

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/ResourceLoader.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/ResourceLoader.kt
@@ -28,16 +28,33 @@ object ResourceLoader {
      *   this class's loader. Pass an explicit class loader when the resource
      *   lives in another module's classpath.
      * @return the resource content with CRLF collapsed to LF and trailing
-     *   whitespace removed.
+     * whitespace removed.
      * @throws AssertionError if the resource cannot be found.
      */
     fun read(resourcePath: String, loader: ClassLoader = javaClass.classLoader): String {
+        return readRaw(resourcePath, loader).trimEnd()
+    }
+
+    /**
+     * Reads a classpath resource with **byte-for-byte** semantics, performing
+     * only the platform-stable CRLF→LF collapse.
+     *
+     * Use this (instead of [read]) for golden-file parity tests that must
+     * preserve trailing whitespace and exact structure, only normalizing the
+     * one thing that legitimately differs across platforms: line endings.
+     *
+     * @param resourcePath the absolute classpath path (e.g. `/result/foo.txt`).
+     * @param loader the [ClassLoader] used to find the resource; defaults to
+     *   this class's loader.
+     * @return the resource content with CRLF collapsed to LF. Trailing
+     * whitespace and final newline are preserved.
+     * @throws AssertionError if the resource cannot be found.
+     */
+    fun readRaw(resourcePath: String, loader: ClassLoader = javaClass.classLoader): String {
         val stream: InputStream = loader.getResourceAsStream(resourcePath.removePrefix("/"))
             ?: throw AssertionError("Resource not found: $resourcePath")
         return stream.bufferedReader(Charsets.UTF_8).use { reader ->
-            reader.readText()
-                .replace("\r\n", "\n")
-                .trimEnd()
+            reader.readText().replace("\r\n", "\n").replace("\r", "\n")
         }
     }
 }

--- a/src/test/resources/com/itangcent/easyapi/exporter/channel/markdown/MarkdownTemplateParityTest.expected.md
+++ b/src/test/resources/com/itangcent/easyapi/exporter/channel/markdown/MarkdownTemplateParityTest.expected.md
@@ -1,0 +1,459 @@
+# Test API
+
+## Users
+
+---
+### Get User
+
+> BASIC
+
+**Path:** /api/users/{id}
+
+**Method:** GET
+
+
+> REQUEST
+
+**Path Params:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| id |  | YES | User ID |
+
+
+---
+### Create User
+
+> BASIC
+
+**Path:** /api/users
+
+**Method:** POST
+
+
+> REQUEST
+
+**Headers:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| Content-Type | application/json | NO |  |
+
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| name | string | user name |
+| age | int | user age |
+
+**Request Demo:**
+
+```json
+{
+  "name": "",
+  "age": 0
+}
+```
+
+> RESPONSE
+
+**Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| code | int | response code |
+| msg | string | message |
+| data | object | response data |
+| &ensp;&ensp;&#124;─id | long | user id |
+| &ensp;&ensp;&#124;─name | string | user name |
+
+**Response Demo:**
+
+```json
+{
+  "code": 0,
+  "msg": "",
+  "data": {
+    "id": 0,
+    "name": ""
+  }
+}
+```
+
+---
+### List Users
+
+> BASIC
+
+**Path:** /api/users
+
+**Method:** GET
+
+
+> REQUEST
+
+**Query:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| page |  | NO | Page number |
+| size |  | NO | Page size |
+
+
+> RESPONSE
+
+**Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| code | int |  |
+| data | object[] | user list |
+| &ensp;&ensp;&#124;─id | long |  |
+| &ensp;&ensp;&#124;─name | string |  |
+
+**Response Demo:**
+
+```json
+{
+  "code": 0,
+  "data": [
+    {
+      "id": 0,
+      "name": ""
+    }
+  ]
+}
+```
+
+---
+### Delete User
+
+> BASIC
+
+**Path:** /api/users/{id}
+
+**Method:** DELETE
+
+
+> REQUEST
+
+
+
+## Misc
+
+---
+### Echo String
+
+> BASIC
+
+**Path:** /api/echo/string
+
+**Method:** POST
+
+
+> REQUEST
+
+**Headers:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| Content-Type | application/json | NO |  |
+
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+|  | string |  |
+
+**Request Demo:**
+
+```json
+""
+```
+
+---
+### Update Metadata
+
+> BASIC
+
+**Path:** /api/resources/{id}/metadata
+
+**Method:** PUT
+
+
+> REQUEST
+
+**Path Params:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| id |  | YES | Resource ID |
+
+**Headers:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| Content-Type | application/json | NO |  |
+
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| metadata | map | key-value metadata |
+
+**Request Demo:**
+
+```json
+{
+  "metadata": {
+    "": 0
+  }
+}
+```
+
+---
+### Create Post
+
+> BASIC
+
+**Path:** /api/posts
+
+**Method:** POST
+
+
+> REQUEST
+
+**Headers:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| Content-Type | application/json | NO |  |
+
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| tags | string[] | tag list |
+
+**Request Demo:**
+
+```json
+{
+  "tags": [
+    ""
+  ]
+}
+```
+
+---
+### Update Status
+
+> BASIC
+
+**Path:** /api/status
+
+**Method:** PUT
+
+
+> REQUEST
+
+**Headers:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| Content-Type | application/json | NO |  |
+
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| status | string | status<br>active :Active user<br>inactive :Inactive user |
+
+**Request Demo:**
+
+```json
+{
+  "status": ""
+}
+```
+
+---
+### Upload File
+
+> BASIC
+
+**Path:** /api/upload
+
+**Method:** POST
+
+
+> REQUEST
+
+**Headers:**
+
+| name | value | required | desc |
+| ------------ | ------------ | ------------ | ------------ |
+| Content-Type | multipart/form-data | NO |  |
+
+**Form:**
+
+| name | value | required | type | desc |
+| ------------ | ------------ | ------------ | ------------ | ------------ |
+| file |  | YES | file | File to upload |
+| description |  | NO | text | File description |
+
+
+---
+### Get Profile
+
+> BASIC
+
+**Path:** /api/profile
+
+**Method:** GET
+
+**Desc:**
+
+Retrieve the current user's profile information
+
+
+> REQUEST
+
+
+
+---
+### Get Tree
+
+> BASIC
+
+**Path:** /api/tree
+
+**Method:** GET
+
+
+> REQUEST
+
+
+
+> RESPONSE
+
+**Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| name | string | node name |
+| children | object[] | child nodes |
+| &ensp;&ensp;&#124;─name | string | node name |
+| &ensp;&ensp;&#124;─children | object[] | child nodes |
+
+**Response Demo:**
+
+```json
+{
+  "name": "",
+  "children": [
+    {
+      "name": "",
+      "children": [
+        {        }
+      ]
+    }
+  ]
+}
+```
+
+---
+### POST /api/webhook
+
+> BASIC
+
+**Path:** /api/webhook
+
+**Method:** POST
+
+
+> REQUEST
+
+
+
+## gRPC
+
+---
+### GetUser
+
+> BASIC
+
+**Protocol:** gRPC
+
+**Service:** UserService
+
+**Method:** GetUser
+
+**Streaming:** UNARY
+
+**Full Path:** /user.UserService/GetUser
+
+
+> REQUEST
+
+**Request Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| user_id | string | user ID |
+
+**Request Demo:**
+
+```json
+{
+  "user_id": ""
+}
+```
+
+> RESPONSE
+
+**Body:**
+
+| name | type | desc |
+| ------------ | ------------ | ------------ |
+| name | string | user name |
+
+**Response Demo:**
+
+```json
+{
+  "name": ""
+}
+```
+
+---
+### ListUsers
+
+> BASIC
+
+**Protocol:** gRPC
+
+**Service:** UserService
+
+**Method:** ListUsers
+
+**Streaming:** SERVER_STREAMING
+
+**Full Path:** /user.UserService/ListUsers
+
+
+---
+### Chat
+
+> BASIC
+
+**Protocol:** gRPC
+
+**Service:** ChatService
+
+**Method:** Chat
+
+**Streaming:** BIDIRECTIONAL
+
+**Full Path:** /chat.ChatService/Chat
+


### PR DESCRIPTION
## Summary

Refactors the Markdown template body model so templates can choose how to render a body (JSON, JSON5, table, list) at render time, instead of having `TemplateModelBuilder` pre-bake two fixed representations (`rows` + `demo`).

## Changes

- **Template engine** — new `MethodCall` AST node and grammar rule, with an explicit `meta.*` carve-out so `meta.date(...)`/`meta.time(...)` keep parsing as `BuiltinCall`. Chained calls (`foo().bar()`) are explicitly out of scope for v1 and render empty + an info log.
- **BodyView reshape** — replaces `rows: List<Row>` and `demo: String?` with:
  - `model: ObjectModel` — the structured source of truth
  - `fields: List<FieldView>` — flat, cycle-safe table rows with pre-computed `indent`, plus `structuralKind` to distinguish primitive/map entries
  - helpers: `asDemo()` (plain JSON), `asJson()`, `asJson5()`
- **ObjectModelVisitTracker** — extended for safe repeated/recursive visits.
- **Templates** — all i18n `.md.tpl` files migrated to the new helper syntax.
- **Tests** — adds `TemplateEngineMethodCallTest`, commits a static parity golden (`MarkdownTemplateParityTest.expected.md`), and updates builder/formatter/parity tests to the new contract.

## Body variant coverage

| Variant | asDemo | asJson5 | table | list |
|---|---|---|---|---|
| Object | ✓ | ✓ | ✓ | ✓ |
| Array<Object> | ✓ | ✓ | ✓ | ✓ |
| Primitive (Single) | ✓ | ✓ | ✓ | ✓ |
| Map | ✓ | ✓ | ✓ | ✓ |
| Recursive | ✓ | ✓ | finite | finite |

## Test plan

- [ ] `./gradlew test` — new and updated unit/parity tests pass
- [ ] `MarkdownTemplateParityTest` golden matches rendered output byte-for-byte
- [ ] Manual: export an endpoint with each body variant and inspect Markdown output