### PR TITLE
feat(ai): add loop-safety and chat-retry to rule authoring agent

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ai/AiRuntimeConfig.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/AiRuntimeConfig.kt
@@ -1,6 +1,7 @@
 package com.itangcent.easyapi.ai
 
 import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.ai.agent.LoopSafetyConfig
 import com.itangcent.easyapi.settings.module.AiSettings
 import com.itangcent.easyapi.settings.settings
 
@@ -19,6 +20,9 @@ import com.itangcent.easyapi.settings.settings
  * @param contextWindow Approximate context window (in tokens) of [model],
  * used to derive the agent's token budget. Defaults to [AiProvider.contextWindow]
  * of [provider]; pass an explicit value when a per-model window is known.
+ * @param loopSafety Loop-safety and chat-retry tuning. Defaults to
+ * [LoopSafetyConfig] MVP values; no settings-UI change is required for the
+ * default.
  */
 data class AiRuntimeConfig(
     val provider: AiProvider,
@@ -27,7 +31,8 @@ data class AiRuntimeConfig(
     val model: String,
     val requestTimeoutSec: Int,
     val maxRequests: Int,
-    val contextWindow: Int = provider.contextWindow
+    val contextWindow: Int = provider.contextWindow,
+    val loopSafety: LoopSafetyConfig = LoopSafetyConfig()
 ) {
     companion object {
         /**

--- a/src/main/kotlin/com/itangcent/easyapi/ai/ChatTimeoutException.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/ChatTimeoutException.kt
@@ -1,0 +1,17 @@
+package com.itangcent.easyapi.ai
+
+/**
+ * Raised when a chat call exceeds its request timeout.
+ *
+ * Produced by converting the underlying coroutine
+ * `TimeoutCancellationException` so that the timeout becomes a normal
+ * transient exception the retry policy can handle, while cooperative
+ * cancellation (`Job.cancel`) still propagates untouched.
+ *
+ * @param timeoutMs The configured timeout in milliseconds that was exceeded.
+ * @param cause The original timeout exception.
+ */
+class ChatTimeoutException(
+    val timeoutMs: Long,
+    cause: Throwable
+) : RuntimeException("chat timed out after ${timeoutMs}ms", cause)

--- a/src/main/kotlin/com/itangcent/easyapi/ai/LangChain4jAIService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/LangChain4jAIService.kt
@@ -19,6 +19,7 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema
 import dev.langchain4j.model.chat.response.ChatResponse
 import com.itangcent.easyapi.util.json.GsonUtils
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.jetbrains.annotations.ApiStatus
@@ -53,10 +54,19 @@ class LangChain4jAIService(
         }
         request.maxTokens?.let { builder.maxOutputTokens(it) }
 
-        val resp = withContext(Dispatchers.IO) {
+        // withTimeout MUST wrap withContext (not the other way around): a
+        // blocking Java call inside withTimeout has no suspension point, so
+        // withTimeout would silently return the block's value instead of
+        // throwing. Wrapping withContext gives a real suspension point
+        // (dispatcher switch) so the timeout is enforced.
+        val resp = try {
             withTimeout(settings.requestTimeoutSec * 1000L) {
-                chatModel.chat(builder.build())
+                withContext(Dispatchers.IO) {
+                    chatModel.chat(builder.build())
+                }
             }
+        } catch (e: TimeoutCancellationException) {
+            throw ChatTimeoutException(settings.requestTimeoutSec * 1000L, e)
         }
         return resp.toAiChatResponse()
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/AgentEvent.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/AgentEvent.kt
@@ -38,6 +38,33 @@ sealed class AgentEvent {
     /** The loop failed terminally. */
     data class Failed(val reason: String) : AgentEvent()
 
+    /**
+     * The agent was detected repeating itself and the turn was terminated.
+     *
+     * Terminal — comparable to [Failed]: the turn has ended abnormally and
+     * no [TurnComplete] / [ProposalReady] will follow. The UI should offer
+     * loop-specific recovery.
+     *
+     * @param reason Human-readable loop-type label (e.g. "consecutive duplicate").
+     * @param tool The tool involved in the loop, if any (`null` for
+     * reasoning repetition).
+     * @param count Repetition count derived from the triggering reason.
+     */
+    data class LoopDetected(val reason: String, val tool: String?, val count: Int) : AgentEvent()
+
+    /**
+     * A transient chat failure is being retried.
+     *
+     * Non-terminal — the turn is still in progress. The UI must NOT treat
+     * this as a turn-end signal (no recovery dialog, no terminal handling);
+     * the indicator is cleared on the next non-retry event. [Failed] is
+     * reserved for terminal exhaustion only.
+     *
+     * @param attempt The current attempt number (1-based).
+     * @param maxRetries The configured maximum number of retries.
+     */
+    data class Retrying(val attempt: Int, val maxRetries: Int) : AgentEvent()
+
     /** The current turn completed normally. */
     object TurnComplete : AgentEvent()
 }

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/ChatRetry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/ChatRetry.kt
@@ -1,0 +1,149 @@
+package com.itangcent.easyapi.ai.agent
+
+import com.itangcent.easyapi.ai.AiChatResponse
+import com.itangcent.easyapi.ai.ChatTimeoutException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import java.io.IOException
+import kotlin.random.Random
+
+/**
+ * Thrown when chat retries are exhausted (terminal).
+ *
+ * Wraps the last failure cause and carries the final attempt count so the
+ * caller can surface both in a terminal failure signal. The original cause
+ * is preserved as [cause].
+ *
+ * @param attempts Total number of attempts made (1 + number of retries).
+ * @param cause The last exception that triggered exhaustion.
+ */
+class ChatRetriesExhausted(
+    val attempts: Int,
+    cause: Throwable
+) : RuntimeException("chat failed after $attempts attempt(s)", cause)
+
+/**
+ * Bounded retry with exponential backoff for transient chat failures.
+ *
+ * Wraps a chat [block] so that transient failures (network errors, timeouts,
+ * 429/5xx responses) are retried with capped exponential backoff plus jitter,
+ * while deterministic failures (auth errors, illegal arguments) fail fast.
+ * Cooperative cancellation ([CancellationException]) is always rethrown —
+ * never swallowed or delayed — so the Stop button remains responsive
+ * mid-backoff.
+ *
+ * Classification and the retry loop are separated deliberately: [isTransient]
+ * is a pure function over an exception (trivially unit-testable), while
+ * [chatWithRetry] is the suspending loop that drives backoff and callbacks.
+ *
+ * @param cfg Loop-safety tuning (retry count + backoff parameters).
+ */
+class ChatRetry(private val cfg: LoopSafetyConfig) {
+
+    /**
+     * Execute [block] with bounded retry on transient failures.
+     *
+     * On success after one or more retries, [onRecovery] is invoked with the
+     * total attempt count so the caller can log/emit a recovery signal.
+     * [onFailure] is invoked per failed attempt with the 1-based attempt
+     * number and the exception, so the caller can log the failure and emit a
+     * non-terminal retry-progress event.
+     *
+     * Terminal failure (non-transient fail-fast OR retries exhausted) throws
+     * [ChatRetriesExhausted] carrying the final attempt count and last cause.
+     * [CancellationException] is rethrown immediately — it never reaches
+     * [onFailure] or [onRecovery].
+     *
+     * Backoff between retries is `min(chatBackoffMaxMs,
+     * chatBackoffBaseMs * 2^(attempt-1))` plus 0–249 ms jitter, realised via
+     * cancellable [delay] (never `Thread.sleep`).
+     *
+     * @param block The chat call to execute (may be retried on transient failure).
+     * @param onFailure Per-attempt failure hook (1-based attempt number + exception).
+     * @param onRecovery Recovery hook invoked on success after retry (attempt > 0).
+     * @return The successful [AiChatResponse] from [block].
+     */
+    suspend fun chatWithRetry(
+        block: suspend () -> AiChatResponse,
+        onFailure: (attempt: Int, e: Exception) -> Unit,
+        onRecovery: (attempts: Int) -> Unit
+    ): AiChatResponse {
+        var attempt = 0
+        while (true) {
+            try {
+                val resp = block()
+                if (attempt > 0) onRecovery(attempt)
+                return resp
+            } catch (e: CancellationException) {
+                // Cooperative cancellation must never be swallowed or delayed.
+                throw e
+            } catch (e: Exception) {
+                attempt++
+                onFailure(attempt, e)
+                if (!isTransient(e) || attempt > cfg.chatMaxRetries) {
+                    throw ChatRetriesExhausted(attempt, e)
+                }
+                val backoff = minOf(
+                    cfg.chatBackoffMaxMs,
+                    cfg.chatBackoffBaseMs * (1L shl (attempt - 1))
+                )
+                delay(backoff + Random.nextLong(0, 250))
+            }
+        }
+    }
+
+    /**
+     * Classify whether [e] may succeed on retry.
+     *
+     * Returns `true` for transient failures — [IOException] (including
+     * `SocketTimeoutException`), [ChatTimeoutException], or any exception
+     * whose (lowercased) message contains a transient substring
+     * (`"429"`, `"rate limit"`, `"ratelimit"`, `"timeout"`, `"timed out"`,
+     * `"502"`, `"503"`, `"504"`, `"temporarily"`, `"unavailable"`,
+     * `"connection reset"`, `"broken pipe"`).
+     *
+     * Returns `false` for deterministic failures —
+     * [IllegalArgumentException], [IllegalStateException], or any exception
+     * whose message contains a non-transient substring (`"401"`, `"403"`,
+     * `"unauthorized"`, `"forbidden"`, `"invalid api key"`,
+     * `"invalid_api_key"`, `"model not found"`, `"context length"`) — and
+     * for unknown exceptions (conservative fail-fast).
+     *
+     * [CancellationException] is never classified here: it is rethrown by
+     * [chatWithRetry] before this method is called.
+     *
+     * @param e The exception to classify.
+     * @return `true` if the failure is transient and worth retrying.
+     */
+    fun isTransient(e: Exception): Boolean {
+        // Deny-list by type — fail fast on deterministic errors.
+        when (e) {
+            is IllegalArgumentException, is IllegalStateException -> return false
+        }
+        // Allow-list by type.
+        when (e) {
+            is IOException -> return true
+            is ChatTimeoutException -> return true
+        }
+        // Message-based classification (case-insensitive).
+        val msg = e.message?.lowercase() ?: return false
+        if (NON_TRANSIENT_SUBSTRINGS.any { msg.contains(it) }) return false
+        if (TRANSIENT_SUBSTRINGS.any { msg.contains(it) }) return true
+        // Default: non-transient (conservative — don't burn retries on unknowns).
+        return false
+    }
+
+    private companion object {
+        private val TRANSIENT_SUBSTRINGS = listOf(
+            "429", "rate limit", "ratelimit", "timeout", "timed out",
+            "502", "503", "504", "temporarily", "unavailable",
+            "connection reset", "broken pipe"
+        )
+
+        private val NON_TRANSIENT_SUBSTRINGS = listOf(
+            "401", "403", "unauthorized", "forbidden",
+            "invalid api key", "invalid_api_key",
+            "model not found", "context length"
+        )
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/LoopGuard.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/LoopGuard.kt
@@ -1,0 +1,300 @@
+package com.itangcent.easyapi.ai.agent
+
+import com.itangcent.easyapi.ai.AiMessage
+import com.itangcent.easyapi.ai.AiToolCall
+import com.itangcent.easyapi.ai.tools.ToolResult
+import com.itangcent.easyapi.util.json.GsonUtils
+import java.util.TreeMap
+
+/**
+ * Per-turn loop detector. Construct one fresh at the start of each agent
+ * turn so detection state never leaks across turns.
+ *
+ * The guard observes tool calls, tool results, and reasoning text, and
+ * returns a [Verdict] telling the agent loop whether to proceed, block a
+ * provably-identical repeat, or terminate the turn. Detection is pure logic
+ * over fingerprints — no suspend calls — so it is trivially unit-testable.
+ *
+ * @param cfg Tuning knobs for thresholds and debounce.
+ */
+class LoopGuard(private val cfg: LoopSafetyConfig) {
+
+    /** A comparable fingerprint of a tool call: (toolName, argsHash). */
+    private data class CallFp(val tool: String, val argsHash: Int)
+
+    private val callHistory = ArrayList<CallFp>()
+    private var lastCall: CallFp? = null
+    private var consecutiveDup = 0
+    private var lastResultHash: Int? = null
+    private var stagnationCount = 0
+    private val reasoningHashes = ArrayList<Int>()
+
+    /**
+     * Pre-dispatch verdict: debounce an identical-to-last call.
+     *
+     * If debounce is enabled and the fingerprint of [tc] matches the last
+     * observed call, returns [Verdict.Block] with an instructive error that
+     * names the tool but never the argument bodies. The streak counter is
+     * NOT advanced here — the caller must still invoke
+     * [observeResult] with the blocked result so consecutive/stagnation
+     * counters advance consistently.
+     *
+     * @param tc The tool call about to be dispatched.
+     * @return [Verdict.Proceed] to dispatch, or [Verdict.Block] to skip
+     * dispatch and feed a synthetic result back to the model.
+     */
+    fun checkBeforeDispatch(tc: AiToolCall): Verdict {
+        if (!cfg.debounceEnabled) return Verdict.Proceed
+        val fp = CallFp(tc.name, normalizeArgs(tc.arguments))
+        if (fp == lastCall) {
+            return Verdict.Block(
+                ToolResult.Error(
+                    "Duplicate call to '${tc.name}' with identical arguments; " +
+                        "the previous result is already in context. " +
+                        "Change your approach or communicate."
+                )
+            )
+        }
+        return Verdict.Proceed
+    }
+
+    /**
+     * Post-dispatch verdict: record the call + result and run consecutive,
+     * cycle, and stagnation detection (in that order — cheapest first).
+     *
+     * @param tc The tool call that was dispatched.
+     * @param result The result produced (or the synthetic debounce result).
+     * @return [Verdict.Proceed] to continue, or [Verdict.Terminate] to end
+     * the turn.
+     */
+    fun observeResult(tc: AiToolCall, result: ToolResult): Verdict {
+        val fp = CallFp(tc.name, normalizeArgs(tc.arguments))
+
+        // --- A. Consecutive duplicate (streak) ---
+        if (fp == lastCall) {
+            consecutiveDup++
+        } else {
+            consecutiveDup = 1
+        }
+        lastCall = fp
+        callHistory.add(fp)
+        if (consecutiveDup >= cfg.repetitionThreshold) {
+            return Verdict.Terminate(LoopReason.ConsecutiveDuplicate(tc.name, consecutiveDup))
+        }
+
+        // --- B. Call-sequence cycle (A→B→A→B) ---
+        // Period-1 is handled by the consecutive detector above; the cycle
+        // detector examines periods 2..maxCyclePeriod as a backstop for
+        // longer repeating sequences.
+        detectCycle()?.let { return Verdict.Terminate(it) }
+
+        // --- C. Output stagnation (identical results) ---
+        val h = resultFingerprint(result)
+        if (h == lastResultHash) {
+            stagnationCount++
+        } else {
+            stagnationCount = 1
+        }
+        lastResultHash = h
+        if (stagnationCount >= cfg.repetitionThreshold) {
+            return Verdict.Terminate(LoopReason.OutputStagnation(tc.name, stagnationCount))
+        }
+
+        return Verdict.Proceed
+    }
+
+    /**
+     * Post-assistant-message verdict: record reasoning text and run
+     * reasoning-repetition detection.
+     *
+     * Blank content (a tool-call-only step) neither advances nor resets the
+     * counter — it is silently skipped.
+     *
+     * @param assistant The assistant message just produced.
+     * @return [Verdict.Proceed] to continue, or [Verdict.Terminate] to end
+     * the turn.
+     */
+    fun observeReasoning(assistant: AiMessage.Assistant): Verdict {
+        val content = assistant.content
+        if (content.isNullOrBlank()) return Verdict.Proceed
+
+        val h = normalizeReasoning(content)
+        reasoningHashes.add(h)
+
+        // Count the trailing run of identical hashes.
+        var run = 1
+        var i = reasoningHashes.size - 2
+        while (i >= 0 && reasoningHashes[i] == h) {
+            run++
+            i--
+        }
+        if (run >= cfg.repetitionThreshold) {
+            return Verdict.Terminate(LoopReason.ReasoningRepetition(run))
+        }
+        return Verdict.Proceed
+    }
+
+    /**
+     * Check whether [callHistory] ends with a repeating cycle of period
+     * `p` (for `p` in `2..maxCyclePeriod`). Returns the matching
+     * [LoopReason.CallCycle] or `null`.
+     */
+    private fun detectCycle(): LoopReason.CallCycle? {
+        val n = callHistory.size
+        for (p in 2..cfg.maxCyclePeriod) {
+            val window = minOf(n, p * cfg.cycleRepetitions)
+            if (window < p * cfg.cycleRepetitions) continue
+            val start = n - window
+            var isCycle = true
+            for (i in 0..<window - p) {
+                if (callHistory[start + i] != callHistory[start + i + p]) {
+                    isCycle = false
+                    break
+                }
+            }
+            if (isCycle) {
+                val sequence = callHistory.subList(n - p, n).map { it.tool }
+                val repetitions = window / p
+                return LoopReason.CallCycle(sequence, p, repetitions)
+            }
+        }
+        return null
+    }
+
+    /** Outcome of consulting the guard. */
+    sealed class Verdict {
+        /** No objection; the agent loop continues. */
+        object Proceed : Verdict()
+
+        /** Skip dispatch and feed [result] back to the model. */
+        data class Block(val result: ToolResult) : Verdict()
+
+        /** Stop the turn — a loop was detected. */
+        data class Terminate(val reason: LoopReason) : Verdict()
+    }
+
+    /** Why the guard terminated the turn. */
+    sealed class LoopReason {
+        /** The same tool call (name + args) was repeated consecutively. */
+        data class ConsecutiveDuplicate(val tool: String, val count: Int) : LoopReason()
+
+        /** The call sequence formed a repeating cycle (e.g. A→B→A→B). */
+        data class CallCycle(val sequence: List<String>, val period: Int, val repetitions: Int) : LoopReason()
+
+        /** Consecutive calls returned identical results. */
+        data class OutputStagnation(val tool: String, val count: Int) : LoopReason()
+
+        /** The model repeated the same reasoning text. */
+        data class ReasoningRepetition(val count: Int) : LoopReason()
+    }
+
+    /**
+     * Human-readable loop-type label for this reason, used in loop-detected
+     * signals and logs. Names the loop kind only — never argument bodies.
+     */
+    fun LoopReason.describe(): String = when (this) {
+        is LoopReason.ConsecutiveDuplicate -> "consecutive duplicate"
+        is LoopReason.CallCycle -> "call cycle"
+        is LoopReason.OutputStagnation -> "output stagnation"
+        is LoopReason.ReasoningRepetition -> "reasoning repetition"
+    }
+}
+
+// ------------------------------------------------------------------
+// Normalization & fingerprinting helpers (Phase 2, task 9)
+// ------------------------------------------------------------------
+
+/**
+ * Sentinel prefix guaranteeing an [ToolResult.Error] fingerprint never
+ * collides with a [ToolResult.Text] fingerprint. Canonical JSON never
+ * starts with a NUL byte, so this prefix is unambiguous.
+ */
+private const val ERROR_SENTINEL = "\u0000__LOOPGUARD_ERROR__\u0000"
+
+/**
+ * Canonicalize a JSON arguments string into a stable form: parse to a map,
+ * sort keys recursively, re-serialize. Blank or unparseable input is treated
+ * as an empty map (`{}`).
+ *
+ * @return the canonical JSON string.
+ */
+private fun canonicalizeJson(json: String): String {
+    if (json.isBlank()) return "{}"
+    val parsed = runCatching {
+        @Suppress("UNCHECKED_CAST")
+        GsonUtils.fromJson(json, Map::class.java) as Map<String, Any?>
+    }.getOrNull() ?: return "{}"
+    return GsonUtils.toJson(sortKeys(parsed))
+}
+
+/**
+ * Recursively sort map keys so key order does not affect the fingerprint.
+ */
+private fun sortKeys(value: Any?): Any? = when (value) {
+    is Map<*, *> -> {
+        val sorted = TreeMap<String, Any?>()
+        for ((k, v) in value) {
+            sorted[k.toString()] = sortKeys(v)
+        }
+        sorted
+    }
+    is List<*> -> value.map { sortKeys(it) }
+    else -> value
+}
+
+/**
+ * Normalize tool-call arguments into a stable hash. Blank, whitespace-only,
+ * and unparseable inputs all collapse to the empty-map fingerprint. Key-order
+ * and whitespace differences collapse to the same hash.
+ *
+ * @param arguments raw JSON arguments string from an [AiToolCall].
+ * @return hash of the canonical form.
+ */
+internal fun normalizeArgs(arguments: String): Int {
+    return canonicalizeJson(arguments).hashCode()
+}
+
+/**
+ * Compute a fingerprint for a [ToolResult]. [ToolResult.Text] content is
+ * canonicalized: valid JSON is sorted and re-serialized; non-JSON text is
+ * trimmed and hashed as-is so that distinct free-text results are not
+ * falsely flagged as stagnation. Blank content collapses to the empty-map
+ * fingerprint. [ToolResult.Error] uses a distinct sentinel so an error is
+ * never identical to a success, while two errors with the same message ARE
+ * identical (stagnation).
+ *
+ * @param result the tool result to fingerprint.
+ * @return hash of the normalized form.
+ */
+internal fun resultFingerprint(result: ToolResult): Int = when (result) {
+    is ToolResult.Text -> canonicalizeResultContent(result.value).hashCode()
+    is ToolResult.Error -> (ERROR_SENTINEL + result.message.trim()).hashCode()
+}
+
+/**
+ * Canonicalize [ToolResult.Text] content. Valid JSON objects are canonicalized
+ * (keys sorted recursively); non-JSON or non-object text is trimmed and used
+ * as-is. Blank content collapses to `{}`. This differs from
+ * [canonicalizeJson] because tool results may be free text, and collapsing
+ * all non-JSON text to the same fingerprint would cause false stagnation.
+ */
+private fun canonicalizeResultContent(content: String): String {
+    if (content.isBlank()) return "{}"
+    val parsed = runCatching {
+        @Suppress("UNCHECKED_CAST")
+        GsonUtils.fromJson(content, Map::class.java) as Map<String, Any?>
+    }.getOrNull() ?: return content.trim()
+    return GsonUtils.toJson(sortKeys(parsed))
+}
+
+/**
+ * Normalize reasoning text: trim, collapse internal whitespace runs to a
+ * single space, lowercase. Returns the hash of the normalized text.
+ *
+ * @param content raw reasoning text from an [AiMessage.Assistant].
+ * @return hash of the normalized form.
+ */
+internal fun normalizeReasoning(content: String): Int {
+    val normalized = content.trim().replace(Regex("\\s+"), " ").lowercase()
+    return normalized.hashCode()
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/LoopSafetyConfig.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/LoopSafetyConfig.kt
@@ -1,0 +1,50 @@
+package com.itangcent.easyapi.ai.agent
+
+/**
+ * Tuning knobs for the agent's loop-safety and chat-retry subsystems.
+ *
+ * Defaults are MVP values; settings-UI exposure is deferred. Constructing a
+ * config with out-of-range values fails fast so a misconfiguration is caught
+ * at the call site rather than degrading loop detection at runtime.
+ *
+ * @param repetitionThreshold Consecutive duplicates / output stagnation /
+ * reasoning repetitions before a turn is terminated.
+ * @param cycleRepetitions Full call-sequence cycles (e.g. A→B→A→B) before
+ * termination.
+ * @param maxCyclePeriod Longest cycle period examined by the cycle detector.
+ * @param debounceEnabled Whether pre-dispatch debounce blocks identical calls.
+ * @param chatMaxRetries Maximum chat retries on transient failures (0 = no retry).
+ * @param chatBackoffBaseMs Base exponential-backoff delay in milliseconds.
+ * @param chatBackoffMaxMs Cap on the exponential-backoff delay in milliseconds.
+ */
+data class LoopSafetyConfig(
+    val repetitionThreshold: Int = 3,
+    val cycleRepetitions: Int = 2,
+    val maxCyclePeriod: Int = 4,
+    val debounceEnabled: Boolean = true,
+    val chatMaxRetries: Int = 2,
+    val chatBackoffBaseMs: Long = 1_000,
+    val chatBackoffMaxMs: Long = 8_000
+) {
+    init {
+        // Clamp all configured values to safe ranges.
+        require(repetitionThreshold >= 1) {
+            "repetitionThreshold must be >= 1 but was $repetitionThreshold"
+        }
+        require(cycleRepetitions >= 1) {
+            "cycleRepetitions must be >= 1 but was $cycleRepetitions"
+        }
+        require(maxCyclePeriod in 1..16) {
+            "maxCyclePeriod must be in 1..16 but was $maxCyclePeriod"
+        }
+        require(chatMaxRetries in 0..5) {
+            "chatMaxRetries must be in 0..5 but was $chatMaxRetries"
+        }
+        require(chatBackoffBaseMs >= 0) {
+            "chatBackoffBaseMs must be >= 0 but was $chatBackoffBaseMs"
+        }
+        require(chatBackoffMaxMs >= chatBackoffBaseMs) {
+            "chatBackoffMaxMs ($chatBackoffMaxMs) must be >= chatBackoffBaseMs ($chatBackoffBaseMs)"
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/RuleAuthoringAgent.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/RuleAuthoringAgent.kt
@@ -77,6 +77,11 @@ class RuleAuthoringAgent(
             "editingRuleFile=${amb.editingRuleFile} " +
             "budget=${ctx.aiSettings.maxRequests}")
 
+        // Fresh per-turn loop guard + retry policy so detection state never
+        // leaks across turns (REQ-1 AC-4).
+        val guard = LoopGuard(ctx.aiSettings.loopSafety)
+        val retry = ChatRetry(ctx.aiSettings.loopSafety)
+
         var step = 0
         val tokenBudget = contextWindowToBudget(ctx.aiSettings.contextWindow)
         while (step < ctx.aiSettings.maxRequests) {
@@ -86,13 +91,41 @@ class RuleAuthoringAgent(
                 "messages=${memory.messages.size} tools=${tools.schemas().size}")
 
             val resp = try {
-                aiService.chat(AiChatRequest(memory.messages, tools.schemas()))
+                retry.chatWithRetry(
+                    { aiService.chat(AiChatRequest(memory.messages, tools.schemas())) },
+                    onFailure = { a, e ->
+                        LOG.warn("agent chat attempt $a failed: ${e::class.simpleName}", e)
+                        // Emit a non-terminal retry-progress signal only for
+                        // transient failures (an actual retry will follow).
+                        // Non-transient failures fail-fast — no Retrying event.
+                        // tryEmit is used because this callback is non-suspending;
+                        // the SharedFlow's replay buffer absorbs the event.
+                        if (retry.isTransient(e)) {
+                            events.tryEmit(
+                                AgentEvent.Retrying(a, ctx.aiSettings.loopSafety.chatMaxRetries)
+                            )
+                        }
+                    },
+                    onRecovery = { attempts ->
+                        LOG.info("agent chat recovered after $attempts retry attempt(s)")
+                    }
+                )
             } catch (e: kotlinx.coroutines.CancellationException) {
                 // Control-flow exception — must be rethrown, never logged.
                 throw e
+            } catch (e: ChatRetriesExhausted) {
+                LOG.warn("agent chat failed at step ${step + 1} after retries exhausted", e)
+                events.emit(
+                    AgentEvent.Failed(
+                        "chat failed after ${e.attempts} attempt(s): " +
+                            "${e.cause?.let { it::class.simpleName } ?: e::class.simpleName}"
+                    )
+                )
+                return logOutcome(TurnOutcome.Answered)
             } catch (e: Exception) {
-                LOG.warn("AI agent chat failed at step ${step + 1}", e)
-                events.emit(AgentEvent.Failed(e.message ?: "chat failed"))
+                // Safety net for any exception that escapes chatWithRetry unwrapped.
+                LOG.warn("agent chat failed at step ${step + 1}", e)
+                events.emit(AgentEvent.Failed("chat failed: ${e::class.simpleName}"))
                 return logOutcome(TurnOutcome.Answered)
             }
             val assistant = resp.message as? AiMessage.Assistant
@@ -102,6 +135,13 @@ class RuleAuthoringAgent(
                     return logOutcome(TurnOutcome.Answered)
                 }
             memory.messages.add(assistant)
+
+            // Reasoning repetition — check before tool-call dispatch so a
+            // looping assistant message is caught even if it carries tool calls.
+            when (val v = guard.observeReasoning(assistant)) {
+                is LoopGuard.Verdict.Terminate -> return endLoopDetected(guard, v.reason, memory)
+                else -> { }
+            }
 
             val calls = assistant.toolCalls
             if (calls.isNullOrEmpty()) {
@@ -117,6 +157,24 @@ class RuleAuthoringAgent(
                 calls.joinToString(",") { it.name })
 
             for (tc in calls!!) {
+                // Debounce: skip dispatch for provably-identical repeats and
+                // feed an instructive error back to the model instead. The
+                // streak counter still advances via observeResult below.
+                when (val pre = guard.checkBeforeDispatch(tc)) {
+                    is LoopGuard.Verdict.Block -> {
+                        memory.messages.add(AiMessage.ToolResult(tc.id, tc.name, pre.result.toJson()))
+                        events.emit(AgentEvent.Observed(tc.name, pre.result.summary()))
+                        LOG.info("agent tool debounced: ${tc.name}")
+                        when (val post = guard.observeResult(tc, pre.result)) {
+                            is LoopGuard.Verdict.Terminate ->
+                                return endLoopDetected(guard, post.reason, memory)
+                            else -> { }
+                        }
+                        continue
+                    }
+                    else -> { }
+                }
+
                 val args = parseArgs(tc.arguments)
                 val kind = tools.kindOf(tc.name)
                 when (kind) {
@@ -145,6 +203,13 @@ class RuleAuthoringAgent(
                 // Log only the result kind + a size hint — never the body.
                 LOG.info("agent tool result: ${tc.name} -> ${result.resultKind()}")
 
+                // Loop detection: consecutive duplicate / call cycle / output stagnation.
+                when (val post = guard.observeResult(tc, result)) {
+                    is LoopGuard.Verdict.Terminate ->
+                        return endLoopDetected(guard, post.reason, memory)
+                    else -> { }
+                }
+
                 if (tc.name == PROPOSE_RULE_CONTENT) {
                     // Terminal action — proposal is staged in working memory.
                     return finish(memory)
@@ -154,6 +219,41 @@ class RuleAuthoringAgent(
         }
         LOG.info("agent turn ended: request budget exhausted (${ctx.aiSettings.maxRequests})")
         return logOutcome(TurnOutcome.StepLimitHit)
+    }
+
+    /**
+     * Terminate the turn abnormally because the [LoopGuard] detected a loop.
+     *
+     * Derives the tool name + repetition count from the [LoopGuard.LoopReason]
+     * subtype, emits a terminal [AgentEvent.LoopDetected], and returns
+     * [TurnOutcome.LoopDetected] via [logOutcome] (NOT [finish] — no
+     * `TurnComplete` / `ProposalReady` is emitted for an abnormal exit).
+     *
+     * @param guard The per-turn guard (used to access [LoopGuard.describe]).
+     * @param reason Why the guard terminated the turn.
+     * @param memory The agent memory (unused but reserved for future telemetry).
+     */
+    private suspend fun endLoopDetected(
+        guard: LoopGuard,
+        reason: LoopGuard.LoopReason,
+        @Suppress("UNUSED_PARAMETER") memory: AgentMemory
+    ): TurnOutcome {
+        val tool = when (reason) {
+            is LoopGuard.LoopReason.ConsecutiveDuplicate -> reason.tool
+            is LoopGuard.LoopReason.OutputStagnation -> reason.tool
+            is LoopGuard.LoopReason.CallCycle -> reason.sequence.firstOrNull()
+            is LoopGuard.LoopReason.ReasoningRepetition -> null
+        }
+        val count = when (reason) {
+            is LoopGuard.LoopReason.ConsecutiveDuplicate -> reason.count
+            is LoopGuard.LoopReason.CallCycle -> reason.repetitions
+            is LoopGuard.LoopReason.OutputStagnation -> reason.count
+            is LoopGuard.LoopReason.ReasoningRepetition -> reason.count
+        }
+        LOG.info("agent turn end: loop detected (${reason::class.simpleName})")
+        val description = with(guard) { reason.describe() }
+        events.emit(AgentEvent.LoopDetected(description, tool, count))
+        return logOutcome(TurnOutcome.LoopDetected)
     }
 
     /**
@@ -198,11 +298,15 @@ class RuleAuthoringAgent(
  * the user may reply again.
  * - [StepLimitHit] → the step budget was exhausted; the UI offers
  * Continue / Cancel.
+ * - [LoopDetected] → the agent was repeating itself and the turn was
+ * terminated; the UI offers loop-specific recovery. This is an abnormal
+ * exit — no `TurnComplete` / `ProposalReady` is emitted.
  */
 sealed class TurnOutcome {
     object Proposed : TurnOutcome()
     object Answered : TurnOutcome()
     object StepLimitHit : TurnOutcome()
+    object LoopDetected : TurnOutcome()
 }
 
 /** Serialise a [ToolResult] to the JSON string fed back to the LLM. */
@@ -232,4 +336,5 @@ private fun TurnOutcome.outcomeName(): String = when (this) {
     TurnOutcome.Proposed -> "proposed"
     TurnOutcome.Answered -> "answered"
     TurnOutcome.StepLimitHit -> "step_limit_hit"
+    TurnOutcome.LoopDetected -> "loop_detected"
 }

--- a/src/main/kotlin/com/itangcent/easyapi/ai/ui/AiChatPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/ui/AiChatPanel.kt
@@ -133,6 +133,14 @@ class AiChatPanel(
     private var clarificationPending: Boolean = false
 
     /**
+     * The reason/tool captured from the most recent [AgentEvent.LoopDetected],
+     * used to enrich the recovery dialog text. Overwritten on each loop
+     * detection; consumed by [offerLoopRecovery].
+     */
+    private var lastLoopReason: String? = null
+    private var lastLoopTool: String? = null
+
+    /**
      * Optional hook. When set, a staged proposal
      * card shows an **"Apply to editor"** button that calls this with the
      * proposal content — used by [com.itangcent.easyapi.settings.ui.RuleFileEditDialog]
@@ -386,6 +394,10 @@ class AiChatPanel(
                             statusLabel.text = "Request limit reached."
                             offerContinueOrCancel(sess)
                         }
+                        TurnOutcome.LoopDetected -> {
+                            statusLabel.text = "Agent appears stuck."
+                            offerLoopRecovery(sess)
+                        }
                     }
                 }
             } catch (e: kotlinx.coroutines.CancellationException) {
@@ -460,6 +472,16 @@ class AiChatPanel(
                     "EasyApi AI Assistant",
                     ev.reason
                 )
+            }
+            is AgentEvent.LoopDetected -> {
+                // Capture the loop reason/tool so the recovery dialog can
+                // name the offending tool. The status label is set from the
+                // TurnOutcome.LoopDetected branch after the turn ends.
+                lastLoopReason = ev.reason
+                lastLoopTool = ev.tool
+            }
+            is AgentEvent.Retrying -> {
+                statusLabel.text = "Retrying chat (attempt ${ev.attempt}/${ev.maxRetries})…"
             }
             AgentEvent.TurnComplete -> {
                 // Turn finished — status already updated in sendCurrentInput.
@@ -914,6 +936,57 @@ class AiChatPanel(
                     throw e
                 } catch (e: Throwable) {
                     LOG.warn("Continue turn failed", e)
+                } finally {
+                    ui { setRunning(false) }
+                }
+            }
+        }
+    }
+
+    /**
+     * Offers loop-recovery after a [TurnOutcome.LoopDetected] turn, mirroring
+     * [offerContinueOrCancel].
+     *
+     * The dialog names the offending tool (captured from
+     * [AgentEvent.LoopDetected]) when available. Continuing injects a
+     * user-style anti-repetition hint (design Decision 5) and re-runs the
+     * turn — a fresh `LoopGuard` starts automatically (it is per-turn).
+     * Recovery is user-initiated; there is no auto-retry.
+     */
+    private fun offerLoopRecovery(sess: ConversationSession) {
+        val tool = lastLoopTool
+        val dialogText = if (tool != null) {
+            "The agent was repeating the same action ($tool). Retry with guidance, or stop?"
+        } else {
+            "The agent was repeating the same action. Retry with guidance, or stop?"
+        }
+        val options = arrayOf("Continue", "Cancel")
+        val choice = JOptionPane.showOptionDialog(
+            null,
+            dialogText,
+            "EasyApi AI Assistant",
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.QUESTION_MESSAGE,
+            null,
+            options,
+            options[0]
+        )
+        if (choice == JOptionPane.YES_OPTION) {
+            // User-style anti-repetition hint (design Decision 5) — same
+            // injection channel as the "(continue)" nudge in offerContinueOrCancel.
+            val hint = "The previous turn repeated without progress. " +
+                "Try a different tool, change the arguments, or communicate your conclusion."
+            setRunning(true)
+            turnJob = workScope.launch {
+                try {
+                    sess.agent.runTurn(
+                        hint, sess.memory,
+                        AmbientPerception.capture(project, editingFilePath)
+                    )
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    LOG.warn("Loop-recovery turn failed", e)
                 } finally {
                     ui { setRunning(false) }
                 }

--- a/src/test/kotlin/com/itangcent/easyapi/ai/LangChain4jAIServiceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/LangChain4jAIServiceTest.kt
@@ -1,0 +1,100 @@
+package com.itangcent.easyapi.ai
+
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.request.ChatRequest
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+
+/**
+ * Regression tests for [LangChain4jAIService] timeout handling.
+ *
+ * Verifies design Decision 4: a chat timeout (the underlying
+ * [ChatModel.chat] blocking longer than
+ * [AiRuntimeConfig.requestTimeoutSec]) is surfaced as a
+ * [ChatTimeoutException] — a normal transient exception the retry policy
+ * classifies as retryable — rather than propagating as a raw coroutine
+ * [TimeoutCancellationException], which the agent layer must rethrow as
+ * cooperative cancellation and therefore cannot retry.
+ *
+ * Plain JUnit 4 + mockito-kotlin; no IDE fixture needed — the service is
+ * constructed directly with a mocked [ChatModel].
+ */
+class LangChain4jAIServiceTest {
+
+    /**
+     * When the underlying [ChatModel.chat] blocks longer than
+     * [AiRuntimeConfig.requestTimeoutSec], the service must throw
+     * [ChatTimeoutException] (NOT a raw [TimeoutCancellationException]).
+     *
+     * Pre-fix this test fails: `withTimeout` propagates
+     * [TimeoutCancellationException] directly, which the agent layer
+     * treats as cooperative cancellation and cannot retry. Post-fix the
+     * service converts it to [ChatTimeoutException], which the retry
+     * policy classifies as transient.
+     *
+     * The fake [ChatModel] blocks for 2 s while the request timeout is
+     * 1 s, so the test completes in ~1–2 s regardless of whether the
+     * coroutine runtime interrupts the IO thread.
+     */
+    @Test
+    fun testChatTimeoutSurfacedAsChatTimeoutException() = runBlocking {
+        // A fake ChatModel that blocks well past the 1s request timeout.
+        // The block runs on Dispatchers.IO inside the service, so a
+        // blocking Thread.sleep is representative of a real stalled
+        // provider call. InterruptedException is deliberately NOT caught:
+        // when withTimeout fires and interrupts the IO thread, the
+        // InterruptedException must propagate so withTimeout converts it
+        // to TimeoutCancellationException (which the fix then converts to
+        // ChatTimeoutException). Catching it would race with the timeout
+        // and let the block return normally.
+        val chatModel = mock<ChatModel> {
+            on { chat(any<ChatRequest>()) } doAnswer {
+                Thread.sleep(2_000) // blocks longer than requestTimeoutSec=1
+                null // unreachable in practice — the timeout fires first
+            }
+        }
+        val settings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "https://api.openai.com/v1",
+            apiKey = "test-key",
+            model = "gpt-4o-mini",
+            requestTimeoutSec = 1,
+            maxRequests = 8
+        )
+        val service = LangChain4jAIService(chatModel, settings)
+
+        val request = AiChatRequest(
+            messages = listOf(AiMessage.User("ping")),
+            tools = emptyList(),
+            maxTokens = 1
+        )
+
+        val thrown: ChatTimeoutException? = try {
+            service.chat(request)
+            null
+        } catch (e: ChatTimeoutException) {
+            e
+        } catch (e: TimeoutCancellationException) {
+            throw AssertionError(
+                "TimeoutCancellationException leaked (bug regressed): the " +
+                    "service must convert it to ChatTimeoutException. Got: $e"
+            )
+        }
+
+        assertNotNull(
+            "ChatTimeoutException must be thrown on chat timeout",
+            thrown
+        )
+        assertEquals(
+            "timeoutMs must match the configured request timeout",
+            1_000L,
+            thrown!!.timeoutMs
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/agent/ChatRetryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/agent/ChatRetryTest.kt
@@ -1,0 +1,442 @@
+package com.itangcent.easyapi.ai.agent
+
+import com.itangcent.easyapi.ai.AiChatResponse
+import com.itangcent.easyapi.ai.AiMessage
+import com.itangcent.easyapi.ai.ChatTimeoutException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Pure unit tests for [ChatRetry] — transient classification ([isTransient])
+ * and retry-loop behavior ([chatWithRetry]).
+ *
+ * No IDE fixture needed — the retry policy is pure logic + a cancellable
+ * suspend loop. Uses plain JUnit 4 with `runBlocking` (the project does not
+ * depend on `kotlinx-coroutines-test`, so virtual-time `runTest` is
+ * unavailable). Backoff is configured to 0 ms to keep tests fast; jitter
+ * (0–249 ms real time) is acceptable.
+ */
+class ChatRetryTest {
+
+    // ==================================================================
+    // Task 16: Transient classifier isTransient
+    // ==================================================================
+
+    // --- Transient by type ---
+
+    @Test
+    fun testTransientByTypeIOException() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        assertTrue("IOException must be transient", retry.isTransient(IOException()))
+    }
+
+    @Test
+    fun testTransientByTypeChatTimeoutException() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        assertTrue(
+            "ChatTimeoutException must be transient",
+            retry.isTransient(ChatTimeoutException(1000L, RuntimeException("upstream")))
+        )
+    }
+
+    // --- Transient by message (neutral carrier: RuntimeException) ---
+
+    @Test
+    fun testTransientByMessageSubstrings() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        val transientMessages = listOf(
+            "429 Too Many Requests",
+            "rate limit exceeded",
+            "ratelimit exceeded",
+            "request timeout",
+            "operation timed out",
+            "502 Bad Gateway",
+            "503 Service Unavailable",
+            "504 Gateway Timeout",
+            "service temporarily unavailable",
+            "server unavailable",
+            "connection reset by peer",
+            "broken pipe"
+        )
+        for (msg in transientMessages) {
+            assertTrue(
+                "message '$msg' must classify as transient",
+                retry.isTransient(RuntimeException(msg))
+            )
+        }
+    }
+
+    // --- Non-transient by type ---
+
+    @Test
+    fun testNonTransientByTypeIllegalArgumentException() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        assertFalse(
+            "IllegalArgumentException must be non-transient",
+            retry.isTransient(IllegalArgumentException("bad arg"))
+        )
+    }
+
+    @Test
+    fun testNonTransientByTypeIllegalStateException() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        assertFalse(
+            "IllegalStateException must be non-transient",
+            retry.isTransient(IllegalStateException("bad state"))
+        )
+    }
+
+    // --- Non-transient by message (neutral carrier: RuntimeException) ---
+
+    @Test
+    fun testNonTransientByMessageSubstrings() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        val nonTransientMessages = listOf(
+            "401 Unauthorized",
+            "403 Forbidden",
+            "unauthorized access",
+            "forbidden resource",
+            "invalid api key",
+            "invalid_api_key",
+            "model not found: gpt-foo",
+            "context length exceeded"
+        )
+        for (msg in nonTransientMessages) {
+            assertFalse(
+                "message '$msg' must classify as non-transient",
+                retry.isTransient(RuntimeException(msg))
+            )
+        }
+    }
+
+    // --- Default: unknown exception type + unknown message → non-transient ---
+
+    @Test
+    fun testDefaultUnknownIsNonTransient() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        assertFalse(
+            "unknown exception with unknown message must default to non-transient",
+            retry.isTransient(RuntimeException("something totally unexpected"))
+        )
+    }
+
+    @Test
+    fun testNullMessageDefaultsToNonTransient() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        // RuntimeException with null message — no type match, no message to check.
+        assertFalse(
+            "exception with null message must default to non-transient",
+            retry.isTransient(RuntimeException())
+        )
+    }
+
+    // --- Case-insensitive message matching ---
+
+    @Test
+    fun testMessageMatchingIsCaseInsensitive() {
+        val retry = ChatRetry(LoopSafetyConfig())
+        assertTrue(
+            "uppercase 'RATE LIMIT' must match 'rate limit'",
+            retry.isTransient(RuntimeException("RATE LIMIT exceeded"))
+        )
+        assertTrue(
+            "mixed-case 'Timed Out' must match 'timed out'",
+            retry.isTransient(RuntimeException("Request Timed Out"))
+        )
+        assertFalse(
+            "uppercase 'UNAUTHORIZED' must match 'unauthorized'",
+            retry.isTransient(RuntimeException("UNAUTHORIZED"))
+        )
+    }
+
+    // ==================================================================
+    // Task 17: chatWithRetry suspend helper
+    // ==================================================================
+
+    /** Fast config: zero backoff so tests run instantly (jitter 0–249 ms only). */
+    private val fastCfg = LoopSafetyConfig(
+        chatMaxRetries = 2,
+        chatBackoffBaseMs = 0,
+        chatBackoffMaxMs = 0
+    )
+
+    @Test
+    fun testFirstTrySuccessNoRecovery() = runBlocking {
+        val retry = ChatRetry(fastCfg)
+        val expected = textResponse("hello")
+        var recoveryCalled = false
+        var failureCalled = false
+
+        val resp = retry.chatWithRetry(
+            block = { expected },
+            onFailure = { _, _ -> failureCalled = true },
+            onRecovery = { recoveryCalled = true }
+        )
+
+        assertSame(expected, resp)
+        assertFalse("onRecovery must NOT be invoked on first-try success", recoveryCalled)
+        assertFalse("onFailure must NOT be invoked on first-try success", failureCalled)
+    }
+
+    @Test
+    fun testTransientFailureRetriedThenSucceeds() = runBlocking {
+        val retry = ChatRetry(fastCfg)
+        val expected = textResponse("recovered")
+        val scripted = ScriptedBlock()
+            .throwNext(IOException("connection reset"))
+            .returnNext(expected)
+        var recoveryAttempts: Int? = null
+        val failures = mutableListOf<Int>()
+
+        val resp = retry.chatWithRetry(
+            block = scripted.block,
+            onFailure = { attempt, _ -> failures.add(attempt) },
+            onRecovery = { attempts -> recoveryAttempts = attempts }
+        )
+
+        assertSame(expected, resp)
+        assertEquals("block must be called twice (1 fail + 1 success)", 2, scripted.callCount)
+        assertEquals("onFailure called once with attempt=1", listOf(1), failures)
+        assertEquals("onRecovery must be invoked with attempt=1", 1, recoveryAttempts)
+    }
+
+    @Test
+    fun testRetriesExhaustedThrowsChatRetriesExhausted() = runBlocking {
+        val cfg = LoopSafetyConfig(chatMaxRetries = 2, chatBackoffBaseMs = 0, chatBackoffMaxMs = 0)
+        val retry = ChatRetry(cfg)
+        val lastException = IOException("fail-3")
+        val scripted = ScriptedBlock()
+            .throwNext(IOException("fail-1"))
+            .throwNext(IOException("fail-2"))
+            .throwNext(lastException)
+        val failures = mutableListOf<Int>()
+        var recoveryCalled = false
+
+        val thrown = try {
+            retry.chatWithRetry(
+                block = scripted.block,
+                onFailure = { attempt, _ -> failures.add(attempt) },
+                onRecovery = { recoveryCalled = true }
+            )
+            null
+        } catch (e: ChatRetriesExhausted) {
+            e
+        }
+
+        assertNotNull("ChatRetriesExhausted must be thrown", thrown)
+        assertEquals(
+            "attempts must be 1 + chatMaxRetries = 3",
+            1 + cfg.chatMaxRetries,
+            thrown!!.attempts
+        )
+        assertSame("cause must be the last exception", lastException, thrown.cause)
+        assertEquals("onFailure called per attempt", listOf(1, 2, 3), failures)
+        assertFalse("onRecovery must NOT be invoked on exhaustion", recoveryCalled)
+    }
+
+    @Test
+    fun testNonTransientFailureThrowsImmediately() = runBlocking {
+        val retry = ChatRetry(fastCfg)
+        val authError = IllegalArgumentException("401 unauthorized")
+        val scripted = ScriptedBlock().throwNext(authError)
+        val failures = mutableListOf<Int>()
+        var recoveryCalled = false
+
+        val thrown = try {
+            retry.chatWithRetry(
+                block = scripted.block,
+                onFailure = { attempt, _ -> failures.add(attempt) },
+                onRecovery = { recoveryCalled = true }
+            )
+            null
+        } catch (e: ChatRetriesExhausted) {
+            e
+        }
+
+        assertNotNull("ChatRetriesExhausted must be thrown", thrown)
+        assertEquals("attempts must be 1 (no retry on non-transient)", 1, thrown!!.attempts)
+        assertSame("cause must be the original exception", authError, thrown.cause)
+        assertEquals("block called exactly once (no retry)", 1, scripted.callCount)
+        assertEquals("onFailure called once with attempt=1", listOf(1), failures)
+        assertFalse("onRecovery must NOT be invoked", recoveryCalled)
+    }
+
+    @Test
+    fun testCancellationExceptionRethrown() = runBlocking {
+        val retry = ChatRetry(fastCfg)
+        val cancelException = CancellationException("user pressed stop")
+        val scripted = ScriptedBlock().throwNext(cancelException)
+        var onFailureCalled = false
+        var onRecoveryCalled = false
+        var caught: Throwable? = null
+
+        try {
+            retry.chatWithRetry(
+                block = scripted.block,
+                onFailure = { _, _ -> onFailureCalled = true },
+                onRecovery = { onRecoveryCalled = true }
+            )
+        } catch (e: CancellationException) {
+            caught = e
+        }
+
+        assertSame("CancellationException must be rethrown as-is", cancelException, caught)
+        assertFalse("onFailure must NOT be called on cancellation", onFailureCalled)
+        assertFalse("onRecovery must NOT be called on cancellation", onRecoveryCalled)
+        assertEquals("block called exactly once", 1, scripted.callCount)
+    }
+
+    @Test
+    fun testOnFailureInvokedPerAttemptWithAttemptNumber() = runBlocking {
+        val retry = ChatRetry(fastCfg)
+        val scripted = ScriptedBlock()
+            .throwNext(IOException("fail-1"))
+            .throwNext(IOException("fail-2"))
+            .throwNext(IOException("fail-3"))
+        val failureAttempts = mutableListOf<Int>()
+        val failureExceptions = mutableListOf<Exception>()
+
+        try {
+            retry.chatWithRetry(
+                block = scripted.block,
+                onFailure = { attempt, e ->
+                    failureAttempts.add(attempt)
+                    failureExceptions.add(e)
+                },
+                onRecovery = { }
+            )
+        } catch (_: ChatRetriesExhausted) {
+            // expected
+        }
+
+        assertEquals(
+            "onFailure must be called with 1-based attempt numbers",
+            listOf(1, 2, 3),
+            failureAttempts
+        )
+        assertEquals(
+            "onFailure must receive the matching exception per attempt",
+            listOf("fail-1", "fail-2", "fail-3"),
+            failureExceptions.map { it.message }
+        )
+    }
+
+    @Test
+    fun testChatTimeoutExceptionRetriedAsTransient() = runBlocking {
+        val retry = ChatRetry(fastCfg)
+        val expected = textResponse("after-timeout")
+        val scripted = ScriptedBlock()
+            .throwNext(ChatTimeoutException(30_000L, RuntimeException("upstream")))
+            .returnNext(expected)
+        var recoveryAttempts: Int? = null
+
+        val resp = retry.chatWithRetry(
+            block = scripted.block,
+            onFailure = { _, _ -> },
+            onRecovery = { attempts -> recoveryAttempts = attempts }
+        )
+
+        assertSame(expected, resp)
+        assertEquals("block called twice (1 timeout + 1 success)", 2, scripted.callCount)
+        assertEquals("onRecovery invoked with attempt=1", 1, recoveryAttempts)
+    }
+
+    @Test
+    fun testZeroMaxRetriesNoRetry() = runBlocking {
+        val cfg = LoopSafetyConfig(chatMaxRetries = 0, chatBackoffBaseMs = 0, chatBackoffMaxMs = 0)
+        val retry = ChatRetry(cfg)
+        val ioError = IOException("transient but no retries allowed")
+        val scripted = ScriptedBlock().throwNext(ioError)
+        var recoveryCalled = false
+
+        val thrown = try {
+            retry.chatWithRetry(
+                block = scripted.block,
+                onFailure = { _, _ -> },
+                onRecovery = { recoveryCalled = true }
+            )
+            null
+        } catch (e: ChatRetriesExhausted) {
+            e
+        }
+
+        assertNotNull("ChatRetriesExhausted must be thrown", thrown)
+        assertEquals("attempts must be 1 (no retries)", 1, thrown!!.attempts)
+        assertSame(ioError, thrown.cause)
+        assertEquals("block called exactly once", 1, scripted.callCount)
+        assertFalse("onRecovery must NOT be invoked", recoveryCalled)
+    }
+
+    @Test
+    fun testBackoffRetriesOnEachTransientFailure() = runBlocking {
+        // Use a non-zero base so we can confirm the loop still completes
+        // quickly enough for a unit test (base=10ms, max=10ms → 10ms+jitter per retry).
+        val cfg = LoopSafetyConfig(
+            chatMaxRetries = 2,
+            chatBackoffBaseMs = 10,
+            chatBackoffMaxMs = 10
+        )
+        val retry = ChatRetry(cfg)
+        val expected = textResponse("done")
+        val scripted = ScriptedBlock()
+            .throwNext(IOException("fail-1"))
+            .throwNext(IOException("fail-2"))
+            .returnNext(expected)
+        val failureAttempts = mutableListOf<Int>()
+        var recoveryAttempts: Int? = null
+
+        val resp = retry.chatWithRetry(
+            block = scripted.block,
+            onFailure = { attempt, _ -> failureAttempts.add(attempt) },
+            onRecovery = { attempts -> recoveryAttempts = attempts }
+        )
+
+        assertSame(expected, resp)
+        assertEquals("three block calls (2 fails + 1 success)", 3, scripted.callCount)
+        assertEquals("onFailure called for attempts 1 and 2", listOf(1, 2), failureAttempts)
+        assertEquals("onRecovery called with attempt=2", 2, recoveryAttempts)
+    }
+
+    // --- Helpers ---
+
+    /** Creates a minimal [AiChatResponse] with plain-text assistant content. */
+    private fun textResponse(content: String): AiChatResponse =
+        AiChatResponse(AiMessage.Assistant(content, null), "stop")
+
+    /**
+     * Scripts a sequence of outcomes for the chat block: exceptions (thrown)
+     * and responses (returned), in insertion order.
+     */
+    private class ScriptedBlock {
+        private val outcomes = ArrayDeque<Any>()
+        private var _callCount = 0
+        val callCount: Int get() = _callCount
+
+        fun throwNext(e: Exception): ScriptedBlock {
+            outcomes.addLast(e)
+            return this
+        }
+
+        fun returnNext(r: AiChatResponse): ScriptedBlock {
+            outcomes.addLast(r)
+            return this
+        }
+
+        val block: suspend () -> AiChatResponse = {
+            _callCount++
+            check(outcomes.isNotEmpty()) { "ScriptedBlock queue exhausted (call #$_callCount)" }
+            when (val item = outcomes.removeFirst()) {
+                is Exception -> throw item
+                is AiChatResponse -> item
+                else -> error("unexpected outcome type: ${item::class}")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/agent/FakeAIService.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/agent/FakeAIService.kt
@@ -17,12 +17,30 @@ import com.itangcent.easyapi.ai.AIService
  */
 class FakeAIService : AIService {
 
-    private val queue: ArrayDeque<AiChatResponse> = ArrayDeque()
+    /** A queued chat outcome: either a response to return or a throwable to throw. */
+    private sealed class QueueEntry {
+        data class Response(val response: AiChatResponse) : QueueEntry()
+        data class Throw(val error: Throwable) : QueueEntry()
+    }
+
+    private val queue: ArrayDeque<QueueEntry> = ArrayDeque()
     private val requests: MutableList<AiChatRequest> = mutableListOf()
 
     /** Enqueue a response that the next [chat] call will return. */
     fun enqueue(response: AiChatResponse): FakeAIService {
-        queue.addLast(response)
+        queue.addLast(QueueEntry.Response(response))
+        return this
+    }
+
+    /**
+     * Enqueue a throwable that the next [chat] call will throw (instead of
+     * returning a response). The request is still recorded before the throw,
+     * so [requests] assertions remain accurate. Entries are dequeued in FIFO
+     * order relative to [enqueue] / [enqueueText] / [enqueueToolCalls], so a
+     * test can script a failure followed by a success.
+     */
+    fun enqueueThrow(e: Throwable): FakeAIService {
+        queue.addLast(QueueEntry.Throw(e))
         return this
     }
 
@@ -54,7 +72,10 @@ class FakeAIService : AIService {
             error("FakeAIService queue is empty — script underflow. " +
                 "Requests received so far: ${requests.size}.")
         }
-        return queue.removeFirst()
+        return when (val entry = queue.removeFirst()) {
+            is QueueEntry.Response -> entry.response
+            is QueueEntry.Throw -> throw entry.error
+        }
     }
 
     override suspend fun testConnection(): Result<String> =

--- a/src/test/kotlin/com/itangcent/easyapi/ai/agent/LoopGuardTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/agent/LoopGuardTest.kt
@@ -1,0 +1,515 @@
+package com.itangcent.easyapi.ai.agent
+
+import com.itangcent.easyapi.ai.AiMessage
+import com.itangcent.easyapi.ai.AiToolCall
+import com.itangcent.easyapi.ai.tools.ToolResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests for [LoopGuard] detection logic.
+ *
+ * No IDE fixture needed — the guard is pure logic over fingerprints.
+ * Uses plain JUnit 4.
+ */
+class LoopGuardTest {
+
+    // ==================================================================
+    // Task 9: Normalization & fingerprinting helpers
+    // ==================================================================
+
+    @Test
+    fun testNormalizeArgsBlankCollapsesToEmptyMap() {
+        val blank = normalizeArgs("")
+        val whitespace = normalizeArgs("  ")
+        val emptyObj = normalizeArgs("{}")
+        val whitespaceObj = normalizeArgs(" {} ")
+        assertEquals("blank and '{}' must collapse to the same fingerprint", blank, emptyObj)
+        assertEquals("whitespace-only and blank must collapse to the same fingerprint", blank, whitespace)
+        assertEquals("' {} ' and '{}' must collapse to the same fingerprint", emptyObj, whitespaceObj)
+    }
+
+    @Test
+    fun testNormalizeArgsKeyOrderIndependence() {
+        val a = normalizeArgs("""{"a":1,"b":2}""")
+        val b = normalizeArgs("""{"b":2,"a":1}""")
+        assertEquals("key order must not affect the fingerprint", a, b)
+    }
+
+    @Test
+    fun testNormalizeArgsWhitespaceIndependence() {
+        val compact = normalizeArgs("""{"a":1}""")
+        val spaced = normalizeArgs("""{ "a" : 1 }""")
+        assertEquals("whitespace differences must not affect the fingerprint", compact, spaced)
+    }
+
+    @Test
+    fun testNormalizeArgsUnparseableTreatedAsEmptyMap() {
+        val unparseable = normalizeArgs("not json")
+        val empty = normalizeArgs("")
+        assertEquals("unparseable arguments must collapse to the empty-map fingerprint", empty, unparseable)
+    }
+
+    @Test
+    fun testNormalizeArgsNestedKeyOrderIndependence() {
+        val a = normalizeArgs("""{"outer":{"x":1,"y":2},"z":3}""")
+        val b = normalizeArgs("""{"z":3,"outer":{"y":2,"x":1}}""")
+        assertEquals("nested key order must not affect the fingerprint", a, b)
+    }
+
+    @Test
+    fun testResultFingerprintTextEquivalentJsonCollapses() {
+        val a = resultFingerprint(ToolResult.Text("""{"a":1,"b":2}"""))
+        val b = resultFingerprint(ToolResult.Text("""{"b":2,"a":1}"""))
+        assertEquals("equivalent JSON-structured text results must collapse to the same fingerprint", a, b)
+    }
+
+    @Test
+    fun testResultFingerprintErrorDistinctFromSuccess() {
+        val errorFp = resultFingerprint(ToolResult.Error("some message"))
+        val textFp = resultFingerprint(ToolResult.Text("some message"))
+        assertFalse(
+            "an Error must NOT have the same fingerprint as a success with the same text",
+            errorFp == textFp
+        )
+    }
+
+    @Test
+    fun testResultFingerprintSameMessageErrorsAreSame() {
+        val a = resultFingerprint(ToolResult.Error("disk full"))
+        val b = resultFingerprint(ToolResult.Error("disk full"))
+        assertEquals("two errors with the same message must be the same fingerprint", a, b)
+    }
+
+    @Test
+    fun testResultFingerprintDifferentMessageErrorsAreDifferent() {
+        val a = resultFingerprint(ToolResult.Error("disk full"))
+        val b = resultFingerprint(ToolResult.Error("network down"))
+        assertFalse("two errors with different messages must be different fingerprints", a == b)
+    }
+
+    @Test
+    fun testNormalizeReasoningCaseAndWhitespace() {
+        val a = normalizeReasoning("Hello  World")
+        val b = normalizeReasoning("hello world")
+        assertEquals("whitespace + case normalization must collapse to the same fingerprint", a, b)
+    }
+
+    @Test
+    fun testNormalizeReasoningTrimAndCollapse() {
+        val a = normalizeReasoning("  The   quick\tbrown\nfox  ")
+        val b = normalizeReasoning("the quick brown fox")
+        assertEquals("trim + whitespace collapse + lowercase must produce the same fingerprint", a, b)
+    }
+
+    // ==================================================================
+    // Task 10: Consecutive duplicate detection
+    // ==================================================================
+
+    @Test
+    fun testConsecutiveDuplicateTerminatesAtThreshold() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val tc = AiToolCall("c1", "list_rule_keys", "{}")
+        val result = ToolResult.Text("ok")
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc, result))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc, result))
+        val verdict = guard.observeResult(tc, result)
+        assertTrue("3rd identical call must terminate", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue("reason must be ConsecutiveDuplicate", reason is LoopGuard.LoopReason.ConsecutiveDuplicate)
+        val cd = reason as LoopGuard.LoopReason.ConsecutiveDuplicate
+        assertEquals("list_rule_keys", cd.tool)
+        assertEquals(3, cd.count)
+    }
+
+    @Test
+    fun testConsecutiveDuplicateDifferentCallResetsStreak() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val b = AiToolCall("c2", "read_rule_file", """{"key":"x"}""")
+        // Distinct results per tool so stagnation doesn't interfere.
+        val resA = ToolResult.Text("""{"r":"a"}""")
+        val resB = ToolResult.Text("""{"r":"b"}""")
+
+        // A, A, B, A — no termination (max streak is 2)
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(b, resB))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+    }
+
+    @Test
+    fun testConsecutiveDuplicateABAStaysAt1() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val b = AiToolCall("c2", "read_rule_file", """{"key":"x"}""")
+        val resA = ToolResult.Text("""{"r":"a"}""")
+        val resB = ToolResult.Text("""{"r":"b"}""")
+
+        // A, B, A — two streaks of length 1, no termination
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(b, resB))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+    }
+
+    @Test
+    fun testConsecutiveDuplicatePerTurnFreshness() {
+        val guard1 = LoopGuard(LoopSafetyConfig())
+        val tc = AiToolCall("c1", "list_rule_keys", "{}")
+        val result = ToolResult.Text("ok")
+
+        // First guard: two calls (streak = 2, no termination)
+        assertEquals(LoopGuard.Verdict.Proceed, guard1.observeResult(tc, result))
+        assertEquals(LoopGuard.Verdict.Proceed, guard1.observeResult(tc, result))
+
+        // Fresh guard: starts with zeroed counter
+        val guard2 = LoopGuard(LoopSafetyConfig())
+        assertEquals(LoopGuard.Verdict.Proceed, guard2.observeResult(tc, result))
+    }
+
+    // ==================================================================
+    // Task 11: Call-sequence cycle detection
+    // ==================================================================
+
+    @Test
+    fun testCallCyclePeriod2Detected() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val b = AiToolCall("c2", "read_rule_file", """{"key":"x"}""")
+        // Distinct results per tool so stagnation doesn't interfere.
+        val resA = ToolResult.Text("""{"r":"a"}""")
+        val resB = ToolResult.Text("""{"r":"b"}""")
+
+        // A, B, A, B → cycle of period 2, 2 repetitions
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(b, resB))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        val verdict = guard.observeResult(b, resB)
+        assertTrue("A,B,A,B must terminate as a cycle", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue("reason must be CallCycle", reason is LoopGuard.LoopReason.CallCycle)
+        val cycle = reason as LoopGuard.LoopReason.CallCycle
+        assertEquals(2, cycle.period)
+        assertEquals(2, cycle.repetitions)
+        assertEquals(listOf("list_rule_keys", "read_rule_file"), cycle.sequence)
+    }
+
+    @Test
+    fun testCallCyclePeriod1CaughtByConsecutive() {
+        // Period-1 cycle (A, A, A) is caught by the consecutive detector
+        // (threshold=3), not the cycle detector.
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val result = ToolResult.Text("ok")
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, result))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, result))
+        val verdict = guard.observeResult(a, result)
+        assertTrue("A,A,A must terminate", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue(
+            "period-1 cycle must be caught by ConsecutiveDuplicate, not CallCycle",
+            reason is LoopGuard.LoopReason.ConsecutiveDuplicate
+        )
+    }
+
+    @Test
+    fun testCallCycleNonCyclicSequenceNoTermination() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val b = AiToolCall("c2", "read_rule_file", """{"key":"x"}""")
+        val c = AiToolCall("c3", "get_psi_class_info", """{"cls":"X"}""")
+        val d = AiToolCall("c4", "find_classes_by_annotation", """{"ann":"Y"}""")
+        // Distinct results per tool so stagnation doesn't interfere.
+        val resA = ToolResult.Text("""{"r":"a"}""")
+        val resB = ToolResult.Text("""{"r":"b"}""")
+        val resC = ToolResult.Text("""{"r":"c"}""")
+        val resD = ToolResult.Text("""{"r":"d"}""")
+
+        // A, B, C, D — no cycle
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(b, resB))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(c, resC))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(d, resD))
+    }
+
+    @Test
+    fun testCallCyclePeriod3Detected() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val b = AiToolCall("c2", "read_rule_file", """{"key":"x"}""")
+        val c = AiToolCall("c3", "get_psi_class_info", """{"cls":"X"}""")
+        // Distinct results per tool so stagnation doesn't interfere.
+        val resA = ToolResult.Text("""{"r":"a"}""")
+        val resB = ToolResult.Text("""{"r":"b"}""")
+        val resC = ToolResult.Text("""{"r":"c"}""")
+
+        // A, B, C, A, B, C → cycle of period 3, 2 repetitions
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(b, resB))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(c, resC))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(b, resB))
+        val verdict = guard.observeResult(c, resC)
+        assertTrue("A,B,C,A,B,C must terminate as a period-3 cycle", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue("reason must be CallCycle", reason is LoopGuard.LoopReason.CallCycle)
+        val cycle = reason as LoopGuard.LoopReason.CallCycle
+        assertEquals(3, cycle.period)
+        assertEquals(2, cycle.repetitions)
+    }
+
+    @Test
+    fun testCallCyclePerTurnFreshness() {
+        val guard1 = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val b = AiToolCall("c2", "read_rule_file", """{"key":"x"}""")
+        val resA = ToolResult.Text("""{"r":"a"}""")
+        val resB = ToolResult.Text("""{"r":"b"}""")
+
+        // First guard: A, B, A (not yet a cycle — only 1.5 repetitions)
+        assertEquals(LoopGuard.Verdict.Proceed, guard1.observeResult(a, resA))
+        assertEquals(LoopGuard.Verdict.Proceed, guard1.observeResult(b, resB))
+        assertEquals(LoopGuard.Verdict.Proceed, guard1.observeResult(a, resA))
+
+        // Fresh guard: starts with empty history
+        val guard2 = LoopGuard(LoopSafetyConfig())
+        assertEquals(LoopGuard.Verdict.Proceed, guard2.observeResult(a, resA))
+    }
+
+    // ==================================================================
+    // Task 12: Output stagnation detection
+    // ==================================================================
+
+    @Test
+    fun testOutputStagnationIdenticalResultsTerminate() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        // Different tools, same result content → stagnation
+        val tc1 = AiToolCall("c1", "list_rule_keys", "{}")
+        val tc2 = AiToolCall("c2", "read_rule_file", """{"key":"a"}""")
+        val tc3 = AiToolCall("c3", "get_psi_class_info", """{"cls":"X"}""")
+        val result = ToolResult.Text("""{"data":"same"}""")
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, result))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, result))
+        val verdict = guard.observeResult(tc3, result)
+        assertTrue("3 identical results must terminate as stagnation", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue("reason must be OutputStagnation", reason is LoopGuard.LoopReason.OutputStagnation)
+        val os = reason as LoopGuard.LoopReason.OutputStagnation
+        assertEquals(3, os.count)
+    }
+
+    @Test
+    fun testOutputStagnationDifferentResultResetsCounter() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        // Different tools so consecutive detection doesn't interfere.
+        val tc1 = AiToolCall("c1", "list_rule_keys", "{}")
+        val tc2 = AiToolCall("c2", "read_rule_file", """{"key":"a"}""")
+        val tc3 = AiToolCall("c3", "get_psi_class_info", """{"cls":"X"}""")
+        val tc4 = AiToolCall("c4", "find_classes_by_annotation", """{"ann":"Y"}""")
+        val r1 = ToolResult.Text("""{"data":"first"}""")
+        val r2 = ToolResult.Text("""{"data":"second"}""")
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, r1)) // stag=1
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, r1)) // stag=2
+        // Different result resets
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc3, r2)) // stag=1
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc4, r2)) // stag=2
+    }
+
+    @Test
+    fun testOutputStagnationErrorDistinctFromSuccess() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        // Different tools so consecutive detection doesn't interfere.
+        val tc1 = AiToolCall("c1", "list_rule_keys", "{}")
+        val tc2 = AiToolCall("c2", "read_rule_file", """{"key":"a"}""")
+        val tc3 = AiToolCall("c3", "get_psi_class_info", """{"cls":"X"}""")
+        // Error with the same text as a success must NOT count as identical
+        val textResult = ToolResult.Text("disk full")
+        val errorResult = ToolResult.Error("disk full")
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, textResult))  // stag=1 (text)
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, errorResult)) // stag=1 (error ≠ text, reset)
+        // text again — error ≠ text so this is also a reset, no stagnation
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc3, textResult))  // stag=1 (text ≠ error, reset)
+    }
+
+    @Test
+    fun testOutputStagnationSameMessageErrorsCount() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val tc1 = AiToolCall("c1", "list_rule_keys", "{}")
+        val tc2 = AiToolCall("c2", "read_rule_file", """{"key":"a"}""")
+        val tc3 = AiToolCall("c3", "get_psi_class_info", """{"cls":"X"}""")
+        val error = ToolResult.Error("permission denied")
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, error))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, error))
+        val verdict = guard.observeResult(tc3, error)
+        assertTrue("3 identical errors must terminate as stagnation", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue("reason must be OutputStagnation", reason is LoopGuard.LoopReason.OutputStagnation)
+    }
+
+    // ==================================================================
+    // Task 13: Reasoning repetition detection
+    // ==================================================================
+
+    @Test
+    fun testReasoningRepetitionIdenticalTextTerminates() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val msg = AiMessage.Assistant("I should check the rules first.", null)
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(msg))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(msg))
+        val verdict = guard.observeReasoning(msg)
+        assertTrue("3 identical reasoning messages must terminate", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue("reason must be ReasoningRepetition", reason is LoopGuard.LoopReason.ReasoningRepetition)
+        val rr = reason as LoopGuard.LoopReason.ReasoningRepetition
+        assertEquals(3, rr.count)
+    }
+
+    @Test
+    fun testReasoningRepetitionBlankSkips() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val blank = AiMessage.Assistant(null, null)
+        val nonBlank = AiMessage.Assistant("thinking...", null)
+
+        // Blank content neither advances nor resets
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(blank))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(nonBlank))  // run=1
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(blank))     // skip (no reset)
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(nonBlank))  // run=2 (blank didn't reset)
+        // Only 2 non-blank observations — no termination (threshold=3)
+    }
+
+    @Test
+    fun testReasoningRepetitionDifferentTextResets() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiMessage.Assistant("Let me check the rules.", null)
+        val b = AiMessage.Assistant("Now I will read the file.", null)
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(a))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(a))
+        // Different text resets
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(b))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(b))
+    }
+
+    @Test
+    fun testReasoningRepetitionNormalization() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        // "Hello  World" and "hello world" normalize to the same fingerprint
+        val a = AiMessage.Assistant("Hello  World", null)
+        val b = AiMessage.Assistant("hello world", null)
+
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(a))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(b))
+        val verdict = guard.observeReasoning(a)
+        assertTrue("normalized-identical reasoning must terminate after 3", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue("reason must be ReasoningRepetition", reason is LoopGuard.LoopReason.ReasoningRepetition)
+    }
+
+    @Test
+    fun testReasoningRepetitionEmptyStringIsBlank() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val empty = AiMessage.Assistant("", null)
+        val nonBlank = AiMessage.Assistant("thinking...", null)
+
+        // Empty string is blank → skip (no advance, no reset)
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(empty))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(nonBlank))  // run=1
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(empty))     // skip (no reset)
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeReasoning(nonBlank))  // run=2
+        // Only 2 non-blank → no termination (threshold=3)
+    }
+
+    // ==================================================================
+    // Task 14: Debounce hook
+    // ==================================================================
+
+    @Test
+    fun testDebounceIdenticalToLastBlocks() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val tc = AiToolCall("c1", "list_rule_keys", "{}")
+        val result = ToolResult.Text("ok")
+
+        // First call: observeResult sets lastCall
+        guard.observeResult(tc, result)
+
+        // Second identical call: checkBeforeDispatch must Block
+        val verdict = guard.checkBeforeDispatch(tc)
+        assertTrue("identical-to-last call must be blocked", verdict is LoopGuard.Verdict.Block)
+        val block = verdict as LoopGuard.Verdict.Block
+        assertTrue("blocked result must be an Error", block.result is ToolResult.Error)
+        val error = block.result as ToolResult.Error
+        assertTrue("error message must name the tool", error.message.contains("list_rule_keys"))
+        // Must NOT contain the arguments body (security)
+        assertFalse("error message must NOT contain arguments", error.message.contains("{}"))
+    }
+
+    @Test
+    fun testDebounceDifferentCallProceeds() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val a = AiToolCall("c1", "list_rule_keys", "{}")
+        val b = AiToolCall("c2", "read_rule_file", """{"key":"x"}""")
+        val result = ToolResult.Text("ok")
+
+        guard.observeResult(a, result)
+        val verdict = guard.checkBeforeDispatch(b)
+        assertEquals("different call must proceed", LoopGuard.Verdict.Proceed, verdict)
+    }
+
+    @Test
+    fun testDebounceDisabledAlwaysProceeds() {
+        val guard = LoopGuard(LoopSafetyConfig(debounceEnabled = false))
+        val tc = AiToolCall("c1", "list_rule_keys", "{}")
+        val result = ToolResult.Text("ok")
+
+        guard.observeResult(tc, result)
+        val verdict = guard.checkBeforeDispatch(tc)
+        assertEquals("with debounce disabled, identical call must proceed", LoopGuard.Verdict.Proceed, verdict)
+    }
+
+    @Test
+    fun testDebounceAfterBlockObserveResultAdvancesStreak() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val tc = AiToolCall("c1", "list_rule_keys", "{}")
+        val result = ToolResult.Text("ok")
+
+        // First call: streak = 1
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc, result))
+
+        // Second call: blocked by debounce
+        val block = guard.checkBeforeDispatch(tc)
+        assertTrue(block is LoopGuard.Verdict.Block)
+        // observeResult is still called with the blocked result → streak = 2
+        val blockedResult = (block as LoopGuard.Verdict.Block).result
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc, blockedResult))
+
+        // Third call: blocked again
+        val block2 = guard.checkBeforeDispatch(tc)
+        assertTrue(block2 is LoopGuard.Verdict.Block)
+        val blockedResult2 = (block2 as LoopGuard.Verdict.Block).result
+        // observeResult → streak = 3 → Terminate
+        val verdict = guard.observeResult(tc, blockedResult2)
+        assertTrue("streak must reach threshold after blocks", verdict is LoopGuard.Verdict.Terminate)
+        val reason = (verdict as LoopGuard.Verdict.Terminate).reason
+        assertTrue(reason is LoopGuard.LoopReason.ConsecutiveDuplicate)
+        assertEquals(3, (reason as LoopGuard.LoopReason.ConsecutiveDuplicate).count)
+    }
+
+    @Test
+    fun testDebounceFirstCallProceeds() {
+        val guard = LoopGuard(LoopSafetyConfig())
+        val tc = AiToolCall("c1", "list_rule_keys", "{}")
+        // First call (no lastCall) → Proceed
+        val verdict = guard.checkBeforeDispatch(tc)
+        assertEquals("first call must proceed", LoopGuard.Verdict.Proceed, verdict)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/agent/RuleAuthoringAgentTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/agent/RuleAuthoringAgentTest.kt
@@ -4,6 +4,7 @@ import com.itangcent.easyapi.ai.AiRuntimeConfig
 import com.itangcent.easyapi.ai.AiMessage
 import com.itangcent.easyapi.ai.AiToolCall
 import com.itangcent.easyapi.ai.AiProvider
+import com.itangcent.easyapi.ai.ChatTimeoutException
 import com.itangcent.easyapi.ai.tools.AiTool
 import com.itangcent.easyapi.ai.tools.AskClarificationTool
 import com.itangcent.easyapi.ai.tools.ToolContext
@@ -14,10 +15,12 @@ import com.itangcent.easyapi.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.cancelAndJoin
+import java.io.IOException
 
 /**
  * Tests for [RuleAuthoringAgent].
@@ -124,8 +127,21 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
     /**
      * Script 3: LLM loops on a non-terminal perception tool `maxRequests`
      * times → `TurnOutcome.StepLimitHit`.
+     *
+     * The guard config is overridden so the loop detector does NOT fire
+     * within the small step budget (repetitionThreshold=10 > maxRequests=3,
+     * debounce off) — this preserves the test's intent of exercising the
+     * step-limit path rather than the loop-detector path.
      */
     fun testStepLimitHit() = runBlocking {
+        ctx = ctx.copy(
+            aiSettings = ctx.aiSettings.copy(
+                loopSafety = LoopSafetyConfig(
+                    repetitionThreshold = 10,
+                    debounceEnabled = false
+                )
+            )
+        )
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
         val events = captureEvents()
         val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
@@ -488,6 +504,398 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
         )
     }
 
