### PR TITLE
fix: YAML export drops @ConfigurationProperties prefix

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/formatter/YamlFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/formatter/YamlFormatter.kt
@@ -42,12 +42,72 @@ object YamlFormatter {
 
     private const val INDENT = "  "
 
-    /** YAML rendering of an [ObjectModel]. */
-    fun format(model: ObjectModel): String {
+    /**
+     * YAML rendering of an [ObjectModel].
+     *
+     * When [prefix] is non-empty (e.g. `"app.config"`), its dot-separated
+     * segments are rendered as nested keys wrapping the model — mirroring
+     * `@ConfigurationProperties(prefix = "app.config")` semantics for
+     * `application.yml`. Empty prefix segments are skipped.
+     *
+     * Examples:
+     * - `format(model, "")` → `id: 0\nname: ""`
+     * - `format(model, "app")` → `app:\n\n  id: 0\n  name: ""`
+     * - `format(model, "app.config")` → `app:\n\n  config:\n\n    id: 0\n    name: ""`
+     */
+    fun format(model: ObjectModel, prefix: String = ""): String {
         val sb = StringBuilder()
         val tracker = ObjectModelVisitTracker()
-        renderTop(model, sb, tracker)
+        val segments = prefix.split('.').filter { it.isNotEmpty() }
+        if (segments.isEmpty()) {
+            renderTop(model, sb, tracker)
+        } else {
+            renderPrefix(segments, 0, model, sb, tracker)
+        }
         return sb.toString().trimEnd()
+    }
+
+    /**
+     * Renders nested prefix keys down to [depth], then the [model] inline at
+     * the deepest level. Mirrors the indent/blank-line convention of
+     * [renderObjectFields] so prefixed output looks like hand-written YAML.
+     */
+    private fun renderPrefix(
+        segments: List<String>,
+        depth: Int,
+        model: ObjectModel,
+        sb: StringBuilder,
+        tracker: ObjectModelVisitTracker
+    ) {
+        sb.append(INDENT.repeat(depth)).append(segments[depth]).append(':')
+        if (depth == segments.lastIndex) {
+            // Deepest level — render the model relative to the prefix.
+            when (model) {
+                is ObjectModel.Object -> {
+                    if (model.fields.isEmpty()) {
+                        sb.append(" {}")
+                    } else {
+                        sb.appendLine()
+                        renderObjectFields(model, segments.size, sb, tracker, firstLine = false)
+                    }
+                }
+                is ObjectModel.Array -> {
+                    sb.appendLine()
+                    renderArray(model, segments.size, sb, tracker)
+                }
+                is ObjectModel.MapModel -> {
+                    sb.appendLine()
+                    renderMap(model, segments.size, sb, tracker)
+                }
+                is ObjectModel.Single -> sb.appendLine().append(INDENT.repeat(segments.size))
+                    .append("value: ").append(formatSingleValue(model, null))
+            }
+        } else {
+            // Blank line before the next indented prefix level, matching the
+            // nested-object convention (see renderFieldValue's Object branch).
+            sb.appendLine().appendLine()
+            renderPrefix(segments, depth + 1, model, sb, tracker)
+        }
     }
 
     private fun renderTop(

--- a/src/main/kotlin/com/itangcent/easyapi/ide/PropertiesService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/PropertiesService.kt
@@ -5,28 +5,34 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.itangcent.easyapi.psi.PsiClassHelper
 import com.itangcent.easyapi.psi.model.toProperties
+import com.itangcent.easyapi.psi.model.toYaml
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 
 /**
- * Project-scoped service that converts a [PsiClass] into Java Properties text.
+ * Project-scoped service that converts a [PsiClass] into config-format text
+ * (Java Properties or YAML).
  *
  * Owns the only stateful part of field-format conversion: resolving the
  * `properties.prefix` rule (typically from `@ConfigurationProperties(prefix=...)`)
  * via [RuleEngine]. The pure rendering is delegated to
- * [ObjectModel.toProperties][com.itangcent.easyapi.psi.model.toProperties].
+ * [ObjectModel.toProperties][com.itangcent.easyapi.psi.model.toProperties] and
+ * [ObjectModel.toYaml][com.itangcent.easyapi.psi.model.toYaml].
  *
  * JSON and JSON5 conversions are pure functions of the model and live as
  * extension functions (`ObjectModel.toJson`, `ObjectModel.toJson5`) — they
- * need no project state. Properties is the only format that needs a service
- * because prefix resolution requires `RuleEngine` (project-scoped).
+ * need no project state. Properties and YAML both honor the config prefix
+ * (flat dot-path for `.properties`, nested keys for `.yml`) and therefore
+ * route through this service.
  *
  * ## Parity contract
  *
  * The `JsonOption` is left at its default (`ALL`) to match the original
- * `FieldsToPropertiesAction`. Returns `""` if the class cannot be modeled.
+ * `FieldsToPropertiesAction` / `FieldsToYamlAction`. Returns `""` if the
+ * class cannot be modeled.
  *
- * @see com.itangcent.easyapi.psi.model.toProperties for the pure rendering
+ * @see com.itangcent.easyapi.psi.model.toProperties for the pure Properties rendering
+ * @see com.itangcent.easyapi.psi.model.toYaml for the pure YAML rendering
  */
 @Service(Service.Level.PROJECT)
 class PropertiesService(private val project: Project) {
@@ -38,12 +44,26 @@ class PropertiesService(private val project: Project) {
      * Fields → Java Properties.
      *
      * Resolves the `properties.prefix` rule and prepends it to all generated
-     * property keys. Returns `""` if the class cannot be modeled.
+     * property keys (dot-separated, e.g. `app.config.id=0`). Returns `""` if
+     * the class cannot be modeled.
      */
     suspend fun toProperties(psiClass: PsiClass): String {
         val model = helper.buildObjectModel(psiClass) ?: return ""
         val prefix = ruleEngine.evaluate(RuleKeys.PROPERTIES_PREFIX, psiClass).orEmpty()
         return model.toProperties(prefix)
+    }
+
+    /**
+     * Fields → YAML.
+     *
+     * Resolves the `properties.prefix` rule and renders it as nested keys
+     * wrapping the model (mirrors `@ConfigurationProperties` for
+     * `application.yml`). Returns `""` if the class cannot be modeled.
+     */
+    suspend fun toYaml(psiClass: PsiClass): String {
+        val model = helper.buildObjectModel(psiClass) ?: return ""
+        val prefix = ruleEngine.evaluate(RuleKeys.PROPERTIES_PREFIX, psiClass).orEmpty()
+        return model.toYaml(prefix)
     }
 
     companion object {

--- a/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/PropertiesFieldFormatChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/PropertiesFieldFormatChannel.kt
@@ -7,8 +7,8 @@ import com.itangcent.easyapi.ide.PropertiesService
 /**
  * Field-format channel for Java Properties output.
  *
- * Delegates to [PropertiesService] because Properties is the only format that
- * needs project-scoped state (resolving `properties.prefix` via `RuleEngine`).
+ * Delegates to [PropertiesService] because Properties, like YAML, needs
+ * project-scoped state (resolving `properties.prefix` via `RuleEngine`).
  * The pure rendering lives in
  * [ObjectModel.toProperties][com.itangcent.easyapi.psi.model.toProperties],
  * called by `PropertiesService` after prefix resolution.

--- a/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/YamlFieldFormatChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/YamlFieldFormatChannel.kt
@@ -2,17 +2,17 @@ package com.itangcent.easyapi.ide.fieldformat
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
-import com.itangcent.easyapi.psi.JsonOption
-import com.itangcent.easyapi.psi.PsiClassHelper
-import com.itangcent.easyapi.psi.model.toYaml
+import com.itangcent.easyapi.ide.PropertiesService
 
 /**
  * Field-format channel for YAML output.
  *
- * Uses `JsonOption.ALL` (same as JSON5 — includes comment metadata in the
- * model, though [YamlFormatter][com.itangcent.easyapi.exporter.formatter.YamlFormatter]
- * does not render comments). Delegates the pure rendering to
- * [ObjectModel.toYaml][com.itangcent.easyapi.psi.model.toYaml].
+ * Delegates to [PropertiesService] because YAML, like Properties, honors the
+ * `properties.prefix` rule (resolved from `@ConfigurationProperties(prefix=...)`
+ * via `RuleEngine`). The prefix is rendered as nested keys — mirroring Spring
+ * Boot's `application.yml` semantics. The pure rendering lives in
+ * [ObjectModel.toYaml][com.itangcent.easyapi.psi.model.toYaml], called by
+ * `PropertiesService.toYaml` after prefix resolution.
  */
 class YamlFieldFormatChannel : FieldFormatChannel {
     override val id: String = "yaml"
@@ -20,7 +20,5 @@ class YamlFieldFormatChannel : FieldFormatChannel {
     override val actionText: String = "ToYaml"
 
     override suspend fun format(project: Project, psiClass: PsiClass): String =
-        PsiClassHelper.getInstance(project)
-            .buildObjectModel(psiClass, option = JsonOption.ALL)
-            ?.toYaml() ?: ""
+        PropertiesService.getInstance(project).toYaml(psiClass)
 }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/model/FieldFormatExtensions.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/model/FieldFormatExtensions.kt
@@ -14,8 +14,8 @@ import com.itangcent.easyapi.exporter.formatter.YamlFormatter
  * These are top-level extensions (not service methods) because the conversions
  * are pure functions of the model — they need no `Project`, `RuleEngine`, or
  * PSI access. Project-scoped concerns (e.g. resolving `properties.prefix`)
- * belong in `PropertiesService`, which calls [toProperties] after resolving
- * the prefix.
+ * belong in `PropertiesService`, which calls [toProperties] and [toYaml]
+ * after resolving the prefix.
  *
  * ## Usage
  * ```kotlin
@@ -40,5 +40,12 @@ fun ObjectModel.toJson5(): String = ObjectModelJsonConverter.toJson5(this)
 fun ObjectModel.toProperties(prefix: String = ""): String =
     PropertiesFormatter().format(this, prefix)
 
-/** YAML rendering — delegates to [YamlFormatter.format]. */
-fun ObjectModel.toYaml(): String = YamlFormatter.format(this)
+/**
+ * YAML rendering with an optional dot-separated [prefix] rendered as nested
+ * keys (mirrors `@ConfigurationProperties(prefix = ...)` for `application.yml`).
+ *
+ * Delegates to [YamlFormatter.format]. The [prefix] is resolved by the caller
+ * (typically `PropertiesService.toYaml` via `RuleEngine`).
+ */
+fun ObjectModel.toYaml(prefix: String = ""): String =
+    YamlFormatter.format(this, prefix)

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/formatter/YamlFormatterBranchTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/formatter/YamlFormatterBranchTest.kt
@@ -599,4 +599,111 @@ class YamlFormatterBranchTest {
         val result = YamlFormatter.format(ObjectModel.Single(JsonType.FLOAT))
         assertEquals("value: 0.0", result)
     }
+
+    // ---------- Prefix (@ConfigurationProperties) ----------
+
+    @Test
+    fun testFormatWithEmptyPrefixEqualsNoPrefix() {
+        val obj = ObjectModel.Object(
+            mapOf(
+                "id" to FieldModel(ObjectModel.Single(JsonType.INT)),
+                "name" to FieldModel(ObjectModel.Single(JsonType.STRING))
+            )
+        )
+        val withoutPrefix = YamlFormatter.format(obj)
+        val withEmptyPrefix = YamlFormatter.format(obj, prefix = "")
+        assertEquals(withoutPrefix, withEmptyPrefix)
+    }
+
+    @Test
+    fun testFormatWithSingleSegmentPrefixForObject() {
+        val obj = ObjectModel.Object(
+            mapOf(
+                "id" to FieldModel(ObjectModel.Single(JsonType.INT)),
+                "name" to FieldModel(ObjectModel.Single(JsonType.STRING))
+            )
+        )
+        val result = YamlFormatter.format(obj, prefix = "app")
+        assertEquals("app:\n\n  id: 0\n  name: \"\"", result)
+    }
+
+    @Test
+    fun testFormatWithMultiSegmentPrefixForObject() {
+        val obj = ObjectModel.Object(
+            mapOf(
+                "id" to FieldModel(ObjectModel.Single(JsonType.INT)),
+                "name" to FieldModel(ObjectModel.Single(JsonType.STRING))
+            )
+        )
+        val result = YamlFormatter.format(obj, prefix = "app.config")
+        assertEquals("app:\n\n  config:\n\n    id: 0\n    name: \"\"", result)
+    }
+
+    @Test
+    fun testFormatWithPrefixCollapsesEmptySegments() {
+        val obj = ObjectModel.Object(
+            mapOf("id" to FieldModel(ObjectModel.Single(JsonType.INT)))
+        )
+        // Leading/trailing/repeated dots collapse to the single segment "app"
+        val result = YamlFormatter.format(obj, prefix = ".app.")
+        assertEquals("app:\n\n  id: 0", result)
+    }
+
+    @Test
+    fun testFormatWithPrefixAndNestedObject() {
+        val inner = ObjectModel.Object(
+            mapOf("id" to FieldModel(ObjectModel.Single(JsonType.INT)))
+        )
+        val obj = ObjectModel.Object(
+            mapOf("nested" to FieldModel(inner))
+        )
+        val result = YamlFormatter.format(obj, prefix = "app")
+        assertEquals("app:\n\n  nested:\n\n    id: 0", result)
+    }
+
+    @Test
+    fun testFormatWithPrefixAndArrayField() {
+        val array = ObjectModel.Array(ObjectModel.Single(JsonType.STRING))
+        val obj = ObjectModel.Object(
+            mapOf("tags" to FieldModel(array))
+        )
+        val result = YamlFormatter.format(obj, prefix = "app")
+        assertEquals("app:\n\n  tags:\n    - \"\"", result)
+    }
+
+    @Test
+    fun testFormatWithPrefixAndEmptyObject() {
+        val obj = ObjectModel.Object(emptyMap())
+        val result = YamlFormatter.format(obj, prefix = "app")
+        assertEquals("app: {}", result)
+    }
+
+    @Test
+    fun testFormatTopLevelArrayWithPrefix() {
+        val item = ObjectModel.Object(
+            mapOf("id" to FieldModel(ObjectModel.Single(JsonType.INT)))
+        )
+        val array = ObjectModel.Array(item)
+        val result = YamlFormatter.format(array, prefix = "app")
+        assertEquals("app:\n  - id: 0", result)
+    }
+
+    @Test
+    fun testFormatTopLevelMapWithPrefix() {
+        val map = ObjectModel.MapModel(
+            ObjectModel.Single(JsonType.STRING),
+            ObjectModel.Single(JsonType.INT)
+        )
+        val result = YamlFormatter.format(map, prefix = "app")
+        // Map follows the same convention as a map field value (no blank line
+        // between the key and its map body — see testFormatMapInObject).
+        assertEquals("app:\n  key: \"\"\n  value: 0", result)
+    }
+
+    @Test
+    fun testFormatTopLevelSingleWithPrefix() {
+        val single = ObjectModel.Single(JsonType.STRING)
+        val result = YamlFormatter.format(single, prefix = "app")
+        assertEquals("app:\n  value: \"\"", result)
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/ide/fieldformat/FieldFormatChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/fieldformat/FieldFormatChannelTest.kt
@@ -125,6 +125,14 @@ class FieldFormatChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertEquals(serviceResult, channelResult)
     }
 
+    fun testYamlChannelDelegatesToService() = runTest {
+        val channel = YamlFieldFormatChannel()
+        val channelResult = channel.format(project, userInfoClass)
+        val serviceResult = PropertiesService.getInstance(project).toYaml(userInfoClass)
+        // The channel should delegate to PropertiesService — outputs must match
+        assertEquals(serviceResult, channelResult)
+    }
+
     // ---------- All channels parity ----------
 
     fun testAllChannelsProduceNonEmptyOutput() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/ide/fieldformat/YamlFieldFormatWithPrefixTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/fieldformat/YamlFieldFormatWithPrefixTest.kt
@@ -1,0 +1,55 @@
+package com.itangcent.easyapi.ide.fieldformat
+
+import com.itangcent.easyapi.ide.PropertiesService
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.ResourceLoader
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Golden-file test for [PropertiesService.toYaml] and [YamlFieldFormatChannel]
+ * with `properties.prefix=demo` configured.
+ *
+ * Mirrors [com.itangcent.easyapi.ide.PropertiesServiceWithPrefixTest]: a
+ * separate class is required because [createConfigReader] is a class-level
+ * override on [EasyApiLightCodeInsightFixtureTestCase], so the no-prefix and
+ * with-prefix cases cannot share a class.
+ *
+ * Locks the bug fix where the YAML channel previously dropped the
+ * `@ConfigurationProperties` prefix — YAML now nests the prefix as keys
+ * (Spring Boot `application.yml` semantics), matching what Properties does
+ * with flat dot-paths.
+ */
+class YamlFieldFormatWithPrefixTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    override fun createConfigReader() =
+        TestConfigReader.fromRules(project, "properties.prefix" to "demo")
+
+    fun testToYamlWithPrefix() = runTest {
+        loadFile("model/UserInfo.java")
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+        val service = PropertiesService.getInstance(project)
+
+        val actual = service.toYaml(psiClass)
+        val expected = ResourceLoader.read(
+            "/result/com.itangcent.easyapi.psi.model.FieldFormatExtensionsTest.toYamlWithPrefix.txt"
+        )
+        assertEquals(expected, actual)
+    }
+
+    fun testYamlChannelHonorsPrefix() = runTest {
+        loadFile("model/UserInfo.java")
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+
+        val channelResult = YamlFieldFormatChannel().format(project, psiClass)
+        val serviceResult = PropertiesService.getInstance(project).toYaml(psiClass)
+        // Channel must delegate to the service so the prefix is applied.
+        assertEquals(serviceResult, channelResult)
+
+        // And the prefixed output must actually wrap keys under "demo".
+        assertTrue("YAML with prefix should start with 'demo:'", channelResult.startsWith("demo:"))
+        assertFalse(
+            "YAML with prefix must NOT leak un-prefixed top-level keys",
+            channelResult.lines().any { it == "id: 0" || it == "name: \"\"" }
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/psi/model/FieldFormatExtensionsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/model/FieldFormatExtensionsTest.kt
@@ -8,7 +8,7 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
 
 /**
  * Golden-file tests for the [ObjectModel] format extension functions
- * ([toJson], [toJson5], [toProperties]).
+ * ([toJson], [toJson5], [toProperties], [toYaml]).
  *
  * Locks the canonical rendering of `model/UserInfo.java` so any drift
  * introduced by refactoring is caught at CI time. The golden files were
@@ -19,6 +19,7 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
  * - [toJson] → [ObjectModelJsonConverter.toJson]
  * - [toJson5] → [ObjectModelJsonConverter.toJson5]
  * - [toProperties] → [PropertiesFormatter.format]
+ * - [toYaml] → [YamlFormatter.format]
  */
 class FieldFormatExtensionsTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -54,6 +55,30 @@ class FieldFormatExtensionsTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         val actual = model.toProperties()
         val expected = ResourceLoader.read("/result/com.itangcent.easyapi.ide.FieldFormatServiceTest.toProperties.txt")
+        assertEquals(expected, actual)
+    }
+
+    fun testToYaml() = runTest {
+        loadFile("model/UserInfo.java")
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+        val helper = DefaultPsiClassHelper.getInstance(project)
+        val model = helper.buildObjectModel(psiClass, option = JsonOption.ALL)!!
+
+        val actual = model.toYaml()
+        val expected = ResourceLoader.read("/result/com.itangcent.easyapi.exporter.formatter.YamlFormatterTest.txt")
+        assertEquals(expected, actual)
+    }
+
+    fun testToYamlWithPrefix() = runTest {
+        loadFile("model/UserInfo.java")
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+        val helper = DefaultPsiClassHelper.getInstance(project)
+        val model = helper.buildObjectModel(psiClass, option = JsonOption.ALL)!!
+
+        val actual = model.toYaml("demo")
+        val expected = ResourceLoader.read(
+            "/result/com.itangcent.easyapi.psi.model.FieldFormatExtensionsTest.toYamlWithPrefix.txt"
+        )
         assertEquals(expected, actual)
     }
 }

--- a/src/test/resources/result/com.itangcent.easyapi.psi.model.FieldFormatExtensionsTest.toYamlWithPrefix.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.psi.model.FieldFormatExtensionsTest.toYamlWithPrefix.txt
@@ -1,0 +1,9 @@
+demo:
+
+  id: 0
+  type: 0
+  name: ""
+  age: 0
+  sex: 0
+  birthDay: null
+  regtime: null


### PR DESCRIPTION
## Problem

The YAML field-format channel (`ToYaml` action) rendered class fields **without** the `properties.prefix` resolved from `@ConfigurationProperties(prefix=...)`. A user with:

```java
@ConfigurationProperties(prefix = "app.config")
public class AppConfig { ... }
```

clicking **ToYaml** got unprefixed top-level keys, while **ToProperties** correctly produced `app.config.*`. Spring Boot treats the prefix identically for `application.properties` and `application.yml`, so YAML must honor it too.

## Root cause

`YamlFieldFormatChannel` called `ObjectModel.toYaml()` (a pure extension) directly, bypassing `PropertiesService` — the only place prefix resolution via `RuleEngine` lived. Properties and YAML are the two *config* formats that need the prefix; JSON/JSON5 are *data* formats and correctly ignore it.

## Solution

- **`YamlFormatter.format(model, prefix="")`** — renders dot-separated prefix segments as nested keys (Spring Boot `application.yml` semantics), with empty segments collapsed.
- **`ObjectModel.toYaml(prefix="")`** — threads the prefix through.
- **`PropertiesService.toYaml()`** — new method that resolves the prefix via `RuleEngine` and delegates the pure rendering to `ObjectModel.toYaml`.
- **`YamlFieldFormatChannel`** — now routes through `PropertiesService`, mirroring `PropertiesFieldFormatChannel`. The two config-format channels are now structurally identical; JSON/JSON5 stay pure-extension calls.

### Before / after

For `@ConfigurationProperties(prefix = "demo")` on `UserInfo`:

```diff
- id: 0
- type: 0
- name: ""
+ demo:
+
+   id: 0
+   type: 0
+   name: ""
```

## Tests

- `YamlFormatterBranchTest`: 10 new prefix cases (single/multi-segment, empty-segment collapse, nested object, array field, empty object, top-level array/map/single).
- `FieldFormatExtensionsTest`: golden coverage for `toYaml()` and `toYaml(prefix)`.
- `YamlFieldFormatWithPrefixTest` (new): golden + delegation test verifying the channel honors the prefix end-to-end.
- `FieldFormatChannelTest`: parity assertion that `YamlFieldFormatChannel` delegates to `PropertiesService.toYaml`.

Full test suite passes (`./gradlew test`), including the `AntiPatternGate` lint.

## Backward compatibility

- `YamlFormatter.format(model)` and `ObjectModel.toYaml()` keep their no-prefix defaults — any external caller is unaffected.
- Rule key unchanged (`properties.prefix`) — user configs and the bundled `spring-configuration.config` extension continue to work as-is.