### PR TITLE
fix: FieldsTo* resolves caret class instead of first class in file

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/FieldFormatAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/FieldFormatAction.kt
@@ -2,14 +2,13 @@ package com.itangcent.easyapi.ide.fieldformat
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
-import com.intellij.psi.util.PsiTreeUtil
 import com.itangcent.easyapi.core.event.ActionCompletedTopic
 import com.itangcent.easyapi.core.event.ActionCompletedTopic.Companion.syncPublish
 import com.itangcent.easyapi.ide.support.NotificationUtils
+import com.itangcent.easyapi.ide.support.SelectedHelper
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.logging.console
 import java.awt.datatransfer.StringSelection
@@ -35,7 +34,7 @@ class FieldFormatAction(
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val psiClass = findPsiClass(e) ?: return
+        val psiClass = SelectedHelper.resolveSelection(e)?.psiClass() ?: return
         val console = project.console
         console.info("FieldFormatAction.actionPerformed: channel=${channel.id}, class=${psiClass.qualifiedName}")
         try {
@@ -49,13 +48,5 @@ class FieldFormatAction(
         } finally {
             project.syncPublish(ActionCompletedTopic.TOPIC)
         }
-    }
-
-    private fun findPsiClass(e: AnActionEvent): PsiClass? {
-        val element = e.getData(CommonDataKeys.PSI_ELEMENT)
-        if (element is PsiClass) return element
-        if (element != null) return PsiTreeUtil.getParentOfType(element, PsiClass::class.java)
-        val file = e.getData(CommonDataKeys.PSI_FILE) ?: return null
-        return PsiTreeUtil.findChildOfType(file, PsiClass::class.java)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/support/SelectedHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/support/SelectedHelper.kt
@@ -69,6 +69,24 @@ object SelectedHelper {
             }
         }
 
+        // Editor caret fallback. PSI_ELEMENT is frequently null for an editor
+        // context-menu invocation (it is primarily populated by the Project
+        // View), so resolve the element at the caret ourselves. Without this,
+        // a file containing multiple top-level classes (e.g. a controller that
+        // also declares VO/DTO classes) always resolves to the *first* class in
+        // the file via the PSI_FILE fallback below, regardless of where the
+        // caret is. (Issue: FieldsTo* targets the controller, not the data class.)
+        if (editor != null && psiFile != null) {
+            val offset = editor.caretModel.offset
+            val atCaret = psiFile.findElementAt(offset)
+            if (atCaret != null) {
+                val resolved = resolveContainingClassOrMethod(atCaret)
+                if (resolved != null) {
+                    return SelectionScope(listOf(resolved))
+                }
+            }
+        }
+
         // NAVIGATABLE_ARRAY is used for project tree selections (e.g. selecting
         // a class/directory in the project view). Filter out classes that are
         // not user-defined targets (annotation types, JDK classes, etc.).

--- a/src/test/kotlin/com/itangcent/easyapi/ide/support/SelectedHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/support/SelectedHelperTest.kt
@@ -336,6 +336,204 @@ class SelectedHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertFalse(selectedMethods.contains(createMethod))
     }
 