+    // --- Loop-detection integration tests (Phase 5, Task 25) ---
+
+    /**
+     * 3 identical `list_rule_keys` calls → `TurnOutcome.LoopDetected` via
+     * consecutive-duplicate detection. The 2nd and 3rd calls are debounced
+     * (default `debounceEnabled=true`); the streak counter advances via
+     * `observeResult` on the blocked results and terminates at 3.
+     */
+    fun testLoopDetectedConsecutive() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
+
+        repeat(3) {
+            aiService.enqueueToolCalls(AiToolCall("c$it", "list_rule_keys", "{}"))
+        }
+
+        val outcome = agent.runTurn("loop", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.LoopDetected, outcome)
+        val loopEvent = events.collected.filterIsInstance<AgentEvent.LoopDetected>().single()
+        assertTrue("reason should contain 'consecutive': ${loopEvent.reason}",
+            loopEvent.reason.contains("consecutive"))
+        assertEquals("list_rule_keys", loopEvent.tool)
+        assertEquals(3, loopEvent.count)
+    }
+
+    /**
+     * Alternating `list_rule_keys` → `read_rule_file` (period 2, 2
+     * repetitions) → `TurnOutcome.LoopDetected` via call-cycle detection.
+     */
+    fun testLoopDetectedCycle() = runBlocking {
+        // Need 4 steps for a period-2 cycle with 2 repetitions.
+        ctx = ctx.copy(aiSettings = ctx.aiSettings.copy(maxRequests = 5))
+        val tools = ToolRegistry(listOf(
+            ListRuleKeysFakeTool(),
+            NamedFakeTool("read_rule_file")
+        ))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
+
+        aiService.enqueueToolCalls(AiToolCall("c1", "list_rule_keys", "{}"))
+        aiService.enqueueToolCalls(AiToolCall("c2", "read_rule_file", "{}"))
+        aiService.enqueueToolCalls(AiToolCall("c3", "list_rule_keys", "{}"))
+        aiService.enqueueToolCalls(AiToolCall("c4", "read_rule_file", "{}"))
+
+        val outcome = agent.runTurn("loop cycle", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.LoopDetected, outcome)
+        val loopEvent = events.collected.filterIsInstance<AgentEvent.LoopDetected>().single()
+        assertTrue("reason should contain 'cycle': ${loopEvent.reason}",
+            loopEvent.reason.contains("cycle"))
+    }
+
+    /**
+     * Same tool, different args, but identical `ToolResult.Text` content 3
+     * times → `TurnOutcome.LoopDetected` via output-stagnation detection.
+     */
+    fun testLoopDetectedStagnation() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
+
+        aiService.enqueueToolCalls(AiToolCall("c1", "list_rule_keys", """{"a":1}"""))
+        aiService.enqueueToolCalls(AiToolCall("c2", "list_rule_keys", """{"b":2}"""))
+        aiService.enqueueToolCalls(AiToolCall("c3", "list_rule_keys", """{"c":3}"""))
+
+        val outcome = agent.runTurn("loop stagnation", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.LoopDetected, outcome)
+        val loopEvent = events.collected.filterIsInstance<AgentEvent.LoopDetected>().single()
+        assertTrue("reason should contain 'stagnation': ${loopEvent.reason}",
+            loopEvent.reason.contains("stagnation"))
+        assertEquals("list_rule_keys", loopEvent.tool)
+        assertEquals(3, loopEvent.count)
+    }
+
+    /**
+     * Identical non-blank assistant text WITH tool calls (so the turn
+     * doesn't end via COMMUNICATE) 3 times → `TurnOutcome.LoopDetected` via
+     * reasoning-repetition detection. Different args so consecutive/stagnation
+     * don't fire first.
+     */
+    fun testLoopDetectedReasoning() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
+
+        repeat(3) { i ->
+            aiService.enqueueToolCalls(
+                AiToolCall("c$i", "list_rule_keys", """{"arg":$i}"""),
+                content = "Let me check the rules."
+            )
+        }
+
+        val outcome = agent.runTurn("loop reasoning", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.LoopDetected, outcome)
+        val loopEvent = events.collected.filterIsInstance<AgentEvent.LoopDetected>().single()
+        assertTrue("reason should contain 'reasoning': ${loopEvent.reason}",
+            loopEvent.reason.contains("reasoning"))
+        assertNull("tool should be null for reasoning repetition", loopEvent.tool)
+        assertEquals(3, loopEvent.count)
+    }
+
+    /**
+     * 2 identical calls with debounce ON → 2nd call is debounced (Observed
+     * carries an Error mentioning "Duplicate"). With `repetitionThreshold=3`,
+     * the 3rd identical call terminates.
+     */
+    fun testDebounceBlocksDuplicate() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
+
+        repeat(3) {
+            aiService.enqueueToolCalls(AiToolCall("c$it", "list_rule_keys", "{}"))
+        }
+
+        val outcome = agent.runTurn("loop debounce", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.LoopDetected, outcome)
+
+        val observed = events.collected.filterIsInstance<AgentEvent.Observed>()
+        assertEquals("should have 3 Observed events", 3, observed.size)
+        // 1st Observed is the actual result.
+        assertFalse(
+            "1st Observed should not mention 'Duplicate': ${observed[0].resultSummary}",
+            observed[0].resultSummary.contains("Duplicate")
+        )
+        // 2nd and 3rd are debounced.
+        assertTrue(
+            "2nd Observed should mention 'Duplicate': ${observed[1].resultSummary}",
+            observed[1].resultSummary.contains("Duplicate")
+        )
+        assertTrue(
+            "3rd Observed should mention 'Duplicate': ${observed[2].resultSummary}",
+            observed[2].resultSummary.contains("Duplicate")
+        )
+    }
+
+    /**
+     * On `LoopDetected`, the event sequence must NOT contain `TurnComplete`
+     * or `ProposalReady` (abnormal exit — REQ-2 AC-2).
+     */
+    fun testLoopDetectedEmitsNoTurnComplete() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
+
+        repeat(3) {
+            aiService.enqueueToolCalls(AiToolCall("c$it", "list_rule_keys", "{}"))
+        }
+
+        val outcome = agent.runTurn("loop", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.LoopDetected, outcome)
+        val phases = events.collected.map { it::class.simpleName }
+        assertFalse("LoopDetected should NOT emit TurnComplete",
+            phases.contains("TurnComplete"))
+        assertFalse("LoopDetected should NOT emit ProposalReady",
+            phases.contains("ProposalReady"))
+    }
+
+    /**
+     * Two sequential `runTurn` calls: turn 1 loops (LoopDetected), turn 2
+     * starts with a fresh `LoopGuard` (counter reset) and can call the same
+     * tool once without immediate termination (REQ-1 AC-4).
+     */
+    fun testPerTurnFreshness() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events.flow)
+
+        // Turn 1: 3 identical calls → LoopDetected.
+        repeat(3) {
+            aiService.enqueueToolCalls(AiToolCall("c$it", "list_rule_keys", "{}"))
+        }
+        val o1 = agent.runTurn("loop", memory)
+        assertEquals(TurnOutcome.LoopDetected, o1)
+
+        // Turn 2: fresh guard — 1 call then answer → Answered.
+        aiService.enqueueToolCalls(AiToolCall("d1", "list_rule_keys", "{}"))
+        aiService.enqueueText("done")
+        val o2 = agent.runTurn("again", memory)
+        assertEquals(TurnOutcome.Answered, o2)
+
+        events.cancelAndCollect()
+    }
+
+    // --- Retry integration tests (Phase 5, Task 26) ---
+
+    /**
+     * Transient `IOException` on the first attempt, then a plain-text answer.
+     * Asserts `TurnOutcome.Answered`, `Retrying(1, 2)` emitted, no `Failed`.
+     */
+    fun testRetryOnTransient() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val rctx = retryCtx()
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, rctx, events.flow)
+
+        aiService.enqueueThrow(IOException("connection reset"))
+        aiService.enqueueText("recovered answer")
+
+        val outcome = agent.runTurn("test", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.Answered, outcome)
+        val phases = events.collected.map { it::class.simpleName }
+        assertTrue("should emit Retrying", phases.contains("Retrying"))
+        assertFalse("should NOT emit Failed", phases.contains("Failed"))
+        assertTrue("should emit Message (recovery)", phases.contains("Message"))
+        val retrying = events.collected.filterIsInstance<AgentEvent.Retrying>().single()
+        assertEquals(1, retrying.attempt)
+        assertEquals(2, retrying.maxRetries)
+    }
+
+    /**
+     * Non-transient `IllegalArgumentException("401 unauthorized")` → fail
+     * fast. Asserts `TurnOutcome.Answered`, `Failed` with "attempt(s)", NO
+     * `Retrying` (REQ-4 AC-3, NFR-2).
+     */
+    fun testNoRetryOnAuth() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val rctx = retryCtx()
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, rctx, events.flow)
+
+        aiService.enqueueThrow(IllegalArgumentException("401 unauthorized"))
+
+        val outcome = agent.runTurn("test", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.Answered, outcome)
+        val phases = events.collected.map { it::class.simpleName }
+        assertFalse("should NOT emit Retrying", phases.contains("Retrying"))
+        val failed = events.collected.filterIsInstance<AgentEvent.Failed>().single()
+        assertTrue("Failed reason should contain 'attempt(s)': ${failed.reason}",
+            failed.reason.contains("attempt(s)"))
+    }
+
+    /**
+     * `ChatTimeoutException` on the first attempt, then a plain-text answer.
+     * Asserts the timeout is classified as transient and retried (end-to-end
+     * test for the Phase 4 fix — REQ-4 Decision 4, NFR-2).
+     */
+    fun testTimeoutRetriedAsTransient() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val rctx = retryCtx()
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, rctx, events.flow)
+
+        aiService.enqueueThrow(ChatTimeoutException(5000L, RuntimeException("inner")))
+        aiService.enqueueText("recovered after timeout")
+
+        val outcome = agent.runTurn("test", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.Answered, outcome)
+        val phases = events.collected.map { it::class.simpleName }
+        assertTrue("should emit Retrying (timeout is transient)", phases.contains("Retrying"))
+        assertFalse("should NOT emit Failed", phases.contains("Failed"))
+    }
+
+    /**
+     * `1 + chatMaxRetries` transient failures → retries exhausted. Asserts
+     * `TurnOutcome.Answered`, `Failed` with attempt count, `Retrying` per
+     * attempt (REQ-4 AC-4, AC-8).
+     */
+    fun testRetriesExhaustedTerminal() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val rctx = retryCtx(maxRetries = 2)
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, rctx, events.flow)
+
+        // 1 + 2 = 3 transient failures → exhausted.
+        repeat(3) { aiService.enqueueThrow(IOException("timeout $it")) }
+
+        val outcome = agent.runTurn("test", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.Answered, outcome)
+        val failed = events.collected.filterIsInstance<AgentEvent.Failed>().single()
+        assertTrue("Failed reason should contain 'after 3 attempt(s)': ${failed.reason}",
+            failed.reason.contains("after 3 attempt(s)"))
+        val retrying = events.collected.filterIsInstance<AgentEvent.Retrying>()
+        assertEquals("should emit Retrying 3 times", 3, retrying.size)
+    }
+
+    /**
+     * Assert `Retrying(attempt, maxRetries)` is emitted on each transient
+     * failure that is retried, and NOT on success or non-transient failures
+     * (REQ-4 AC-8).
+     */
+    fun testRetryingEventEmitted() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val rctx = retryCtx(maxRetries = 2)
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, rctx, events.flow)
+
+        // 2 transient failures then success.
+        aiService.enqueueThrow(IOException("fail 1"))
+        aiService.enqueueThrow(IOException("fail 2"))
+        aiService.enqueueText("recovered")
+
+        val outcome = agent.runTurn("test", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.Answered, outcome)
+        val retrying = events.collected.filterIsInstance<AgentEvent.Retrying>()
+        assertEquals("should emit Retrying 2 times", 2, retrying.size)
+        assertEquals(1, retrying[0].attempt)
+        assertEquals(2, retrying[1].attempt)
+        assertEquals(2, retrying[0].maxRetries)
+        val phases = events.collected.map { it::class.simpleName }
+        assertFalse("should NOT emit Failed", phases.contains("Failed"))
+    }
+
+    /**
+     * Assert `Failed.reason` contains "after N attempt(s)" on terminal
+     * exhaustion (REQ-4 AC-4).
+     */
+    fun testTerminalFailedHasAttemptCount() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val rctx = retryCtx(maxRetries = 1)
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, rctx, events.flow)
+
+        // 1 + 1 = 2 transient failures → exhausted.
+        repeat(2) { aiService.enqueueThrow(IOException("fail $it")) }
+
+        val outcome = agent.runTurn("test", memory)
+        events.cancelAndCollect()
+
+        assertEquals(TurnOutcome.Answered, outcome)
+        val failed = events.collected.filterIsInstance<AgentEvent.Failed>().single()
+        assertTrue("Failed reason should contain 'after 2 attempt(s)': ${failed.reason}",
+            failed.reason.contains("after 2 attempt(s)"))
+    }
+
+    /**
+     * Cancel the turn job mid-retry backoff → `CancellationException` must
+     * propagate (not swallowed by the retry policy). Asserts the job is
+     * cancelled and no `Failed` event was emitted (REQ-4 AC-5).
+     *
+     * NOTE: tested with `runBlocking` + a long backoff. The agent job is
+     * launched UNDISPATCHED so it runs synchronously until it suspends in
+     * `delay`; the test then cancels during the backoff window.
+     */
+    fun testCancellationNotSwallowed() = runBlocking {
+        // Long backoff so we can reliably cancel mid-backoff.
+        val cancelCtx = ctx.copy(
+            aiSettings = ctx.aiSettings.copy(
+                loopSafety = LoopSafetyConfig(
+                    chatMaxRetries = 2,
+                    chatBackoffBaseMs = 10_000,
+                    chatBackoffMaxMs = 10_000
+                )
+            )
+        )
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+        val events = captureEvents()
+        val agent = RuleAuthoringAgent(aiService, tools, cancelCtx, events.flow)
+
+        aiService.enqueueThrow(IOException("timeout"))
+        aiService.enqueueText("recovered")
+
+        val job = scope().launch(
+            context = kotlinx.coroutines.Dispatchers.Unconfined,
+            start = CoroutineStart.UNDISPATCHED
+        ) {
+            agent.runTurn("test", memory)
+        }
+        // The agent has run synchronously until the backoff `delay` —
+        // give a short breather then cancel.
+        delay(100)
+        job.cancelAndJoin()
+
+        assertTrue("job should be cancelled (CancellationException propagated)",
+            job.isCancelled)
+        val phases = events.collected.map { it::class.simpleName }
+        assertFalse("cancellation should not emit Failed", phases.contains("Failed"))
+        events.cancelAndCollect()
+    }
+
     // --- Helpers ---
 
     /**
@@ -517,6 +925,23 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     private fun scope() =
         kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Unconfined)
+
+    /**
+     * Build a [ToolContext] tuned for retry tests: short backoff (1–10 ms)
+     * so retried turns stay snappy, with a configurable [chatMaxRetries].
+     * All other loop-safety knobs keep their defaults.
+     */
+    private fun retryCtx(maxRetries: Int = 2): ToolContext {
+        return ctx.copy(
+            aiSettings = ctx.aiSettings.copy(
+                loopSafety = LoopSafetyConfig(
+                    chatMaxRetries = maxRetries,
+                    chatBackoffBaseMs = 1,
+                    chatBackoffMaxMs = 10
+                )
+            )
+        )
+    }
 
     private class EventCapture(
         val flow: MutableSharedFlow<AgentEvent>,
@@ -584,5 +1009,18 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
             executed = true
             return ToolResult.Text("wrote")
         }
