### PR TITLE
feat(curl): add variable rendering, output options, pre-scripts, and reusable cURL builder

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
@@ -19,6 +19,9 @@ import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.exporter.ExportOrchestrator
 import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.channel.ChannelRegistry
+import com.itangcent.easyapi.exporter.channel.curl.CurlExportResolver
+import com.itangcent.easyapi.exporter.channel.curl.CurlScriptScopes
+import com.itangcent.easyapi.exporter.channel.curl.CurlSettings
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ExportResult
 import com.itangcent.easyapi.exporter.model.path
@@ -30,6 +33,7 @@ import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.type.areMethodsRelated
 import com.itangcent.easyapi.script.ScriptEditorPanel
 import com.itangcent.easyapi.script.ScriptScope
+import com.itangcent.easyapi.settings.settings
 import java.awt.BorderLayout
 import java.awt.CardLayout
 import java.awt.Dimension
@@ -339,11 +343,38 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
             })
             popupMenu.add(createMenuItem("Copy as cURL") {
                 val host = endpointDetailsPanel.getSelectedHost()
-                val curl = com.itangcent.easyapi.exporter.channel.curl.CurlFormatter.format(endpoint, host)
-                val clipboard = java.awt.Toolkit.getDefaultToolkit().systemClipboard
-                val selection = java.awt.datatransfer.StringSelection(curl)
-                clipboard.setContents(selection, null)
-                showCopyNotification()
+                val settings = project.settings<CurlSettings>()
+                val sourceEndpoint = if (settings.copyFromEdited) {
+                    endpointDetailsPanel.buildEditedEndpoint() ?: endpoint
+                } else {
+                    endpoint
+                }
+                backgroundAsync {
+                    try {
+                        // The resolve→format pipeline (incl. format options from settings)
+                        // lives in CurlExportResolver.formatForCopy; this handler only owns
+                        // the dashboard-specific UI concerns: host, edited-vs-original,
+                        // clipboard, notification.
+                        val curl = CurlExportResolver.getInstance(project).formatForCopy(sourceEndpoint, host)
+                            ?: return@backgroundAsync  // user cancelled env dialog
+                        swing {
+                            val clipboard = java.awt.Toolkit.getDefaultToolkit().systemClipboard
+                            clipboard.setContents(java.awt.datatransfer.StringSelection(curl), null)
+                            showCopyNotification()
+                        }
+                    } catch (_: kotlin.coroutines.cancellation.CancellationException) {
+                        LOG.info("Copy as cURL cancelled by user")
+                    } catch (e: Throwable) {
+                        LOG.warn("Copy as cURL failed", e)
+                        swing {
+                            NotificationUtils.notifyError(
+                                project,
+                                "Copy as cURL Failed",
+                                "Copy as cURL failed: ${e.message}"
+                            )
+                        }
+                    }
+                }
             })
             popupMenu.addSeparator()
             popupMenu.add(createMenuItem("Navigate to Source") {
@@ -683,18 +714,10 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
     }
 
     fun resolveScriptScopesForEndpoint(endpoint: ApiEndpoint): List<ScriptScope> {
-        val scopes = mutableListOf<ScriptScope>()
-        val folder = endpoint.folder?.takeIf { it.isNotBlank() }
-        if (folder != null) {
-            scopes.add(ScriptScope.Module(folder))
-        }
-        val qualifiedName = ApplicationManager.getApplication().runReadAction<String?> {
-            endpoint.sourceClass?.qualifiedName
-        } ?: endpoint.className
-        if (qualifiedName != null) {
-            scopes.add(ScriptScope.Class(qualifiedName))
-        }
-        return scopes
+        // Delegates to the shared curl-package helper (DRY) — folder + class
+        // scopes only, matching the dashboard's prior behavior. The curl single-endpoint
+        // path (CurlExportResolver.formatForCopy) additionally appends the Endpoint scope.
+        return CurlScriptScopes.resolveFolderAndClassScopes(endpoint)
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
@@ -21,10 +21,13 @@ import com.itangcent.easyapi.settings.module.GrpcSettings
 import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.script.pm.*
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.ApiParameter
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
 import com.itangcent.easyapi.exporter.model.GrpcStreamingType
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.MutableExtension
 import com.itangcent.easyapi.exporter.model.ParameterBinding
 import com.itangcent.easyapi.exporter.model.ParameterType
 import com.itangcent.easyapi.http.*
@@ -35,6 +38,7 @@ import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.exporter.model.grpcMetadata
 import com.itangcent.easyapi.exporter.model.isGrpc
 import com.itangcent.easyapi.ide.support.NotificationUtils
+import com.itangcent.easyapi.exporter.channel.curl.EndpointVariableResolver
 import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
 import kotlinx.coroutines.*
 import java.awt.BorderLayout
@@ -1503,6 +1507,58 @@ class EndpointDetailsPanel(
             }
             editCacheService.delete(key, endpoint.isGrpc)
         }
+    }
+
+    /**
+     * Builds an [ApiEndpoint] reflecting the user's dashboard edits (path, headers,
+     * query params, body, contentType). Returns null if no endpoint is loaded.
+     *
+     * The edited body JSON is stashed in [extensions][ApiEndpoint.extensions] under
+     * [EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] so that [com.itangcent.easyapi.exporter.channel.curl.CurlFormatter]
+     * picks it up instead of re-serializing the original [com.itangcent.easyapi.psi.model.ObjectModel] body.
+     *
+     * Path params and form params are preserved from the original endpoint (their
+     * values are edited in separate table models that feed into the request sender,
+     * not into the cURL formatter's URL/header construction).
+     */
+    fun buildEditedEndpoint(): ApiEndpoint? {
+        val original = currentEndpoint ?: return null
+        val editedBody = bodyArea.text.takeIf { it.isNotBlank() }
+
+        val extensions = MutableExtension()
+        extensions.putAll(original.extensions.exts)
+        if (editedBody != null) {
+            extensions[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] = editedBody
+        }
+
+        val editedMeta = when (val meta = original.metadata) {
+            is HttpMetadata -> {
+                val editedHeaders = (0 until headersTableModel.rowCount).mapNotNull { row ->
+                    val name = headersTableModel.getValueAt(row, 0)?.toString()?.trim().orEmpty()
+                    val value = headersTableModel.getValueAt(row, 1)?.toString()?.trim().orEmpty()
+                    if (name.isNotEmpty()) ApiHeader(name = name, value = value) else null
+                }
+                val editedQueryParams = (0 until paramsTableModel.rowCount).mapNotNull { row ->
+                    val name = paramsTableModel.getValueAt(row, 0)?.toString()?.trim().orEmpty()
+                    val value = paramsTableModel.getValueAt(row, 1)?.toString()?.trim().orEmpty()
+                    if (name.isNotEmpty()) {
+                        ApiParameter(name = name, defaultValue = value, binding = ParameterBinding.Query)
+                    } else null
+                }
+                val preservedParams = meta.parameters.filter {
+                    it.binding == ParameterBinding.Path || it.binding == ParameterBinding.Form
+                }
+                meta.copy(
+                    path = pathField.text,
+                    headers = editedHeaders.toMutableList(),
+                    parameters = (preservedParams + editedQueryParams).toMutableList(),
+                    contentType = endpointContentType,
+                )
+            }
+            else -> meta
+        }
+
+        return original.copy(metadata = editedMeta, extensions = extensions)
     }
 
     private fun saveCurrentEdit() {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlBuildOptions.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlBuildOptions.kt
@@ -1,0 +1,32 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.script.ScriptScope
+
+/**
+ * Composite options for [CurlBuilder]. Composes the existing [CurlFormatOptions]
+ * (5 format flags) with the pre-script controls.
+ *
+ * Default [CurlBuildOptions] yields format-default output with NO script
+ * execution — preserving byte-for-byte output (no script machinery is invoked).
+ *
+ * ## Script gate semantics
+ *
+ * Pre-script execution is gated by `runPreScripts && scopes.isNotEmpty()`.
+ * A caller that enables [runPreScripts] but supplies an empty [scopes] list
+ * incurs no script machinery. This keeps the
+ * [CurlBuilder.format] step pure and plain-JUnit-testable when scripts
+ * are off, and lets [CurlBuilder.build] short-circuit before touching [PreScriptApplier].
+ *
+ * @property format The 5 formatting flags forwarded to [CurlFormatter].
+ * @property runPreScripts When `true` AND [scopes] is non-empty AND a `Project` is
+ *   available, the builder runs the resolved pre-request scripts against the
+ *   endpoint (deep copy) before formatting. When `false` (default), no scripts run.
+ * @property scopes Script scopes to resolve (folder → class → endpoint inline, in
+ *   outer→inner order matching [com.itangcent.easyapi.dashboard.RequestExecutor.resolveScripts]).
+ *   Ignored when [runPreScripts] is `false`.
+ */
+data class CurlBuildOptions(
+    val format: CurlFormatOptions = CurlFormatOptions(),
+    val runPreScripts: Boolean = false,
+    val scopes: List<ScriptScope> = emptyList(),
+)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlBuilder.kt
@@ -1,0 +1,132 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+
+/**
+ * General, reusable "build a cURL command from an endpoint" entry point.
+ *
+ * Usable from:
+ * - The cURL export channel ([CurlChannel]) and Dashboard "Copy as cURL" (via [CurlExportResolver])
+ * - `export.after` rule scripts via [com.itangcent.easyapi.rule.context.ScriptApiEndpoint.toCurl]
+ * - Markdown templates via [com.itangcent.easyapi.exporter.channel.markdown.template.HttpView.curl]
+ *
+ * ## Purity contract
+ *
+ * The [format] step is **pure** with respect to `Project`/EDT — no `Project`,
+ * no `suspend`, no coroutine suspension. It delegates to [CurlFormatter] and is
+ * unit-testable with plain JUnit. This is the entry point Markdown's
+ * `HttpView.curl()` and rule `api.toCurl()` (with `runPreScripts=false`) use.
+ *
+ * The [build] step is `suspend` because the optional pre-script application
+ * requires a `Project` for [ScriptCacheService] / [PmScriptExecutor]. When
+ * [CurlBuildOptions.runPreScripts] is `false` (or [CurlBuildOptions.scopes] is
+ * empty, or `project` is null), [build] early-returns [format] and incurs no
+ * `Project` dependency.
+ *
+ * ## Headless-safe
+ *
+ * The builder NEVER prompts the user for a host and NEVER shows an environment
+ * dialog — it is headless-safe. [DEFAULT_HOST] (`"{{host}}"`) is used when no host
+ * is supplied, so output is non-empty and round-trips through variable resolution
+ * later (matches the Postman `{{url}}` convention).
+ *
+ * ## Determinism
+ *
+ * Output is deterministic for a given `(endpoint, host, options)` — same inputs
+ * produce the same string. This holds for [format] unconditionally; for [build]
+ * it holds when `runPreScripts=false` (scripts may introduce nondeterminism via
+ * `pm.environment.get` lookups, which is expected).
+ */
+object CurlBuilder {
+
+    /**
+     * Default placeholder host when none is supplied.
+     *
+     * Using the literal `{{host}}` keeps output non-empty and round-trips through
+     * [EndpointVariableResolver] / environment rendering later. The builder never
+     * prompts and never touches EDT to resolve this — callers resolve it
+     * themselves (rules via Groovy + [com.itangcent.easyapi.config.ConfigReader];
+     * Markdown via the `markdown.curl.host` config key).
+     */
+    const val DEFAULT_HOST = "{{host}}"
+
+    /**
+     * Pure format step — NO `Project`, NO `suspend`, NO scripts.
+     *
+     * Delegates to [CurlFormatter.format] with [options.format]. If
+     * [options.runPreScripts] is `true`, the caller MUST have already applied
+     * scripts to [endpoint]; this entry point does not run them. Use [build] for
+     * the full pipeline.
+     *
+     * Unit-testable with plain JUnit.
+     *
+     * @param endpoint The endpoint to format.
+     * @param host Target host; defaults to [DEFAULT_HOST] when blank.
+     * @param options Build options; only [CurlBuildOptions.format] is consulted here.
+     * @return The formatted cURL command string.
+     */
+    fun format(
+        endpoint: ApiEndpoint,
+        host: String = DEFAULT_HOST,
+        options: CurlBuildOptions = CurlBuildOptions(),
+    ): String {
+        val effectiveHost = host.takeIf { it.isNotBlank() } ?: DEFAULT_HOST
+        return CurlFormatter.format(endpoint, effectiveHost, options.format)
+    }
+
+    /**
+     * Full pipeline: optional pre-script execution → format.
+     *
+     * `suspend` because the script step needs `Project` (for [PreScriptApplier] →
+     * [PmScriptExecutor]) and the Groovy engine may do I/O. When
+     * [options.runPreScripts] is `false` (or [options.scopes] is empty, or
+     * `project` is null), this early-returns [format] and never touches `Project`
+     * or suspends meaningfully.
+     *
+     * @param project Required only when running scripts; ignored otherwise. Pass
+     *   `null` for the pure-format path.
+     * @param endpoint The endpoint to build a cURL command for.
+     * @param host Target host; defaults to [DEFAULT_HOST] when blank.
+     * @param options Build options (format flags + script controls).
+     * @return The formatted cURL command.
+     */
+    suspend fun build(
+        project: Project?,
+        endpoint: ApiEndpoint,
+        host: String = DEFAULT_HOST,
+        options: CurlBuildOptions = CurlBuildOptions(),
+    ): String {
+        if (!options.runPreScripts || options.scopes.isEmpty() || project == null) {
+            return format(endpoint, host, options)
+        }
+        val scripted = PreScriptApplier.getInstance(project).applyScripts(endpoint, host, options.scopes)
+        return CurlFormatter.format(scripted, host, options.format)
+    }
+
+    /**
+     * Non-suspend wrapper for rule-script callers.
+     *
+     * `export.after` rules fire synchronously inside the rule engine's script
+     * thread (a background worker via `Jsr223ScriptParser`), which is not a
+     * suspend context. This entry point wraps [build] in `runBlocking` so rule
+     * scripts can call `api.toCurl(...)` naturally.
+     *
+     * Safe because [PreScriptApplier.applyScripts] is EDT-free (no `swing { }`
+     * hops) — `runBlocking` on a background thread never deadlocks with EDT.
+     *
+     * @param project Required only when running scripts; ignored otherwise.
+     * @param endpoint The endpoint to build a cURL command for.
+     * @param host Target host; defaults to [DEFAULT_HOST] when blank.
+     * @param options Build options.
+     * @return The formatted cURL command.
+     */
+    fun buildSync(
+        project: Project?,
+        endpoint: ApiEndpoint,
+        host: String = DEFAULT_HOST,
+        options: CurlBuildOptions = CurlBuildOptions(),
+    ): String = kotlinx.coroutines.runBlocking {
+        build(project, endpoint, host, options)
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlChannel.kt
@@ -11,21 +11,28 @@ import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.exporter.channel.Channel
 import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
-import com.itangcent.easyapi.exporter.channel.curl.CurlExportMetadata
-import com.itangcent.easyapi.exporter.channel.curl.CurlFormatter
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportResult
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.settings
+import com.itangcent.easyapi.settings.ui.SettingsPanel
 import kotlinx.coroutines.CancellationException
 import java.io.File
+import kotlin.reflect.KClass
 
 /**
  * [Channel] that exports API endpoints as cURL commands.
  *
- * Supports both HTTP and gRPC endpoints. No configuration panel needed.
+ * Supports both HTTP and gRPC endpoints. Variable rendering (`{{var}}` / `${var}`)
+ * is driven by [CurlSettings.renderMode] and delegated to [CurlExportResolver]; the
+ * per-export formatting flags come from [CurlConfig.options] (collected by
+ * [CurlOptionsPanel] in the export dialog). Persistent formatting defaults live in
+ * [CurlSettings] and are edited via [CurlSettingsPanel] in the EasyApi settings.
  *
  * @see Channel
  * @see CurlFormatter
+ * @see CurlExportResolver
  */
 class CurlChannel : Channel, IdeaLog {
 
@@ -33,16 +40,47 @@ class CurlChannel : Channel, IdeaLog {
     override val displayName: String = "cURL"
     override val supportsGrpc: Boolean = true
 
-    override fun createOptionsPanel(project: Project): ChannelOptionsPanel? = null
+    override val settingsType: KClass<out Settings> = CurlSettings::class
+    override val settingsTabOrder: Int = 110
+
+    override fun createOptionsPanel(project: Project): ChannelOptionsPanel = CurlOptionsPanel(project)
+
+    override fun createSettingsPanel(project: Project): SettingsPanel<*>? = CurlSettingsPanel(project)
 
     override suspend fun export(context: ExportContext): ExportResult {
         LOG.info("CurlChannel.export: endpoints=${context.endpointsToExport.size}")
-        val hostCacheHelper = DefaultHttpContextCacheHelper.getInstance(context.project)
+        val project = context.project
+        val hostCacheHelper = DefaultHttpContextCacheHelper.getInstance(project)
         val host = swing {
             hostCacheHelper.selectHost("Select Host For cURL Export")
         }
 
-        val content = CurlFormatter.formatAll(context.endpointsToExport, host)
+        val curlConfig = context.channelConfig as? CurlConfig
+        val options = curlConfig?.options ?: CurlFormatOptions()
+        // runPreScripts: per-export override (null → use persistent CurlSettings default).
+        val runPreScripts = curlConfig?.runPreScripts ?: project.settings<CurlSettings>().runPreScripts
+
+        // CurlExportResolver is a project service — it reads renderMode from
+        // CurlSettings internally. resetBatchCache() ensures a fresh prompt per export.
+        val resolver = CurlExportResolver.getInstance(project)
+        resolver.resetBatchCache()
+        val resolved = resolver.resolveAll(context.endpointsToExport, host)
+            ?: throw CancellationException("User cancelled environment selection")
+
+        // Run folder+class pre-scripts on each endpoint before formatting.
+        // Batch path uses folder+class scopes only (no per-endpoint inline scripts) —
+        // PreScriptApplier is EDT-free, safe to call from this background coroutine.
+        val scriptedEndpoints = if (runPreScripts && resolved.first.isNotEmpty()) {
+            val applier = PreScriptApplier.getInstance(project)
+            resolved.first.map { ep ->
+                val scopes = CurlScriptScopes.resolveFolderAndClassScopes(ep)
+                applier.applyScripts(ep, resolved.second, scopes)
+            }
+        } else {
+            resolved.first
+        }
+
+        val content = CurlFormatter.formatAll(scriptedEndpoints, resolved.second, options)
 
         return ExportResult.Success(
             count = context.endpointsToExport.size,
@@ -57,9 +95,13 @@ class CurlChannel : Channel, IdeaLog {
         config: ChannelConfig
     ): Boolean {
         val metadata = result.metadata as? CurlExportMetadata ?: return false
-        val fileConfig = config as? ChannelConfig.FileConfig
+        val (outputDir, fileName) = when (config) {
+            is CurlConfig -> config.outputDir to config.fileName
+            is ChannelConfig.FileConfig -> config.outputDir to config.fileName
+            else -> null to null
+        }
 
-        val targetFile = resolveTargetFile(project, fileConfig, "curl_commands.sh")
+        val targetFile = resolveTargetFile(project, outputDir, fileName, "curl_commands.sh")
             ?: throw CancellationException("User cancelled file selection")
 
         background {
@@ -78,11 +120,10 @@ class CurlChannel : Channel, IdeaLog {
 
     private suspend fun resolveTargetFile(
         project: Project,
-        fileConfig: ChannelConfig.FileConfig?,
-        defaultFileName: String
+        outputDir: String?,
+        fileName: String?,
+        defaultFileName: String,
     ): File? {
-        val outputDir = fileConfig?.outputDir
-        val fileName = fileConfig?.fileName
         if (!outputDir.isNullOrBlank()) {
             val dir = File(outputDir)
             if (!dir.exists()) {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlConfig.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlConfig.kt
@@ -1,0 +1,28 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+
+/**
+ * Per-export configuration for [CurlChannel].
+ *
+ * Combines file-output settings ([outputDir]/[fileName], mirroring
+ * [com.itangcent.easyapi.exporter.channel.markdown.MarkdownConfig]) with
+ * the 5 per-export formatting overrides in [options].
+ *
+ * `renderMode` is NOT here — it lives in [CurlSettings] (persistent,
+ * not per-export overridable).
+ *
+ * @property outputDir the target output directory, or `null` to prompt the user
+ * @property fileName the output file name (without extension), or `null` to use the default
+ * @property options per-export formatting overrides; defaults preserve the
+ *  pre-enhancement output byte-for-byte
+ * @property runPreScripts per-export override for the pre-script flag.
+ *  `null` = use [CurlSettings.runPreScripts] (the persistent default); non-null
+ *  = apply the per-export choice. Resolved by [CurlChannel.export].
+ */
+data class CurlConfig(
+    val outputDir: String? = null,
+    val fileName: String? = null,
+    val options: CurlFormatOptions = CurlFormatOptions(),
+    val runPreScripts: Boolean? = null,
+) : ChannelConfig()

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlExportResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlExportResolver.kt
@@ -1,0 +1,259 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.core.threading.swing
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.script.env.Environment
+import com.itangcent.easyapi.script.env.EnvironmentService
+import com.itangcent.easyapi.settings.settings
+
+/**
+ * Bridges persistent [CurlSettings] (render mode) + live environment/config sources
+ * to the pure [EndpointVariableResolver]. Used by both [CurlChannel] (batch export)
+ * and the Dashboard "Copy as cURL" action (single endpoint), so the env-service /
+ * ConfigReader / EDT-prompt wiring lives in exactly one place.
+ *
+ * Following the [com.itangcent.easyapi.exporter.channel.yapi.DefaultUpdateConfirmation]
+ * pattern: a project-scoped service that reads the export mode from settings internally
+ * and caches an "apply-to-all" decision across the batch. Callers no longer pass
+ * `renderMode` — the service reads it from [CurlSettings] on each call, so settings
+ * changes take effect immediately without re-constructing the resolver.
+ *
+ * Threading: all entry points are `suspend`. `ALWAYS_ASK` shows the environment
+ * chooser on EDT via [swing]; the caller is expected to be on a background coroutine
+ * (e.g. [com.itangcent.easyapi.core.threading.backgroundAsync] / the export pipeline).
+ *
+ * Cancel semantics: if the user closes the environment dialog (Esc / X), `resolve`
+ * and `resolveAll` return `null` — callers should abort silently. "Skip (keep
+ * placeholders)" is distinct: it proceeds with an empty variable map, so placeholders
+ * stay unreplaced (only the [ConfigReader] fallback is consulted). In `resolveAll`,
+ * the skip decision is cached for the remainder of the batch (like
+ * [DefaultUpdateConfirmation.applyAllDecision]).
+ */
+@Service(Service.Level.PROJECT)
+class CurlExportResolver(
+    private val project: Project,
+) : IdeaLog {
+
+    /** Cached user decision for the current batch (resolveAll). Null = not yet decided. */
+    private var applyAllEnv: Environment? = null
+    private var applyAllSkip: Boolean = false
+
+    /**
+     * Resolves [endpoint] + [host] for a single cURL command (Copy-as-cURL path).
+     *
+     * Reads [CurlRenderMode] from [CurlSettings] directly — callers no longer pass it.
+     *
+     * @return the resolved pair, or `null` if the user cancelled the environment prompt.
+     */
+    suspend fun resolve(
+        endpoint: ApiEndpoint,
+        host: String,
+    ): Pair<ApiEndpoint, String>? {
+        val renderMode = project.settings<CurlSettings>().renderModeEnum()
+        if (renderMode == CurlRenderMode.NEVER_RENDER) return endpoint to host
+
+        val envMap = resolveEnvMap(renderMode, isBatch = false) ?: return null
+        val fallback = fallback()
+        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+
+        val r = EndpointVariableResolver.resolve(endpoint, host, envMap, fallback)
+        if (r.missing.isNotEmpty()) {
+            console.warn("curl: unresolved variables in '${endpoint.name}': ${r.missing.joinToString(", ")}")
+        }
+        return r.endpoint to r.host
+    }
+
+    /**
+     * Single-endpoint "copy as cURL" pipeline: resolve variables → format with the
+     * user's persisted [CurlSettings] format flags.
+     *
+     * Centralizes the resolve→format sequence that previously lived inline in
+     * `ApiDashboardPanel.showPopupMenu`. Format options are read from
+     * [CurlSettings.toFormatOptions] so the settings→options mapping has exactly
+     * one home (a 6th format flag added to [CurlSettings] flows here for free).
+     *
+     * Callers remain responsible for the surrounding UI concerns only:
+     * - selecting the host (e.g. from the dashboard env dropdown)
+     * - the `copyFromEdited` decision (original vs edited endpoint)
+     * - clipboard write + success notification
+     *
+     * Cancel/error handling policy:
+     * - [CancellationException] is **not** caught here — it propagates so the
+     *   caller can log "cancelled by user" distinctly (matches the pre-refactor
+     *   Copy action behavior and [CurlChannel.export]).
+     * - Other throwables propagate too; the caller is expected to wrap in a
+     *   try/catch that logs and notifies. Keeping this method free of UI
+     *   notification code means it stays unit-testable without EDT.
+     *
+     * @param endpoint The endpoint to render (caller decides edited vs original).
+     * @param host The target host (already resolved by the caller).
+     * @return the formatted cURL command, or `null` if the user cancelled the
+     *         environment selection prompt.
+     */
+    suspend fun formatForCopy(endpoint: ApiEndpoint, host: String): String? {
+        val resolved = resolve(endpoint, host) ?: return null
+        val settings = project.settings<CurlSettings>()
+        val options = settings.toFormatOptions()
+
+        // When pre-scripts are enabled, run folder+class+endpoint scopes
+        // before formatting. The endpoint scope is included here (unlike
+        // the batch path) so per-endpoint inline scripts saved via the dashboard UI are
+        // consulted for the single-endpoint copy action — mirrors RequestExecutor which
+        // appends `input.preRequestScript` after folder+class scopes.
+        val endpointToFormat = if (settings.runPreScripts) {
+            val scopes = CurlScriptScopes.resolveAllScopes(resolved.first)
+            PreScriptApplier.getInstance(project).applyScripts(resolved.first, resolved.second, scopes)
+        } else {
+            resolved.first
+        }
+        return CurlFormatter.format(endpointToFormat, resolved.second, options)
+    }
+
+    /**
+     * Resolves [endpoints] + [host] for a batch cURL export (CurlChannel.export path).
+     *
+     * Reads [CurlRenderMode] from [CurlSettings] directly — callers no longer pass it.
+     *
+     * The host is resolved once (from the first endpoint's result) since it is shared
+     * across the batch. Each endpoint is still resolved individually so per-endpoint
+     * `missing` sets are reported correctly.
+     *
+     * @return the resolved pair, or `null` if the user cancelled the environment prompt
+     *         or the endpoint list is empty AND the user cancelled (empty input short-
+     *         circuits to the input unchanged).
+     */
+    suspend fun resolveAll(
+        endpoints: List<ApiEndpoint>,
+        host: String,
+    ): Pair<List<ApiEndpoint>, String>? {
+        val renderMode = project.settings<CurlSettings>().renderModeEnum()
+        if (renderMode == CurlRenderMode.NEVER_RENDER) return endpoints to host
+        if (endpoints.isEmpty()) return endpoints to host
+
+        val envMap = resolveEnvMap(renderMode, isBatch = true) ?: return null
+        val fallback = fallback()
+        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+
+        var resolvedHost = host
+        val resolvedEndpoints = endpoints.mapIndexed { idx, ep ->
+            val r = EndpointVariableResolver.resolve(ep, host, envMap, fallback)
+            if (r.missing.isNotEmpty()) {
+                console.warn("curl: unresolved variables in '${ep.name}': ${r.missing.joinToString(", ")}")
+            }
+            if (idx == 0) resolvedHost = r.host
+            r.endpoint
+        }
+        return resolvedEndpoints to resolvedHost
+    }
+
+    /**
+     * Builds the variable map for [renderMode]. Returns `null` if the user cancelled
+     * the ALWAYS_ASK prompt (caller should abort); returns an empty map for Skip or
+     * no-active-environment (caller proceeds, placeholders may still resolve via
+     * [ConfigReader] fallback).
+     *
+     * When [isBatch] is true and the user picks an environment, the decision is cached
+     * in [applyAllEnv] / [applyAllSkip] so subsequent calls in the same batch skip the
+     * prompt (mirrors [DefaultUpdateConfirmation.applyAllDecision]).
+     */
+    private suspend fun resolveEnvMap(
+        renderMode: CurlRenderMode,
+        isBatch: Boolean,
+    ): Map<String, String>? {
+        val envService = EnvironmentService.getInstance(project)
+        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        return when (renderMode) {
+            CurlRenderMode.ALWAYS_RENDER -> {
+                val active = envService.getActiveEnvironment()
+                if (active == null) {
+                    console.warn("curl: no active environment; ConfigReader fallback only")
+                }
+                active?.variables ?: emptyMap()
+            }
+            CurlRenderMode.ALWAYS_ASK -> {
+                // Fast path: reuse cached decision within the same batch
+                if (isBatch && applyAllSkip) return emptyMap()
+                if (isBatch && applyAllEnv != null) return applyAllEnv!!.variables
+
+                val prompt = swing { promptEnvironment(envService) } ?: return null
+                when (prompt) {
+                    EnvPrompt.Skip -> {
+                        if (isBatch) applyAllSkip = true
+                        emptyMap()
+                    }
+                    is EnvPrompt.Selected -> {
+                        if (isBatch) applyAllEnv = prompt.environment
+                        prompt.environment.variables
+                    }
+                }
+            }
+            CurlRenderMode.NEVER_RENDER -> emptyMap()
+        }
+    }
+
+    private fun fallback(): (String) -> String? =
+        { k -> ConfigReader.getInstance(project).getFirst(k) }
+
+    /**
+     * Shows the environment chooser on EDT. Returns `null` if the user cancelled
+     * (Esc / X / closed window), [EnvPrompt.Skip] if the user chose "Skip", or
+     * [EnvPrompt.Selected] wrapping the chosen [Environment].
+     *
+     * Uses [Messages.showEditableChooseDialog] (non-deprecated) which returns the
+     * selected value as a String (or null on cancel) rather than an index.
+     */
+    private suspend fun promptEnvironment(envService: EnvironmentService): EnvPrompt? {
+        val envs = envService.getEnvironments()
+        val skipLabel = "Skip (keep placeholders)"
+        val labels = listOf(skipLabel) + envs.map { it.name }
+        val selected = Messages.showEditableChooseDialog(
+            "Select environment for variable rendering:",
+            "cURL Export - Environment",
+            Messages.getQuestionIcon(),
+            labels.toTypedArray(),
+            labels.first(),
+            null,
+        ) ?: return null       // cancelled (Esc / X)
+        if (selected == skipLabel) return EnvPrompt.Skip
+        val env = envs.firstOrNull { it.name == selected } ?: return EnvPrompt.Skip
+        return EnvPrompt.Selected(env)
+    }
+
+    /**
+     * Resets cached batch decisions. Call between independent export runs.
+     * (IntelliJ constructs one service instance per project, so the cache persists
+     * across exports — callers should invoke this at the start of a fresh batch.)
+     */
+    fun resetBatchCache() {
+        applyAllEnv = null
+        applyAllSkip = false
+    }
+
+    /**
+     * User's decision when prompted to pick an environment.
+     *
+     * Mirrors [com.itangcent.easyapi.exporter.channel.yapi.UpdateDecision]:
+     * sealed type so the caller exhaustively handles cancel vs skip vs selected.
+     */
+    private sealed interface EnvPrompt {
+        /** User chose "Skip (keep placeholders)" — proceed with empty variable map. */
+        data object Skip : EnvPrompt
+        /** User selected a specific environment. */
+        data class Selected(val environment: Environment) : EnvPrompt
+    }
+
+    companion object {
+        /**
+         * Gets the resolver service instance for the given project.
+         * Following the [ApiDashboardService.getInstance] pattern.
+         */
+        fun getInstance(project: Project): CurlExportResolver = project.service()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlFormatOptions.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlFormatOptions.kt
@@ -1,0 +1,25 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+/**
+ * Formatting options for [CurlFormatter].
+ *
+ * All defaults preserve the pre-enhancement output byte-for-byte:
+ * - [includeComments] `true`  → matches current `formatAll` (emits `## name` + `---`)
+ * - [prettyPrintBody] `false` → current output is compact JSON
+ * - [multiLineFormat] `false` → current output is single-line
+ * - [longFlags] `false`       → current output uses `-X`/`-H`/`-d`/`-F`
+ * - [includeResponseExample] `false` → current output has no response comment
+ *
+ * @property includeComments Include `## API Name` comments and `---` section dividers in `formatAll`.
+ * @property prettyPrintBody Format JSON body payload with 2-space indentation.
+ * @property multiLineFormat Place each flag on its own line with `\` continuation.
+ * @property longFlags Use `--request`/`--header`/`--data`/`--form` instead of `-X`/`-H`/`-d`/`-F`.
+ * @property includeResponseExample Append `# Response: <json>` comment when `responseBody` is present.
+ */
+data class CurlFormatOptions(
+    val includeComments: Boolean = true,
+    val prettyPrintBody: Boolean = false,
+    val multiLineFormat: Boolean = false,
+    val longFlags: Boolean = false,
+    val includeResponseExample: Boolean = false,
+)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlFormatter.kt
@@ -1,53 +1,68 @@
 package com.itangcent.easyapi.exporter.channel.curl
 
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
 import com.itangcent.easyapi.exporter.model.HttpMetadata
-import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.ParameterBinding
 import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
 
 /**
  * Utility object for formatting API endpoints as cURL commands.
- * 
+ *
  * This formatter generates shell-compatible cURL commands with:
  * - Proper HTTP method specification
  * - Header inclusion
  * - Body content handling (JSON, form-urlencoded, multipart)
  * - Shell-safe escaping of special characters
+ *
+ * Output formatting is controlled by [CurlFormatOptions]. The default options
+ * ([CurlFormatOptions] with all defaults) produce byte-identical output to the
+ * pre-options formatter, ensuring backward compatibility.
  */
 object CurlFormatter {
 
     /**
      * Formats a single API endpoint as a cURL command (for HTTP) or grpcurl command (for gRPC).
-     * 
+     *
      * @param endpoint The API endpoint to format
      * @param host Optional host URL to prepend to the path
+     * @param options Formatting options (default produces backward-compatible output)
      * @return A cURL or grpcurl command string
      */
-    fun format(endpoint: ApiEndpoint, host: String = ""): String {
+    fun format(endpoint: ApiEndpoint, host: String = "", options: CurlFormatOptions = CurlFormatOptions()): String {
         return when (val meta = endpoint.metadata) {
-            is HttpMetadata -> formatHttp(endpoint, meta, host)
-            is GrpcMetadata -> formatGrpc(endpoint, meta, host)
+            is HttpMetadata -> formatHttp(endpoint, meta, host, options)
+            is GrpcMetadata -> formatGrpc(endpoint, meta, host, options)
         }
     }
 
     /**
      * Formats an HTTP endpoint as a cURL command.
      */
-    private fun formatHttp(endpoint: ApiEndpoint, meta: HttpMetadata, host: String): String {
+    private fun formatHttp(endpoint: ApiEndpoint, meta: HttpMetadata, host: String, options: CurlFormatOptions): String {
         val url = buildUrl(meta, host)
-        val headers = buildHeaders(meta)
-        val body = buildBody(meta)
+        val headers = buildHeaders(meta, options)
+        val body = buildBody(endpoint, meta, options)
         val method = meta.method.name
-        return listOf(
+        val parts = listOf(
             "curl",
-            "-X",
+            if (options.longFlags) "--request" else "-X",
             method,
             headers,
             body,
             "'${escapeShell(url)}'"
-        ).filter { it.isNotBlank() }.joinToString(" ")
+        ).filter { it.isNotBlank() }
+
+        val separator = if (options.multiLineFormat) " \\\n  " else " "
+        val cmd = parts.joinToString(separator)
+
+        if (options.includeResponseExample && meta.responseBody != null) {
+            val respJson = responseBodyJson(endpoint, meta, options)
+            return "$cmd\n# Response: $respJson"
+        }
+        return cmd
     }
 
     /**
@@ -55,27 +70,35 @@ object CurlFormatter {
      *
      * Generates: grpcurl -plaintext -d '{json}' 'host:port' 'package.Service/Method'
      */
-    private fun formatGrpc(endpoint: ApiEndpoint, meta: GrpcMetadata, host: String): String {
+    private fun formatGrpc(endpoint: ApiEndpoint, meta: GrpcMetadata, host: String, options: CurlFormatOptions): String {
         val target = if (host.isNotBlank()) host.removePrefix("http://").removePrefix("https://") else "localhost:50051"
         val servicePath = "${meta.packageName}.${meta.serviceName}/${meta.path.substringAfterLast('/')}"
         val parts = mutableListOf("grpcurl", "-plaintext")
         meta.body?.let { body ->
-            parts.add("-d '${escapeShell(ObjectModelJsonConverter.toJson(body))}'")
+            val json = ObjectModelJsonConverter.toJson(body)
+            val finalJson = if (options.prettyPrintBody) prettyJson(json) else json
+            parts.add("-d '${escapeShell(finalJson)}'")
         }
         parts.add("'${escapeShell(target)}'")
         parts.add("'${escapeShell(servicePath)}'")
-        return parts.joinToString(" ")
+
+        val separator = if (options.multiLineFormat) " \\\n  " else " "
+        return parts.joinToString(separator)
     }
 
     /**
      * Formats multiple API endpoints as a shell script with markdown-style sections.
      * Each endpoint is separated by a divider and includes its name as a comment.
-     * 
+     *
      * @param endpoints The list of API endpoints to format
      * @param host Optional host URL to prepend to paths
+     * @param options Formatting options (default produces backward-compatible output)
      * @return A shell script containing cURL commands for all endpoints
      */
-    fun formatAll(endpoints: List<ApiEndpoint>, host: String = ""): String {
+    fun formatAll(endpoints: List<ApiEndpoint>, host: String = "", options: CurlFormatOptions = CurlFormatOptions()): String {
+        if (!options.includeComments) {
+            return endpoints.joinToString("\n\n") { format(it, host, options) }
+        }
         return endpoints.joinToString("\n\n---\n\n") { endpoint ->
             val apiName = when (val meta = endpoint.metadata) {
                 is HttpMetadata -> endpoint.name ?: "${meta.method.name}:${meta.path}"
@@ -84,7 +107,7 @@ object CurlFormatter {
             buildString {
                 append("## $apiName\n")
                 append("```bash\n")
-                append(format(endpoint, host))
+                append(format(endpoint, host, options))
                 append("\n```")
             }
         }
@@ -93,24 +116,26 @@ object CurlFormatter {
     /**
      * Builds the headers section of a cURL command.
      * Includes both endpoint-defined headers and Content-Type.
-     * 
+     *
      * @param meta The HTTP metadata
-     * @return A string of -H flags with properly escaped values
+     * @param options Formatting options (controls `-H` vs `--header`)
+     * @return A string of header flags with properly escaped values
      */
-    private fun buildHeaders(meta: HttpMetadata): String {
+    private fun buildHeaders(meta: HttpMetadata, options: CurlFormatOptions): String {
+        val flag = if (options.longFlags) "--header" else "-H"
         val headerList = mutableListOf<String>()
         meta.headers.forEach { h ->
-            headerList.add("-H '${escapeShell(h.name)}: ${escapeShell(h.value ?: "")}'")
+            headerList.add("$flag '${escapeShell(h.name)}: ${escapeShell(h.value ?: "")}'")
         }
         meta.contentType?.takeIf { it.isNotBlank() }?.let { ct ->
-            headerList.add("-H 'Content-Type: ${escapeShell(ct)}'")
+            headerList.add("$flag 'Content-Type: ${escapeShell(ct)}'")
         }
         return headerList.joinToString(" ")
     }
 
     /**
      * Builds the complete URL with query parameters.
-     * 
+     *
      * @param meta The HTTP metadata
      * @param host The host URL to prepend
      * @return The complete URL with query string if applicable
@@ -125,48 +150,87 @@ object CurlFormatter {
     /**
      * Builds the body/data section of a cURL command.
      * Handles different content types: JSON, form-urlencoded, and multipart.
-     * 
+     *
+     * If the resolver stashed a resolved body JSON in [ApiEndpoint.extensions]
+     * (under [EndpointVariableResolver.RESOLVED_BODY_JSON_KEY]), that JSON is used
+     * as the body source (placeholders already resolved).
+     *
+     * @param endpoint The API endpoint (for accessing resolved body JSON in extensions)
      * @param meta The HTTP metadata
-     * @return A string of -d or -F flags, or empty string if no body
+     * @param options Formatting options (controls flags and pretty-printing)
+     * @return A string of -d/--data or -F/--form flags, or empty string if no body
      */
-    private fun buildBody(meta: HttpMetadata): String {
+    private fun buildBody(endpoint: ApiEndpoint, meta: HttpMetadata, options: CurlFormatOptions): String {
         val contentType = meta.contentType?.lowercase().orEmpty()
         val bodyParams = meta.parameters.filter { it.binding == ParameterBinding.Body }
         val formParams = meta.parameters.filter { it.binding == ParameterBinding.Form }
 
         if (contentType.contains("json")) {
+            val resolvedBodyJson = endpoint.extensions.exts[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] as? String
             val json = when {
+                resolvedBodyJson != null -> resolvedBodyJson
                 meta.body != null -> ObjectModelJsonConverter.toJson(meta.body)
                 bodyParams.isEmpty() -> "{}"
-                else -> bodyParams.joinToString(prefix = "{", postfix = "}") { 
-                    "\"${it.name}\": \"${escapeShell(it.example ?: it.defaultValue ?: "")}\"" 
+                else -> bodyParams.joinToString(prefix = "{", postfix = "}") {
+                    "\"${it.name}\": \"${escapeShell(it.example ?: it.defaultValue ?: "")}\""
                 }
             }
-            return "-d '${escapeShell(json)}'"
+            val finalJson = if (options.prettyPrintBody) prettyJson(json) else json
+            val flag = if (options.longFlags) "--data" else "-d"
+            return "$flag '${escapeShell(finalJson)}'"
         }
         if (contentType.contains("x-www-form-urlencoded")) {
-            return formParams.joinToString(" ") { 
-                "--data-urlencode '${escapeShell(it.name)}=${escapeShell(it.example ?: it.defaultValue ?: "")}'" 
+            return formParams.joinToString(" ") {
+                "--data-urlencode '${escapeShell(it.name)}=${escapeShell(it.example ?: it.defaultValue ?: "")}'"
             }
         }
         if (contentType.contains("multipart")) {
-            return formParams.joinToString(" ") { 
-                "-F '${escapeShell(it.name)}=${escapeShell(it.example ?: it.defaultValue ?: "")}'" 
+            val flag = if (options.longFlags) "--form" else "-F"
+            return formParams.joinToString(" ") {
+                "$flag '${escapeShell(it.name)}=${escapeShell(it.example ?: it.defaultValue ?: "")}'"
             }
         }
 
         if (meta.body != null) {
-            val bodyJson = ObjectModelJsonConverter.toJson(meta.body)
-            return "-d '${escapeShell(bodyJson)}'"
+            val resolvedBodyJson = endpoint.extensions.exts[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] as? String
+            val bodyJson = resolvedBodyJson ?: ObjectModelJsonConverter.toJson(meta.body)
+            val finalJson = if (options.prettyPrintBody) prettyJson(bodyJson) else bodyJson
+            val flag = if (options.longFlags) "--data" else "-d"
+            return "$flag '${escapeShell(finalJson)}'"
         }
 
         return ""
     }
 
     /**
+     * Computes the response body JSON for the `# Response:` comment.
+     *
+     * Uses the resolved body JSON from extensions if present (unlikely for response,
+     * but kept for consistency), otherwise serializes [HttpMetadata.responseBody].
+     * Pretty-prints if [CurlFormatOptions.prettyPrintBody] is set.
+     */
+    private fun responseBodyJson(endpoint: ApiEndpoint, meta: HttpMetadata, options: CurlFormatOptions): String {
+        val resolved = endpoint.extensions.exts[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] as? String
+        val compact = resolved ?: ObjectModelJsonConverter.toJson(meta.responseBody)
+        return if (options.prettyPrintBody) prettyJson(compact) else compact
+    }
+
+    /**
+     * Pretty-prints a compact JSON string. Falls back to the input on parse failure.
+     */
+    private fun prettyJson(compact: String): String {
+        return try {
+            val parsed = JsonParser.parseString(compact)
+            GsonBuilder().setPrettyPrinting().create().toJson(parsed)
+        } catch (t: Throwable) {
+            compact
+        }
+    }
+
+    /**
      * Escapes special characters for safe shell usage.
      * Replaces backslashes and single quotes with their escaped equivalents.
-     * 
+     *
      * @param value The string to escape
      * @return The shell-safe string
      */

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlOptionsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlOptionsPanel.kt
@@ -1,0 +1,100 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.FormBuilder
+import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
+import com.itangcent.easyapi.settings.settings
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JSeparator
+
+/**
+ * Per-export options panel for [CurlChannel].
+ *
+ * Mirrors the [com.itangcent.easyapi.exporter.channel.markdown.MarkdownOptionsPanel]
+ * layout: file-output fields at top + channel-specific fields below. The 5
+ * formatting checkboxes are seeded from [CurlSettings] in [onShown] so the
+ * panel reflects the user's saved defaults; the user's per-export overrides
+ * are what get applied.
+ */
+class CurlOptionsPanel(private val project: Project) : ChannelOptionsPanel {
+
+    private val outputDirField = TextFieldWithBrowseButton().apply {
+        text = project.basePath ?: ""
+        addBrowseFolderListener(
+            project,
+            FileChooserDescriptorFactory.createSingleFolderDescriptor()
+                .withTitle("Select Output Directory")
+                .withDescription("Choose the directory to export the cURL script to")
+        )
+    }
+
+    private val fileNameField = JBTextField().apply {
+        text = "curl_export"
+        columns = 30
+    }
+
+    private val includeCommentsCb = JBCheckBox("Include comments and section dividers").apply {
+        toolTipText = "Wrap each endpoint in a `## name\\n```bash\\n...\\n``` block separated by `---` (default: on)"
+    }
+    private val prettyPrintBodyCb = JBCheckBox("Pretty-print JSON body (2-space indent)").apply {
+        toolTipText = "Run JSON bodies through a pretty-printer (default: off, compact JSON)"
+    }
+    private val multiLineFormatCb = JBCheckBox("Multi-line format (one flag per line with \\ continuation)").apply {
+        toolTipText = "Join cURL parts with ` \\\\\\n  ` instead of a single space (default: off, single line)"
+    }
+    private val longFlagsCb = JBCheckBox("Use long flags (--header/--data/--request/--form)").apply {
+        toolTipText = "Prefer --request/--header/--data/--form over -X/-H/-d/-F (default: off, short flags)"
+    }
+    private val includeResponseExampleCb = JBCheckBox("Append response body example as comment").apply {
+        toolTipText = "Append a `# Response:` comment with the response body JSON (default: off). No-op for gRPC."
+    }
+    private val runPreScriptsCb = JBCheckBox("Run pre-request scripts (folder + API)").apply {
+        toolTipText = "When on, folder- and class-level pre-request scripts are run before generating each " +
+            "cURL command, so script-driven header injection / auth tokens / body rewriting are reflected " +
+            "in the output. Default: off (no script machinery invoked, byte-identical output)."
+    }
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addLabeledComponent("Output Directory:", outputDirField)
+        .addLabeledComponent("File Name (without extension):", fileNameField)
+        .addComponent(JSeparator())
+        .addComponent(includeCommentsCb)
+        .addComponent(prettyPrintBodyCb)
+        .addComponent(multiLineFormatCb)
+        .addComponent(longFlagsCb)
+        .addComponent(includeResponseExampleCb)
+        .addComponent(JSeparator())
+        .addComponent(runPreScriptsCb)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    override fun onShown() {
+        // Seed checkboxes from saved CurlSettings defaults so the panel reflects
+        // what the user configured in Settings → EasyApi → Curl.
+        val s = project.settings<CurlSettings>()
+        includeCommentsCb.isSelected = s.includeComments
+        prettyPrintBodyCb.isSelected = s.prettyPrintBody
+        multiLineFormatCb.isSelected = s.multiLineFormat
+        longFlagsCb.isSelected = s.longFlags
+        includeResponseExampleCb.isSelected = s.includeResponseExample
+        runPreScriptsCb.isSelected = s.runPreScripts
+    }
+
+    override fun buildConfig(): CurlConfig = CurlConfig(
+        outputDir = outputDirField.text.takeIf { it.isNotBlank() },
+        fileName = fileNameField.text.takeIf { it.isNotBlank() },
+        options = CurlFormatOptions(
+            includeComments = includeCommentsCb.isSelected,
+            prettyPrintBody = prettyPrintBodyCb.isSelected,
+            multiLineFormat = multiLineFormatCb.isSelected,
+            longFlags = longFlagsCb.isSelected,
+            includeResponseExample = includeResponseExampleCb.isSelected,
+        ),
+        runPreScripts = runPreScriptsCb.isSelected,
+    )
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlRenderMode.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlRenderMode.kt
@@ -1,0 +1,31 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+/**
+ * Controls whether/when environment variable rendering occurs during cURL export.
+ *
+ * Mirrors the [com.itangcent.easyapi.exporter.channel.yapi.YapiExportMode] pattern:
+ * each variant carries a human-readable [desc] used by settings UI and logs.
+ *
+ * - [NEVER_RENDER] — leave `{{var}}` / `${var}` placeholders untouched.
+ * - [ALWAYS_RENDER] — resolve placeholders using the active environment, falling back to `ConfigReader`.
+ * - [ALWAYS_ASK] — prompt the user to pick an environment (or skip) before each export.
+ *
+ * @param desc Description shown in the settings panel combo and log output.
+ */
+enum class CurlRenderMode(val desc: String) {
+    /** Leave `{{var}}` / `${var}` placeholders untouched. */
+    NEVER_RENDER("keep placeholders"),
+    /** Resolve placeholders using the active environment, falling back to `ConfigReader`. */
+    ALWAYS_RENDER("resolve with active environment"),
+    /** Prompt the user to pick an environment (or skip) before each export. */
+    ALWAYS_ASK("ask each export");
+
+    companion object {
+        /**
+         * Parses a stored [value] (a String from settings) into the enum.
+         * Returns [NEVER_RENDER] for null or unrecognized values (forward-compatible).
+         */
+        fun fromStored(value: String?): CurlRenderMode =
+            value?.let { runCatching { valueOf(it) }.getOrNull() } ?: NEVER_RENDER
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlScriptScopes.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlScriptScopes.kt
@@ -1,0 +1,73 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.core.threading.readSync
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.script.ScriptScope
+
+/**
+ * Shared script-scope resolution for the cURL path.
+ *
+ * Centralizes the folder→class→endpoint scope formation so [CurlChannel.export]
+ * (batch, folder+class only), [CurlExportResolver.formatForCopy] (single,
+ * folder+class+endpoint), and [com.itangcent.easyapi.rule.context.ScriptApiEndpoint.toCurl]
+ * (rule path) all derive scopes from one place. The dashboard's
+ * `ApiDashboardPanel.resolveScriptScopesForEndpoint` is the prior art — this helper
+ * replaces it (DRY).
+ *
+ * ## Threading
+ *
+ * [endpointKeyFor] reads `PsiClass.qualifiedName` via [readSync] (a synchronous read
+ * action — acquires the read lock, does NOT dispatch to EDT). Safe to call from
+ * background coroutines and rule-script threads. The EDT-free guarantee of
+ * [PreScriptApplier.applyScripts] is preserved because scope resolution happens in
+ * the caller, before [PreScriptApplier] is invoked.
+ */
+object CurlScriptScopes {
+
+    /**
+     * Resolves folder + class scopes for [endpoint] (outer → inner order, matching
+     * [com.itangcent.easyapi.dashboard.RequestExecutor.resolveScripts]).
+     *
+     * Used by the **batch export** path ([CurlChannel.export]) where per-endpoint
+     * inline scripts are not consulted.
+     */
+    fun resolveFolderAndClassScopes(endpoint: ApiEndpoint): List<ScriptScope> {
+        val scopes = mutableListOf<ScriptScope>()
+        endpoint.folder?.takeIf { it.isNotBlank() }?.let { scopes.add(ScriptScope.Module(it)) }
+        val qualifiedName = readSync { endpoint.sourceClass?.qualifiedName }
+            ?: endpoint.className
+        qualifiedName?.takeIf { it.isNotBlank() }?.let { scopes.add(ScriptScope.Class(it)) }
+        return scopes
+    }
+
+    /**
+     * Resolves folder + class + endpoint scopes for [endpoint] (outer → inner order).
+     *
+     * Used by the **single-endpoint** path ([CurlExportResolver.formatForCopy],
+     * where per-endpoint inline scripts ARE consulted
+     * (mirrors `RequestExecutor.resolveScripts` which appends `input.preRequestScript`).
+     *
+     * The endpoint scope key is formed via [endpointKeyFor], matching the dashboard's
+     * `EndpointDetailsPanel.computeCacheKey` so scripts saved by the dashboard UI
+     * are found.
+     */
+    fun resolveAllScopes(endpoint: ApiEndpoint): List<ScriptScope> {
+        val scopes = resolveFolderAndClassScopes(endpoint).toMutableList()
+        endpointKeyFor(endpoint).takeIf { it.isNotBlank() }?.let { scopes.add(ScriptScope.Endpoint(it)) }
+        return scopes
+    }
+
+    /**
+     * Forms the endpoint-scope key for [endpoint], matching the dashboard's
+     * `EndpointDetailsPanel.computeCacheKey`: `"${qualifiedClassName}#${methodName}"`.
+     *
+     * Returns `""` when [ApiEndpoint.sourceMethod] or its containing class is unavailable
+     * (e.g. synthetic endpoints) — the caller treats blank as "no endpoint scope".
+     */
+    fun endpointKeyFor(endpoint: ApiEndpoint): String {
+        val method = endpoint.sourceMethod ?: return ""
+        val cls = endpoint.sourceClass ?: method.containingClass ?: return ""
+        val className = readSync { cls.qualifiedName ?: cls.name ?: "" }
+        return "$className#${method.name}"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlSettings.kt
@@ -1,0 +1,68 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.settings.Scope
+import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.StorageScope
+
+/**
+ * cURL channel settings.
+ *
+ * All fields are APPLICATION scope, persisted via the unified
+ * [com.itangcent.easyapi.settings.state.UnifiedAppSettingsState].
+ *
+ * Mirrors the [com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchSettings]
+ * shape: a `data class` with `@StorageScope(Scope.APPLICATION)` on every field,
+ * read/written via [com.itangcent.easyapi.settings.SettingBinder] and
+ * `project.settings<CurlSettings>()`.
+ *
+ * @property renderMode Controls when `{{var}}`/`${var}` placeholders in the
+ *  endpoint are resolved against the active environment before formatting.
+ *  Stored as a string (enum name) for serialization stability; use
+ *  [renderModeEnum] for the typed value. Defaults to [CurlRenderMode.ALWAYS_ASK]
+ *  so the user is prompted to pick an environment on each export (most discoverable).
+ * @property copyFromEdited When true, the Dashboard "Copy as cURL" action uses the
+ *  endpoint with dashboard edits applied (path/headers/params/body from the UI
+ *  fields). When false (default), the original source-code endpoint is used.
+ * @property includeComments Default value for the corresponding [CurlFormatOptions] flag.
+ * @property prettyPrintBody Default value for the corresponding [CurlFormatOptions] flag.
+ * @property multiLineFormat Default value for the corresponding [CurlFormatOptions] flag.
+ * @property longFlags Default value for the corresponding [CurlFormatOptions] flag.
+ * @property includeResponseExample Default value for the corresponding [CurlFormatOptions] flag.
+ * @property runPreScripts When true, pre-request scripts (folder + API level) are run
+ *  during cURL conversion so script-driven header injection / auth tokens / body
+ *  rewriting are reflected in the generated command. Default `false`
+ *  (no script machinery invoked, byte-identical output).
+ */
+data class CurlSettings(
+    @StorageScope(Scope.APPLICATION) var renderMode: String = CurlRenderMode.ALWAYS_ASK.name,
+    @StorageScope(Scope.APPLICATION) var copyFromEdited: Boolean = false,
+    @StorageScope(Scope.APPLICATION) var includeComments: Boolean = true,
+    @StorageScope(Scope.APPLICATION) var prettyPrintBody: Boolean = true,
+    @StorageScope(Scope.APPLICATION) var multiLineFormat: Boolean = false,
+    @StorageScope(Scope.APPLICATION) var longFlags: Boolean = false,
+    @StorageScope(Scope.APPLICATION) var includeResponseExample: Boolean = false,
+    @StorageScope(Scope.APPLICATION) var runPreScripts: Boolean = false,
+) : Settings {
+
+    /** Convenience: parse [renderMode] into the enum safely. */
+    fun renderModeEnum(): CurlRenderMode = CurlRenderMode.fromStored(renderMode)
+
+    /**
+     * Maps the persistent formatting fields of this settings object to a
+     * [CurlFormatOptions] instance. Centralizes the settings→options mapping so
+     * every "copy as cURL" / single-endpoint render site (Dashboard, future
+     * callers) derives options from one place — add a format flag here and it
+     * flows everywhere automatically.
+     *
+     * Note: [renderMode] and [copyFromEdited] are *not* format options and are
+     * intentionally excluded (they are consumed by [CurlExportResolver] and the
+     * Copy action respectively).
+     */
+    fun toFormatOptions(): CurlFormatOptions = CurlFormatOptions(
+        includeComments = includeComments,
+        prettyPrintBody = prettyPrintBody,
+        multiLineFormat = multiLineFormat,
+        longFlags = longFlags,
+        includeResponseExample = includeResponseExample,
+    )
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlSettingsPanel.kt
@@ -1,0 +1,145 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.util.ui.FormBuilder
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.settings
+import com.itangcent.easyapi.settings.update
+import com.itangcent.easyapi.settings.ui.SettingsPanel
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JSeparator
+
+/**
+ * Settings panel for the cURL channel.
+ *
+ * Fields are read from / written to the unified
+ * [com.itangcent.easyapi.settings.state.UnifiedAppSettingsState] via
+ * [SettingBinder] — never touching state components directly. Mirrors
+ * [com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchSettingsPanel]
+ * (typed as `SettingsPanel<Settings>` so the configurable's
+ * `ChannelPanelEntry.panel` cast works).
+ *
+ * The combo box items and ordering are derived from [CurlRenderMode] values +
+ * their [CurlRenderMode.desc] (the YapiExportMode.desc pattern), so the enum is
+ * the single source of truth for both the settings UI and stored value.
+ *
+ * Field semantics:
+ *  - Variable resolution: when to resolve `{{var}}`/`${var}` placeholders against
+ *    the active environment before formatting. See [CurlRenderMode.desc] for the
+ *    per-option description shown in the combo.
+ *  - Copy from edited endpoint: when on, the Dashboard "Copy as cURL" action
+ *    uses the endpoint with dashboard UI edits applied (path, headers, params,
+ *    body). When off, the original source-code endpoint is used.
+ *  - 5 formatting flags: defaults for the [CurlFormatOptions] used at export
+ *    time. The export dialog's options panel can override per-export.
+ */
+class CurlSettingsPanel(private val project: Project) : SettingsPanel<Settings> {
+
+    /**
+     * Combo entries — `[CurlRenderMode.desc]` strings in enum-declaration order.
+     * Index ↔ enum mapping: 0=NEVER_RENDER, 1=ALWAYS_RENDER, 2=ALWAYS_ASK.
+     */
+    private val modeEntries: List<CurlRenderMode> = CurlRenderMode.entries
+
+    private val renderModeCombo = ComboBox(modeEntries.map { it.desc }.toTypedArray()).apply {
+        toolTipText = buildString {
+            append("Controls when {{var}}/\${var} placeholders are resolved against the active environment. ")
+            modeEntries.forEach { mode ->
+                append("\"${mode.desc}\" — ")
+                append(when (mode) {
+                    CurlRenderMode.NEVER_RENDER -> "leave placeholders in the output. "
+                    CurlRenderMode.ALWAYS_RENDER -> "resolve using the active environment without prompting. "
+                    CurlRenderMode.ALWAYS_ASK -> "prompt to pick an environment at export time (default). "
+                })
+            }
+        }
+    }
+
+    private val copyFromEditedCb = JBCheckBox("Copy as cURL uses dashboard-edited endpoint").apply {
+        toolTipText = "When on, the Dashboard right-click \"Copy as cURL\" action uses the endpoint with " +
+            "dashboard edits applied (path, headers, params, body from the UI fields). " +
+            "When off (default), the original source-code endpoint is used."
+    }
+
+    private val includeCommentsCb = JBCheckBox("Include comments and section dividers").apply {
+        toolTipText = "Wrap each endpoint in a `## name\\n```bash\\n...\\n``` block separated by `---` (default: on)"
+    }
+    private val prettyPrintBodyCb = JBCheckBox("Pretty-print JSON body (2-space indent)").apply {
+        toolTipText = "Run JSON bodies through a pretty-printer (default: on, 2-space indent)"
+    }
+    private val multiLineFormatCb = JBCheckBox("Multi-line format (one flag per line with \\ continuation)").apply {
+        toolTipText = "Join cURL parts with ` \\\\\\n  ` instead of a single space (default: off, single line)"
+    }
+    private val longFlagsCb = JBCheckBox("Use long flags (--header/--data/--request/--form)").apply {
+        toolTipText = "Prefer --request/--header/--data/--form over -X/-H/-d/-F (default: off, short flags)"
+    }
+    private val includeResponseExampleCb = JBCheckBox("Append response body example as comment").apply {
+        toolTipText = "Append a `# Response:` comment with the response body JSON (default: off). No-op for gRPC."
+    }
+    private val runPreScriptsCb = JBCheckBox("Run pre-request scripts (folder + API)").apply {
+        toolTipText = "When on, folder- and class-level pre-request scripts are run before generating each " +
+            "cURL command (export + Copy-as-cURL), so script-driven header injection / auth tokens / body " +
+            "rewriting are reflected in the output. Default: off (no script machinery invoked, " +
+            "byte-identical output). The export dialog can override per-export."
+    }
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addLabeledComponent("Variable resolution:", renderModeCombo)
+        .addComponent(copyFromEditedCb)
+        .addComponent(JSeparator())
+        .addComponent(includeCommentsCb)
+        .addComponent(prettyPrintBodyCb)
+        .addComponent(multiLineFormatCb)
+        .addComponent(longFlagsCb)
+        .addComponent(includeResponseExampleCb)
+        .addComponent(JSeparator())
+        .addComponent(runPreScriptsCb)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    override fun resetFrom(settings: Settings?) {
+        val s = project.settings<CurlSettings>()
+        renderModeCombo.selectedIndex = modeToIndex(s.renderModeEnum())
+        copyFromEditedCb.isSelected = s.copyFromEdited
+        includeCommentsCb.isSelected = s.includeComments
+        prettyPrintBodyCb.isSelected = s.prettyPrintBody
+        multiLineFormatCb.isSelected = s.multiLineFormat
+        longFlagsCb.isSelected = s.longFlags
+        includeResponseExampleCb.isSelected = s.includeResponseExample
+        runPreScriptsCb.isSelected = s.runPreScripts
+    }
+
+    override fun applyTo(settings: Settings) {
+        SettingBinder.getInstance(project).update(CurlSettings::class) {
+            renderMode = indexToMode(renderModeCombo.selectedIndex).name
+            copyFromEdited = copyFromEditedCb.isSelected
+            includeComments = includeCommentsCb.isSelected
+            prettyPrintBody = prettyPrintBodyCb.isSelected
+            multiLineFormat = multiLineFormatCb.isSelected
+            longFlags = longFlagsCb.isSelected
+            includeResponseExample = includeResponseExampleCb.isSelected
+            runPreScripts = runPreScriptsCb.isSelected
+        }
+    }
+
+    override fun isModified(settings: Settings?): Boolean {
+        val s = project.settings<CurlSettings>()
+        if (renderModeCombo.selectedIndex != modeToIndex(s.renderModeEnum())) return true
+        if (copyFromEditedCb.isSelected != s.copyFromEdited) return true
+        if (includeCommentsCb.isSelected != s.includeComments) return true
+        if (prettyPrintBodyCb.isSelected != s.prettyPrintBody) return true
+        if (multiLineFormatCb.isSelected != s.multiLineFormat) return true
+        if (longFlagsCb.isSelected != s.longFlags) return true
+        if (includeResponseExampleCb.isSelected != s.includeResponseExample) return true
+        if (runPreScriptsCb.isSelected != s.runPreScripts) return true
+        return false
+    }
+
+    private fun modeToIndex(mode: CurlRenderMode): Int = modeEntries.indexOf(mode).coerceAtLeast(0)
+
+    private fun indexToMode(index: Int): CurlRenderMode = modeEntries.getOrNull(index) ?: CurlRenderMode.NEVER_RENDER
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/EndpointVariableResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/EndpointVariableResolver.kt
@@ -1,0 +1,185 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.config.DOUBLE_BRACE_PATTERN
+import com.itangcent.easyapi.config.DOLLAR_BRACE_PATTERN
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.GrpcMetadata
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.MutableExtension
+import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+
+/**
+ * Result of resolving `{{var}}` / `${var}` placeholders in an [ApiEndpoint] + host string.
+ *
+ * @property endpoint Deep copy with resolved string fields; the original is untouched.
+ * @property host Resolved host string.
+ * @property resolved Variable names that were successfully resolved (from either source).
+ * @property missing Variable names that no source could resolve (placeholders left as-is).
+ */
+data class ResolutionResult(
+    val endpoint: ApiEndpoint,
+    val host: String,
+    val resolved: Set<String>,
+    val missing: Set<String>,
+)
+
+/**
+ * Pure placeholder resolver for [ApiEndpoint] + host strings.
+ *
+ * No `Project` / `EnvironmentService` / `ConfigReader` dependency — the caller assembles
+ * [variables] and [fallback] (unit-testable with plain JUnit, no IntelliJ fixture).
+ *
+ * Reuses the existing [DOUBLE_BRACE_PATTERN] / [DOLLAR_BRACE_PATTERN] regexes from
+ * `com.itangcent.easyapi.config` (the same patterns [com.itangcent.easyapi.dashboard.RequestExecutor]
+ * uses for variable resolution).
+ *
+ * ## Body JSON handling
+ *
+ * `ObjectModel` bodies ([HttpMetadata.body], [GrpcMetadata.body]) are resolved by serializing
+ * to JSON, resolving placeholders in the JSON string, and stashing the result in
+ * [ApiEndpoint.extensions] under [RESOLVED_BODY_JSON_KEY]. The downstream formatter reads
+ * this key first; if absent, it serializes the (unresolved) body itself. This keeps the
+ * resolver pure (no formatter dependency) and the formatter pure (no resolution logic).
+ */
+object EndpointVariableResolver {
+
+    /** Extension key carrying the resolved body JSON, if the resolver produced one. */
+    const val RESOLVED_BODY_JSON_KEY = "curl.resolvedBodyJson"
+
+    /**
+     * Resolves `{{var}}` and `${var}` placeholders in [endpoint] and [host].
+     *
+     * For each placeholder: look up [variables] first, then [fallback]. If neither resolves,
+     * the placeholder is left as-is and the variable name is added to `missing`.
+     *
+     * The input [endpoint] is NOT mutated; a deep copy is returned.
+     */
+    fun resolve(
+        endpoint: ApiEndpoint,
+        host: String,
+        variables: Map<String, String>,
+        fallback: (String) -> String?,
+    ): ResolutionResult {
+        val resolved = mutableSetOf<String>()
+        val missing = mutableSetOf<String>()
+
+        fun resolveStr(s: String?): String? {
+            if (s == null) return null
+            if (!s.contains("{{") && !s.contains("\${")) return s
+            return replacePlaceholders(s, variables, fallback, resolved, missing)
+        }
+
+        val resolvedHost = resolveStr(host) ?: host
+        val resolvedEndpoint = when (val meta = endpoint.metadata) {
+            is HttpMetadata -> {
+                val resolvedBodyJson = meta.body?.let {
+                    val compact = ObjectModelJsonConverter.toJson(it)
+                    resolveStr(compact)
+                }
+                endpoint.copy(
+                    metadata = meta.copy(
+                        path = resolveStr(meta.path) ?: meta.path,
+                        headers = meta.headers.map { h ->
+                            h.copy(
+                                name = resolveStr(h.name) ?: h.name,
+                                value = resolveStr(h.value),
+                                example = resolveStr(h.example),
+                            )
+                        }.toMutableList(),
+                        parameters = meta.parameters.map { p ->
+                            p.copy(
+                                name = resolveStr(p.name) ?: p.name,
+                                defaultValue = resolveStr(p.defaultValue),
+                                example = resolveStr(p.example),
+                            )
+                        }.toMutableList(),
+                        contentType = resolveStr(meta.contentType),
+                    ),
+                    extensions = withNewExtension(endpoint, resolvedBodyJson),
+                )
+            }
+            is GrpcMetadata -> {
+                val resolvedBodyJson = meta.body?.let {
+                    val compact = ObjectModelJsonConverter.toJson(it)
+                    resolveStr(compact)
+                }
+                endpoint.copy(
+                    metadata = meta.copy(
+                        path = resolveStr(meta.path) ?: meta.path,
+                        serviceName = resolveStr(meta.serviceName) ?: meta.serviceName,
+                        methodName = resolveStr(meta.methodName) ?: meta.methodName,
+                        packageName = resolveStr(meta.packageName) ?: meta.packageName,
+                        protoFile = resolveStr(meta.protoFile),
+                    ),
+                    extensions = withNewExtension(endpoint, resolvedBodyJson),
+                )
+            }
+            else -> endpoint
+        }
+        return ResolutionResult(resolvedEndpoint, resolvedHost, resolved.toSet(), missing.toSet())
+    }
+
+    /**
+     * Resolves placeholders in a single string. Exposed for callers that need to resolve
+     * a standalone string (e.g. the host) without building a full [ApiEndpoint].
+     */
+    fun resolveString(
+        s: String,
+        variables: Map<String, String>,
+        fallback: (String) -> String?,
+    ): String {
+        if (!s.contains("{{") && !s.contains("\${")) return s
+        val resolved = mutableSetOf<String>()
+        val missing = mutableSetOf<String>()
+        return replacePlaceholders(s, variables, fallback, resolved, missing)
+    }
+
+    private fun replacePlaceholders(
+        input: String,
+        variables: Map<String, String>,
+        fallback: (String) -> String?,
+        resolved: MutableSet<String>,
+        missing: MutableSet<String>,
+    ): String {
+        var result = DOLLAR_BRACE_PATTERN.replace(input) { match ->
+            val key = match.groupValues[1].trim()
+            resolveOne(key, variables, fallback, resolved, missing) ?: match.value
+        }
+        result = DOUBLE_BRACE_PATTERN.replace(result) { match ->
+            val key = match.groupValues[1].trim()
+            resolveOne(key, variables, fallback, resolved, missing) ?: match.value
+        }
+        return result
+    }
+
+    private fun resolveOne(
+        key: String,
+        variables: Map<String, String>,
+        fallback: (String) -> String?,
+        resolved: MutableSet<String>,
+        missing: MutableSet<String>,
+    ): String? {
+        val fromEnv = variables[key]
+        if (fromEnv != null) {
+            resolved += key
+            return fromEnv
+        }
+        val fromFallback = fallback(key)
+        if (fromFallback != null) {
+            resolved += key
+            return fromFallback
+        }
+        missing += key
+        return null
+    }
+
+    /** Builds a fresh [MutableExtension] copying [endpoint]'s existing entries + the resolved body JSON (if any). */
+    private fun withNewExtension(endpoint: ApiEndpoint, resolvedBodyJson: String?): MutableExtension {
+        val mutable = MutableExtension()
+        mutable.putAll(endpoint.extensions.exts)
+        if (resolvedBodyJson != null) {
+            mutable[RESOLVED_BODY_JSON_KEY] = resolvedBodyJson
+        }
+        return mutable
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/PreScriptApplier.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/curl/PreScriptApplier.kt
@@ -1,0 +1,232 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.MutableExtension
+import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+import com.itangcent.easyapi.script.ScriptCacheService
+import com.itangcent.easyapi.script.ScriptScope
+import com.itangcent.easyapi.script.env.EnvironmentService
+import com.itangcent.easyapi.script.pm.LivePmVariableScope
+import com.itangcent.easyapi.script.pm.PmInfo
+import com.itangcent.easyapi.script.pm.PmObject
+import com.itangcent.easyapi.script.pm.PmRequest
+import com.itangcent.easyapi.script.pm.PmRequestBody
+import com.itangcent.easyapi.script.pm.PmScriptExecutor
+import com.itangcent.easyapi.script.pm.PmTestCollector
+import com.itangcent.easyapi.script.pm.PmVariableScope
+
+/**
+ * Project-scoped service that applies pre-request scripts to an [ApiEndpoint]
+ * producing a deep copy with script-driven url/method/headers/body
+ * written back. The original endpoint is never mutated.
+ *
+ * Mirrors [com.itangcent.easyapi.dashboard.RequestExecutor.executeWithScripts]
+ * (PmRequest build → script run → write-back), but writes to an endpoint deep copy
+ * instead of an `HttpRequest`, and never sends the request (`httpClient = null`).
+ *
+ * ## Threading
+ *
+ * **EDT-free guarantee:** [applyScripts] SHALL NOT do `swing { }` / EDT hops — it reads
+ * [ScriptCacheService] (sync) + runs Groovy via [PmScriptExecutor] (background-safe).
+ * This guarantees [CurlBuilder.buildSync]'s `runBlocking` is deadlock-free when called
+ * from rule-script threads (EDT-free constraint).
+ *
+ * ## Error handling
+ *
+ * If a script throws, [applyScripts] logs `console.warn` + `LOG.warn` and returns an
+ * un-mutated deep copy. Per AGENTS.md this is a per-item recoverable
+ * failure → no Notification. The cURL path uses `console.warn` (NOT `console.error`);
+ * `RequestExecutor.executeWithScripts` uses `console.error` but that is pre-existing
+ * and out of scope to change.
+ *
+ * ## Known limitations
+ *
+ * - **HTTP-only:** gRPC endpoints return a deep copy unchanged (no `PmRequest` analog).
+ * - **Host rewrite dropped:** if a script changes the host portion of `pm.request.url`,
+ *   that change is currently dropped on write-back (only the path is stored). Scripts
+ *   that rewrite the host are rare; full host rewrite support would require carrying
+ *   the host separately.
+ */
+@Service(Service.Level.PROJECT)
+class PreScriptApplier(
+    private val project: Project,
+) : IdeaLog {
+
+    /**
+     * Resolves + runs the folder/API/endpoint pre-request scripts for [scopes] (in
+     * outer→inner order, matching [com.itangcent.easyapi.dashboard.RequestExecutor.resolveScripts]),
+     * then writes the script's resulting url/method/headers/body onto a DEEP COPY of
+     * [endpoint]. The original [endpoint] is never mutated.
+     *
+     * Best-effort: if a script throws, logs `console.warn` with the scope and returns
+     * the un-mutated deep copy for this endpoint.
+     *
+     * @param host the host to seed the PmRequest URL with (already resolved by caller).
+     * @param scopes script scopes to resolve (folder → class → endpoint, outer→inner).
+     * @return a deep copy of [endpoint] with script effects applied; or an un-mutated
+     *         deep copy if no script ran, the endpoint is gRPC, or the script failed.
+     */
+    suspend fun applyScripts(endpoint: ApiEndpoint, host: String, scopes: List<ScriptScope>): ApiEndpoint {
+        // Short-circuit: no scopes → nothing to run. Still return a deep copy so callers
+        // can rely on the "original is never touched, never returned" contract.
+        if (scopes.isEmpty()) return endpoint.deepCopy()
+
+        val scriptCache = ScriptCacheService.getInstance(project)
+        val resolved = scriptCache.resolveScripts(scopes)
+        val preScript = resolved.preRequestScript
+        if (preScript.isNullOrBlank()) return endpoint.deepCopy()  // nothing to run
+
+        // HTTP-only: gRPC endpoints have no PmRequest analog.
+        val http = endpoint.metadata as? HttpMetadata
+            ?: return endpoint.deepCopy()
+
+        // 1. Build PmRequest from endpoint (mirrors RequestExecutor ~line 184)
+        val pmRequest = buildPmRequest(http, endpoint, host)
+
+        // 2. Run pre-request script (best-effort, mirrors executeWithScripts ~line 249)
+        val pm = buildPmObject(pmRequest, endpoint)
+        try {
+            PmScriptExecutor.getInstance(project).executePreRequestScript(preScript, pm)
+        } catch (e: Exception) {
+            val scopeDesc = scopes.joinToString(" → ") { it.displayLabel() }
+            LOG.warn("curl: pre-script error in [$scopeDesc] for '${endpoint.name}': ${e.message}", e)
+            IdeaConsoleProvider.getInstance(project).getConsole()
+                .warn("curl: pre-script failed for '${endpoint.name}': ${e.message}")
+            return endpoint.deepCopy()  // script failed → return un-mutated copy
+        }
+
+        // 3. Write script effects onto a deep copy
+        return writeScriptEffects(endpoint, pmRequest, http, host)
+    }
+
+    /**
+     * Builds a [PmRequest] from the endpoint's [HttpMetadata].
+     *
+     * - URL = `host + path` (so `pm.request.url` is meaningful to scripts; on write-back
+     *   the host is stripped — see [writeScriptEffects]).
+     * - Body = JSON-serialized `http.body` via [ObjectModelJsonConverter.toJson] (same
+     *   source as [EndpointVariableResolver] uses for the resolved-body extension).
+     * - Headers copied 1:1 from `http.headers`.
+     */
+    private fun buildPmRequest(http: HttpMetadata, endpoint: ApiEndpoint, host: String): PmRequest {
+        val url = if (host.isBlank()) http.path else "$host${http.path}"
+        val body = http.body?.let { ObjectModelJsonConverter.toJson(it) }
+        val req = PmRequest(url = url, method = http.method.name, body = PmRequestBody(raw = body))
+        http.headers.forEach { req.headers.add(it.name, it.value ?: "") }
+        return req
+    }
+
+    /**
+     * Builds a [PmObject.forPreRequest] context for the script run.
+     *
+     * - `httpClient = null` — cURL conversion never sends a request.
+     * - `environment = LivePmVariableScope(EnvironmentService)` so scripts can read/write
+     *   env vars the same way they do in [RequestExecutor].
+     * - `globals`/`collectionVariables` are empty scopes (no collection concept in cURL path).
+     */
+    private fun buildPmObject(pmRequest: PmRequest, endpoint: ApiEndpoint): PmObject {
+        val envVars = LivePmVariableScope(EnvironmentService.getInstance(project))
+        val info = PmInfo(eventName = "prerequest", requestName = endpoint.name ?: "", requestId = "")
+        return PmObject.forPreRequest(
+            request = pmRequest,
+            environment = envVars,
+            globals = PmVariableScope(),
+            collectionVariables = PmVariableScope(),
+            testCollector = PmTestCollector(),
+            info = info,
+            httpClient = null,
+        )
+    }
+
+    /**
+     * Writes the script's resulting url/method/headers/body onto a DEEP COPY of [endpoint].
+     * The original [endpoint] is never touched.
+     *
+     * - **path:** `pmRequest.url` with the host prefix stripped (the formatter re-prepends host).
+     *   If the URL is blank, fall back to the original path.
+     * - **method:** mapped back to [HttpMethod] (case-insensitive); blank falls back to original.
+     * - **headers:** replaced wholesale if the script produced any (matches `RequestExecutor`
+     *   line 268: `modifiedHeaders.ifEmpty { originalHeaders }` — but here we keep original
+     *   on empty so the deep copy stays self-consistent).
+     * - **body:** stashed via [EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] extension
+     *   (reuses the existing carrier; [CurlFormatter.buildBody] already checks this key first).
+     */
+    private fun writeScriptEffects(
+        endpoint: ApiEndpoint,
+        pmRequest: PmRequest,
+        originalHttp: HttpMetadata,
+        host: String,
+    ): ApiEndpoint {
+        val copy = endpoint.deepCopy()
+        val copyHttp = copy.metadata as? HttpMetadata ?: return copy
+
+        // path (strip host prefix; blank → fall back to original)
+        val modifiedUrl = pmRequest.url.ifBlank { host + originalHttp.path }
+        copyHttp.path = stripHost(modifiedUrl, host, originalHttp.path)
+
+        // method
+        pmRequest.method.takeIf { it.isNotBlank() }?.let { m ->
+            HttpMethod.values().find { it.name.equals(m, ignoreCase = true) }?.let { copyHttp.method = it }
+        }
+
+        // headers (replace only if script produced any)
+        val scriptedHeaders = pmRequest.headers.toPairs()
+        if (scriptedHeaders.isNotEmpty()) {
+            copyHttp.headers.clear()
+            scriptedHeaders.forEach { (k, v) -> copyHttp.headers.add(ApiHeader(k, v)) }
+        }
+
+        // body via RESOLVED_BODY_JSON_KEY extension (reuses the existing carrier).
+        // deepCopy() installed a fresh MutableExtension, so the cast is always safe.
+        pmRequest.body.raw?.takeIf { it.isNotBlank() }?.let { bodyRaw ->
+            (copy.extensions as MutableExtension)[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] = bodyRaw
+        }
+        return copy
+    }
+
+    /**
+     * Strips the [host] prefix from [url], returning the path-only portion.
+     *
+     * - If [url] starts with [host], returns the suffix (with leading `/` preserved).
+     * - If [url] does not start with [host] (script rewrote host), returns [fallback]
+     *   — host rewrite is a known dropped effect (KDoc above).
+     * - If [host] is blank, returns [url] as-is (no host to strip).
+     */
+    private fun stripHost(url: String, host: String, fallback: String): String {
+        if (host.isBlank()) return url
+        if (!url.startsWith(host)) return fallback  // host rewritten → drop (known limitation)
+        return url.substring(host.length).ifBlank { fallback }
+    }
+
+    /**
+     * Deep-copies an [ApiEndpoint] so script mutations never touch the original.
+     *
+     * - [HttpMetadata] is copied with new mutable `headers`/`parameters` lists (each
+     *   element copied so header/parameter instances are not shared).
+     * - [ApiEndpoint.extensions] is replaced with a fresh [MutableExtension] carrying
+     *   copies of the original's entries, so writes via
+     *   `(extensions as MutableExtension)[key] = value` land on the copy, not the original.
+     */
+    private fun ApiEndpoint.deepCopy(): ApiEndpoint {
+        val copiedMeta = (this.metadata as? HttpMetadata)?.let { http ->
+            http.copy(
+                headers = http.headers.map { it.copy() }.toMutableList(),
+                parameters = http.parameters.map { it.copy() }.toMutableList(),
+            )
+        } ?: this.metadata
+        val copiedExt: MutableExtension = MutableExtension().also { it.putAll(this.extensions.exts) }
+        return this.copy(metadata = copiedMeta, extensions = copiedExt)
+    }
+
+    companion object {
+        fun getInstance(project: Project): PreScriptApplier = project.service()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/MarkdownChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/MarkdownChannel.kt
@@ -22,6 +22,7 @@ import com.itangcent.easyapi.exporter.channel.Channel
 import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
 import com.itangcent.easyapi.exporter.channel.markdown.MarkdownExportMetadata
+import com.itangcent.easyapi.exporter.channel.curl.CurlSettings
 import com.itangcent.easyapi.exporter.channel.markdown.template.BundledLanguageTemplates
 import com.itangcent.easyapi.exporter.channel.markdown.template.DefaultMarkdownTemplate
 import com.itangcent.easyapi.exporter.channel.markdown.template.FetchResult
@@ -36,6 +37,7 @@ import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportResult
 import com.itangcent.easyapi.ide.support.NotificationUtils
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.settings
 import kotlinx.coroutines.CancellationException
 import java.awt.BorderLayout
 import java.awt.CardLayout
@@ -123,7 +125,19 @@ class MarkdownChannel : Channel, IdeaLog {
 
         LOG.info("Markdown template resolved from tier: ${resolved.source}")
 
-        val model = TemplateModelBuilder.build(context.endpointsToExport, "API Documentation")
+        // Host + format options for `{{{api.http.curl()}}}`:
+        //  - `markdown.curl.host` config key (blank → `CurlBuilder.DEFAULT_HOST` placeholder).
+        //  - Format flags from the cURL settings tab (`CurlSettings.toFormatOptions()`),
+        //    so the user's cURL formatting preferences flow into Markdown-generated curls.
+        //    Markdown render path pins `runPreScripts = false`.
+        val curlHost = configReader.getFirst("markdown.curl.host").orEmpty()
+        val curlFormatOptions = project.settings<CurlSettings>().toFormatOptions()
+        val model = TemplateModelBuilder.build(
+            context.endpointsToExport,
+            "API Documentation",
+            host = curlHost,
+            formatOptions = curlFormatOptions,
+        )
         val ctx = RenderContext.production(projectName = project.name ?: "", pluginVersion = "")
         val content = MarkdownTemplateRenderer.renderWithFallback(resolved.templateText, model, ctx)
         return ExportResult.Success(

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/BundledLanguageTemplates.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/BundledLanguageTemplates.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Registry of bundled locale→classpath-resource Markdown templates .
  *
- * The Default Template (English, byte-identical per Req 2) is **not** in this registry —
+ * The Default Template (English, byte-identical) is **not** in this registry —
  * it is handled by [DefaultMarkdownTemplate] and serves as the floor of the precedence
  * chain. `en` therefore appears in [availableLocales] but [templateFor]("en") returns `null`
  * so the resolver falls through to the default tier .

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngine.kt
@@ -456,10 +456,12 @@ object TemplateEngine : IdeaLog {
         }
 
         /**
-         * Dispatches a method call `target.name(args)` (review finding F7).
+         * Dispatches a method call `target.name(args)`.
          *
          * - `BodyView` receiver: `asDemo`/`asJson` → `BodyView.asDemo()` (alias); `asJson5` → `asJson5()`;
          *   unknown name → null + `info` log.
+         * - `HttpView` receiver: `curl` → `HttpView.curl()` (may return null when the
+         *   provider yields null — backward-compat); unknown name → null + `info` log.
          * - Any other receiver type → null + `info` log "Unknown method '<name>' on <receiverType>".
          */
         private fun invokeMethod(target: Any, name: String, args: List<Any?>): Any? {
@@ -469,6 +471,13 @@ object TemplateEngine : IdeaLog {
                     "asJson5" -> target.asJson5()
                     else -> {
                         LOG.info("Unknown method '$name' on BodyView")
+                        null
+                    }
+                }
+                is HttpView -> when (name) {
+                    "curl" -> target.curl()
+                    else -> {
+                        LOG.info("Unknown method '$name' on HttpView")
                         null
                     }
                 }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModel.kt
@@ -62,7 +62,28 @@ data class HttpView(
      * to other templates.
      */
     val hasRequestContent: Boolean,
-)
+    /**
+     * Lazy cURL provider. Default `{ null }` so templates that never call
+     * `curl()` pay no formatting cost, and so direct construction without this field
+     * (existing tests / parity fixtures) renders byte-identically.
+     *
+     * Computed by [TemplateModelBuilder.toHttpView] from the endpoint + injected host +
+     * format options. Markdown renders with `runPreScripts = false`,
+     * so the provider invokes the pure [com.itangcent.easyapi.exporter.channel.curl.CurlBuilder.format]
+     * — no `Project`, no suspend, no scripts.
+     */
+    val curlProvider: () -> String? = { null },
+) {
+    /**
+     * Template-callable no-arg method: `{{{api.http.curl()}}}`.
+     *
+     * Returns the cURL command string, or `null` if the provider yields null (e.g.
+     * construction without a provider — backward-compat). The template engine
+     * stringifies `null` as `""`, so existing templates that don't reference
+     * `curl()` are unaffected.
+     */
+    fun curl(): String? = curlProvider()
+}
 
 /** gRPC-specific view of an endpoint. */
 data class GrpcView(
@@ -115,23 +136,23 @@ data class Header(
  *
  * The three method-call targets — [asDemo], [asJson], [asJson5] — are evaluated
  * lazily at render time (NOT pre-computed in the builder). `asJson` is sugar for
- * `asDemo` (D5 — byte-identical output). All three return strings **without** a
+ * `asDemo` (byte-identical output). All three return strings **without** a
  * markdown code fence; the template owns the fence.
  *
- * **Breaking change (D4):** replaces the legacy `BodyView(rows, demo)` shape.
+ * **Breaking change:** replaces the legacy `BodyView(rows, demo)` shape.
  * Migration: `body.rows` → `{{#each body.fields as f}}…{{/each}}` with `{{{f.indent}}}{{f.name}}`;
  * `body.demo` → `{{{body.asDemo()}}}` (or `asJson5()` for JSON5).
  */
 data class BodyView(
-    /** The structured body. FR-1. */
+    /** The structured body. */
     val model: ObjectModel,
-    /** Cycle-safe, pre-flattened, with depth+indent. FR-3/FR-4. */
+    /** Cycle-safe, pre-flattened, with depth+indent. */
     val fields: List<FieldView>,
 ) {
     /** Plain JSON, no fence. Always non-empty when called on a non-null BodyView. */
     fun asDemo(): String = ObjectModelJsonConverter.toJson(model)
 
-    /** Byte-identical to [asDemo] (D5 — asDemo is sugar for asJson). */
+    /** Byte-identical to [asDemo] (asDemo is sugar for asJson). */
     fun asJson(): String = asDemo()
 
     /** JSON5 with comments, no fence. */

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilder.kt
@@ -1,9 +1,13 @@
 package com.itangcent.easyapi.exporter.channel.markdown.template
 
+import com.itangcent.easyapi.exporter.channel.curl.CurlBuildOptions
+import com.itangcent.easyapi.exporter.channel.curl.CurlBuilder
+import com.itangcent.easyapi.exporter.channel.curl.CurlFormatOptions
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelVisitTracker
@@ -21,23 +25,42 @@ import com.itangcent.easyapi.psi.model.ObjectModelVisitTracker
  * output byte-for-byte (the parity gate — [MarkdownTemplateParityTest]).
  *
  * The JSON demo is **not** pre-rendered here — `BodyView.asDemo()`/`asJson()`/`asJson5()`
- * are evaluated lazily at render time. See [BodyView] (D5).
+ * are evaluated lazily at render time. See [BodyView].
+ *
+ * ## Lazy cURL provider
+ *
+ * [build] accepts an optional [host] + [CurlFormatOptions]; when supplied (or via the
+ * defaults — `CurlBuilder.DEFAULT_HOST` + `CurlFormatOptions()`), each [HttpView] carries
+ * a lazy [HttpView.curlProvider] that templates can invoke as `{{{api.http.curl()}}}`.
+ * The provider invokes the pure [CurlBuilder.format] (no `Project`, no suspend, no
+ * scripts). [IdeaLog] is implemented only so the provider can warn on
+ * an unexpected formatting failure; the builder itself remains side-effect-free.
  *
  * @see TemplateModel
  */
-object TemplateModelBuilder {
+object TemplateModelBuilder : IdeaLog {
 
     /**
      * @param endpoints the endpoints to render, already resolved (no PSI reads happen here).
      * @param moduleName the document title passed to `MarkdownChannel.export`.
+     * @param host Target host for [HttpView.curl]. Defaults to
+     *   [CurlBuilder.DEFAULT_HOST] (`"{{host}}"`) so a bare `build(...)` call — as in
+     *   [MarkdownTemplateParityTest] / [TemplateModelBuilderTest] — yields `curl()` output
+     *   with the placeholder host (or `null` if the template never invokes it). Blank
+     *   string is treated as the default.
+     * @param formatOptions Format flags forwarded to [CurlBuilder.format] inside the
+     *   `curlProvider`. Defaults to [CurlFormatOptions] (5 flags at their defaults).
      */
     fun build(
         endpoints: List<ApiEndpoint>,
         moduleName: String,
+        host: String = CurlBuilder.DEFAULT_HOST,
+        formatOptions: CurlFormatOptions = CurlFormatOptions(),
     ): TemplateModel {
+        val curlHost = host.takeIf { it.isNotBlank() } ?: CurlBuilder.DEFAULT_HOST
         val groups = endpoints
             .groupBy { it.folder ?: "" }
-            .map { (folder, list) -> Group(folder = folder, endpoints = list.map { it.toView() }) }
+            .map { (folder, list) -> Group(folder = folder, endpoints = list.map { it.toView(curlHost, formatOptions) }) }
         return TemplateModel(
             moduleName = moduleName,
             groups = groups,
@@ -47,7 +70,7 @@ object TemplateModelBuilder {
 
     // ---- Endpoint → view ----
 
-    private fun ApiEndpoint.toView(): Endpoint {
+    private fun ApiEndpoint.toView(curlHost: String, formatOptions: CurlFormatOptions): Endpoint {
         val meta = metadata
         // Mirror DefaultMarkdownFormatter: `ep.description?.takeIf { it.isNotBlank() }`
         // so whitespace-only descriptions are treated as absent (parity gate).
@@ -59,7 +82,7 @@ object TemplateModelBuilder {
                 protocol = meta.protocol,
                 path = meta.path,
                 method = meta.method.name,
-                http = meta.toHttpView(),
+                http = meta.toHttpView(this, curlHost, formatOptions),
                 grpc = null,
             )
             is GrpcMetadata -> Endpoint(
@@ -74,7 +97,11 @@ object TemplateModelBuilder {
         }
     }
 
-    private fun HttpMetadata.toHttpView(): HttpView {
+    private fun HttpMetadata.toHttpView(
+        endpoint: ApiEndpoint,
+        curlHost: String,
+        formatOptions: CurlFormatOptions,
+    ): HttpView {
         val pathParams = parameters.filter { it.binding == ParameterBinding.Path }.map { it.toParam() }
         val queryParams = parameters.filter { it.binding == ParameterBinding.Query }.map { it.toParam() }
         val formParams = parameters.filter { it.binding == ParameterBinding.Form }.map { it.toParam() }
@@ -94,6 +121,14 @@ object TemplateModelBuilder {
             body = body,
             response = response,
             hasRequestContent = hasRequestContent,
+            // Lazy cURL; `runPreScripts=false` (pure format only).
+            curlProvider = {
+                runCatching {
+                    CurlBuilder.format(endpoint, curlHost, CurlBuildOptions(format = formatOptions))
+                }.onFailure {
+                    LOG.warn("curl: failed to build for '${endpoint.name}': ${it.message}", it)
+                }.getOrNull()
+            },
         )
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
@@ -154,7 +154,7 @@ class RuleContext private constructor(
         if (value == null) return null
         if (key == "fieldContext" && value is String) return ScriptFieldPathContext(value)
         if (value is PsiElement) return withElement(value).asScriptIt()
-        if (value is ApiEndpoint) return ScriptApiEndpoint(value)
+        if (value is ApiEndpoint) return ScriptApiEndpoint(value, project)
         return value
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptApiEndpoint.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptApiEndpoint.kt
@@ -1,10 +1,31 @@
 package com.itangcent.easyapi.rule.context
 
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.exporter.channel.curl.CurlBuildOptions
+import com.itangcent.easyapi.exporter.channel.curl.CurlBuilder
+import com.itangcent.easyapi.exporter.channel.curl.CurlScriptScopes
+import com.itangcent.easyapi.exporter.channel.curl.CurlSettings
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.settings.settings
 
-class ScriptApiEndpoint(val endpoint: ApiEndpoint) {
+/**
+ * Script-facing wrapper around [ApiEndpoint], exposed to rule scripts as `it` / `api`.
+ *
+ * Constructed by [RuleContext.wrapExt] (single construction site). The optional
+ * [project] is carried so [toCurl] can read [CurlSettings] and run pre-scripts;
+ * rules that don't call [toCurl] pay no Project-coupling cost.
+ *
+ * @param endpoint The underlying endpoint. Rule mutations (e.g. [setPath],
+ *  [appendDesc]) write through to this instance.
+ * @param project The current IntelliJ project, or null when constructed outside
+ *  a rule context (e.g. in unit tests). Used only by [toCurl].
+ */
+class ScriptApiEndpoint(
+    val endpoint: ApiEndpoint,
+    private val project: Project? = null,
+) {
 
     private val http: HttpMetadata? get() = endpoint.metadata as? HttpMetadata
 
@@ -66,6 +87,56 @@ class ScriptApiEndpoint(val endpoint: ApiEndpoint) {
 
     fun appendDesc(desc: String?) {
         endpoint.appendDesc(desc)
+    }
+
+    /**
+     * Builds a cURL command for this endpoint. Available in rule scripts as
+     * `api.toCurl()`.
+     *
+     * ## Example
+     *
+     * ```config
+     * export.after=groovy:api.appendDesc("\n\n```\n" + api.toCurl() + "\n```\n")
+     * ```
+     *
+     * ## Behavior
+     *
+     * - [host] defaults to [CurlBuilder.DEFAULT_HOST] (`"{{host}}"`) so rule authors
+     *   can resolve it later via environment/config. Pass an explicit host (e.g.
+     *   `api.toCurl("https://api.example.com")`) to bake it in.
+     * - Format options (long flags, pretty-print, etc.) flow from the persisted
+     *   [CurlSettings], so the user's cURL settings tab controls rule-generated
+     *   cURL too.
+     * - When [runPreScripts] is `true` AND [project] is non-null, folder+class
+     *   pre-request scripts are applied to a deep copy before formatting
+     *   (original endpoint untouched). Endpoint-scope scripts are
+     *   intentionally NOT included here because `export.after` fires post-build and
+     *   the endpoint-key scope semantics differ from the copy/export path.
+     * - When [project] is null (e.g. unit tests, headless rule eval), falls back to
+     *   the pure [CurlBuilder.format] path — no settings, no scripts.
+     *
+     * ## Threading
+     *
+     * `export.after` rules fire synchronously inside the rule engine's script
+     * thread (a background worker). This method is non-suspend and delegates to
+     * [CurlBuilder.buildSync], which `runBlocking`s the suspend builder internally.
+     * That is safe because [PreScriptApplier.applyScripts] is EDT-free (no `swing`
+     * hops) — `runBlocking` on a background thread never deadlocks with EDT.
+     *
+     * @param host Target host; defaults to [CurlBuilder.DEFAULT_HOST] when blank.
+     * @param runPreScripts When true and [project] is set, run folder+class
+     *  pre-request scripts before formatting. Default false.
+     * @return The formatted cURL command string.
+     */
+    @JvmOverloads
+    fun toCurl(host: String = CurlBuilder.DEFAULT_HOST, runPreScripts: Boolean = false): String {
+        val p = project ?: return CurlBuilder.format(endpoint, host)
+        val options = CurlBuildOptions(
+            format = p.settings<CurlSettings>().toFormatOptions(),
+            runPreScripts = runPreScripts,
+            scopes = if (runPreScripts) CurlScriptScopes.resolveFolderAndClassScopes(endpoint) else emptyList(),
+        )
+        return CurlBuilder.buildSync(p, endpoint, host, options)
     }
 
     override fun toString(): String = endpoint.toString()

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlBuilderTest.kt
@@ -1,0 +1,110 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain-JUnit coverage for [CurlBuilder] (pure format step, no IDE fixture).
+ *
+ * The script-capable [CurlBuilder.build] paths that hit [PreScriptApplier] are
+ * covered by `PreScriptApplierTest` (IDE fixture). Here we assert:
+ * - [CurlBuilder.format] delegates to [CurlFormatter.format] (pure)
+ * - [CurlBuilder.DEFAULT_HOST] is used when host is blank
+ * - [CurlBuilder.build] early-returns [CurlBuilder.format] when scripts are gated off
+ *   (so no `Project` / no `PreScriptApplier` dependency is incurred)
+ * - Output is deterministic for identical inputs
+ */
+class CurlBuilderTest {
+
+    private fun sampleEndpoint() = ApiEndpoint(
+        name = "Get User",
+        metadata = httpMetadata(
+            path = "/api/users/1",
+            method = HttpMethod.GET,
+        ),
+    )
+
+    @Test
+    fun `format with defaults delegates to CurlFormatter`() {
+        val endpoint = sampleEndpoint()
+        val fromBuilder = CurlBuilder.format(endpoint, "http://localhost:8080")
+        val fromFormatter = CurlFormatter.format(endpoint, "http://localhost:8080")
+        assertEquals(fromFormatter, fromBuilder)
+    }
+
+    @Test
+    fun `format with default host contains placeholder`() {
+        val endpoint = sampleEndpoint()
+        val result = CurlBuilder.format(endpoint)
+        // DEFAULT_HOST is "{{host}}" — output should be non-empty and contain it
+        assertTrue("output must contain the default host placeholder", result.contains(CurlBuilder.DEFAULT_HOST))
+        assertTrue(result.contains("curl"))
+        assertTrue(result.contains("-X GET"))
+    }
+
+    @Test
+    fun `format with blank host falls back to DEFAULT_HOST`() {
+        val endpoint = sampleEndpoint()
+        val result = CurlBuilder.format(endpoint, host = "")
+        assertTrue(result.contains(CurlBuilder.DEFAULT_HOST))
+    }
+
+    @Test
+    fun `build with runPreScripts false equals format`() = runBlocking {
+        val endpoint = sampleEndpoint()
+        val host = "http://localhost:8080"
+        val options = CurlBuildOptions(runPreScripts = false)
+        val built = CurlBuilder.build(project = null, endpoint, host, options)
+        val formatted = CurlBuilder.format(endpoint, host, options)
+        assertEquals(formatted, built)
+    }
+
+    @Test
+    fun `build with empty scopes equals format even when runPreScripts true`() = runBlocking {
+        // Gate: runPreScripts && scopes.isNotEmpty() — empty scopes short-circuits
+        val endpoint = sampleEndpoint()
+        val host = "http://localhost:8080"
+        val options = CurlBuildOptions(runPreScripts = true, scopes = emptyList())
+        val built = CurlBuilder.build(project = null, endpoint, host, options)
+        val formatted = CurlBuilder.format(endpoint, host, options)
+        assertEquals(formatted, built)
+    }
+
+    @Test
+    fun `build with null project equals format even when runPreScripts true and scopes non-empty`() = runBlocking {
+        // No project → cannot run scripts → short-circuits to format
+        val endpoint = sampleEndpoint()
+        val host = "http://localhost:8080"
+        val options = CurlBuildOptions(
+            runPreScripts = true,
+            scopes = listOf(com.itangcent.easyapi.script.ScriptScope.Module("dummy")),
+        )
+        val built = CurlBuilder.build(project = null, endpoint, host, options)
+        val formatted = CurlBuilder.format(endpoint, host, options)
+        assertEquals(formatted, built)
+    }
+
+    @Test
+    fun `format is deterministic for identical inputs`() {
+        val endpoint = sampleEndpoint()
+        val a = CurlBuilder.format(endpoint, "http://x", CurlBuildOptions())
+        val b = CurlBuilder.format(endpoint, "http://x", CurlBuildOptions())
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `buildSync with no scripts equals format`() {
+        // buildSync wraps build in runBlocking; with scripts off it must equal format
+        val endpoint = sampleEndpoint()
+        val host = "http://localhost:8080"
+        val options = CurlBuildOptions(runPreScripts = false)
+        val built = CurlBuilder.buildSync(project = null, endpoint, host, options)
+        val formatted = CurlBuilder.format(endpoint, host, options)
+        assertEquals(formatted, built)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlConfigTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlConfigTest.kt
@@ -1,0 +1,78 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain-JUnit tests for [CurlConfig] and [CurlFormatOptions].
+ */
+class CurlConfigTest {
+
+    @Test
+    fun `CurlConfig is a ChannelConfig subclass`() {
+        val config: ChannelConfig = CurlConfig()
+        assertNotNull(config)
+    }
+
+    @Test
+    fun `CurlConfig defaults are null for outputDir and fileName`() {
+        val config = CurlConfig()
+        assertNull(config.outputDir)
+        assertNull(config.fileName)
+    }
+
+    @Test
+    fun `CurlConfig default options are CurlFormatOptions defaults`() {
+        val config = CurlConfig()
+        assertEquals(CurlFormatOptions(), config.options)
+    }
+
+    @Test
+    fun `CurlConfig preserves custom outputDir and fileName`() {
+        val config = CurlConfig(outputDir = "/tmp/output", fileName = "my-curls")
+        assertEquals("/tmp/output", config.outputDir)
+        assertEquals("my-curls", config.fileName)
+    }
+
+    @Test
+    fun `CurlConfig preserves custom options`() {
+        val options = CurlFormatOptions(
+            includeComments = false,
+            prettyPrintBody = true,
+            multiLineFormat = true,
+            longFlags = true,
+            includeResponseExample = true,
+        )
+        val config = CurlConfig(options = options)
+        assertEquals(options, config.options)
+    }
+
+    @Test
+    fun `CurlFormatOptions defaults preserve backward-compatible output`() {
+        // CurlFormatOptions defaults are independent of CurlSettings defaults.
+        // CurlFormatOptions() is used as a fallback when no config is provided,
+        // so it must preserve the pre-enhancement output.
+        val opts = CurlFormatOptions()
+        assertTrue(opts.includeComments)
+        assertFalse(opts.prettyPrintBody)
+        assertFalse(opts.multiLineFormat)
+        assertFalse(opts.longFlags)
+        assertFalse(opts.includeResponseExample)
+    }
+
+    @Test
+    fun `CurlFormatOptions copy produces independent instance`() {
+        val original = CurlFormatOptions()
+        val modified = original.copy(longFlags = true)
+        assertFalse(original.longFlags)
+        assertTrue(modified.longFlags)
+        // other fields unchanged
+        assertEquals(original.includeComments, modified.includeComments)
+        assertEquals(original.prettyPrintBody, modified.prettyPrintBody)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlExportResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlExportResolverTest.kt
@@ -1,0 +1,153 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.ApiParameter
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * IDE-fixture tests for [CurlExportResolver].
+ *
+ * [CurlExportResolver] is a [com.intellij.openapi.components.Service] scoped to
+ * the project, so it needs a real [com.intellij.openapi.project.Project] to
+ * construct (via [CurlExportResolver.getInstance]). It also reads [CurlSettings]
+ * internally via [com.itangcent.easyapi.settings.settings], so we use
+ * [SettingBinder.update] to set the render mode before each test.
+ *
+ * The ALWAYS_ASK paths that show a dialog are NOT covered here (they require
+ * UI interaction). NEVER_RENDER and empty-list short-circuits are covered.
+ */
+class CurlExportResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun setRenderMode(mode: CurlRenderMode) {
+        SettingBinder.getInstance(project).update(CurlSettings::class) {
+            renderMode = mode.name
+        }
+    }
+
+    private fun updateSettings(block: CurlSettings.() -> Unit) {
+        SettingBinder.getInstance(project).update(CurlSettings::class) { block() }
+    }
+
+    private fun simpleEndpoint(name: String = "Test", path: String = "/api/test") = ApiEndpoint(
+        name = name,
+        metadata = httpMetadata(path = path, method = HttpMethod.GET),
+    )
+
+    fun `test resolve with NEVER_RENDER returns endpoint unchanged`() = runBlocking {
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        val endpoint = simpleEndpoint()
+        val result = CurlExportResolver.getInstance(project).resolve(endpoint, "http://localhost:8080")
+        assertNotNull(result)
+        assertEquals(endpoint, result!!.first)
+        assertEquals("http://localhost:8080", result.second)
+    }
+
+    fun `test resolve with NEVER_RENDER preserves placeholders in path`() = runBlocking {
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        val endpoint = simpleEndpoint(path = "/api/{{userId}}")
+        val result = CurlExportResolver.getInstance(project).resolve(endpoint, "http://localhost:8080")
+        assertNotNull(result)
+        assertEquals("/api/{{userId}}", result!!.first.httpMetadata?.path)
+    }
+
+    fun `test resolveAll with NEVER_RENDER returns endpoints unchanged`() = runBlocking {
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        val endpoints = listOf(
+            simpleEndpoint("A", "/api/a"),
+            simpleEndpoint("B", "/api/b"),
+        )
+        val result = CurlExportResolver.getInstance(project).resolveAll(endpoints, "http://localhost:8080")
+        assertNotNull(result)
+        assertEquals(2, result!!.first.size)
+        assertEquals("A", result.first[0].name)
+        assertEquals("B", result.first[1].name)
+    }
+
+    fun `test resolveAll with empty endpoint list returns empty list regardless of renderMode`() = runBlocking {
+        // Empty list short-circuits before touching services, so ALWAYS_ASK won't prompt.
+        setRenderMode(CurlRenderMode.ALWAYS_ASK)
+        val result = CurlExportResolver.getInstance(project).resolveAll(emptyList(), "http://localhost:8080")
+        assertNotNull(result)
+        assertEquals(0, result!!.first.size)
+    }
+
+    fun `test resolveAll with NEVER_RENDER preserves placeholders`() = runBlocking {
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        val endpoints = listOf(simpleEndpoint(path = "/api/{{userId}}"))
+        val result = CurlExportResolver.getInstance(project).resolveAll(endpoints, "http://localhost:8080")
+        assertNotNull(result)
+        assertEquals("/api/{{userId}}", result!!.first[0].httpMetadata?.path)
+    }
+
+    // ===== formatForCopy tests =====
+    //
+    // formatForCopy is the single-endpoint "copy as cURL" pipeline
+    // (resolve → format with persisted settings options). The ALWAYS_ASK prompt
+    // path needs a UI dialog and is NOT covered here; NEVER_RENDER short-circuits
+    // deterministically and lets us assert the full pipeline end-to-end.
+
+    fun `test formatForCopy with NEVER_RENDER returns formatted curl`() = runBlocking {
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        val endpoint = simpleEndpoint(name = "Get User", path = "/api/users/1")
+        val curl = CurlExportResolver.getInstance(project).formatForCopy(endpoint, "http://localhost:8080")
+        assertNotNull("NEVER_RENDER never cancels, so result must be non-null", curl)
+        assertTrue("should contain curl: $curl", curl!!.contains("curl"))
+        assertTrue("should contain method: $curl", curl.contains("-X GET"))
+        assertTrue("should contain url: $curl", curl.contains("http://localhost:8080/api/users/1"))
+    }
+
+    fun `test formatForCopy preserves placeholders when NEVER_RENDER`() = runBlocking {
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        val endpoint = simpleEndpoint(path = "/api/{{userId}}")
+        val curl = CurlExportResolver.getInstance(project).formatForCopy(endpoint, "http://localhost:8080")
+        assertNotNull(curl)
+        assertTrue("placeholder should survive: $curl", curl!!.contains("{{userId}}"))
+    }
+
+    fun `test formatForCopy reflects CurlSettings longFlags in output`() = runBlocking {
+        // Pin the central contract of the refactor: format options flow from
+        // CurlSettings through toFormatOptions into the formatted output. If a
+        // future change decouples formatForCopy from settings, this catches it.
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        updateSettings { longFlags = true }
+        val endpoint = ApiEndpoint(
+            name = "Create",
+            metadata = httpMetadata(
+                path = "/api/create",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                parameters = listOf(
+                    ApiParameter(name = "name", binding = ParameterBinding.Body, example = "John")
+                ),
+            ),
+        )
+        val curl = CurlExportResolver.getInstance(project).formatForCopy(endpoint, "http://localhost:8080")
+        assertNotNull(curl)
+        assertTrue("longFlags from settings should produce --request: $curl", curl!!.contains("--request"))
+        assertTrue("longFlags from settings should produce --data: $curl", curl.contains("--data"))
+        assertFalse("should not use short -X: $curl", curl.contains("-X "))
+    }
+
+    fun `test formatForCopy respects includeComments off for single endpoint`() = runBlocking {
+        // Single-endpoint format() never emits ## comments regardless of option,
+        // but flipping includeComments=false should at least not break the pipeline
+        // and still produce a valid curl. Guards against option-wiring regressions.
+        setRenderMode(CurlRenderMode.NEVER_RENDER)
+        updateSettings { includeComments = false }
+        val endpoint = simpleEndpoint(name = "Get", path = "/api/test")
+        val curl = CurlExportResolver.getInstance(project).formatForCopy(endpoint, "http://localhost:8080")
+        assertNotNull(curl)
+        assertTrue("should still contain curl: $curl", curl!!.contains("curl"))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlFormatterTest.kt
@@ -389,4 +389,370 @@ class CurlFormatterTest {
         assertTrue(result.contains("## Get User"))
         assertTrue(result.contains("## SayHello"))
     }
+
+    // ===== Options tests =====
+
+    @Test
+    fun testDefaultOptionsMatchesCurrentOutput() {
+        val getEndpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(path = "/api/users/1", method = HttpMethod.GET)
+        )
+        val postEndpoint = ApiEndpoint(
+            name = "Create User",
+            metadata = httpMetadata(
+                path = "/api/users",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                parameters = listOf(
+                    ApiParameter(name = "name", binding = ParameterBinding.Body, example = "John")
+                )
+            )
+        )
+        // Default options == no options (backward compat)
+        assertEquals(CurlFormatter.format(getEndpoint, "http://localhost"), CurlFormatter.format(getEndpoint, "http://localhost", CurlFormatOptions()))
+        assertEquals(CurlFormatter.format(postEndpoint, "http://localhost"), CurlFormatter.format(postEndpoint, "http://localhost", CurlFormatOptions()))
+        assertEquals(
+            CurlFormatter.formatAll(listOf(getEndpoint, postEndpoint), "http://localhost"),
+            CurlFormatter.formatAll(listOf(getEndpoint, postEndpoint), "http://localhost", CurlFormatOptions())
+        )
+    }
+
+    @Test
+    fun testLongFlags() {
+        val endpoint = ApiEndpoint(
+            name = "Create User",
+            metadata = httpMetadata(
+                path = "/api/users",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                headers = listOf(ApiHeader("Authorization", "Bearer token")),
+                parameters = listOf(
+                    ApiParameter(name = "name", binding = ParameterBinding.Body, example = "John")
+                )
+            )
+        )
+        val result = CurlFormatter.format(endpoint, "http://localhost", CurlFormatOptions(longFlags = true))
+        assertTrue("should contain --request", result.contains("--request"))
+        assertTrue("should contain --header", result.contains("--header"))
+        assertTrue("should contain --data", result.contains("--data"))
+        assertFalse("should not contain -X ", result.contains("-X "))
+        assertFalse("should not contain -H '", result.contains("-H '"))
+        assertFalse("should not contain -d '", result.contains("-d '"))
+    }
+
+    @Test
+    fun testLongFlagsMultipart() {
+        val endpoint = ApiEndpoint(
+            name = "Upload",
+            metadata = httpMetadata(
+                path = "/api/upload",
+                method = HttpMethod.POST,
+                contentType = "multipart/form-data",
+                parameters = listOf(
+                    ApiParameter(name = "file", binding = ParameterBinding.Form, example = "@/path")
+                )
+            )
+        )
+        val result = CurlFormatter.format(endpoint, "http://localhost", CurlFormatOptions(longFlags = true))
+        assertTrue("should contain --form", result.contains("--form"))
+        assertFalse("should not contain -F '", result.contains("-F '"))
+    }
+
+    @Test
+    fun testPrettyPrintBody() {
+        val body = ObjectModel.Object(
+            mapOf("name" to FieldModel(ObjectModel.single("string")))
+        )
+        val endpoint = ApiEndpoint(
+            name = "Create",
+            metadata = httpMetadata(
+                path = "/api/create",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                body = body
+            )
+        )
+        val result = CurlFormatter.format(endpoint, "http://localhost", CurlFormatOptions(prettyPrintBody = true))
+        assertTrue("pretty JSON should contain newline+indent: $result", result.contains("\n  \""))
+    }
+
+    @Test
+    fun testMultiLineFormat() {
+        val endpoint = ApiEndpoint(
+            name = "Get",
+            metadata = httpMetadata(
+                path = "/api/users/1",
+                method = HttpMethod.GET,
+                headers = listOf(ApiHeader("Authorization", "Bearer token"))
+            )
+        )
+        val result = CurlFormatter.format(endpoint, "http://localhost", CurlFormatOptions(multiLineFormat = true))
+        assertTrue("should contain line continuation: $result", result.contains(" \\\n  "))
+    }
+
+    @Test
+    fun testIncludeCommentsFalse() {
+        val e1 = ApiEndpoint(name = "A", metadata = httpMetadata(path = "/a", method = HttpMethod.GET))
+        val e2 = ApiEndpoint(name = "B", metadata = httpMetadata(path = "/b", method = HttpMethod.GET))
+        val result = CurlFormatter.formatAll(listOf(e1, e2), "http://localhost", CurlFormatOptions(includeComments = false))
+        assertFalse("should not contain ##: $result", result.contains("##"))
+        assertFalse("should not contain ---: $result", result.contains("---"))
+        assertTrue("should contain curl", result.contains("curl"))
+    }
+
+    @Test
+    fun testIncludeResponseExample() {
+        val respBody = ObjectModel.Object(
+            mapOf("id" to FieldModel(ObjectModel.single("int")))
+        )
+        val endpoint = ApiEndpoint(
+            name = "Get",
+            metadata = httpMetadata(
+                path = "/api/users/1",
+                method = HttpMethod.GET,
+                responseBody = respBody
+            )
+        )
+        val result = CurlFormatter.format(endpoint, "http://localhost", CurlFormatOptions(includeResponseExample = true))
+        assertTrue("should contain # Response: $result", result.contains("# Response:"))
+
+        // gRPC should NOT have response example (no-op)
+        val grpcEndpoint = ApiEndpoint(
+            name = "SayHello",
+            metadata = GrpcMetadata(
+                path = "/com.example.Greeter/SayHello",
+                serviceName = "Greeter",
+                methodName = "SayHello",
+                packageName = "com.example",
+                streamingType = GrpcStreamingType.UNARY
+            )
+        )
+        val grpcResult = CurlFormatter.format(grpcEndpoint, "localhost:50051", CurlFormatOptions(includeResponseExample = true))
+        assertFalse("gRPC should not have response example: $grpcResult", grpcResult.contains("# Response:"))
+    }
+
+    @Test
+    fun testGrpcWithDefaultOptions() {
+        val endpoint = ApiEndpoint(
+            name = "SayHello",
+            metadata = GrpcMetadata(
+                path = "/com.example.Greeter/SayHello",
+                serviceName = "Greeter",
+                methodName = "SayHello",
+                packageName = "com.example",
+                streamingType = GrpcStreamingType.UNARY
+            )
+        )
+        val defaultResult = CurlFormatter.format(endpoint, "localhost:50051")
+        val optionsResult = CurlFormatter.format(endpoint, "localhost:50051", CurlFormatOptions())
+        assertEquals(defaultResult, optionsResult)
+    }
+
+    // ===== Additional edge-case tests =====
+
+    @Test
+    fun testLongFlagsAndMultiLineCombo() {
+        val endpoint = ApiEndpoint(
+            name = "Create",
+            metadata = httpMetadata(
+                path = "/api/create",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                headers = listOf(ApiHeader("Authorization", "Bearer token")),
+                parameters = listOf(
+                    ApiParameter(name = "name", binding = ParameterBinding.Body, example = "John")
+                )
+            )
+        )
+        val result = CurlFormatter.format(
+            endpoint, "http://localhost",
+            CurlFormatOptions(longFlags = true, multiLineFormat = true)
+        )
+        assertTrue("should use long flags: $result", result.contains("--request"))
+        assertTrue("should use line continuation: $result", result.contains(" \\\n  "))
+        assertFalse("should not use short -X: $result", result.contains("-X "))
+    }
+
+    @Test
+    fun testPrettyPrintAndCommentsCombo() {
+        val body = ObjectModel.Object(
+            mapOf("name" to FieldModel(ObjectModel.single("string")))
+        )
+        val endpoint = ApiEndpoint(
+            name = "Create",
+            metadata = httpMetadata(
+                path = "/api/create",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                body = body
+            )
+        )
+        // Comments (## name) are only added by formatAll, not format
+        val result = CurlFormatter.formatAll(
+            listOf(endpoint), "http://localhost",
+            CurlFormatOptions(includeComments = true, prettyPrintBody = true)
+        )
+        assertTrue("should have comments: $result", result.contains("## Create"))
+        assertTrue("should have pretty JSON: $result", result.contains("\n  \""))
+    }
+
+    @Test
+    fun testAllOptionsEnabled() {
+        val body = ObjectModel.Object(
+            mapOf("name" to FieldModel(ObjectModel.single("string")))
+        )
+        val respBody = ObjectModel.Object(
+            mapOf("id" to FieldModel(ObjectModel.single("int")))
+        )
+        val endpoint = ApiEndpoint(
+            name = "Create",
+            metadata = httpMetadata(
+                path = "/api/create",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                headers = listOf(ApiHeader("X-Custom", "value")),
+                body = body,
+                responseBody = respBody
+            )
+        )
+        // Comments (## name) are only added by formatAll, not format
+        val result = CurlFormatter.formatAll(
+            listOf(endpoint), "http://localhost",
+            CurlFormatOptions(
+                includeComments = true,
+                prettyPrintBody = true,
+                multiLineFormat = true,
+                longFlags = true,
+                includeResponseExample = true,
+            )
+        )
+        assertTrue("comments: $result", result.contains("## Create"))
+        assertTrue("pretty JSON: $result", result.contains("\n  \""))
+        assertTrue("multi-line: $result", result.contains(" \\\n  "))
+        assertTrue("long flags: $result", result.contains("--request"))
+        assertTrue("response example: $result", result.contains("# Response:"))
+    }
+
+    @Test
+    fun testResolvedBodyJsonFromExtensions() {
+        // When extensions contain RESOLVED_BODY_JSON_KEY, the formatter should use
+        // that JSON instead of serializing the ObjectModel body.
+        val body = ObjectModel.Object(
+            mapOf("name" to FieldModel(ObjectModel.single("string")))
+        )
+        val extensions = com.itangcent.easyapi.exporter.model.MutableExtension()
+        extensions[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] = """{"name":"alice"}"""
+
+        val endpoint = ApiEndpoint(
+            name = "Create",
+            metadata = httpMetadata(
+                path = "/api/create",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                body = body
+            ),
+            extensions = extensions
+        )
+        val result = CurlFormatter.format(endpoint, "http://localhost")
+        assertTrue("should use resolved body JSON: $result", result.contains("alice"))
+    }
+
+    @Test
+    fun testFormatWithEmptyHost() {
+        val endpoint = ApiEndpoint(
+            name = "Get",
+            metadata = httpMetadata(path = "/api/test", method = HttpMethod.GET)
+        )
+        val result = CurlFormatter.format(endpoint, "")
+        assertTrue("should still contain curl: $result", result.contains("curl"))
+    }
+
+    @Test
+    fun testFormatAllWithOptionsAndMultipleEndpoints() {
+        val e1 = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(
+                path = "/api/users/1",
+                method = HttpMethod.GET,
+                headers = listOf(ApiHeader("Auth", "token"))
+            )
+        )
+        val e2 = ApiEndpoint(
+            name = "Create User",
+            metadata = httpMetadata(
+                path = "/api/users",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                parameters = listOf(
+                    ApiParameter(name = "name", binding = ParameterBinding.Body, example = "John")
+                )
+            )
+        )
+        val result = CurlFormatter.formatAll(
+            listOf(e1, e2), "http://localhost",
+            CurlFormatOptions(longFlags = true, multiLineFormat = true)
+        )
+        assertTrue("should contain both names: $result", result.contains("## Get User"))
+        assertTrue("should contain both names: $result", result.contains("## Create User"))
+        assertTrue("should use long flags: $result", result.contains("--request"))
+        assertTrue("should use multi-line: $result", result.contains(" \\\n  "))
+    }
+
+    @Test
+    fun testPrettyPrintInvalidJsonFallsBackToCompact() {
+        // If the body serializes to invalid JSON, prettyJson should fall back to
+        // the compact string rather than throwing.
+        val extensions = com.itangcent.easyapi.exporter.model.MutableExtension()
+        extensions[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] = "not valid json"
+
+        val endpoint = ApiEndpoint(
+            name = "Create",
+            metadata = httpMetadata(
+                path = "/api/create",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                body = ObjectModel.Object(emptyMap())
+            ),
+            extensions = extensions
+        )
+        val result = CurlFormatter.format(
+            endpoint, "http://localhost",
+            CurlFormatOptions(prettyPrintBody = true)
+        )
+        // Should not throw, should still produce a curl command
+        assertTrue("should contain curl: $result", result.contains("curl"))
+        assertTrue("should contain the invalid json: $result", result.contains("not valid json"))
+    }
+
+    @Test
+    fun testNoContentTypeNoHeader() {
+        val endpoint = ApiEndpoint(
+            name = "Get",
+            metadata = httpMetadata(path = "/api/test", method = HttpMethod.GET)
+        )
+        val result = CurlFormatter.format(endpoint, "http://localhost")
+        assertFalse("should not contain Content-Type: $result", result.contains("Content-Type"))
+    }
+
+    @Test
+    fun testGrpcWithLongFlags() {
+        // gRPC formatting should not be affected by longFlags (grpcurl uses its own flags)
+        val endpoint = ApiEndpoint(
+            name = "SayHello",
+            metadata = GrpcMetadata(
+                path = "/com.example.Greeter/SayHello",
+                serviceName = "Greeter",
+                methodName = "SayHello",
+                packageName = "com.example",
+                streamingType = GrpcStreamingType.UNARY
+            )
+        )
+        val result = CurlFormatter.format(
+            endpoint, "localhost:50051",
+            CurlFormatOptions(longFlags = true)
+        )
+        assertTrue("should contain grpcurl: $result", result.contains("grpcurl"))
+        assertFalse("should not contain --request: $result", result.contains("--request"))
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlSettingsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/CurlSettingsTest.kt
@@ -1,0 +1,161 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain-JUnit tests for [CurlSettings] defaults and [CurlRenderMode] parsing.
+ *
+ * Verifies the user-requested defaults:
+ *  - renderMode → ALWAYS_ASK (most discoverable)
+ *  - prettyPrintBody → true (more readable)
+ *  - copyFromEdited → false (safe default — use original endpoint)
+ *  - includeComments → true (preserve section dividers)
+ *  - multiLineFormat / longFlags / includeResponseExample → false
+ */
+class CurlSettingsTest {
+
+    @Test
+    fun `default renderMode is ALWAYS_ASK`() {
+        val s = CurlSettings()
+        assertEquals(CurlRenderMode.ALWAYS_ASK.name, s.renderMode)
+        assertEquals(CurlRenderMode.ALWAYS_ASK, s.renderModeEnum())
+    }
+
+    @Test
+    fun `default prettyPrintBody is true`() {
+        val s = CurlSettings()
+        assertTrue("prettyPrintBody should default to true", s.prettyPrintBody)
+    }
+
+    @Test
+    fun `default copyFromEdited is false`() {
+        val s = CurlSettings()
+        assertFalse("copyFromEdited should default to false", s.copyFromEdited)
+    }
+
+    @Test
+    fun `default includeComments is true`() {
+        val s = CurlSettings()
+        assertTrue(s.includeComments)
+    }
+
+    @Test
+    fun `default multiLineFormat longFlags includeResponseExample are false`() {
+        val s = CurlSettings()
+        assertFalse(s.multiLineFormat)
+        assertFalse(s.longFlags)
+        assertFalse(s.includeResponseExample)
+    }
+
+    @Test
+    fun `renderModeEnum parses valid stored value`() {
+        val s = CurlSettings(renderMode = "ALWAYS_RENDER")
+        assertEquals(CurlRenderMode.ALWAYS_RENDER, s.renderModeEnum())
+    }
+
+    @Test
+    fun `renderModeEnum falls back to NEVER_RENDER for invalid stored value`() {
+        val s = CurlSettings(renderMode = "INVALID_MODE")
+        assertEquals(CurlRenderMode.NEVER_RENDER, s.renderModeEnum())
+    }
+
+    @Test
+    fun `renderModeEnum falls back to NEVER_RENDER for null-like stored value`() {
+        val s = CurlSettings(renderMode = "")
+        assertEquals(CurlRenderMode.NEVER_RENDER, s.renderModeEnum())
+    }
+
+    // ===== toFormatOptions tests =====
+
+    @Test
+    fun `toFormatOptions defaults match CurlSettings defaults`() {
+        // The persisted defaults (see class KDoc) must flow through to the
+        // default CurlFormatOptions produced by toFormatOptions. If this breaks,
+        // the Dashboard "Copy as cURL" default output changes silently.
+        val s = CurlSettings()
+        val opts = s.toFormatOptions()
+        assertEquals(s.includeComments, opts.includeComments)
+        assertEquals(s.prettyPrintBody, opts.prettyPrintBody)
+        assertEquals(s.multiLineFormat, opts.multiLineFormat)
+        assertEquals(s.longFlags, opts.longFlags)
+        assertEquals(s.includeResponseExample, opts.includeResponseExample)
+    }
+
+    @Test
+    fun `toFormatOptions maps every format field`() {
+        val s = CurlSettings(
+            includeComments = false,
+            prettyPrintBody = false,
+            multiLineFormat = true,
+            longFlags = true,
+            includeResponseExample = true,
+        )
+        val opts = s.toFormatOptions()
+        assertFalse(opts.includeComments)
+        assertFalse(opts.prettyPrintBody)
+        assertTrue(opts.multiLineFormat)
+        assertTrue(opts.longFlags)
+        assertTrue(opts.includeResponseExample)
+    }
+
+    @Test
+    fun `toFormatOptions is unaffected by non-format settings`() {
+        // renderMode and copyFromEdited are NOT format options — they must not
+        // leak into CurlFormatOptions. This pins the exclusion documented in the
+        // toFormatOptions KDoc.
+        val withRender = CurlSettings(renderMode = CurlRenderMode.ALWAYS_RENDER.name, copyFromEdited = true)
+        val withoutRender = CurlSettings(renderMode = CurlRenderMode.NEVER_RENDER.name, copyFromEdited = false)
+        assertEquals(withRender.toFormatOptions(), withoutRender.toFormatOptions())
+    }
+}
+
+/**
+ * Plain-JUnit tests for [CurlRenderMode] enum.
+ */
+class CurlRenderModeTest {
+
+    @Test
+    fun `fromStored returns the enum for valid name`() {
+        assertEquals(CurlRenderMode.NEVER_RENDER, CurlRenderMode.fromStored("NEVER_RENDER"))
+        assertEquals(CurlRenderMode.ALWAYS_RENDER, CurlRenderMode.fromStored("ALWAYS_RENDER"))
+        assertEquals(CurlRenderMode.ALWAYS_ASK, CurlRenderMode.fromStored("ALWAYS_ASK"))
+    }
+
+    @Test
+    fun `fromStored returns NEVER_RENDER for null`() {
+        assertEquals(CurlRenderMode.NEVER_RENDER, CurlRenderMode.fromStored(null))
+    }
+
+    @Test
+    fun `fromStored returns NEVER_RENDER for invalid string`() {
+        assertEquals(CurlRenderMode.NEVER_RENDER, CurlRenderMode.fromStored("foobar"))
+        assertEquals(CurlRenderMode.NEVER_RENDER, CurlRenderMode.fromStored(""))
+    }
+
+    @Test
+    fun `fromStored is case-sensitive`() {
+        // valueOf is case-sensitive; invalid casing falls back to NEVER_RENDER
+        assertEquals(CurlRenderMode.NEVER_RENDER, CurlRenderMode.fromStored("always_ask"))
+    }
+
+    @Test
+    fun `each mode has a non-empty desc`() {
+        // desc is used by the settings panel combo — must be non-empty and unique.
+        val descs = CurlRenderMode.values().map { it.desc }
+        descs.forEach { d ->
+            assertTrue("desc should be non-empty: $d", d.isNotEmpty())
+        }
+        assertEquals("descs should be unique", descs.size, descs.toSet().size)
+    }
+
+    @Test
+    fun `desc matches expected human-readable labels`() {
+        // Pin the labels so the settings panel ordering stays stable.
+        assertEquals("keep placeholders", CurlRenderMode.NEVER_RENDER.desc)
+        assertEquals("resolve with active environment", CurlRenderMode.ALWAYS_RENDER.desc)
+        assertEquals("ask each export", CurlRenderMode.ALWAYS_ASK.desc)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/EndpointVariableResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/EndpointVariableResolverTest.kt
@@ -1,0 +1,299 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.ApiParameter
+import com.itangcent.easyapi.exporter.model.GrpcMetadata
+import com.itangcent.easyapi.exporter.model.GrpcStreamingType
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.psi.model.ObjectModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain-JUnit tests for [EndpointVariableResolver] (no IntelliJ fixture required).
+ */
+class EndpointVariableResolverTest {
+
+    private val emptyFallback: (String) -> String? = { null }
+
+    @Test
+    fun `resolves double-brace placeholders from variables map`() {
+        val endpoint = httpEndpoint(path = "/api/{{userId}}")
+        val r = EndpointVariableResolver.resolve(
+            endpoint = endpoint,
+            host = "http://localhost",
+            variables = mapOf("userId" to "42"),
+            fallback = emptyFallback,
+        )
+        assertEquals("/api/42", (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path)
+        assertTrue("userId" in r.resolved)
+        assertTrue("userId" !in r.missing)
+    }
+
+    @Test
+    fun `resolves dollar-brace placeholders from variables map`() {
+        val endpoint = httpEndpoint(path = "/api/\${userId}")
+        val r = EndpointVariableResolver.resolve(endpoint, "http://localhost", mapOf("userId" to "42"), emptyFallback)
+        assertEquals("/api/42", (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path)
+    }
+
+    @Test
+    fun `fallback lambda is called for vars not in map`() {
+        val endpoint = httpEndpoint(path = "/{{token}}")
+        val fallback: (String) -> String? = { k -> if (k == "token") "abc123" else null }
+        val r = EndpointVariableResolver.resolve(endpoint, "h", emptyMap(), fallback)
+        assertEquals("/abc123", (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path)
+        assertTrue("token" in r.resolved)
+    }
+
+    @Test
+    fun `unresolved vars stay as-is and appear in missing`() {
+        val endpoint = httpEndpoint(path = "/{{unknown}}")
+        val r = EndpointVariableResolver.resolve(endpoint, "h", emptyMap(), emptyFallback)
+        assertEquals("/{{unknown}}", (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path)
+        assertTrue("unknown" in r.missing)
+        assertFalse("unknown" in r.resolved)
+    }
+
+    @Test
+    fun `host is resolved`() {
+        val endpoint = httpEndpoint(path = "/api")
+        val r = EndpointVariableResolver.resolve(endpoint, "http://{{host}}", mapOf("host" to "example.com"), emptyFallback)
+        assertEquals("http://example.com", r.host)
+    }
+
+    @Test
+    fun `HttpMetadata headers are resolved`() {
+        val endpoint = ApiEndpoint(
+            name = "t",
+            metadata = httpMetadata(
+                path = "/api",
+                method = HttpMethod.GET,
+                headers = listOf(
+                    ApiHeader(name = "X-User", value = "{{user}}"),
+                    ApiHeader(name = "{{hdr}}", value = "v"),
+                ),
+            ),
+        )
+        val r = EndpointVariableResolver.resolve(endpoint, "h", mapOf("user" to "alice", "hdr" to "X-Trace-Id"), emptyFallback)
+        val headers = (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).headers
+        assertEquals("alice", headers[0].value)
+        assertEquals("X-Trace-Id", headers[1].name)
+    }
+
+    @Test
+    fun `HttpMetadata parameters name example default are resolved`() {
+        val endpoint = ApiEndpoint(
+            name = "t",
+            metadata = httpMetadata(
+                path = "/api",
+                method = HttpMethod.GET,
+                parameters = listOf(
+                    ApiParameter(name = "{{p}}", example = "{{ex}}", defaultValue = "{{df}}", binding = ParameterBinding.Query),
+                ),
+            ),
+        )
+        val r = EndpointVariableResolver.resolve(endpoint, "h", mapOf("p" to "page", "ex" to "1", "df" to "0"), emptyFallback)
+        val param = (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).parameters[0]
+        assertEquals("page", param.name)
+        assertEquals("1", param.example)
+        assertEquals("0", param.defaultValue)
+    }
+
+    @Test
+    fun `HttpMetadata contentType is resolved`() {
+        val endpoint = ApiEndpoint(
+            name = "t",
+            metadata = httpMetadata(path = "/api", method = HttpMethod.POST, contentType = "application/{{fmt}}"),
+        )
+        val r = EndpointVariableResolver.resolve(endpoint, "h", mapOf("fmt" to "json"), emptyFallback)
+        assertEquals("application/json", (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).contentType)
+    }
+
+    @Test
+    fun `GrpcMetadata fields are resolved`() {
+        val endpoint = ApiEndpoint(
+            name = "g",
+            metadata = GrpcMetadata(
+                path = "/{{pkg}}.{{svc}}/{{m}}",
+                serviceName = "{{svc}}",
+                methodName = "{{m}}",
+                packageName = "{{pkg}}",
+                streamingType = GrpcStreamingType.UNARY,
+            ),
+        )
+        val r = EndpointVariableResolver.resolve(endpoint, "h", mapOf("pkg" to "demo", "svc" to "Greeter", "m" to "SayHello"), emptyFallback)
+        val meta = r.endpoint.metadata as GrpcMetadata
+        assertEquals("demo", meta.packageName)
+        assertEquals("Greeter", meta.serviceName)
+        assertEquals("SayHello", meta.methodName)
+        assertEquals("/demo.Greeter/SayHello", meta.path)
+    }
+
+    @Test
+    fun `original endpoint is not mutated`() {
+        val original = httpEndpoint(path = "/{{x}}")
+        EndpointVariableResolver.resolve(original, "h", mapOf("x" to "1"), emptyFallback)
+        assertEquals("/{{x}}", (original.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path)
+    }
+
+    @Test
+    fun `body JSON is resolved and stashed in extensions`() {
+        // Place placeholder in field NAME (serialized as-is by RawJsonHandler);
+        // field VALUES use type-based defaults, so placeholders in Single(type) won't appear in JSON.
+        val obj = ObjectModel.Object(
+            linkedMapOf(
+                "{{user}}" to com.itangcent.easyapi.psi.model.FieldModel(ObjectModel.Single("string")),
+            ),
+        )
+        val endpoint = ApiEndpoint(
+            name = "t",
+            metadata = httpMetadata(path = "/api", method = HttpMethod.POST, body = obj),
+        )
+        val r = EndpointVariableResolver.resolve(endpoint, "h", mapOf("user" to "alice"), emptyFallback)
+        val stashed = r.endpoint.extensions.exts[EndpointVariableResolver.RESOLVED_BODY_JSON_KEY] as? String
+        assertNotNull("resolved body JSON should be stashed in extensions", stashed)
+        assertTrue("stashed JSON should contain resolved value: $stashed", stashed!!.contains("alice"))
+        assertFalse("stashed JSON should not contain placeholder: $stashed", stashed.contains("{{user}}"))
+        assertTrue("user" in r.resolved)
+    }
+
+    @Test
+    fun `string without placeholders is returned as-is`() {
+        assertEquals("plain", EndpointVariableResolver.resolveString("plain", emptyMap(), emptyFallback))
+    }
+
+    @Test
+    fun `empty variables map with null-returning fallback leaves all placeholders`() {
+        val endpoint = httpEndpoint(path = "/{{a}}/{{b}}")
+        val r = EndpointVariableResolver.resolve(endpoint, "h", emptyMap(), emptyFallback)
+        assertEquals("/{{a}}/{{b}}", (r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path)
+        assertEquals(setOf("a", "b"), r.missing)
+        assertTrue(r.resolved.isEmpty())
+    }
+
+    @Test
+    fun `null optional fields stay null after resolution`() {
+        val endpoint = httpEndpoint(path = "/api", method = HttpMethod.GET)
+        val r = EndpointVariableResolver.resolve(endpoint, "h", mapOf("x" to "1"), emptyFallback)
+        val meta = r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata
+        assertNull(meta.contentType)
+    }
+
+    @Test
+    fun `does not mutate the original endpoint`() {
+        val endpoint = httpEndpoint(path = "/api/{{userId}}")
+        val originalPath = (endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path
+        EndpointVariableResolver.resolve(endpoint, "h", mapOf("userId" to "42"), emptyFallback)
+        // Original should be untouched
+        assertEquals("/api/{{userId}}", originalPath)
+        assertEquals("/api/{{userId}}", (endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata).path)
+    }
+
+    @Test
+    fun `resolves mixed brace styles in same string`() {
+        val endpoint = httpEndpoint(path = "/api/{{a}}/\${b}")
+        val r = EndpointVariableResolver.resolve(
+            endpoint, "h", mapOf("a" to "1", "b" to "2"), emptyFallback
+        )
+        val meta = r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata
+        assertEquals("/api/1/2", meta.path)
+        assertEquals(setOf("a", "b"), r.resolved)
+        assertTrue(r.missing.isEmpty())
+    }
+
+    @Test
+    fun `falls back to ConfigReader when variable not in map`() {
+        val endpoint = httpEndpoint(path = "/api/{{host}}")
+        val r = EndpointVariableResolver.resolve(
+            endpoint, "h", emptyMap(), { k -> if (k == "host") "example.com" else null }
+        )
+        val meta = r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata
+        assertEquals("/api/example.com", meta.path)
+        assertTrue(r.resolved.contains("host"))
+        assertTrue(r.missing.isEmpty())
+    }
+
+    @Test
+    fun `variables map takes priority over fallback`() {
+        val endpoint = httpEndpoint(path = "/api/{{env}}")
+        val r = EndpointVariableResolver.resolve(
+            endpoint, "h", mapOf("env" to "prod"), { _ -> "dev" }
+        )
+        val meta = r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata
+        assertEquals("/api/prod", meta.path)
+    }
+
+    @Test
+    fun `resolves placeholders in headers`() {
+        val endpoint = ApiEndpoint(
+            name = "t",
+            metadata = httpMetadata(
+                path = "/api",
+                method = HttpMethod.GET,
+                headers = listOf(com.itangcent.easyapi.exporter.model.ApiHeader("Authorization", "Bearer {{token}}"))
+            )
+        )
+        val r = EndpointVariableResolver.resolve(
+            endpoint, "h", mapOf("token" to "abc123"), emptyFallback
+        )
+        val meta = r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata
+        assertEquals("Bearer abc123", meta.headers[0].value)
+    }
+
+    @Test
+    fun `resolves placeholders in query parameter values`() {
+        val endpoint = ApiEndpoint(
+            name = "t",
+            metadata = httpMetadata(
+                path = "/api",
+                method = HttpMethod.GET,
+                parameters = listOf(
+                    com.itangcent.easyapi.exporter.model.ApiParameter(
+                        name = "filter",
+                        defaultValue = "{{filterValue}}",
+                        binding = com.itangcent.easyapi.exporter.model.ParameterBinding.Query
+                    )
+                )
+            )
+        )
+        val r = EndpointVariableResolver.resolve(
+            endpoint, "h", mapOf("filterValue" to "active"), emptyFallback
+        )
+        val meta = r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata
+        assertEquals("active", meta.parameters[0].defaultValue)
+    }
+
+    @Test
+    fun `partial resolution reports both resolved and missing`() {
+        val endpoint = httpEndpoint(path = "/{{a}}/{{b}}/{{c}}")
+        val r = EndpointVariableResolver.resolve(
+            endpoint, "h", mapOf("a" to "1"), emptyFallback
+        )
+        assertEquals(setOf("a"), r.resolved)
+        assertEquals(setOf("b", "c"), r.missing)
+        val meta = r.endpoint.metadata as com.itangcent.easyapi.exporter.model.HttpMetadata
+        assertEquals("/1/{{b}}/{{c}}", meta.path)
+    }
+
+    @Test
+    fun `resolves placeholders in host string`() {
+        val endpoint = httpEndpoint(path = "/api")
+        val r = EndpointVariableResolver.resolve(
+            endpoint, "http://{{host}}:{{port}}", mapOf("host" to "localhost", "port" to "8080"), emptyFallback
+        )
+        assertEquals("http://localhost:8080", r.host)
+        assertEquals(setOf("host", "port"), r.resolved)
+    }
+
+    private fun httpEndpoint(path: String, method: HttpMethod = HttpMethod.GET): ApiEndpoint {
+        return ApiEndpoint(name = "t", metadata = httpMetadata(path = path, method = method))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/PreScriptApplierTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/curl/PreScriptApplierTest.kt
@@ -1,0 +1,219 @@
+package com.itangcent.easyapi.exporter.channel.curl
+
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.GrpcMetadata
+import com.itangcent.easyapi.exporter.model.GrpcStreamingType
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.script.ScriptCache
+import com.itangcent.easyapi.script.ScriptCacheService
+import com.itangcent.easyapi.script.ScriptScope
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.module.EnvironmentSettings
+import com.itangcent.easyapi.settings.module.ParsingOutputSettings
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+/**
+ * IDE-fixture tests for [PreScriptApplier].
+ *
+ * [PreScriptApplier] is a `@Service(PROJECT)` that needs a real [com.intellij.openapi.project.Project]
+ * (for [ScriptCacheService], [com.itangcent.easyapi.script.env.EnvironmentService],
+ * [com.itangcent.easyapi.script.pm.PmScriptExecutor]). The light fixture provides all of these.
+ *
+ * Coverage:
+ *  - No script cached → returned deep copy has no mutation effect.
+ *  - gRPC endpoint → returned copy unchanged (HTTP-only gate).
+ *  - Header-upserting script → returned copy contains the header; **original endpoint unchanged**.
+ *  - Throwing script → returns un-mutated copy; no exception escapes.
+ *  - Body-setting script → returned copy formats with the scripted body.
+ *
+ * Each test uses a distinct [ScriptScope.Class] key so cached scripts cannot leak across
+ * tests; [tearDown] deletes them for good measure.
+ *
+ * NOTE: [EasyApiLightCodeInsightFixtureTestCase] extends the JUnit 3-style
+ * [com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase], so setup/teardown
+ * must override [setUp] / [tearDown] (JUnit 4 `@Before` is NOT honored).
+ */
+class PreScriptApplierTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var applier: PreScriptApplier
+    private lateinit var scriptCache: ScriptCacheService
+
+    /** Scopes seeded per-test; tracked for tearDown cleanup. */
+    private val seededScopes = mutableListOf<ScriptScope>()
+
+    override fun setUp() {
+        super.setUp()
+        // EnvironmentService reads EnvironmentSettings; seed empty so LivePmVariableScope
+        // (used inside PreScriptApplier) has an empty variable map.
+        val settingBinder = SettingBinder.getInstance(project)
+        settingBinder.save(EnvironmentSettings())
+        settingBinder.save(ParsingOutputSettings())
+        applier = PreScriptApplier.getInstance(project)
+        scriptCache = ScriptCacheService.getInstance(project)
+    }
+
+    override fun tearDown() {
+        try {
+            seededScopes.forEach { runCatching { scriptCache.delete(it) } }
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun httpEndpoint(
+        name: String = "Test",
+        path: String = "/api/test",
+        method: HttpMethod = HttpMethod.GET,
+        headers: List<ApiHeader> = emptyList(),
+    ): ApiEndpoint = ApiEndpoint(
+        name = name,
+        metadata = httpMetadata(path = path, method = method, headers = headers),
+    )
+
+    private fun grpcEndpoint(): ApiEndpoint = ApiEndpoint(
+        name = "GrpcTest",
+        metadata = GrpcMetadata(
+            path = "/test.Service/Method",
+            serviceName = "Service",
+            methodName = "Method",
+            packageName = "test",
+            streamingType = GrpcStreamingType.UNARY,
+        ),
+    )
+
+    /** Seeds a pre-request script for [scope] and tracks it for tearDown. */
+    private fun seedScript(scope: ScriptScope, script: String) {
+        scriptCache.save(scope, ScriptCache(preRequestScript = script))
+        seededScopes.add(scope)
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1: no script cached → deep copy with no mutation effect
+    // ------------------------------------------------------------------
+
+    fun `test no script cached returns deep copy with no mutation effect`() = runTest {
+        val endpoint = httpEndpoint(headers = listOf(ApiHeader("Accept", "application/json")))
+        val originalHeaders = endpoint.metadata.let { (it as HttpMetadata).headers.toList() }
+
+        val result = applier.applyScripts(endpoint, "http://localhost:8080", listOf(ScriptScope.Class("test.none")))
+
+        val resultHttp = result.metadata as HttpMetadata
+        assertEquals("path preserved", "/api/test", resultHttp.path)
+        assertEquals("method preserved", HttpMethod.GET, resultHttp.method)
+        assertEquals("header count preserved", 1, resultHttp.headers.size)
+        assertEquals("Accept", resultHttp.headers[0].name)
+        // original endpoint untouched
+        assertEquals(originalHeaders, endpoint.metadata.let { (it as HttpMetadata).headers.toList() })
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: gRPC endpoint → returned copy unchanged (HTTP-only gate)
+    // ------------------------------------------------------------------
+
+    fun `test grpc endpoint returns deep copy unchanged`() = runTest {
+        val endpoint = grpcEndpoint()
+        // Seed a script that would mutate headers if it ran — proves the HTTP-only gate holds.
+        seedScript(ScriptScope.Class("test.grpc"), "pm.request.headers.upsert('X-Foo','bar')")
+
+        val result = applier.applyScripts(endpoint, "http://localhost:8080", listOf(ScriptScope.Class("test.grpc")))
+
+        assertTrue("gRPC metadata preserved", result.metadata is GrpcMetadata)
+        val resultGrpc = result.metadata as GrpcMetadata
+        assertEquals("/test.Service/Method", resultGrpc.path)
+        assertEquals("Service", resultGrpc.serviceName)
+        assertEquals("Method", resultGrpc.methodName)
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: header-upserting script → returned copy has header; original unchanged
+    // ------------------------------------------------------------------
+
+    fun `test script upserts header on returned copy and leaves original unchanged`() = runTest {
+        val scope = ScriptScope.Class("test.header-upsert")
+        seedScript(scope, "pm.request.headers.upsert('X-Foo', 'bar')")
+        val endpoint = httpEndpoint(headers = listOf(ApiHeader("Accept", "application/json")))
+
+        // Capture original header state BEFORE the call (deep-copy contract).
+        val originalHeaders = (endpoint.metadata as HttpMetadata).headers.toList()
+
+        val result = applier.applyScripts(endpoint, "http://localhost:8080", listOf(scope))
+
+        val resultHttp = result.metadata as HttpMetadata
+        val headerNames = resultHttp.headers.map { it.name }
+        assertTrue("returned copy should contain scripted header X-Foo", headerNames.contains("X-Foo"))
+        assertEquals("bar", resultHttp.headers.first { it.name == "X-Foo" }.value)
+
+        // Original endpoint MUST NOT be mutated.
+        val originalAfter = (endpoint.metadata as HttpMetadata).headers.toList()
+        assertEquals("original header count unchanged", 1, originalAfter.size)
+        assertEquals("Accept", originalAfter[0].name)
+        assertFalse("original should NOT contain X-Foo", originalAfter.any { it.name == "X-Foo" })
+        assertEquals("captured-before equals current-after", originalHeaders, originalAfter)
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: throwing script → returns un-mutated copy; no exception escapes
+    // ------------------------------------------------------------------
+
+    fun `test throwing script returns unmutated copy and no exception escapes`() = runTest {
+        val scope = ScriptScope.Class("test.throwing")
+        seedScript(scope, "throw new RuntimeException('boom')")
+        val endpoint = httpEndpoint(headers = listOf(ApiHeader("Accept", "application/json")))
+
+        // The call should NOT throw — best-effort.
+        val result = applier.applyScripts(endpoint, "http://localhost:8080", listOf(scope))
+
+        val resultHttp = result.metadata as HttpMetadata
+        assertEquals("path unchanged on script failure", "/api/test", resultHttp.path)
+        assertEquals("method unchanged on script failure", HttpMethod.GET, resultHttp.method)
+        assertEquals("header count unchanged on script failure", 1, resultHttp.headers.size)
+        assertEquals("Accept", resultHttp.headers[0].name)
+        // Original untouched too.
+        val originalAfter = (endpoint.metadata as HttpMetadata).headers.toList()
+        assertEquals(1, originalAfter.size)
+    }
+
+    // ------------------------------------------------------------------
+    // Test 5: body-setting script → returned copy formats with scripted body
+    // ------------------------------------------------------------------
+
+    fun `test script sets body raw and formatter picks it up`() = runTest {
+        val scope = ScriptScope.Class("test.body-raw")
+        seedScript(scope, "pm.request.body.raw = '{\"x\":1}'")
+        // buildBody only emits the JSON branch when contentType contains "json";
+        // without a contentType (and no meta.body), the formatter returns "".
+        val endpoint = ApiEndpoint(
+            name = "Test",
+            metadata = httpMetadata(
+                path = "/api/test",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+            ),
+        )
+
+        val result = applier.applyScripts(endpoint, "http://localhost:8080", listOf(scope))
+
+        // The scripted body is stashed in extensions[RESOLVED_BODY_JSON_KEY]; CurlFormatter
+        // checks that key first (carrier reuse).
+        val curl = CurlFormatter.format(result, "http://localhost:8080", CurlFormatOptions())
+        assertTrue("curl should contain scripted body", curl.contains("\"x\":1"))
+    }
+
+    // ------------------------------------------------------------------
+    // Test 6: empty scopes → no-op deep copy (defensive)
+    // ------------------------------------------------------------------
+
+    fun `test empty scopes returns deep copy`() = runTest {
+        val endpoint = httpEndpoint()
+        val result = applier.applyScripts(endpoint, "http://localhost:8080", emptyList())
+        val resultHttp = result.metadata as HttpMetadata
+        assertEquals("/api/test", resultHttp.path)
+        assertEquals(HttpMethod.GET, resultHttp.method)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngineTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateEngineTest.kt
@@ -2,6 +2,8 @@ package com.itangcent.easyapi.exporter.channel.markdown.template
 
 import com.itangcent.easyapi.psi.model.ObjectModel
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Clock
 import java.time.Instant
@@ -432,5 +434,97 @@ class TemplateEngineTest {
         val model = singleEndpointModel()
         val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{api.protocol}}|{{api.path}}|{{api.method}}{{/each}}{{/each}}"
         assertEquals("HTTP|/api/users/{id}|GET", TemplateEngine.render(template, model, ctx))
+    }
+
+    // ---------- HttpView.curl() method call ----------
+
+    @Test
+    fun testHttpViewCurlMethodRendersCommand() {
+        // `{{{api.http.curl()}}}` is the user-facing template surface.
+        // The provider is wired by TemplateModelBuilder; here we pass a model built via
+        // the builder so the provider is real (not the default `{ null }`).
+        val endpoint = com.itangcent.easyapi.exporter.model.ApiEndpoint(
+            name = "Get User",
+            metadata = com.itangcent.easyapi.exporter.model.httpMetadata(
+                path = "/api/users/{id}",
+                method = com.itangcent.easyapi.exporter.model.HttpMethod.GET,
+            ),
+        )
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.curl()}}}{{/each}}{{/each}}"
+        val rendered = TemplateEngine.render(template, model, ctx)
+
+        assertTrue("rendered output should contain 'curl' banner: $rendered", rendered.contains("curl"))
+        assertTrue("rendered output should contain '-X GET' method: $rendered", rendered.contains("-X GET"))
+        assertTrue(
+            "rendered output should contain default '{{host}}' placeholder: $rendered",
+            rendered.contains("{{host}}"),
+        )
+    }
+
+    @Test
+    fun testHttpViewCurlMethodWithExplicitHost() {
+        val endpoint = com.itangcent.easyapi.exporter.model.ApiEndpoint(
+            name = "Get User",
+            metadata = com.itangcent.easyapi.exporter.model.httpMetadata(
+                path = "/api/users/{id}",
+                method = com.itangcent.easyapi.exporter.model.HttpMethod.GET,
+            ),
+        )
+        val model = TemplateModelBuilder.build(
+            listOf(endpoint),
+            moduleName = "API",
+            host = "https://api.example.com",
+        )
+
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}{{{api.http.curl()}}}{{/each}}{{/each}}"
+        val rendered = TemplateEngine.render(template, model, ctx)
+
+        assertTrue(
+            "rendered curl should contain explicit host: $rendered",
+            rendered.contains("https://api.example.com"),
+        )
+        assertFalse(
+            "rendered curl should NOT contain '{{host}}' when host is explicit: $rendered",
+            rendered.contains("{{host}}"),
+        )
+    }
+
+    @Test
+    fun testHttpViewCurlMethodReturnsEmptyWhenProviderIsNull() {
+        // Backward-compat: an HttpView constructed directly (not via the builder) has the
+        // default `curlProvider = { null }`. `{{{api.http.curl()}}}` must render as empty,
+        // NOT throw — pins the byte-parity guarantee for templates that don't use curl().
+        val endpoint = simpleHttpEndpointView("x").copy(
+            http = HttpView(
+                pathParams = emptyList(),
+                queryParams = emptyList(),
+                formParams = emptyList(),
+                headers = emptyList(),
+                body = null,
+                response = null,
+                hasRequestContent = false,
+                // curlProvider defaults to { null }
+            ),
+        )
+        val model = TemplateModel(
+            moduleName = "M",
+            groups = listOf(Group(folder = "", endpoints = listOf(endpoint))),
+            endpointCount = 1,
+        )
+
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}[{{{api.http.curl()}}}]{{/each}}{{/each}}"
+        assertEquals("[]", TemplateEngine.render(template, model, ctx))
+    }
+
+    @Test
+    fun testHttpViewUnknownMethodReturnsEmpty() {
+        // Unknown method name on HttpView → null + info log → empty (no throw).
+        val endpoint = simpleHttpEndpointView("x")
+        val model = singleEndpointModel()
+
+        val template = "{{#each groups as g}}{{#each g.endpoints as api}}[{{{api.http.unknownMethod()}}}]{{/each}}{{/each}}"
+        assertEquals("[]", TemplateEngine.render(template, model, ctx))
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/markdown/template/TemplateModelBuilderTest.kt
@@ -1,5 +1,7 @@
 package com.itangcent.easyapi.exporter.channel.markdown.template
 
+import com.itangcent.easyapi.exporter.channel.curl.CurlBuilder
+import com.itangcent.easyapi.exporter.channel.curl.CurlFormatOptions
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ApiHeader
 import com.itangcent.easyapi.exporter.model.ApiParameter
@@ -203,7 +205,7 @@ class TemplateModelBuilderTest {
         assertEquals("age", bodyView.fields[1].name)
         assertEquals("int", bodyView.fields[1].type)
         assertEquals("user age", bodyView.fields[1].desc)
-        // model is the original ObjectModel (FR-1)
+        // model is the original ObjectModel
         assertSame(body, bodyView.model)
     }
 
@@ -277,7 +279,7 @@ class TemplateModelBuilderTest {
 
         // asDemo() is evaluated lazily; equals ObjectModelJsonConverter.toJson(body)
         assertEquals(ObjectModelJsonConverter.toJson(body), bodyView.asDemo())
-        // asJson is an alias of asDemo (D5 / FR-9)
+        // asJson is an alias of asDemo
         assertEquals(bodyView.asDemo(), bodyView.asJson())
         // asJson5 is JSON5 with comments
         assertEquals(ObjectModelJsonConverter.toJson5(body), bodyView.asJson5())
@@ -569,5 +571,142 @@ class TemplateModelBuilderTest {
         // Mirrors DefaultMarkdownFormatter.buildFieldDescription:
         // "<comment><br><value1 :desc1><br><value2>"
         assertEquals("user status<br>ACTIVE :active user<br>INACTIVE", desc)
+    }
+
+    // ---- HttpView.curl() ----
+
+    @Test
+    fun testHttpViewCurlDefaultHostContainsPlaceholderAndMethod() {
+        // Default host = CurlBuilder.DEFAULT_HOST = "{{host}}". curl() must be non-null and
+        // contain the cURL banner + the method + the placeholder host.
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+        )
+
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "API")
+        val curl = model.groups[0].endpoints[0].http!!.curl()
+
+        assertNotNull("curl() must be non-null with default host", curl)
+        val c = curl!!
+        assertTrue("curl should contain 'curl' banner: $c", c.contains("curl"))
+        assertTrue("curl should contain '-X GET' method: $c", c.contains("-X GET"))
+        assertTrue("curl should contain default '{{host}}' placeholder: $c", c.contains("{{host}}"))
+    }
+
+    @Test
+    fun testHttpViewCurlWithExplicitHost() {
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+        )
+
+        val model = TemplateModelBuilder.build(
+            listOf(endpoint),
+            moduleName = "API",
+            host = "https://api.example.com",
+        )
+        val curl = model.groups[0].endpoints[0].http!!.curl()!!
+
+        assertTrue("curl should contain explicit host: $curl", curl.contains("https://api.example.com"))
+        assertFalse(
+            "curl should NOT contain '{{host}}' placeholder when explicit host given: $curl",
+            curl.contains("{{host}}"),
+        )
+    }
+
+    @Test
+    fun testHttpViewCurlWithBlankHostFallsBackToDefault() {
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+        )
+
+        val model = TemplateModelBuilder.build(
+            listOf(endpoint),
+            moduleName = "API",
+            host = "   ", // blank
+        )
+        val curl = model.groups[0].endpoints[0].http!!.curl()!!
+
+        assertTrue("blank host should fall back to default placeholder: $curl", curl.contains("{{host}}"))
+    }
+
+    @Test
+    fun testHttpViewCurlRespectsFormatOptions() {
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(path = "/api/users/{id}", method = HttpMethod.GET)
+        )
+
+        val model = TemplateModelBuilder.build(
+            listOf(endpoint),
+            moduleName = "API",
+            host = "https://api.example.com",
+            formatOptions = CurlFormatOptions(longFlags = true),
+        )
+        val curl = model.groups[0].endpoints[0].http!!.curl()!!
+
+        assertTrue("long-flags option should produce --request: $curl", curl.contains("--request"))
+        assertFalse(
+            "long-flags option should NOT produce short -X: $curl",
+            curl.contains("-X GET"),
+        )
+    }
+
+    @Test
+    fun testGrpcEndpointHasNoHttpViewSoCurlNotApplicable() {
+        // gRPC endpoints have http=null → curl() is unreachable. This pins that the curlProvider
+        // is only wired on HttpView, never on GrpcView.
+        val endpoint = ApiEndpoint(
+            name = "GetUser",
+            metadata = GrpcMetadata(
+                path = "/user.UserService/GetUser",
+                serviceName = "UserService",
+                methodName = "GetUser",
+                packageName = "user",
+                streamingType = GrpcStreamingType.UNARY,
+            )
+        )
+
+        val model = TemplateModelBuilder.build(listOf(endpoint), moduleName = "gRPC API")
+        val ep = model.groups[0].endpoints[0]
+
+        assertNull("gRPC endpoint has no HttpView", ep.http)
+        assertNotNull("gRPC endpoint has GrpcView", ep.grpc)
+    }
+
+    @Test
+    fun testHttpViewCurlMatchesCurlBuilderFormatDirectly() {
+        // Cross-check: the provider's output must equal a direct CurlBuilder.format call
+        // with the same inputs — pins that the provider is a thin delegate.
+        val endpoint = ApiEndpoint(
+            name = "Create User",
+            metadata = httpMetadata(
+                path = "/api/users",
+                method = HttpMethod.POST,
+                contentType = "application/json",
+                body = ObjectModel.Object(
+                    mapOf("name" to FieldModel(ObjectModel.single(JsonType.STRING), comment = "user name"))
+                ),
+            ),
+        )
+
+        val host = "https://api.example.com"
+        val options = CurlFormatOptions(includeComments = false)
+        val model = TemplateModelBuilder.build(
+            listOf(endpoint),
+            moduleName = "API",
+            host = host,
+            formatOptions = options,
+        )
+        val providerCurl = model.groups[0].endpoints[0].http!!.curl()!!
+        val directCurl = CurlBuilder.format(
+            endpoint,
+            host,
+            com.itangcent.easyapi.exporter.channel.curl.CurlBuildOptions(format = options),
+        )
+
+        assertEquals(directCurl, providerCurl)
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/lifecycle/ApiLifecycleEventsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/lifecycle/ApiLifecycleEventsTest.kt
@@ -105,7 +105,7 @@ class ApiLifecycleEventsTest : EasyApiLightCodeInsightFixtureTestCase() {
         api.class.parse.after=groovy:logger.info("lifecycle:api.class.parse.after:" + it.name())
         api.method.parse.before=groovy:logger.info("lifecycle:api.method.parse.before:" + it.name())
         api.method.parse.after=groovy:logger.info("lifecycle:api.method.parse.after:" + it.name())
-        export.after=groovy:logger.info("lifecycle:export.after:" + it.name())
+        export.after=groovy:api.appendDesc("\n```\n" + api.toCurl() + "\n```\n")
         """.trimIndent()
     )
 
@@ -223,5 +223,54 @@ class ApiLifecycleEventsTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         val endpoints = springExporter.export(psiClass!!)
         assertTrue("Should not export endpoints for non-controller", endpoints.isEmpty())
+    }
+
+    // ── export.after rule: api.toCurl() ──────────────────
+
+    /**
+     * Verifies the `export.after` rule's `api.toCurl()` (default host) appends a
+     * cURL command containing `curl`, the HTTP method, and the `{{host}}` default
+     * placeholder to the endpoint description.
+     */
+    fun testSpringMvcExportAfterToCurlDefaultHost() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull(psiClass)
+
+        val endpoints = springExporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        val ep = endpoints.first()
+        val desc = ep.description ?: ""
+        assertTrue("description should contain curl command: $desc", desc.contains("curl"))
+        assertTrue("description should contain {{host}} default: $desc", desc.contains("{{host}}"))
+        // The HTTP method should appear in the curl command (-X GET / --request GET)
+        val method = (ep.metadata as? com.itangcent.easyapi.exporter.model.HttpMetadata)?.method?.name
+        assertNotNull("endpoint should have HTTP method", method)
+        assertTrue("description should contain method $method: $desc", desc.contains(method!!))
+    }
+
+    /**
+     * Verifies `api.toCurl("https://api.example.com")` bakes the explicit host
+     * into the generated cURL command (host parameter).
+     *
+     * Uses a direct [com.itangcent.easyapi.rule.context.ScriptApiEndpoint] call
+     * (rather than a second rule config) because [createConfigReader] is shared
+     * across the whole class. The direct call exercises the same code path:
+     * `CurlBuilder.buildSync(project, endpoint, host, options)` with
+     * `runPreScripts=false`.
+     */
+    fun testToCurlWithExplicitHost() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull(psiClass)
+
+        val endpoints = springExporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        val ep = endpoints.first()
+        val scriptEp = com.itangcent.easyapi.rule.context.ScriptApiEndpoint(ep, project)
+        val curl = scriptEp.toCurl("https://api.example.com")
+        assertTrue("curl should contain explicit host: $curl", curl.contains("https://api.example.com"))
+        assertTrue("curl should not contain {{host}} placeholder when explicit host given: $curl",
+            !curl.contains("{{host}}"))
     }
 }


### PR DESCRIPTION
Enhance the cURL export channel with environment-variable rendering, configurable output formatting, optional pre-request script execution, and a headless-safe reusable builder so cURL generation is no longer hard-coded to the cURL channel + Copy action.

## Variable rendering
- Add pure `EndpointVariableResolver` (no Project/EnvironmentService deps) that resolves `{{var}}`/`${var}` placeholders in HTTP + gRPC fields and body JSON; original endpoint never mutated.
- `CurlExportResolver` bridges `CurlSettings.renderMode` to `EnvironmentService` + `ConfigReader` fallback, shared by `CurlChannel.export` and Dashboard "Copy as cURL". `NEVER_RENDER` default preserves byte-identical pre-enhancement output.

## Output formatting
- `CurlFormatOptions` (`includeComments`, `prettyPrintBody`, `multiLineFormat`, `longFlags`, `includeResponseExample`) threaded through `CurlFormatter`; default options reproduce current layout.
- `CurlOptionsPanel` (per-export) + `CurlSettingsPanel` (persistent tab under **Settings → EasyApi**), auto-discovered via `settingsType`/`settingsTabOrder=110`.
- `CurlConfig` carries the 5 overrides + output dir/file name.

## Pre-request scripts
- `PreScriptApplier` (project service) runs folder+class (+ endpoint for Copy-as-cURL) pre-request scripts against a deep copy before formatting; original endpoint untouched. Script throw → `console.warn` + un-mutated copy.
- Gated by `CurlSettings.runPreScripts` (default `false`) + per-export override.

## Reusable builder + rules + Markdown
- `CurlBuilder`: pure `format()` + suspend `build()` + non-suspend `buildSync()`, headless-safe with `DEFAULT_HOST="{{host}}"`.
- `ScriptApiEndpoint.toCurl()` exposes `api.toCurl()` in `export.after` rules (`@JvmOverloads` so Groovy can call all arity variants).
- `HttpView.curl()` makes `{{{api.http.curl()}}}` available in custom Markdown templates; default template untouched so byte-parity holds.

## Backward compatibility
- Default settings (`renderMode=NEVER_RENDER`, all format flags off, `runPreScripts=false`, no rule, no template change) produce byte-identical output to the pre-enhancement cURL export.

## Tests
Full suite green. New: `CurlBuilderTest`, `EndpointVariableResolverTest`, `PreScriptApplierTest`, `CurlConfigTest`, `CurlSettingsTest`, `CurlExportResolverTest`; extended `CurlFormatterTest`, `TemplateModelBuilderTest`, `TemplateEngineTest`, `ApiLifecycleEventsTest`.