+    // ---- Editor caret resolution (PSI_ELEMENT=null, editor context-menu) ----
+
+    /**
+     * Builds an inline Java source file containing multiple top-level classes
+     * — a controller followed by sibling VO/DTO classes — mirroring the layout
+     * of `AnalyticsController.java` that originally triggered the FieldsTo*
+     * "wrong class" bug. All referenced types are explicitly imported per the
+     * light-fixture resolver requirement.
+     */
+    private fun setupMultiClassFile(): Pair<PsiFile, List<PsiClass>> {
+        val source = """
+            package com.itangcent.api;
+
+            import org.springframework.web.bind.annotation.RestController;
+            import org.springframework.web.bind.annotation.RequestMapping;
+            import org.springframework.web.bind.annotation.GetMapping;
+
+            @RestController
+            @RequestMapping("/api/analytics")
+            public class AnalyticsController {
+
+                @GetMapping("/sales/report")
+                public String getSalesReport() {
+                    return "";
+                }
+            }
+
+            class SalesReportVO {
+                private String totalSales;
+                private Long totalOrders;
+
+                public String getTotalSales() {
+                    return totalSales;
+                }
+
+                public void setTotalSales(String totalSales) {
+                    this.totalSales = totalSales;
+                }
+
+                public Long getTotalOrders() {
+                    return totalOrders;
+                }
+
+                public void setTotalOrders(Long totalOrders) {
+                    this.totalOrders = totalOrders;
+                }
+            }
+
+            class DailySalesVO {
+                private String date;
+                private Long sales;
+
+                public String getDate() {
+                    return date;
+                }
+
+                public void setDate(String date) {
+                    this.date = date;
+                }
+
+                public Long getSales() {
+                    return sales;
+                }
+
+                public void setSales(Long sales) {
+                    this.sales = sales;
+                }
+            }
+        """.trimIndent()
+
+        val file = loadFile("api/MultiClassCtrl.java", source)
+        myFixture.configureFromExistingVirtualFile(file.virtualFile)
+        val classes = listOf(
+            findClass("com.itangcent.api.AnalyticsController")!!,
+            findClass("com.itangcent.api.SalesReportVO")!!,
+            findClass("com.itangcent.api.DailySalesVO")!!
+        )
+        return file to classes
+    }
+
+    /**
+     * Right-click inside a *non-first* top-level class (`SalesReportVO`) with
+     * no PSI_ELEMENT set — the editor context-menu scenario. Should resolve to
+     * `SalesReportVO`, NOT the first class in the file (`AnalyticsController`).
+     *
+     * Regression test for the FieldsTo* bug where the PSI_FILE fallback always
+     * returned the first class regardless of caret position.
+     */
+    fun testResolveSelectionFromCaretInNonFirstClass() {
+        val (file, classes) = setupMultiClassFile()
+        val salesReport = classes[1]
+        // Place the caret on the `totalSales` field identifier inside SalesReportVO.
+        val totalSalesField = salesReport.fields.first { it.name == "totalSales" }
+        val caretOffset = totalSalesField.textOffset + 2
+        myFixture.editor.caretModel.moveToOffset(caretOffset)
+
+        val event = createEvent(
+            psiFile = file,
+            editor = myFixture.editor
+            // Note: PSI_ELEMENT deliberately omitted — this is what the editor
+            // context-menu looks like; PSI_ELEMENT is populated by the Project
+            // View, not by the editor right-click.
+        )
+        val selection = SelectedHelper.resolveSelection(event)
+        assertNotNull("Selection must not be null in editor caret context", selection)
+        assertEquals(
+            "Should resolve to SalesReportVO (caret class), not AnalyticsController (first in file)",
+            "com.itangcent.api.SalesReportVO",
+            selection!!.psiClass()!!.qualifiedName
+        )
+    }
+
+    /**
+     * Right-click inside the *first* top-level class with no PSI_ELEMENT.
+     * Caret-based resolution should still find that class.
+     */
+    fun testResolveSelectionFromCaretInFirstClass() {
+        val (file, classes) = setupMultiClassFile()
+        val controller = classes[0]
+        // Place the caret somewhere inside the controller body (the getter method).
+        val method = controller.findMethodsByName("getSalesReport", false).first()
+        myFixture.editor.caretModel.moveToOffset(method.textOffset + 5)
+
+        val event = createEvent(psiFile = file, editor = myFixture.editor)
+        val selection = SelectedHelper.resolveSelection(event)
+        assertNotNull(selection)
+        assertEquals(
+            "com.itangcent.api.AnalyticsController",
+            selection!!.psiClass()!!.qualifiedName
+        )
+    }
+
+    /**
+     * Caret inside a method should resolve to the method's containing class.
+     */
+    fun testResolveSelectionFromCaretInMethodResolvesContainingClass() {
+        val (file, classes) = setupMultiClassFile()
+        val dailySales = classes[2]
+        val setter = dailySales.findMethodsByName("setDate", false).first()
+        myFixture.editor.caretModel.moveToOffset(setter.textOffset + 3)
+
+        val event = createEvent(psiFile = file, editor = myFixture.editor)
+        val selection = SelectedHelper.resolveSelection(event)
+        assertNotNull(selection)
+        assertEquals(
+            "com.itangcent.api.DailySalesVO",
+            selection!!.psiClass()!!.qualifiedName
+        )
+    }
+
+    /**
+     * Editor present but PSI_ELEMENT and caret element both null (caret at EOF
+     * with no resolvable element). Should fall through to the PSI_FILE branch
+     * and return all classes in the file. The first class is the controller.
+     */
+    fun testResolveSelectionFallsBackToFileWhenCaretResolvesNothing() {
+        val (file, _) = setupMultiClassFile()
+        // Caret past end of file — findElementAt returns null.
+        myFixture.editor.caretModel.moveToOffset(file.textLength + 100)
+
+        val event = createEvent(psiFile = file, editor = myFixture.editor)
+        val selection = SelectedHelper.resolveSelection(event)
+        assertNotNull(selection)
+        // PSI_FILE fallback yields all classes; psiClass() returns the first.
+        assertEquals(
+            "com.itangcent.api.AnalyticsController",
+            selection!!.psiClass()!!.qualifiedName
+        )
+    }
+
+    /**
+     * PSI_ELEMENT takes precedence over the editor caret — when both are set,
+     * the explicit element context wins. This guards against the caret branch
+     * shadowing the documented PSI_ELEMENT-first behaviour.
+     */
+    fun testPsiElementTakesPrecedenceOverEditorCaret() {
+        val (file, classes) = setupMultiClassFile()
+        val salesReport = classes[1]
+        val dailySales = classes[2]
+        // Caret inside DailySalesVO, but PSI_ELEMENT points at SalesReportVO.
+        myFixture.editor.caretModel.moveToOffset(
+            dailySales.fields.first { it.name == "date" }.textOffset
+        )
+
+        val event = createEvent(
+            psiElement = salesReport,
+            psiFile = file,
+            editor = myFixture.editor
+        )
+        val selection = SelectedHelper.resolveSelection(event)
+        assertNotNull(selection)
+        assertEquals(
+            "PSI_ELEMENT should win over caret",
+            "com.itangcent.api.SalesReportVO",
+            selection!!.psiClass()!!.qualifiedName
+        )
+    }
+
     // ---- Helper ----
 
     private fun createEvent(


### PR DESCRIPTION
## Problem

Right-clicking inside a data class in the editor (e.g. `SalesReportVO` declared after `AnalyticsController` in the same file) and selecting **ToJson / ToJson5 / ToProperties** formatted the wrong class — the controller, not the data class under the caret.

## Root cause

`FieldFormatAction.findPsiClass` relied on `CommonDataKeys.PSI_ELEMENT`, which is populated by the **Project View**, not by the editor context-menu. With `PSI_ELEMENT` null, resolution fell through to:

```kotlin
PsiTreeUtil.findChildOfType(file, PsiClass::class.java)
```

which always returns the **first** top-level class in the file regardless of caret position. Any file with multiple top-level classes (controller + sibling VO/DTO classes, common in sample projects) hit this bug.

## Fix

- **`SelectedHelper.resolveSelection`** — added a caret-based resolution step (between the `PSI_ELEMENT` check and the `PSI_FILE` fallback) that resolves the PSI element at the caret offset and walks up to the nearest `PsiMethod`/`PsiClass`. Benefits every caller of `SelectedHelper` (export actions, field-format actions).
- **`FieldFormatAction`** — dropped the bespoke `findPsiClass` and now uses `SelectedHelper.resolveSelection(e)?.psiClass()`, matching the convention used by `ChannelExportAction`/`ExportApiAction`.

## Behavior

Right-clicking inside `SalesReportVO` (or any VO/DTO class) and choosing **ToJson** now correctly formats that data class, not `AnalyticsController`.

## Tests

Added 5 cases to `SelectedHelperTest` covering caret-based resolution in a multi-class file:

| Test | Verifies |
|------|----------|
| `testResolveSelectionFromCaretInNonFirstClass` | Caret in `SalesReportVO` → resolves `SalesReportVO`, not `AnalyticsController` (the regression test for this bug) |
| `testResolveSelectionFromCaretInFirstClass` | Caret in the first class still resolves correctly |
| `testResolveSelectionFromCaretInMethodResolvesContainingClass` | Caret in a method walks up to its containing class |
| `testResolveSelectionFallsBackToFileWhenCaretResolvesNothing` | EOF caret → falls through to `PSI_FILE` branch (preserves existing behaviour) |
| `testPsiElementTakesPrecedenceOverEditorCaret` | `PSI_ELEMENT` wins over caret (guards documented precedence) |

All 21 `SelectedHelperTest` cases pass.