+    }
+
+    /**
+     * A perception tool with a configurable name, returning a stub `ok`
+     * result. Used by loop-detection tests that need a second tool (e.g.
+     * `read_rule_file` for call-cycle detection).
+     */
+    private class NamedFakeTool(override val name: String) : AiTool {
+        override val description = "A fake tool for testing."
+        override val kind = ToolKind.PERCEPTION
+        override val parametersSchema: Map<String, Any?> = emptyMap()
+        override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult =
+            ToolResult.Text("ok")
     }
 }


### PR DESCRIPTION
## Summary

Adds a loop-safety and chat-retry subsystem to the rule authoring agent so it stops burning its request budget when the model gets stuck, and recovers transient chat failures automatically.

## Motivation

The agent could previously waste its entire `maxRequests` budget by repeating the same tool call, cycling between tools (A→B→A→B), re-emitting identical reasoning, or stalling on identical outputs — with no recovery path. Transient chat failures (timeouts, 429/5xx, connection resets) also aborted the turn immediately instead of being retried.

## Changes

**`LoopGuard`** — per-turn, pure-logic detector over fingerprints:
- Consecutive-duplicate, call-sequence cycle (period 2..N), output-stagnation, and reasoning-repetition detection
- Pre-dispatch debounce: skips provably-identical repeats and feeds an instructive error back to the model
- Argument/result fingerprinting canonicalizes JSON (key-order + whitespace independent); `Error` uses a sentinel so it never collides with a success

**`ChatRetry`** — bounded retry with exponential backoff:
- Cap + jitter via cancellable `delay` (never `Thread.sleep`)
- Transient classifier: `IOException`, `ChatTimeoutException`, and 429/5xx/timeout messages retry; auth/illegal-arg/unknown fail fast
- `CancellationException` is always rethrown so the Stop button stays responsive mid-backoff

**`ChatTimeoutException`** — `LangChain4jAIService` now wraps `withTimeout` *around* `withContext` (the blocking `chat` call needed a real suspension point) and converts the coroutine `TimeoutCancellationException` into `ChatTimeoutException`, so timeouts are retryable instead of being treated as cooperative cancellation.

**Agent + UI integration:**
- `RuleAuthoringAgent` wires both in with **fresh per-turn state**, emits new `LoopDetected` (terminal) and `Retrying` (non-terminal) events, and exposes a `LoopDetected` turn outcome
- `AiChatPanel` surfaces a loop-recovery dialog (naming the offending tool) and a retry status indicator
- `LoopSafetyConfig` holds the tuning knobs with fail-fast validation; defaults require no settings-UI change

## Testing

- `LoopGuardTest` — pure unit tests for normalization/fingerprinting and each detector (consecutive, cycle, stagnation, reasoning, debounce), incl. per-turn freshness
- `ChatRetryTest` — transient classification (type + message substrings, case-insensitive) and the retry loop (success-after-retry, exhaustion, non-transient fail-fast, cancellation rethrow, zero-retries, backoff)
- `LangChain4jAIServiceTest` — regression test that a chat timeout surfaces as `ChatTimeoutException` (not a leaked `TimeoutCancellationException`)
- `RuleAuthoringAgentTest` — agent integration tests for each loop type, debounce behavior, per-turn reset, retry-on-transient, no-retry-on-auth, timeout-retried, exhaustion, and cancellation-not-swallowed

## Notes

- Detection state never leaks across turns (fresh guard per turn)
- Error messages name the tool but never argument bodies
- Unknown exceptions default to non-transient (conservative — don't burn retries)