### PR TITLE
feat(ai): enrich PSI perception tools with name resolution, type FQNs, and method bodies

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByAnnotationTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByAnnotationTool.kt
@@ -1,6 +1,6 @@
 package com.itangcent.easyapi.ai.tools
 
-import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import com.itangcent.easyapi.core.threading.read
@@ -9,11 +9,12 @@ import com.itangcent.easyapi.util.json.GsonUtils
 
 /**
  * Perception tool that finds classes annotated with one or more annotation FQNs
- *.
+ * or simple names.
  *
  * Uses [AnnotatedElementsSearch.searchPsiClasses] — the same API the dashboard
- * scanner uses. Resolves the annotation class first (project + library scope)
- * then searches for classes annotated with it in the project scope.
+ * scanner uses. Resolves the annotation class (or simple name with optional
+ * `context`) via [PsiNameResolver.resolveAllClasses], then searches for classes
+ * annotated with it in the project scope.
  *
  * Only sees annotation-declared components; pair with
  * [FindClassesBySupertypeTool] to cover inheritance-declared components
@@ -40,53 +41,59 @@ class FindClassesByAnnotationTool : AiTool, IdeaLog {
         "properties" to mapOf(
             "annotationFqn" to mapOf(
                 "type" to "string",
-                "description" to "Fully qualified annotation name (e.g. \"org.springframework.web.bind.annotation.RestController\")."
+                "description" to "Fully qualified annotation name (or simple name when `context` is supplied)."
             ),
             "annotationFqns" to mapOf(
                 "type" to "array",
                 "items" to mapOf("type" to "string"),
                 "description" to "Multiple annotation FQNs to probe in one call (batch mode)."
+            ),
+            "context" to mapOf(
+                "type" to "string",
+                "description" to "Optional: file path or class FQN whose import scope " +
+                    "is used to resolve simple-name annotation entries."
             )
         )
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val fqns = extractFqns(args)
+        val fqns = PsiNameResolver.extractStringList(args, "annotationFqn", "annotationFqns")
         if (fqns.isEmpty()) return ToolResult.Error("missing parameter: provide `annotationFqn` (string) or `annotationFqns` (array)")
 
+        val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
+
         if (fqns.size == 1) {
-            return ToolResult.Text(GsonUtils.toJson(searchOne(fqns[0], ctx)))
+            return ToolResult.Text(GsonUtils.toJson(searchOne(fqns[0], ctx, contextElement)))
         }
-        val result = fqns.associateWith { searchOne(it, ctx) }
+        val result = fqns.associateWith { searchOne(it, ctx, contextElement) }
         return ToolResult.Text(GsonUtils.toJson(result))
     }
 
-    private fun extractFqns(args: Map<String, Any?>): List<String> {
-        val batch = args["annotationFqns"] as? List<*>
-        if (batch != null) {
-            return batch.mapNotNull { it?.toString()?.takeIf { s -> s.isNotBlank() } }
-        }
-        val single = args["annotationFqn"] as? String
-        return if (single.isNullOrBlank()) emptyList() else listOf(single)
-    }
-
-    private suspend fun searchOne(annotationFqn: String, ctx: ToolContext): List<String> = read {
-        val annotationClass = JavaPsiFacade.getInstance(ctx.project)
-.findClass(annotationFqn, GlobalSearchScope.allScope(ctx.project))
-        if (annotationClass == null) {
+    private suspend fun searchOne(
+        annotationFqn: String,
+        ctx: ToolContext,
+        contextElement: PsiElement?
+    ): List<String> = read {
+        val annotationClasses = PsiNameResolver.resolveAllClasses(
+            annotationFqn, ctx.project, contextElement
+        )
+        if (annotationClasses.isEmpty()) {
             LOG.info("annotation not resolvable in scope: $annotationFqn")
             return@read emptyList<String>()
         }
-        if (!annotationClass.isAnnotationType) {
+        val validAnnotations = annotationClasses.filter { it.isAnnotationType }
+        if (validAnnotations.isEmpty()) {
             LOG.info("resolved FQN is not an annotation type: $annotationFqn")
             return@read emptyList<String>()
         }
         val scope = GlobalSearchScope.projectScope(ctx.project)
-        val hits = AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope)
-.findAll()
-.mapNotNull { it.qualifiedName }
-.distinct()
-.sorted()
+        val hits = validAnnotations.flatMap { annotationClass ->
+            AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope)
+                .findAll()
+                .mapNotNull { it.qualifiedName }
+        }
+            .distinct()
+            .sorted()
         LOG.info("found ${hits.size} class(es) annotated with $annotationFqn")
         hits
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByNameTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByNameTool.kt
@@ -1,0 +1,139 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
+import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.type.ResolvedType
+import com.itangcent.easyapi.psi.type.TypeResolver
+import com.itangcent.easyapi.util.json.GsonUtils
+
+/**
+ * Perception tool that resolves class simple names to their fully qualified
+ * names via [PsiShortNamesCache], with an FQN short-circuit and batch mode.
+ *
+ * The agent often knows only a class's simple name (e.g. `"AuthResponse"`)
+ * from a `find_classes_by_supertype` or `find_classes_by_annotation` result,
+ * a method signature, or a doc comment. Without this tool the agent must
+ * guess the package, which is unreliable for project-private types.
+ *
+ * Resolution strategy:
+ * - **FQN short-circuit** (input contains `.`): direct
+ *   [JavaPsiFacade.findClass] in [GlobalSearchScope.projectScope]. Returns a
+ *   single-element or empty array. Does NOT invoke [PsiShortNamesCache]
+ *   (per REQ-1 AC-6).
+ * - **Simple name**: [PsiShortNamesCache.getClassesByName] in
+ *   [GlobalSearchScope.projectScope], sorted alphabetically. When a
+ *   `context` is supplied, a context-reachable match (resolved via
+ *   [TypeResolver.resolveFromCanonicalText]) is moved to the front of the
+ *   array so the agent gets a hint about which match to inspect first.
+ *
+ * Returns FQNs only (lean shape — matches `find_classes_by_annotation` /
+ * `find_classes_by_supertype`). The agent disambiguates by passing the FQN
+ * to `get_psi_class_info`.
+ *
+ * Supports batch: pass `names` (array) to resolve multiple simple names in
+ * one call. Returns a JSON object mapping each name to its FQN array.
+ */
+class FindClassesByNameTool : AiTool, IdeaLog {
+
+    override val name: String = "find_classes_by_name"
+
+    override val description: String =
+        "Resolve class simple names to their fully qualified names. Pass `name` " +
+            "(string) for one, or `names` (array) to batch-resolve multiple. Returns " +
+            "a JSON array of FQNs for a single name, or a JSON object mapping each " +
+            "name to its array for batch. Use this when you only know a class's " +
+            "simple name (e.g. \"AuthResponse\") and need the FQN to pass to " +
+            "get_psi_class_info. If the input contains a dot it is treated as an " +
+            "FQN and looked up directly. Optional `context` (file path or class FQN) " +
+            "prefers matches reachable from that file's imports."
+
+    override val kind: ToolKind = ToolKind.PERCEPTION
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "name" to mapOf(
+                "type" to "string",
+                "description" to "Class simple name (e.g. \"AuthResponse\") or FQN."
+            ),
+            "names" to mapOf(
+                "type" to "array",
+                "items" to mapOf("type" to "string"),
+                "description" to "Multiple names to resolve in one call (batch mode)."
+            ),
+            "context" to mapOf(
+                "type" to "string",
+                "description" to "Optional: file path or class FQN whose import " +
+                    "scope should be used to prefer matches reachable from that file."
+            )
+        )
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val names = PsiNameResolver.extractStringList(args, "name", "names")
+        if (names.isEmpty()) {
+            return ToolResult.Error("missing parameter: provide `name` (string) or `names` (array)")
+        }
+
+        val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
+
+        return if (names.size == 1) {
+            ToolResult.Text(GsonUtils.toJson(searchOne(names[0], ctx, contextElement)))
+        } else {
+            val result = names.associateWith { searchOne(it, ctx, contextElement) }
+            ToolResult.Text(GsonUtils.toJson(result))
+        }
+    }
+
+    /**
+     * Resolves a single name to a list of FQNs.
+     *
+     * FQN short-circuit: returns a single-element or empty list without
+     * touching [PsiShortNamesCache]. Simple name: all project-scope matches,
+     * sorted alphabetically with the context-preferred match moved to the
+     * front (if any).
+     */
+    private suspend fun searchOne(
+        name: String,
+        ctx: ToolContext,
+        contextElement: PsiElement?
+    ): List<String> = read {
+        val project = ctx.project
+
+        // FQN short-circuit — direct lookup, no PsiShortNamesCache.
+        if (name.contains('.')) {
+            val cls = JavaPsiFacade.getInstance(project)
+                .findClass(name, GlobalSearchScope.projectScope(project))
+            return@read listOfNotNull(cls?.qualifiedName)
+        }
+
+        // Optional context-preferred FQN.
+        val preferredFqn: String? = if (contextElement != null) {
+            val resolved = TypeResolver.resolveFromCanonicalText(name, project, contextElement)
+            (resolved as? ResolvedType.ClassType)?.psiClass?.qualifiedName
+        } else {
+            null
+        }
+
+        // All project-scope matches, sorted alphabetically.
+        val scope = GlobalSearchScope.projectScope(project)
+        val fqns = PsiShortNamesCache.getInstance(project)
+            .getClassesByName(name, scope)
+            .mapNotNull { it.qualifiedName }
+            .distinct()
+            .sorted()
+            .toMutableList()
+
+        // Move the context-preferred FQN to the front (stable).
+        if (preferredFqn != null && fqns.remove(preferredFqn)) {
+            fqns.add(0, preferredFqn)
+        }
+
+        LOG.info("find_classes_by_name: '$name' → ${fqns.size} match(es)")
+        fqns
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/FindClassesBySupertypeTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/FindClassesBySupertypeTool.kt
@@ -1,7 +1,7 @@
 package com.itangcent.easyapi.ai.tools
 
-import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ClassInheritorsSearch
 import com.itangcent.easyapi.core.threading.read
@@ -18,10 +18,11 @@ import com.itangcent.easyapi.util.json.GsonUtils
  * `OncePerRequestFilter` and interceptors implement `HandlerInterceptor`,
  * with no annotation marking them as such. This tool closes that gap.
  *
- * Resolves the supertype by FQN (project + library scope), then searches its
- * inheritors in the project scope via [ClassInheritorsSearch]. The supertype
- * itself is excluded from the result so the agent gets only the concrete
- * implementations it cares about.
+ * Resolves the supertype by FQN (or simple name with optional `context`) via
+ * [PsiNameResolver.resolveAllClasses], then searches its inheritors in the
+ * project scope via [ClassInheritorsSearch]. The supertype itself is excluded
+ * from the result so the agent gets only the concrete implementations it
+ * cares about.
  *
  * Supports batch: pass `supertypeFqns` (array) to probe multiple supertypes
  * in one call. Returns a JSON object mapping each supertype FQN to its results.
@@ -49,7 +50,8 @@ class FindClassesBySupertypeTool : AiTool, IdeaLog {
             "supertypeFqn" to mapOf(
                 "type" to "string",
                 "description" to "Fully qualified name of the class or interface " +
-                    "whose subclasses/implementations to find " +
+                    "(or simple name when `context` is supplied) whose " +
+                    "subclasses/implementations to find " +
                     "(e.g. \"org.springframework.web.filter.OncePerRequestFilter\" " +
                     "or \"org.springframework.web.servlet.HandlerInterceptor\")."
             ),
@@ -57,45 +59,50 @@ class FindClassesBySupertypeTool : AiTool, IdeaLog {
                 "type" to "array",
                 "items" to mapOf("type" to "string"),
                 "description" to "Multiple supertype FQNs to probe in one call (batch mode)."
+            ),
+            "context" to mapOf(
+                "type" to "string",
+                "description" to "Optional: file path or class FQN whose import scope " +
+                    "is used to resolve simple-name supertype entries."
             )
         )
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val fqns = extractFqns(args)
+        val fqns = PsiNameResolver.extractStringList(args, "supertypeFqn", "supertypeFqns")
         if (fqns.isEmpty()) return ToolResult.Error("missing parameter: provide `supertypeFqn` (string) or `supertypeFqns` (array)")
 
+        val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
+
         if (fqns.size == 1) {
-            return ToolResult.Text(GsonUtils.toJson(searchOne(fqns[0], ctx)))
+            return ToolResult.Text(GsonUtils.toJson(searchOne(fqns[0], ctx, contextElement)))
         }
-        val result = fqns.associateWith { searchOne(it, ctx) }
+        val result = fqns.associateWith { searchOne(it, ctx, contextElement) }
         return ToolResult.Text(GsonUtils.toJson(result))
     }
 
-    private fun extractFqns(args: Map<String, Any?>): List<String> {
-        val batch = args["supertypeFqns"] as? List<*>
-        if (batch != null) {
-            return batch.mapNotNull { it?.toString()?.takeIf { s -> s.isNotBlank() } }
-        }
-        val single = args["supertypeFqn"] as? String
-        return if (single.isNullOrBlank()) emptyList() else listOf(single)
-    }
-
-    private suspend fun searchOne(supertypeFqn: String, ctx: ToolContext): List<String> = read {
-        val supertype = JavaPsiFacade.getInstance(ctx.project)
-.findClass(supertypeFqn, GlobalSearchScope.allScope(ctx.project))
-        if (supertype == null) {
+    private suspend fun searchOne(
+        supertypeFqn: String,
+        ctx: ToolContext,
+        contextElement: PsiElement?
+    ): List<String> = read {
+        val supertypes = PsiNameResolver.resolveAllClasses(
+            supertypeFqn, ctx.project, contextElement
+        )
+        if (supertypes.isEmpty()) {
             LOG.info("supertype not resolvable in scope: $supertypeFqn")
             return@read emptyList<String>()
         }
         val scope = GlobalSearchScope.projectScope(ctx.project)
-        val inheritors = ClassInheritorsSearch.search(supertype, scope, false)
-.findAll()
-.filterIsInstance<PsiClass>()
-.mapNotNull { it.qualifiedName }
-.filter { it != supertypeFqn }
-.distinct()
-.sorted()
+        val inheritors = supertypes.flatMap { supertype ->
+            ClassInheritorsSearch.search(supertype, scope, false)
+                .findAll()
+                .filterIsInstance<PsiClass>()
+                .mapNotNull { it.qualifiedName }
+                .filter { it != supertypeFqn }
+        }
+            .distinct()
+            .sorted()
         LOG.info("found ${inheritors.size} inheritor(s) of $supertypeFqn")
         inheritors
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetExistingRulesForKeyTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetExistingRulesForKeyTool.kt
@@ -43,7 +43,7 @@ class GetExistingRulesForKeyTool : AiTool {
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val keys = extractKeys(args)
+        val keys = PsiNameResolver.extractStringList(args, "key", "keys")
         if (keys.isEmpty()) return ToolResult.Error("missing parameter: provide `key` (string) or `keys` (array)")
 
         if (keys.size == 1) {
@@ -51,15 +51,6 @@ class GetExistingRulesForKeyTool : AiTool {
         }
         val result = keys.associateWith { lookupOne(it, ctx) }
         return ToolResult.Text(GsonUtils.toJson(result))
-    }
-
-    private fun extractKeys(args: Map<String, Any?>): List<String> {
-        val batch = args["keys"] as? List<*>
-        if (batch != null) {
-            return batch.mapNotNull { it?.toString()?.takeIf { s -> s.isNotBlank() } }
-        }
-        val single = args["key"] as? String
-        return if (single.isNullOrBlank()) emptyList() else listOf(single)
     }
 
     private fun lookupOne(key: String, ctx: ToolContext): List<Map<String, Any?>> {

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetModuleDependencyGraphTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetModuleDependencyGraphTool.kt
@@ -49,14 +49,16 @@ class GetModuleDependencyGraphTool : AiTool, IdeaLog {
             for (module in modules) {
                 try {
                     val deps = ModuleRootManager.getInstance(module).orderEntries
+                        .asSequence()
                         .filterIsInstance<ModuleOrderEntry>()
                         // Req 8.1: restrict to workspace (non-external) modules —
                         // a ModuleOrderEntry whose Module is null is an external /
                         // unloaded reference, not a structural workspace edge.
                         .filter { it.module != null }
-                        .mapNotNull { it.moduleName }
+                        .map { it.moduleName }
                         .filter { it.isNotBlank() && it != module.name }
                         .distinct()
+                        .toList()
                     result[module.name] = deps.toMutableList()
                 } catch (e: Exception) {
                     LOG.warn("module-dep-graph: error reading module ${module.name}", e)

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetPsiClassInfoTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetPsiClassInfoTool.kt
@@ -1,24 +1,28 @@
 package com.itangcent.easyapi.ai.tools
 
-import com.intellij.psi.JavaPsiFacade
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiMethod
-import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.PsiElement
 import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.util.json.GsonUtils
 
 /**
  * Perception tool that returns PSI class info for one or more classes
  *.
  *
- * Resolves each class by FQN inside a read action and returns name, modifiers,
- * annotations, fields, and method signatures.
+ * Resolves each class by FQN (or simple name with optional `context`) inside a
+ * read action and returns name, modifiers, annotations, fields (with additive
+ * `typeFqn` — the [com.itangcent.easyapi.psi.type.ResolvedType.qualifiedName]
+ * with type args encoded inline), and method signatures (with additive
+ * `returnTypeFqn` and per-parameter `typeFqn`).
+ *
+ * All signature building is delegated to [PsiSignatureBuilder] — this tool
+ * only resolves the PSI class and builds error messages.
  *
  * Supports batch: pass `fqns` (array) to inspect multiple classes in one call.
  * Returns a JSON object for a single class, or a JSON object mapping each FQN
  * to its info (or an error string) for batch mode.
  */
-class GetPsiClassInfoTool : AiTool {
+class GetPsiClassInfoTool : AiTool, IdeaLog {
 
     override val name: String = "get_psi_class_info"
 
@@ -36,65 +40,74 @@ class GetPsiClassInfoTool : AiTool {
         "properties" to mapOf(
             "fqn" to mapOf(
                 "type" to "string",
-                "description" to "Fully qualified class name."
+                "description" to "Fully qualified class name (or simple name when `context` is supplied)."
             ),
             "fqns" to mapOf(
                 "type" to "array",
                 "items" to mapOf("type" to "string"),
                 "description" to "Multiple fully qualified class names to inspect in one call (batch mode)."
+            ),
+            "context" to mapOf(
+                "type" to "string",
+                "description" to "Optional: file path or class FQN whose import scope " +
+                    "is used to resolve simple-name `fqn`/`fqns` entries and field " +
+                    "type FQNs."
             )
         )
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val fqns = extractFqns(args)
+        val fqns = PsiNameResolver.extractStringList(args, "fqn", "fqns")
         if (fqns.isEmpty()) return ToolResult.Error("missing parameter: provide `fqn` (string) or `fqns` (array)")
 
+        val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
+
         if (fqns.size == 1) {
-            val info = lookupOne(fqns[0], ctx)
-                ?: return ToolResult.Error("class not found: ${fqns[0]}")
+            val info = lookupOne(fqns[0], ctx, contextElement)
+            if (info == null) {
+                return ToolResult.Error(buildNotFoundMessage(fqns[0], ctx, contextElement))
+            }
             return ToolResult.Text(GsonUtils.toJson(info))
         }
-        val result = fqns.associateWith { lookupOne(it, ctx) ?: "not found" }
+        val result = fqns.associateWith { lookupOne(it, ctx, contextElement) ?: "not found" }
         return ToolResult.Text(GsonUtils.toJson(result))
     }
 
-    private fun extractFqns(args: Map<String, Any?>): List<String> {
-        val batch = args["fqns"] as? List<*>
-        if (batch != null) {
-            return batch.mapNotNull { it?.toString()?.takeIf { s -> s.isNotBlank() } }
+    /**
+     * Builds the error message for a missing class. When the lookup was a
+     * simple name without context and `PsiNameResolver` found multiple
+     * matches, the message guides the agent to `find_classes_by_name`
+     * (Design Decision 4). Otherwise a plain "class not found" is returned.
+     */
+    private suspend fun buildNotFoundMessage(
+        fqn: String,
+        ctx: ToolContext,
+        contextElement: PsiElement?
+    ): String {
+        // Ambiguity only applies to simple names (no dot) without a context
+        // that could have nailed the resolution.
+        if (!fqn.contains('.') && contextElement == null) {
+            val matches = PsiNameResolver.resolveAllClasses(fqn, ctx.project, null)
+            if (matches.size > 1) {
+                return "ambiguous simple name '$fqn': ${matches.size} classes match, " +
+                    "use find_classes_by_name to disambiguate"
+            }
         }
-        val single = args["fqn"] as? String
-        return if (single.isNullOrBlank()) emptyList() else listOf(single)
+        return "class not found: $fqn"
     }
 
     // All PSI access (name, fields, methods, annotations) must happen inside
     // the read action — PSI element getters require a read action.
-    private suspend fun lookupOne(fqn: String, ctx: ToolContext): Map<String, Any?>? = read {
-        val psiClass = JavaPsiFacade.getInstance(ctx.project)
-.findClass(fqn, GlobalSearchScope.projectScope(ctx.project))
+    private suspend fun lookupOne(
+        fqn: String,
+        ctx: ToolContext,
+        contextElement: PsiElement?
+    ): Map<String, Any?>? = read {
+        val psiClass = PsiNameResolver.resolveClass(fqn, ctx.project, contextElement)
             ?: return@read null
-        psiClass.toInfoMap()
+        // Implicit contextElement for type enrichment: when no explicit context
+        // was supplied, use the resolved class's containing file (REQ-4 AC-9).
+        val enrichmentContext = contextElement ?: psiClass.containingFile
+        PsiSignatureBuilder.classToMap(psiClass, ctx.project, enrichmentContext)
     }
-
-    private fun PsiClass.toInfoMap(): Map<String, Any?> = mapOf(
-        "name" to name,
-        "fqn" to qualifiedName,
-        "modifiers" to modifierList?.text,
-        "annotations" to annotations.map { it.qualifiedName },
-        "fields" to fields.map {
-            mapOf("name" to it.name, "type" to it.type.presentableText)
-        },
-        "methods" to methods.map { it.toSignatureMap() }
-    )
-
-    private fun PsiMethod.toSignatureMap(): Map<String, Any?> = mapOf(
-        "name" to name,
-        "modifiers" to modifierList?.text,
-        "returnType" to returnType?.presentableText,
-        "parameters" to parameterList.parameters.map { p ->
-            mapOf("name" to p.name, "type" to p.type.presentableText)
-        },
-        "annotations" to annotations.map { it.qualifiedName }
-    )
 }

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetPsiMethodInfoTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetPsiMethodInfoTool.kt
@@ -1,26 +1,41 @@
 package com.itangcent.easyapi.ai.tools
 
-import com.intellij.psi.JavaPsiFacade
-import com.intellij.psi.PsiMethod
-import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.PsiElement
 import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.util.json.GsonUtils
 
 /**
  * Perception tool that returns info about a single PSI method.
  *
- * Resolves the class by FQN, then walks its methods matching by name + (optional)
- * parameter count. Returns the signature, annotations, parameters, and the
- * doc-comment text.
+ * Resolves the class by FQN (or simple name with optional `context`), then
+ * walks its methods matching by name + (optional) parameter count. Returns
+ * the signature, annotations, parameters (with additive `typeFqn` — the
+ * [com.itangcent.easyapi.psi.type.ResolvedType.qualifiedName] with type args
+ * encoded inline), return type info (`returnType` / `returnTypeFqn`), the
+ * doc-comment text, and — when `detail="full"` — the method body (truncated
+ * to `maxBodyChars`).
+ *
+ * All signature building is delegated to [PsiSignatureBuilder] — this tool
+ * only resolves the PSI method and builds error messages.
+ *
+ * @see PsiNameResolver
  */
-class GetPsiMethodInfoTool : AiTool {
+class GetPsiMethodInfoTool : AiTool, IdeaLog {
+
+    companion object {
+        /** Default character budget for the `body` field when `detail="full"`. */
+        private const val DEFAULT_MAX_BODY_CHARS = 4000
+    }
 
     override val name: String = "get_psi_method_info"
 
     override val description: String =
         "Get info about a method in a class. Returns JSON {className, name, " +
-            "signature, annotations, parameters, docComment}. `paramCount` is " +
-            "optional and narrows the match when a class overloads the method name."
+            "signature, annotations, parameters, docComment, returnType, " +
+            "returnTypeFqn}. `paramCount` is optional and narrows the match " +
+            "when a class overloads the method name. Pass `detail=\"full\"` " +
+            "to include the method `body` (truncated to `maxBodyChars`)."
 
     override val kind: ToolKind = ToolKind.PERCEPTION
 
@@ -29,7 +44,7 @@ class GetPsiMethodInfoTool : AiTool {
         "properties" to mapOf(
             "fqn" to mapOf(
                 "type" to "string",
-                "description" to "Fully qualified class name."
+                "description" to "Fully qualified class name (or simple name when `context` is supplied)."
             ),
             "methodName" to mapOf(
                 "type" to "string",
@@ -38,6 +53,22 @@ class GetPsiMethodInfoTool : AiTool {
             "paramCount" to mapOf(
                 "type" to "integer",
                 "description" to "Optional: parameter count, to disambiguate overloads."
+            ),
+            "detail" to mapOf(
+                "type" to "string",
+                "enum" to listOf("signature", "full"),
+                "description" to "Optional: level of detail. \"signature\" (default) " +
+                    "omits the body; \"full\" includes a truncated `body` field."
+            ),
+            "maxBodyChars" to mapOf(
+                "type" to "integer",
+                "description" to "Optional: max characters for the `body` field " +
+                    "(only when detail=\"full\"). Defaults to $DEFAULT_MAX_BODY_CHARS."
+            ),
+            "context" to mapOf(
+                "type" to "string",
+                "description" to "Optional: file path or class FQN whose import scope " +
+                    "is used to resolve simple-name `fqn` and parameter/return type FQNs."
             )
         ),
         "required" to listOf("fqn", "methodName")
@@ -50,42 +81,58 @@ class GetPsiMethodInfoTool : AiTool {
             return ToolResult.Error("missing required parameter(s): fqn, methodName")
         }
         val paramCount = (args["paramCount"] as? Number)?.toInt()
+        val detail = (args["detail"] as? String)?.takeIf { it == "full" } ?: "signature"
+        val maxBodyChars = (args["maxBodyChars"] as? Number)?.toInt()?.takeIf { it > 0 }
+            ?: DEFAULT_MAX_BODY_CHARS
+        val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
 
-        // All PSI access (name, signature, annotations, parameters, docComment)
-        // must happen inside the read action — PSI element getters require one.
+        // All PSI access (name, signature, annotations, parameters, docComment,
+        // body) must happen inside the read action — PSI element getters
+        // require one. The detail="signature" fast path does NOT touch
+        // psiMethod.body?.text (REQ-3 AC-9).
         val info = read {
-            val psiClass = JavaPsiFacade.getInstance(ctx.project)
-.findClass(fqn, GlobalSearchScope.projectScope(ctx.project))
+            val psiClass = PsiNameResolver.resolveClass(fqn, ctx.project, contextElement)
                 ?: return@read null
             val psiMethod = psiClass.methods.firstOrNull { m ->
                 m.name == methodName &&
                     (paramCount == null || m.parameterList.parameters.size == paramCount)
             } ?: return@read null
-            psiMethod.toInfoMap(fqn)
-        } ?: return ToolResult.Error("method not found: $fqn#$methodName")
+            // Implicit contextElement for type enrichment: when no explicit
+            // context was supplied, use the resolved class's containing file
+            // (REQ-4 AC-9).
+            val enrichmentContext = contextElement ?: psiClass.containingFile
+            PsiSignatureBuilder.methodToInfoMap(
+                psiMethod = psiMethod,
+                className = psiClass.qualifiedName ?: fqn,
+                project = ctx.project,
+                contextElement = enrichmentContext,
+                detail = detail,
+                maxBodyChars = maxBodyChars
+            )
+        } ?: return ToolResult.Error(buildNotFoundMessage(fqn, ctx, contextElement, methodName))
 
         return ToolResult.Text(GsonUtils.toJson(info))
     }
 
-    private fun PsiMethod.toInfoMap(className: String): Map<String, Any?> = mapOf(
-        "className" to className,
-        "name" to name,
-        "signature" to signatureString(),
-        "annotations" to annotations.map { it.qualifiedName },
-        "parameters" to parameterList.parameters.map { p ->
-            mapOf("name" to p.name, "type" to p.type.presentableText)
-        },
-        "docComment" to docComment?.text
-    )
-
-    private fun PsiMethod.signatureString(): String =
-        buildString {
-            modifierList?.text?.takeIf { it.isNotBlank() }?.let { append(it).append(' ') }
-            returnType?.presentableText?.let { append(it).append(' ') }
-            append(name).append('(')
-            parameterList.parameters.joinTo(this, ", ") { p ->
-                "${p.type.presentableText} ${p.name}"
+    /**
+     * Builds the error message for a missing class or method. When the
+     * lookup was a simple name without context and `PsiNameResolver` found
+     * multiple matches, the message guides the agent to `find_classes_by_name`
+     * (Design Decision 4).
+     */
+    private suspend fun buildNotFoundMessage(
+        fqn: String,
+        ctx: ToolContext,
+        contextElement: PsiElement?,
+        methodName: String
+    ): String {
+        if (!fqn.contains('.') && contextElement == null) {
+            val matches = PsiNameResolver.resolveAllClasses(fqn, ctx.project, null)
+            if (matches.size > 1) {
+                return "ambiguous simple name '$fqn': ${matches.size} classes match, " +
+                    "use find_classes_by_name to disambiguate"
             }
-            append(')')
         }
+        return "method not found: $fqn#$methodName"
+    }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/PsiNameResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/PsiNameResolver.kt
@@ -1,0 +1,229 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
+import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.type.ResolvedType
+import com.itangcent.easyapi.psi.type.TypeResolver
+
+/**
+ * Resolves class simple names / FQNs to [PsiClass] instances and normalizes
+ * the `context` argument supplied by AI tools to a [PsiElement] suitable for
+ * import-scope resolution.
+ *
+ * Three resolution strategies are supported for class lookup:
+ * - **FQN path** (name contains `.`): [JavaPsiFacade.findClass] in
+ *   [GlobalSearchScope.allScope].
+ * - **Simple name + context**: [TypeResolver.resolveFromCanonicalText] using
+ *   the context element's import scope.
+ * - **Simple name, no context**: [PsiShortNamesCache.getClassesByName] in
+ *   [GlobalSearchScope.allScope]. Returns the single match, or `null` with a
+ *   `LOG.info` decision log when zero or >1 matches are found.
+ *
+ * All PSI access is performed inside a read action (NFR-1). Logging follows
+ * NFR-2 — `LOG.info` is the floor; no arguments or result bodies are logged
+ * beyond the identifier needed to explain a decision.
+ */
+internal object PsiNameResolver : IdeaLog {
+
+    /**
+     * Resolves [name] to a single [PsiClass], or `null` when the name is
+     * blank, ambiguous (more than one match in the no-context simple-name
+     * path), or simply not found.
+     *
+     * @param name simple name (e.g. `"User"`) or FQN (e.g. `"com.example.User"`).
+     * @param project the IntelliJ project used for PSI lookups.
+     * @param contextElement optional [PsiElement] whose import scope is used
+     *   to resolve simple names (typically the [com.intellij.psi.PsiFile]
+     *   returned by [resolveContextElement]).
+     * @return the resolved [PsiClass], or `null`.
+     */
+    suspend fun resolveClass(
+        name: String,
+        project: Project,
+        contextElement: PsiElement? = null
+    ): PsiClass? = read {
+        if (name.isBlank()) return@read null
+
+        // FQN path — direct lookup in all scope.
+        if (name.contains('.')) {
+            return@read JavaPsiFacade.getInstance(project)
+                .findClass(name, GlobalSearchScope.allScope(project))
+        }
+
+        // Simple name + context — use TypeResolver's 4-step import resolution.
+        if (contextElement != null) {
+            val resolved = TypeResolver.resolveFromCanonicalText(name, project, contextElement)
+            (resolved as? ResolvedType.ClassType)?.psiClass?.let { return@read it }
+        }
+
+        // Simple name, no context (or context didn't resolve) — short-names cache.
+        val matches = PsiShortNamesCache.getInstance(project)
+            .getClassesByName(name, GlobalSearchScope.allScope(project))
+        when {
+            matches.isEmpty() -> {
+                LOG.info("no class found for '$name'")
+                null
+            }
+            matches.size == 1 -> matches[0]
+            else -> {
+                LOG.info("ambiguous: '$name' (${matches.size} matches)")
+                null
+            }
+        }
+    }
+
+    /**
+     * Resolves [name] to all matching [PsiClass] instances.
+     *
+     * Unlike [resolveClass], this never returns `null` for ambiguity — it
+     * returns every match so the caller can probe each candidate (used by
+     * `find_classes_by_annotation` / `find_classes_by_supertype` for
+     * tolerance resolution).
+     *
+     * @param name simple name or FQN.
+     * @param project the IntelliJ project used for PSI lookups.
+     * @param contextElement optional [PsiElement] whose import scope is used
+     *   to prefer a context-reachable match. If the context nails the
+     *   resolution, only that single class is returned.
+     * @return a list of matching [PsiClass] instances (possibly empty).
+     */
+    suspend fun resolveAllClasses(
+        name: String,
+        project: Project,
+        contextElement: PsiElement? = null
+    ): List<PsiClass> = read {
+        if (name.isBlank()) return@read emptyList()
+
+        // FQN path — single-or-empty.
+        if (name.contains('.')) {
+            return@read listOfNotNull(
+                JavaPsiFacade.getInstance(project)
+                    .findClass(name, GlobalSearchScope.allScope(project))
+            )
+        }
+
+        // Simple name + context — if context nails it, return just that class.
+        if (contextElement != null) {
+            val resolved = TypeResolver.resolveFromCanonicalText(name, project, contextElement)
+            if (resolved is ResolvedType.ClassType) {
+                return@read listOf(resolved.psiClass)
+            }
+        }
+
+        // Simple name, no context → all matches.
+        PsiShortNamesCache.getInstance(project)
+            .getClassesByName(name, GlobalSearchScope.allScope(project))
+            .toList()
+    }
+
+    /**
+     * Normalizes the `context` argument supplied by AI tools to a [PsiElement]
+     * suitable for import-scope resolution.
+     *
+     * Tries, in order:
+     * 1. **Class FQN** → [PsiClass.getContainingFile] via [JavaPsiFacade.findClass].
+     * 2. **Absolute file path** → [com.intellij.psi.PsiFile] via
+     *    [LocalFileSystem] + [PsiManager].
+     * 3. **Project-relative file path** → [com.intellij.psi.PsiFile] via
+     *    the project base path + [PsiManager].
+     *
+     * Returns `null` and logs a decision `LOG.info` when [context] cannot be
+     * resolved by any path; the caller falls back to the no-context path.
+     *
+     * @param context a class FQN or file path (absolute or project-relative).
+     * @param project the IntelliJ project.
+     * @return a [PsiElement] (typically a [com.intellij.psi.PsiFile]) usable
+     *   as the `contextElement` for [resolveClass] / [resolveAllClasses], or
+     *   `null`.
+     */
+    suspend fun resolveContextElement(
+        context: String,
+        project: Project
+    ): PsiElement? = read {
+        // 1. Try as class FQN.
+        JavaPsiFacade.getInstance(project)
+            .findClass(context, GlobalSearchScope.allScope(project))
+            ?.let { return@read it.containingFile }
+
+        // 2. Try as absolute file path.
+        LocalFileSystem.getInstance().findFileByPath(context)?.let { vf ->
+            PsiManager.getInstance(project).findFile(vf)?.let { return@read it }
+        }
+
+        // 3. Try as project-relative file path.
+        project.basePath?.let { basePath ->
+            LocalFileSystem.getInstance().findFileByPath(basePath)?.findFileByRelativePath(context)
+        }?.let { vf ->
+            PsiManager.getInstance(project).findFile(vf)?.let { return@read it }
+        }
+
+        // 4. Not resolvable — log the decision and return null so the caller
+        //    falls back to the no-context path.
+        LOG.info("context not resolvable: $context")
+        null
+    }
+
+    /**
+     * Resolves the optional `context` argument supplied by AI tools to a
+     * [PsiElement] for import-scope resolution. Non-string values are logged
+     * and treated as `null` (per REQ-4 AC-5).
+     *
+     * Shared by tools that accept a `context` parameter
+     * ([GetPsiClassInfoTool], [GetPsiMethodInfoTool], [FindClassesByAnnotationTool],
+     * [FindClassesBySupertypeTool], [FindClassesByNameTool]).
+     *
+     * @param args the tool's argument map.
+     * @param project the IntelliJ project.
+     * @return the resolved [PsiElement], or `null` when the argument is absent,
+     *   blank, non-string, or unresolvable.
+     */
+    suspend fun resolveContextArg(
+        args: Map<String, Any?>,
+        project: Project
+    ): PsiElement? {
+        val raw = args["context"] ?: return null
+        if (raw !is String) {
+            LOG.info("context argument ignored: non-string value")
+            return null
+        }
+        if (raw.isBlank()) return null
+        return resolveContextElement(raw, project)
+    }
+
+    /**
+     * Extracts a string list from a tool's argument map, supporting both
+     * single-value (`[singleKey]` → string) and batch (`[batchKey]` → array)
+     * modes. Blank entries are filtered out.
+     *
+     * Shared by tools that accept single-or-batch name/FQN parameters
+     * ([GetPsiClassInfoTool], [FindClassesByAnnotationTool],
+     * [FindClassesBySupertypeTool], [FindClassesByNameTool],
+     * [GetExistingRulesForKeyTool]).
+     *
+     * @param args the tool's argument map.
+     * @param singleKey the key for the single-value form (e.g. `"fqn"`, `"name"`).
+     * @param batchKey the key for the batch form (e.g. `"fqns"`, `"names"`).
+     *   When present, takes precedence over [singleKey].
+     * @return the non-blank string list (possibly empty).
+     */
+    fun extractStringList(
+        args: Map<String, Any?>,
+        singleKey: String,
+        batchKey: String
+    ): List<String> {
+        val batch = args[batchKey] as? List<*>
+        if (batch != null) {
+            return batch.mapNotNull { it?.toString()?.takeIf { s -> s.isNotBlank() } }
+        }
+        val single = args[singleKey] as? String
+        return if (single.isNullOrBlank()) emptyList() else listOf(single)
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/PsiSignatureBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/PsiSignatureBuilder.kt
@@ -1,0 +1,270 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiParameter
+import com.intellij.psi.PsiType
+import com.itangcent.easyapi.psi.type.ResolvedType
+import com.itangcent.easyapi.psi.type.TypeResolver
+
+/**
+ * Builds signatures (JSON-serializable maps and signature strings) for PSI
+ * classes, methods, fields, and parameters consumed by the AI tool JSON output.
+ *
+ * Uses [ResolvedType.qualifiedName] as the golden standard for type FQNs —
+ * i.e. resolves [PsiType] through [TypeResolver] and returns
+ * [ResolvedType.ClassType.qualifiedName] for class types, or `null` for
+ * primitives, arrays, wildcards, type parameters, and unresolved types.
+ *
+ * The returned FQN encodes type arguments inline (e.g.
+ * `"com.example.Result<com.example.User>"`), so no separate
+ * `typeArguments` field is emitted — minimizing token noise while preserving
+ * full type information.
+ *
+ * When a [contextElement] is supplied, types are resolved via
+ * [TypeResolver.resolveFromCanonicalText] so simple class names resolve via
+ * the context element's import scope, with a fallback to the no-context path
+ * ([TypeResolver.resolve]) for JDK types whose `createTypeFromText` resolution
+ * may not complete via the context's import scope.
+ *
+ * This helper is a stateless `internal object` — it is the single place where
+ * PSI elements are formatted into signatures, shared by all tools that need
+ * class/method/field/parameter signatures. Tested in isolation.
+ */
+internal object PsiSignatureBuilder {
+
+    // ------------------------------------------------------------------
+    // Type FQN resolution
+    // ------------------------------------------------------------------
+
+    /**
+     * Resolves [psiType] to its fully qualified name using [ResolvedType] as
+     * the golden standard.
+     *
+     * @param psiType the PSI type to resolve (may be `null`).
+     * @param project the IntelliJ project (used when [contextElement] is set).
+     * @param contextElement optional [PsiElement] whose import scope is used
+     *   to resolve simple-named types via [TypeResolver.resolveFromCanonicalText].
+     * @return the [ResolvedType.ClassType.qualifiedName] for class types
+     *   (including type arguments inline), or `null` for primitives, arrays,
+     *   wildcards, type parameters, and unresolved types.
+     */
+    fun resolve(
+        psiType: PsiType?,
+        project: Project,
+        contextElement: PsiElement? = null
+    ): String? {
+        // null or non-PsiClassType (primitive, array, wildcard) ⇒ no FQN.
+        if (psiType == null || psiType !is PsiClassType) return null
+
+        val withContext = resolveType(psiType, project, contextElement)
+        if (withContext is ResolvedType.ClassType) {
+            return withContext.qualifiedName()
+        }
+        // Fall back to no-context resolution for JDK types whose
+        // `createTypeFromText` may not complete via the context's import scope.
+        if (contextElement != null) {
+            val withoutContext = resolveType(psiType, project, null)
+            if (withoutContext is ResolvedType.ClassType) {
+                return withoutContext.qualifiedName()
+            }
+        }
+        return null
+    }
+
+    // ------------------------------------------------------------------
+    // Field / parameter maps
+    // ------------------------------------------------------------------
+
+    /**
+     * Builds the field map: `name` + `type` (presentable text) + `typeFqn`
+     * (the [ResolvedType.qualifiedName] or `null`).
+     */
+    fun fieldToMap(
+        field: PsiField,
+        project: Project,
+        contextElement: PsiElement?
+    ): Map<String, Any?> {
+        val map = LinkedHashMap<String, Any?>()
+        map["name"] = field.name
+        map["type"] = field.type.presentableText
+        map["typeFqn"] = resolve(field.type, project, contextElement)
+        return map
+    }
+
+    /**
+     * Builds the parameter map: `name` + `type` (presentable text) +
+     * `typeFqn` (the [ResolvedType.qualifiedName] or `null`).
+     */
+    fun paramToMap(
+        param: PsiParameter,
+        project: Project,
+        contextElement: PsiElement?
+    ): Map<String, Any?> {
+        val map = LinkedHashMap<String, Any?>()
+        map["name"] = param.name
+        map["type"] = param.type.presentableText
+        map["typeFqn"] = resolve(param.type, project, contextElement)
+        return map
+    }
+
+    // ------------------------------------------------------------------
+    // Class signature
+    // ------------------------------------------------------------------
+
+    /**
+     * Builds the class info map: `name` + `fqn` + `modifiers` + `annotations`
+     * + `fields` (each via [fieldToMap]) + `methods` (each via
+     * [methodToSignatureMap]).
+     *
+     * @param psiClass the class to describe.
+     * @param project the IntelliJ project (for type-FQN resolution).
+     * @param contextElement optional [PsiElement] whose import scope is used
+     *   to resolve field/method type FQNs.
+     */
+    fun classToMap(
+        psiClass: PsiClass,
+        project: Project,
+        contextElement: PsiElement?
+    ): Map<String, Any?> = mapOf(
+        "name" to psiClass.name,
+        "fqn" to psiClass.qualifiedName,
+        "modifiers" to psiClass.modifierList?.text,
+        "annotations" to psiClass.annotations.map { it.qualifiedName },
+        "fields" to psiClass.fields.map {
+            fieldToMap(it, project, contextElement)
+        },
+        "methods" to psiClass.methods.map {
+            methodToSignatureMap(it, project, contextElement)
+        }
+    )
+
+    // ------------------------------------------------------------------
+    // Method signatures
+    // ------------------------------------------------------------------
+
+    /**
+     * Builds the method signature map (used in class info's `methods` array):
+     * `name` + `modifiers` + `returnType` (presentable text) + `returnTypeFqn`
+     * + `parameters` (each via [paramToMap]) + `annotations`.
+     *
+     * Type arguments are encoded inline in the FQN string via
+     * [ResolvedType.qualifiedName] — no separate `typeArguments` key.
+     */
+    fun methodToSignatureMap(
+        psiMethod: PsiMethod,
+        project: Project,
+        contextElement: PsiElement?
+    ): Map<String, Any?> {
+        val map = LinkedHashMap<String, Any?>()
+        map["name"] = psiMethod.name
+        map["modifiers"] = psiMethod.modifierList?.text
+        map["returnType"] = psiMethod.returnType?.presentableText
+        map["returnTypeFqn"] = resolve(psiMethod.returnType, project, contextElement)
+        map["parameters"] = psiMethod.parameterList.parameters.map { p ->
+            paramToMap(p, project, contextElement)
+        }
+        map["annotations"] = psiMethod.annotations.map { it.qualifiedName }
+        return map
+    }
+
+    /**
+     * Builds the method info map (returned by `get_psi_method_info`):
+     * `className` + `name` + `signature` (via [methodSignatureString]) +
+     * `annotations` + `parameters` (each via [paramToMap]) + `docComment` +
+     * `returnType` (presentable text) + `returnTypeFqn`, and — when
+     * `detail="full"` — a truncated `body` field.
+     *
+     * @param className the owning class's FQN (used for the `className` field).
+     * @param detail `"signature"` (default) omits the body; `"full"` includes
+     *   a truncated `body` field.
+     * @param maxBodyChars character budget for the `body` field (only when
+     *   `detail="full"`).
+     */
+    fun methodToInfoMap(
+        psiMethod: PsiMethod,
+        className: String,
+        project: Project,
+        contextElement: PsiElement?,
+        detail: String,
+        maxBodyChars: Int
+    ): Map<String, Any?> {
+        val map = LinkedHashMap<String, Any?>()
+        map["className"] = className
+        map["name"] = psiMethod.name
+        map["signature"] = methodSignatureString(psiMethod)
+        map["annotations"] = psiMethod.annotations.map { it.qualifiedName }
+        map["parameters"] = psiMethod.parameterList.parameters.map { p ->
+            paramToMap(p, project, contextElement)
+        }
+        map["docComment"] = psiMethod.docComment?.text
+        map["returnType"] = psiMethod.returnType?.presentableText
+        map["returnTypeFqn"] = resolve(psiMethod.returnType, project, contextElement)
+        if (detail == "full") {
+            val rawBody = psiMethod.body?.text
+            map["body"] = if (rawBody == null) {
+                null
+            } else {
+                truncateBody(rawBody.removePrefix("{").removeSuffix("}").trim(), maxBodyChars)
+            }
+        }
+        return map
+    }
+
+    /**
+     * Builds the method signature string: `modifiers returnType name(paramType paramName, ...)`.
+     */
+    fun methodSignatureString(psiMethod: PsiMethod): String =
+        buildString {
+            psiMethod.modifierList?.text?.takeIf { it.isNotBlank() }?.let { append(it).append(' ') }
+            psiMethod.returnType?.presentableText?.let { append(it).append(' ') }
+            append(psiMethod.name).append('(')
+            psiMethod.parameterList.parameters.joinTo(this, ", ") { p ->
+                "${p.type.presentableText} ${p.name}"
+            }
+            append(')')
+        }
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Truncates `body` to at most `maxChars` characters (including the
+     * truncation suffix). When the body fits, it is returned unchanged.
+     *
+     * The suffix is `" ... (truncated)"` (16 chars). The floor is
+     * `suffix.length + 1` so at least 1 char of body is always shown.
+     */
+    private fun truncateBody(body: String, maxChars: Int): String {
+        val suffix = " ... (truncated)"
+        if (body.length <= maxChars) return body
+        val effectiveLimit = maxOf(maxChars, suffix.length + 1)
+        val bodyPortion = effectiveLimit - suffix.length
+        return body.substring(0, bodyPortion) + suffix
+    }
+
+    /**
+     * Resolves a [PsiType] to a [ResolvedType] using the golden standard
+     * [TypeResolver]. When [contextElement] is provided, uses
+     * [TypeResolver.resolveFromCanonicalText] to resolve simple names via
+     * the context's import scope.
+     */
+    private fun resolveType(
+        psiType: PsiType,
+        project: Project,
+        contextElement: PsiElement?
+    ): ResolvedType {
+        return if (contextElement != null) {
+            TypeResolver.resolveFromCanonicalText(
+                psiType.canonicalText, project, contextElement
+            )
+        } else {
+            TypeResolver.resolve(psiType)
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/RuleTools.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/RuleTools.kt
@@ -4,7 +4,7 @@ package com.itangcent.easyapi.ai.tools
  * The standard set of tools handed to the [ToolRegistry] for a real
  * conversation.
  *
- * 11 perception tools + 1 staging action (`propose_rule_content`).
+ * 12 perception tools + 1 staging action (`propose_rule_content`).
  * `write_rule_file` is intentionally NOT registered in v1 — the disk write
  * happens only through the user-confirmed "Save…" UI flow.
  *
@@ -15,6 +15,8 @@ package com.itangcent.easyapi.ai.tools
  * (filters extending `OncePerRequestFilter`, interceptors implementing
  * `HandlerInterceptor`,...). Without it the agent reports false negatives
  * like "no Filters" for the standard Spring Boot declaration style.
+ * - [FindClassesByNameTool] — resolves class simple names to FQNs via
+ * `PsiShortNamesCache`, with an FQN short-circuit and batch mode.
  */
 fun standardRuleTools(): List<AiTool> = listOf(
     ListRuleKeysTool(),
@@ -25,6 +27,7 @@ fun standardRuleTools(): List<AiTool> = listOf(
     GetPsiMethodInfoTool(),
     FindClassesByAnnotationTool(),
     FindClassesBySupertypeTool(),
+    FindClassesByNameTool(),
     GetExistingRulesForKeyTool(),
     GetModuleDependencyGraphTool(),
     AskClarificationTool(),

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizer.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.exporter.core
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -23,15 +24,20 @@ import com.itangcent.easyapi.settings.onSettingsChanged
  * should use this class instead of checking annotations directly.
  */
 @Service(Service.Level.PROJECT)
-class CompositeApiClassRecognizer(private val project: Project) {
+class CompositeApiClassRecognizer(private val project: Project) : Disposable {
 
     @Volatile
     private var cachedRecognizers: List<ApiClassRecognizer> = buildRecognizers()
 
     init {
-        project.onSettingsChanged {
+        project.onSettingsChanged(this) {
             cachedRecognizers = buildRecognizers()
         }
+    }
+
+    override fun dispose() {
+        // The MessageBus connection created in init with `this` as the parent
+        // is automatically disposed when this service is disposed.
     }
 
     private fun buildRecognizers(): List<ApiClassRecognizer> {

--- a/src/main/kotlin/com/itangcent/easyapi/ide/ApiIndexStartupActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/ApiIndexStartupActivity.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.ide
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.itangcent.easyapi.cache.api.ApiFileChangeListener
@@ -21,11 +22,19 @@ import kotlin.time.Duration.Companion.seconds
  * Uses [backgroundAsync] to ensure all downstream PSI operations run on clean
  * background threads without inherited EDT context.
  *
+ * **Test mode:** This activity is a no-op when `ApplicationManager.isUnitTestMode`
+ * is true. Tests explicitly control the [ApiIndexManager] lifecycle (setUp/tearDown),
+ * and the delayed background initialization (5s + 10s delays) would leak coroutines
+ * on the singleton `IdeDispatchers.scope` that outlive disposed test projects,
+ * causing `AlreadyDisposedException` on CI where the delays elapse during later tests.
+ *
  * @see ApiIndexManager
  * @see ApiFileChangeListener
  */
 class ApiIndexStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
+        if (ApplicationManager.getApplication().isUnitTestMode) return
+
         backgroundAsync {
             DumbModeHelper.waitForSmartMode(project)
 

--- a/src/main/resources/ai/agent-preamble.md
+++ b/src/main/resources/ai/agent-preamble.md
@@ -8,7 +8,8 @@ Work in a perceive → reason → act loop:
   "index", "settings-guide", "usage-guide"), the user's
   endpoints (`list_project_endpoints`), relevant classes/methods
   (`get_psi_class_info`, `get_psi_method_info`,
-  `find_classes_by_annotation`, `find_classes_by_supertype`), and
+  `find_classes_by_annotation`, `find_classes_by_supertype`,
+  `find_classes_by_name`), and
   existing values for keys you intend to set
   (`get_existing_rules_for_key`).
 - Reason about whether you have enough context. If the request is
@@ -53,10 +54,14 @@ To inspect source code, use the PSI tools instead:
   `find_classes_by_supertype` to discover classes, then
   `get_psi_class_info` to inspect each hit.
 
-If you only know the class's simple name (e.g. `MyJwtFilter`), first
-find it with `find_classes_by_supertype` (e.g. probe
-`OncePerRequestFilter`) or `find_classes_by_annotation`, then use the
-returned FQN with `get_psi_class_info`.
+If you only know the class's simple name (e.g. `MyJwtFilter`), use
+`find_classes_by_name` as the **primary** tool — it resolves simple
+names to FQNs via the stub index and accepts an optional `context`
+(class FQN or file path) to prefer an import-reachable match. Keep
+`find_classes_by_supertype` (e.g. probe `OncePerRequestFilter`) and
+`find_classes_by_annotation` for when you know the supertype or
+annotation but not the class name; then use the returned FQN with
+`get_psi_class_info`.
 
 ## Rule file format (CRITICAL — follow exactly)
 
@@ -116,11 +121,11 @@ Both can return empty, so probe the annotation AND the supertype before
 concluding "none found".
 
 **Batch mode:** `find_classes_by_annotation`,
-`find_classes_by_supertype`, `get_psi_class_info`, and
-`get_existing_rules_for_key` all accept an array parameter
-(`annotationFqns`, `supertypeFqns`, `fqns`, `keys`) in addition to the
-single-string form. **Prefer the array form** when you need to probe
-multiple items — it costs one request instead of N.
+`find_classes_by_supertype`, `find_classes_by_name`, `get_psi_class_info`,
+and `get_existing_rules_for_key` all accept an array parameter
+(`annotationFqns`, `supertypeFqns`, `names`, `fqns`, `keys`) in
+addition to the single-string form. **Prefer the array form** when you
+need to probe multiple items — it costs one request instead of N.
 
 Confirm a hit with `get_psi_class_info`, then ask: *does it change the
 request/response contract invisibly?* If yes, apply the catalog recipe.
@@ -218,6 +223,14 @@ pre-fetch framework-specific recipes without inferring from endpoints.
   confirm the token field name; `get_existing_rules_for_key` for
   `method.additional.header`, `postman.test`, `postman.prerequest`,
   `http.call.after` to avoid duplicates. Prefer the array form to batch.
+  `get_psi_class_info` and `get_psi_method_info` now return `typeFqn`
+  (and `returnTypeFqn` on methods) on every typed reference — chain a
+  returned `typeFqn` straight into `get_psi_class_info` without a
+  separate `find_classes_by_name` call. `get_psi_method_info` also
+  accepts `detail="full"` to expose the method `body` (e.g. read a
+  filter's `shouldNotFilter` scope logic); the default
+  `detail="signature"` is the cheap contract-only path — opt into
+  `"full"` only when you need to read the implementation.
 - **Reason.** Confirm the producer/consumer split. If the token field is
   ambiguous (multiple `*token*` keys) or the consumer scope is unclear,
   call `ask_clarification` with concrete options — do not guess. Reuse an

--- a/src/test/kotlin/com/itangcent/easyapi/ai/agent/SystemPromptBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/agent/SystemPromptBuilderTest.kt
@@ -310,9 +310,13 @@ class SystemPromptBuilderTest {
         // (per Decision 5: ~600-800-char target subsection + on-demand fetch via
         // `get_plugin_doc name="rule-guide"` for the full recipe; ceiling is the new
         // actual ~16.8k + ~1k headroom).
+        // Ceiling raised 17_800 → 19_200 for the agent-psi-resolution spec (Task 14):
+        // preamble now documents `find_classes_by_name` as the primary simple-name
+        // resolver, `typeFqn` chaining, and `detail="full"` opt-in. Actual ~18.2k
+        // + ~1k headroom.
         val msg = SystemPromptBuilder.build()
         val content = msg.content
-        val ceiling = 17_800 // raised for Multi-app namespacing subsection (Decision 5): actual ~16.8k + ~1k headroom
+        val ceiling = 19_200 // raised for agent-psi-resolution preamble update: actual ~18.2k + ~1k headroom
         Assert.assertTrue(
             "Preamble content length (${content.length} chars) must stay under $ceiling chars " +
                 "to stay within NFR-3's token budget. If a future section is added, raise the " +

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByAnnotationToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByAnnotationToolTest.kt
@@ -252,6 +252,81 @@ class FindClassesByAnnotationToolTest : EasyApiLightCodeInsightFixtureTestCase()
         Assert.assertEquals(ToolKind.PERCEPTION, FindClassesByAnnotationTool().kind)
     }
 
+    // ------------------------------------------------------------------
+    // Task 11 — tolerance + context parameter
+    // ------------------------------------------------------------------
+
+    fun testAcceptsSimpleNameForAnnotationFqn() {
+        addClasses()
+        // "Marker" is a simple name — resolveAllClasses finds com.example.Marker.
+        val result = runBlocking {
+            FindClassesByAnnotationTool().execute(
+                mapOf("annotationFqn" to "Marker"),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertTrue(
+            "should find MarkedOne via simple-name resolution",
+            fqns.contains("com.example.MarkedOne")
+        )
+        Assert.assertTrue(
+            "should find MarkedTwo via simple-name resolution",
+            fqns.contains("com.example.MarkedTwo")
+        )
+    }
+
+    fun testAcceptsSimpleNameWithContext() {
+        addClasses()
+        // "Marker" + context "com.example.MarkedOne" → context nails it to
+        // com.example.Marker (MarkedOne's same-package scope).
+        val result = runBlocking {
+            FindClassesByAnnotationTool().execute(
+                mapOf(
+                    "annotationFqn" to "Marker",
+                    "context" to "com.example.MarkedOne"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertTrue(
+            "should find MarkedOne with context",
+            fqns.contains("com.example.MarkedOne")
+        )
+    }
+
+    fun testContextUnresolvableFallsBackSilently() {
+        addClasses()
+        // Bogus context → falls back to no-context simple-name resolution.
+        val result = runBlocking {
+            FindClassesByAnnotationTool().execute(
+                mapOf(
+                    "annotationFqn" to "Marker",
+                    "context" to "bogus.not.a.real.fqn.or.path"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(
+            "bogus context should fall back silently: $result",
+            result is ToolResult.Text
+        )
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertTrue(
+            "should still find MarkedOne via fallback",
+            fqns.contains("com.example.MarkedOne")
+        )
+    }
+
+    fun testSchemaDeclaresContextProperty() {
+        val schema = FindClassesByAnnotationTool().parametersSchema
+        val props = schema["properties"] as Map<*, *>
+        Assert.assertTrue("should declare context", props.containsKey("context"))
+    }
+
     private class NoOpApprovalGate : ApprovalGate {
         override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
     }

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByNameToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/FindClassesByNameToolTest.kt
@@ -1,0 +1,240 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.intellij.openapi.application.ApplicationManager
+import com.itangcent.easyapi.ai.AiRuntimeConfig
+import com.itangcent.easyapi.ai.AiProvider
+import com.itangcent.easyapi.ai.agent.AgentMemory
+import com.itangcent.easyapi.ai.agent.ApprovalGate
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.source.RuleFileResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.util.json.GsonUtils
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+
+/**
+ * Tests for [FindClassesByNameTool].
+ *
+ * Covers the 12-case test plan from the spec: simple-name resolution, FQN
+ * short-circuit, batch mode, multiple-match sorting, context-preferred
+ * match ordering, missing/blank parameter rejection, registration, kind,
+ * and schema shape.
+ *
+ * Uses the light fixture's VFS — the tool resolves classes via
+ * [com.intellij.psi.search.PsiShortNamesCache] in the project scope.
+ */
+class FindClassesByNameToolTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun ctx(): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30, maxRequests = 8
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = AgentMemory(),
+        approvals = NoOpApprovalGate()
+    )
+
+    private fun addClasses() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/AuthResponse.java",
+                "package com.example; public class AuthResponse {}"
+            )
+            myFixture.addFileToProject(
+                "com/example/User.java",
+                "package com.example; public class User {}"
+            )
+        }
+    }
+
+    // --- single-name resolution ---
+
+    fun testResolvesSimpleNameToFqn() {
+        addClasses()
+        val result = runBlocking {
+            FindClassesByNameTool().execute(mapOf("name" to "AuthResponse"), ctx())
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertTrue(
+            "should find com.example.AuthResponse",
+            fqns.contains("com.example.AuthResponse")
+        )
+    }
+
+    fun testReturnsEmptyArrayForNoMatch() {
+        addClasses()
+        val result = runBlocking {
+            FindClassesByNameTool().execute(mapOf("name" to "DoesNotExist"), ctx())
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        Assert.assertEquals("[]", (result as ToolResult.Text).value)
+    }
+
+    // --- FQN short-circuit ---
+
+    fun testFqnShortCircuitReturnsSingleElement() {
+        addClasses()
+        val result = runBlocking {
+            FindClassesByNameTool().execute(
+                mapOf("name" to "com.example.AuthResponse"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertEquals("FQN short-circuit should return single element", 1, fqns.size)
+        Assert.assertEquals("com.example.AuthResponse", fqns[0])
+    }
+
+    fun testFqnShortCircuitReturnsEmptyForUnknownFqn() {
+        addClasses()
+        val result = runBlocking {
+            FindClassesByNameTool().execute(
+                mapOf("name" to "com.example.Missing"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        Assert.assertEquals("[]", (result as ToolResult.Text).value)
+    }
+
+    // --- batch mode ---
+
+    fun testBatchReturnsMapOfNamesToFqns() {
+        addClasses()
+        val result = runBlocking {
+            FindClassesByNameTool().execute(
+                mapOf("names" to listOf("AuthResponse", "User")),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        // Batch mode returns a JSON object mapping each name to its array.
+        Assert.assertTrue("should contain AuthResponse key", text.contains("\"AuthResponse\""))
+        Assert.assertTrue("should contain User key", text.contains("\"User\""))
+        Assert.assertTrue("should find com.example.AuthResponse", text.contains("com.example.AuthResponse"))
+        Assert.assertTrue("should find com.example.User", text.contains("com.example.User"))
+    }
+
+    // --- multiple matches + sorting ---
+
+    fun testMultipleMatchesReturnedSorted() {
+        ApplicationManager.getApplication().runWriteAction {
+            // Two classes with the same simple name "AuthResponse" in
+            // different packages — both should be returned, sorted.
+            myFixture.addFileToProject(
+                "com/example/aaa/AuthResponse.java",
+                "package com.example.aaa; public class AuthResponse {}"
+            )
+            myFixture.addFileToProject(
+                "com/example/zzz/AuthResponse.java",
+                "package com.example.zzz; public class AuthResponse {}"
+            )
+        }
+        val result = runBlocking {
+            FindClassesByNameTool().execute(mapOf("name" to "AuthResponse"), ctx())
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertEquals("should find both matches", 2, fqns.size)
+        // Alphabetically sorted: aaa before zzz.
+        Assert.assertEquals("com.example.aaa.AuthResponse", fqns[0])
+        Assert.assertEquals("com.example.zzz.AuthResponse", fqns[1])
+    }
+
+    fun testContextPrefersImportReachableMatch() {
+        ApplicationManager.getApplication().runWriteAction {
+            // Two classes with the same simple name "AuthResponse".
+            // com.example.aaa is alphabetically first; com.example.zzz is
+            // last. The context file imports com.example.zzz.AuthResponse,
+            // so the zzz variant should be moved to the front.
+            myFixture.addFileToProject(
+                "com/example/aaa/AuthResponse.java",
+                "package com.example.aaa; public class AuthResponse {}"
+            )
+            myFixture.addFileToProject(
+                "com/example/zzz/AuthResponse.java",
+                "package com.example.zzz; public class AuthResponse {}"
+            )
+            // Context file that imports the zzz variant.
+            myFixture.addFileToProject(
+                "com/example/Order.java",
+                """
+                package com.example;
+                import com.example.zzz.AuthResponse;
+                public class Order {
+                    public AuthResponse auth;
+                }
+                """.trimIndent()
+            )
+        }
+        val result = runBlocking {
+            FindClassesByNameTool().execute(
+                mapOf("name" to "AuthResponse", "context" to "com.example.Order"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertEquals("should find both matches", 2, fqns.size)
+        // The context-preferred (zzz) variant should be moved to the front,
+        // even though aaa is alphabetically first.
+        Assert.assertEquals(
+            "context-reachable match should be first",
+            "com.example.zzz.AuthResponse",
+            fqns[0]
+        )
+        Assert.assertEquals("com.example.aaa.AuthResponse", fqns[1])
+    }
+
+    // --- parameter validation ---
+
+    fun testRejectsMissingParameter() {
+        val result = runBlocking {
+            FindClassesByNameTool().execute(emptyMap(), ctx())
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("name")
+        )
+    }
+
+    fun testBlankNameTreatedAsMissing() {
+        val result = runBlocking {
+            FindClassesByNameTool().execute(mapOf("name" to "   "), ctx())
+        }
+        Assert.assertTrue("blank name should be treated as missing", result is ToolResult.Error)
+    }
+
+    // --- registration + kind + schema ---
+
+    fun testIsRegisteredInStandardToolSet() {
+        val names = standardRuleTools().map { it.name }
+        Assert.assertTrue(
+            "find_classes_by_name must be registered",
+            names.contains("find_classes_by_name")
+        )
+    }
+
+    fun testIsPerceptionTool() {
+        Assert.assertEquals(ToolKind.PERCEPTION, FindClassesByNameTool().kind)
+    }
+
+    fun testSchemaDeclaresNameAndNamesProperties() {
+        val schema = FindClassesByNameTool().parametersSchema
+        val props = schema["properties"] as Map<*, *>
+        Assert.assertTrue("should declare name", props.containsKey("name"))
+        Assert.assertTrue("should declare names", props.containsKey("names"))
+        Assert.assertTrue("should declare context", props.containsKey("context"))
+    }
+
+    private class NoOpApprovalGate : ApprovalGate {
+        override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/FindClassesBySupertypeToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/FindClassesBySupertypeToolTest.kt
@@ -199,6 +199,81 @@ class FindClassesBySupertypeToolTest : EasyApiLightCodeInsightFixtureTestCase() 
         Assert.assertEquals(ToolKind.PERCEPTION, FindClassesBySupertypeTool().kind)
     }
 
+    // ------------------------------------------------------------------
+    // Task 12 — tolerance + context parameter
+    // ------------------------------------------------------------------
+
+    fun testAcceptsSimpleNameForSupertypeFqn() {
+        addClasses()
+        // "OncePerRequestFilter" is a simple name — resolveAllClasses finds it.
+        val result = runBlocking {
+            FindClassesBySupertypeTool().execute(
+                mapOf("supertypeFqn" to "OncePerRequestFilter"),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertTrue(
+            "should find MerchantJwtFilter via simple-name resolution",
+            fqns.contains("com.example.MerchantJwtFilter")
+        )
+        Assert.assertTrue(
+            "should find OpsJwtFilter via simple-name resolution",
+            fqns.contains("com.example.OpsJwtFilter")
+        )
+    }
+
+    fun testAcceptsSimpleNameWithContext() {
+        addClasses()
+        // "OncePerRequestFilter" + context "com.example.MerchantJwtFilter" →
+        // context nails it via MerchantJwtFilter's import.
+        val result = runBlocking {
+            FindClassesBySupertypeTool().execute(
+                mapOf(
+                    "supertypeFqn" to "OncePerRequestFilter",
+                    "context" to "com.example.MerchantJwtFilter"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertTrue(
+            "should find MerchantJwtFilter with context",
+            fqns.contains("com.example.MerchantJwtFilter")
+        )
+    }
+
+    fun testContextUnresolvableFallsBackSilently() {
+        addClasses()
+        // Bogus context → falls back to no-context simple-name resolution.
+        val result = runBlocking {
+            FindClassesBySupertypeTool().execute(
+                mapOf(
+                    "supertypeFqn" to "OncePerRequestFilter",
+                    "context" to "bogus.not.a.real.fqn.or.path"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(
+            "bogus context should fall back silently: $result",
+            result is ToolResult.Text
+        )
+        val fqns: List<String> = GsonUtils.fromJson((result as ToolResult.Text).value)
+        Assert.assertTrue(
+            "should still find MerchantJwtFilter via fallback",
+            fqns.contains("com.example.MerchantJwtFilter")
+        )
+    }
+
+    fun testSchemaDeclaresContextProperty() {
+        val schema = FindClassesBySupertypeTool().parametersSchema
+        val props = schema["properties"] as Map<*, *>
+        Assert.assertTrue("should declare context", props.containsKey("context"))
+    }
+
     private class NoOpApprovalGate : ApprovalGate {
         override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
     }

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/GetPsiClassInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/GetPsiClassInfoToolTest.kt
@@ -62,6 +62,321 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         }
     }
 
+    /**
+     * Seeds a generic `Result<T>` container and an `AuthResponse` DTO that
+     * references `Result<User>`. Used by the type-enrichment tests to verify
+     * `typeFqn` on the outer class encodes type args inline.
+     */
+    private fun addClassesForTypeEnrichment() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/User.java",
+                """
+                package com.example;
+                public class User {
+                    private String name;
+                    private int age;
+                    public String getName() { return name; }
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/Result.java",
+                """
+                package com.example;
+                public class Result<T> {
+                    public T data;
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/AuthResponse.java",
+                """
+                package com.example;
+                import com.example.User;
+                public class AuthResponse {
+                    public String token;
+                    public Result<User> data;
+                    public String getToken() { return token; }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Task 6 — type enrichment (typeFqn / returnTypeFqn — inline type args)
+    // ------------------------------------------------------------------
+
+    fun testFieldIncludesTypeFqnForClassType() {
+        addClasses()
+        // Ensure java.lang.String is resolvable in the light fixture — the
+        // mock JDK may not expose a resolvable qualifiedName for it.
+        loadJDKClass("java.lang.String")
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf("fqn" to "com.example.User"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        val fields = map["fields"] as List<*>
+        val nameField = fields.first {
+            (it as Map<*, *>)["name"] == "name"
+        } as Map<*, *>
+        Assert.assertEquals(
+            "String field should resolve typeFqn to java.lang.String",
+            "java.lang.String",
+            nameField["typeFqn"]
+        )
+    }
+
+    fun testFieldEncodesTypeArgsInlineInTypeFqn() {
+        addClassesForTypeEnrichment()
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf("fqn" to "com.example.AuthResponse"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        val fields = map["fields"] as List<*>
+        val dataField = fields.first {
+            (it as Map<*, *>)["name"] == "data"
+        } as Map<*, *>
+        // Type arguments are encoded inline in `typeFqn` via
+        // ResolvedType.qualifiedName() — no separate `typeArguments` key.
+        Assert.assertEquals(
+            "Result<User> typeFqn should encode type arg inline",
+            "com.example.Result<com.example.User>",
+            dataField["typeFqn"]
+        )
+        Assert.assertFalse(
+            "no typeArguments key — type args are inline in typeFqn",
+            dataField.containsKey("typeArguments")
+        )
+    }
+
+    fun testFieldTypeFqnNullForPrimitive() {
+        addClasses()
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf("fqn" to "com.example.User"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        val fields = map["fields"] as List<*>
+        val ageField = fields.first {
+            (it as Map<*, *>)["name"] == "age"
+        } as Map<*, *>
+        Assert.assertNull(
+            "primitive int field should have null typeFqn",
+            ageField["typeFqn"]
+        )
+    }
+
+    fun testFieldNeverEmitsTypeArgumentsKey() {
+        addClasses()
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf("fqn" to "com.example.User"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        val fields = map["fields"] as List<*>
+        val nameField = fields.first {
+            (it as Map<*, *>)["name"] == "name"
+        } as Map<*, *>
+        Assert.assertFalse(
+            "typeArguments key is never emitted — type args are inline in typeFqn",
+            nameField.containsKey("typeArguments")
+        )
+    }
+
+    fun testMethodReturnTypeFqnResolved() {
+        addClasses()
+        // Ensure java.lang.String is resolvable in the light fixture.
+        loadJDKClass("java.lang.String")
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf("fqn" to "com.example.User"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        val methods = map["methods"] as List<*>
+        val getNameMethod = methods.first {
+            (it as Map<*, *>)["name"] == "getName"
+        } as Map<*, *>
+        Assert.assertEquals(
+            "getName(): String should resolve returnTypeFqn to java.lang.String",
+            "java.lang.String",
+            getNameMethod["returnTypeFqn"]
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Task 7 — tolerance + context parameter
+    // ------------------------------------------------------------------
+
+    /**
+     * Seeds two `User` classes in different packages plus an `Order` class in
+     * `com.example` that imports `com.example.User`. Used by the tolerance
+     * tests to verify simple-name resolution with and without context.
+     */
+    private fun addClassesForTolerance() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/User.java",
+                """
+                package com.example;
+                public class User {
+                    public String name;
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/dto/User.java",
+                """
+                package com.example.dto;
+                public class User {
+                    public String name;
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/Order.java",
+                """
+                package com.example;
+                import com.example.User;
+                public class Order {
+                    public User buyer;
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    fun testAcceptsSimpleNameWithContext() {
+        addClassesForTolerance()
+        // Simple name "User" + context "com.example.Order" → Order's imports
+        // resolve to com.example.User (not com.example.dto.User).
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf(
+                    "fqn" to "User",
+                    "context" to "com.example.Order"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals(
+            "context should resolve User to com.example.User",
+            "com.example.User",
+            map["fqn"]
+        )
+    }
+
+    fun testAcceptsSimpleNameWithoutContextWhenUnambiguous() {
+        // Seed only one User class — simple name resolves via PsiShortNamesCache.
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/User.java",
+                """
+                package com.example;
+                public class User {
+                    public String name;
+                }
+                """.trimIndent()
+            )
+        }
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf("fqn" to "User"),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals("com.example.User", map["fqn"])
+    }
+
+    fun testAmbiguousSimpleNameReturnsErrorGuidingToFindClassesByName() {
+        addClassesForTolerance()
+        // Two User classes (com.example.User + com.example.dto.User), no
+        // context → ambiguous → error guiding to find_classes_by_name.
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf("fqn" to "User"),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Error result, got $result", result is ToolResult.Error)
+        val msg = (result as ToolResult.Error).message
+        Assert.assertTrue(
+            "error should mention find_classes_by_name: $msg",
+            msg.contains("find_classes_by_name")
+        )
+        Assert.assertTrue(
+            "error should mention ambiguous: $msg",
+            msg.contains("ambiguous")
+        )
+    }
+
+    fun testContextUnresolvableFallsBackSilently() {
+        addClassesForTolerance()
+        // Bogus context → falls back to no-context path. With two User
+        // classes this would be ambiguous, so instead seed only one User
+        // class and use a bogus context to verify silent fallback.
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/OnlyUser.java",
+                """
+                package com.example;
+                public class OnlyUser {
+                    public String name;
+                }
+                """.trimIndent()
+            )
+        }
+        val result = runBlocking {
+            GetPsiClassInfoTool().execute(
+                mapOf(
+                    "fqn" to "OnlyUser",
+                    "context" to "bogus.not.a.real.fqn.or.path"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(
+            "bogus context should fall back silently to no-context resolution: $result",
+            result is ToolResult.Text
+        )
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals("com.example.OnlyUser", map["fqn"])
+    }
+
+    fun testSchemaDeclaresContextProperty() {
+        val schema = GetPsiClassInfoTool().parametersSchema
+        val props = schema["properties"] as Map<*, *>
+        Assert.assertTrue("should declare context", props.containsKey("context"))
+        // context must be optional — not in `required`.
+        val required = schema["required"] as? List<*>
+        Assert.assertNull(
+            "context must be optional (no required array expected)",
+            required
+        )
+    }
+
     fun testReturnsInfoForSingleClass() {
         addClasses()
         val result = runBlocking {

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/GetPsiMethodInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/GetPsiMethodInfoToolTest.kt
@@ -265,6 +265,502 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertTrue("methodName must be required", required.contains("methodName"))
     }
 
+    // ------------------------------------------------------------------
+    // Task 8 — type enrichment (returnType/returnTypeFqn/per-param typeFqn)
+    // ------------------------------------------------------------------
+
+    /**
+     * Seeds a `Greeter` class with a `String` parameter and `String` return
+     * type for type-enrichment assertions.
+     */
+    private fun addClassesForTypeEnrichment() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/Greeter.java",
+                """
+                package com.example;
+                public class Greeter {
+                    public String greet(String name) {
+                        return "hello " + name;
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    fun testParameterIncludesTypeFqn() {
+        addClassesForTypeEnrichment()
+        // Ensure java.lang.String is resolvable in the light fixture.
+        loadJDKClass("java.lang.String")
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Greeter",
+                    "methodName" to "greet"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        val params = map["parameters"] as List<*>
+        val nameParam = params.first {
+            (it as Map<*, *>)["name"] == "name"
+        } as Map<*, *>
+        Assert.assertEquals(
+            "String parameter should resolve typeFqn to java.lang.String",
+            "java.lang.String",
+            nameParam["typeFqn"]
+        )
+    }
+
+    fun testReturnTypeFqnResolved() {
+        addClassesForTypeEnrichment()
+        // Ensure java.lang.String is resolvable in the light fixture.
+        loadJDKClass("java.lang.String")
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Greeter",
+                    "methodName" to "greet"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals(
+            "String return type should resolve returnTypeFqn to java.lang.String",
+            "java.lang.String",
+            map["returnTypeFqn"]
+        )
+    }
+
+    fun testReturnTypeAndReturnTypeFqnBothPresent() {
+        addClassesForTypeEnrichment()
+        loadJDKClass("java.lang.String")
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Greeter",
+                    "methodName" to "greet"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        // Both the additive returnType (presentableText) and returnTypeFqn
+        // should be present. signature stays unchanged.
+        Assert.assertEquals("String", map["returnType"])
+        Assert.assertEquals("java.lang.String", map["returnTypeFqn"])
+        val signature = map["signature"] as String
+        Assert.assertTrue(
+            "signature should still contain String: $signature",
+            signature.contains("String")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Task 9 — detail / maxBodyChars / body (REQ-3 core)
+    // ------------------------------------------------------------------
+
+    /**
+     * Seeds a class with: a normal method body (`multiply`), an abstract
+     * method (`abstractMethod`), and an empty-body method (`emptyMethod`).
+     */
+    private fun addClassesForBodyExtraction() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/Calculator.java",
+                """
+                package com.example;
+
+                public class Calculator {
+
+                    public int multiply(int a, int b) {
+                        return a * b;
+                    }
+
+                    public void emptyMethod() {}
+
+                    public abstract void abstractMethod();
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/LongBody.java",
+                """
+                package com.example;
+
+                public class LongBody {
+                    public void longMethod() {
+                        ${"// padding line\n                        ".repeat(20)}int x = 1;
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    fun testSignatureDetailHasNoBodyField() {
+        addClasses()
+        // Default call (no `detail` arg) → no `body` key in JSON.
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "multiply"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertFalse(
+            "default detail (signature) should NOT include body key",
+            map.containsKey("body")
+        )
+    }
+
+    fun testExplicitSignatureDetailHasNoBodyField() {
+        addClasses()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "multiply",
+                    "detail" to "signature"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertFalse(
+            "detail=signature should NOT include body key",
+            map.containsKey("body")
+        )
+    }
+
+    fun testFullDetailIncludesBody() {
+        addClassesForBodyExtraction()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "multiply",
+                    "detail" to "full"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals(
+            "detail=full should include the stripped body",
+            "return a * b;",
+            map["body"]
+        )
+    }
+
+    fun testFullDetailBodyNullForAbstractMethod() {
+        addClassesForBodyExtraction()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "abstractMethod",
+                    "detail" to "full"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertNull(
+            "abstract method body should be null",
+            map["body"]
+        )
+    }
+
+    fun testFullDetailBodyEmptyStringForEmptyBody() {
+        addClassesForBodyExtraction()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "emptyMethod",
+                    "detail" to "full"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals(
+            "empty body {} should produce body=\"\"",
+            "",
+            map["body"]
+        )
+    }
+
+    fun testMaxBodyCharsTruncatesBodyWithSuffix() {
+        addClassesForBodyExtraction()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.LongBody",
+                    "methodName" to "longMethod",
+                    "detail" to "full",
+                    "maxBodyChars" to 50
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        val body = map["body"] as String
+        Assert.assertTrue(
+            "body should be truncated to ≤ 50 chars: actual length=${body.length}",
+            body.length <= 50
+        )
+        Assert.assertTrue(
+            "body should end with truncation suffix: $body",
+            body.endsWith("... (truncated)")
+        )
+    }
+
+    fun testMaxBodyCharsZeroUsesDefault() {
+        addClassesForBodyExtraction()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "multiply",
+                    "detail" to "full",
+                    "maxBodyChars" to 0
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        // With default 4000, the short body fits without truncation.
+        Assert.assertEquals(
+            "maxBodyChars=0 should fall back to default (no truncation)",
+            "return a * b;",
+            map["body"]
+        )
+    }
+
+    fun testMaxBodyCharsNegativeUsesDefault() {
+        addClassesForBodyExtraction()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "multiply",
+                    "detail" to "full",
+                    "maxBodyChars" to -1
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals(
+            "maxBodyChars=-1 should fall back to default (no truncation)",
+            "return a * b;",
+            map["body"]
+        )
+    }
+
+    fun testInvalidDetailValueDefaultsToSignature() {
+        addClasses()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "com.example.Calculator",
+                    "methodName" to "multiply",
+                    "detail" to "bogus"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertFalse(
+            "invalid detail value should default to signature (no body key)",
+            map.containsKey("body")
+        )
+    }
+
+    fun testSchemaDeclaresDetailAndMaxBodyChars() {
+        val schema = GetPsiMethodInfoTool().parametersSchema
+        val props = schema["properties"] as Map<*, *>
+        Assert.assertTrue("should declare detail", props.containsKey("detail"))
+        Assert.assertTrue("should declare maxBodyChars", props.containsKey("maxBodyChars"))
+        val detailSchema = props["detail"] as Map<*, *>
+        val enumValues = detailSchema["enum"] as List<*>
+        Assert.assertTrue("detail enum should include signature", enumValues.contains("signature"))
+        Assert.assertTrue("detail enum should include full", enumValues.contains("full"))
+    }
+
+    // ------------------------------------------------------------------
+    // Task 10 — tolerance + context parameter
+    // ------------------------------------------------------------------
+
+    /**
+     * Seeds two `Calculator` classes in different packages plus a `Caller`
+     * class that imports `com.example.Calculator`, for tolerance tests.
+     */
+    private fun addClassesForTolerance() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/Calculator.java",
+                """
+                package com.example;
+                public class Calculator {
+                    public int multiply(int a, int b) { return a * b; }
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/dto/Calculator.java",
+                """
+                package com.example.dto;
+                public class Calculator {
+                    public int multiply(int a, int b) { return a * b; }
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/Caller.java",
+                """
+                package com.example;
+                import com.example.Calculator;
+                public class Caller {
+                    public Calculator calc;
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    fun testAcceptsSimpleNameForFqn() {
+        // Seed only one Calculator — simple name resolves via PsiShortNamesCache.
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/Calculator.java",
+                """
+                package com.example;
+                public class Calculator {
+                    public int multiply(int a, int b) { return a * b; }
+                }
+                """.trimIndent()
+            )
+        }
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "Calculator",
+                    "methodName" to "multiply"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals("com.example.Calculator", map["className"])
+    }
+
+    fun testAcceptsSimpleNameWithContext() {
+        addClassesForTolerance()
+        // Simple name "Calculator" + context "com.example.Caller" → Caller's
+        // imports resolve to com.example.Calculator.
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "Calculator",
+                    "methodName" to "multiply",
+                    "context" to "com.example.Caller"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals(
+            "context should resolve Calculator to com.example.Calculator",
+            "com.example.Calculator",
+            map["className"]
+        )
+    }
+
+    fun testAmbiguousSimpleNameReturnsError() {
+        addClassesForTolerance()
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "Calculator",
+                    "methodName" to "multiply"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue("expected Error result, got $result", result is ToolResult.Error)
+        val msg = (result as ToolResult.Error).message
+        Assert.assertTrue(
+            "error should mention find_classes_by_name: $msg",
+            msg.contains("find_classes_by_name")
+        )
+    }
+
+    fun testContextUnresolvableFallsBackSilently() {
+        // Seed only one Calculator — bogus context falls back to no-context.
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/Calc.java",
+                """
+                package com.example;
+                public class Calc {
+                    public int multiply(int a, int b) { return a * b; }
+                }
+                """.trimIndent()
+            )
+        }
+        val result = runBlocking {
+            GetPsiMethodInfoTool().execute(
+                mapOf(
+                    "fqn" to "Calc",
+                    "methodName" to "multiply",
+                    "context" to "bogus.not.a.real.fqn.or.path"
+                ),
+                ctx()
+            )
+        }
+        Assert.assertTrue(
+            "bogus context should fall back silently: $result",
+            result is ToolResult.Text
+        )
+        val map = GsonUtils.fromJson<Map<String, Any?>>((result as ToolResult.Text).value)
+        Assert.assertEquals("com.example.Calc", map["className"])
+    }
+
+    fun testSchemaDeclaresContextProperty() {
+        val schema = GetPsiMethodInfoTool().parametersSchema
+        val props = schema["properties"] as Map<*, *>
+        Assert.assertTrue("should declare context", props.containsKey("context"))
+        // context must be optional — `required` must NOT contain it.
+        val required = schema["required"] as List<*>
+        Assert.assertFalse(
+            "context must be optional",
+            required.contains("context")
+        )
+    }
+
     private class NoOpApprovalGate : ApprovalGate {
         override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
     }

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/ListProjectEndpointsToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/ListProjectEndpointsToolTest.kt
@@ -1,0 +1,215 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.itangcent.easyapi.ai.AiProvider
+import com.itangcent.easyapi.ai.AiRuntimeConfig
+import com.itangcent.easyapi.ai.agent.AgentMemory
+import com.itangcent.easyapi.ai.agent.ApprovalGate
+import com.itangcent.easyapi.cache.api.ApiIndex
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.source.RuleFileResolver
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.GrpcMetadata
+import com.itangcent.easyapi.exporter.model.GrpcStreamingType
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.util.json.GsonUtils
+import com.intellij.testFramework.registerServiceInstance
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+
+/**
+ * Tests for [ListProjectEndpointsTool].
+ *
+ * Verifies the three documented behaviors:
+ * - Returns `"cache not ready"` when [ApiIndex.isReady] is `false`.
+ * - Returns a JSON array of `{className, name, httpMethod, path}` summaries
+ *   for HTTP endpoints.
+ * - Filters out gRPC endpoints (only HTTP metadata is exposed in v1).
+ *
+ * Each test registers a fresh [ApiIndex] via `registerServiceInstance` so
+ * the cache state is fully controlled — no real scan is performed.
+ */
+class ListProjectEndpointsToolTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun ctx(): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30, maxRequests = 8
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = AgentMemory(),
+        approvals = NoOpApprovalGate()
+    )
+
+    override fun setUp() {
+        super.setUp()
+        // Default: register an empty (not-yet-ready) ApiIndex. Individual
+        // tests override with a populated index when needed.
+        project.registerServiceInstance(
+            serviceInterface = ApiIndex::class.java,
+            instance = ApiIndex()
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // cache-not-ready path
+    // ------------------------------------------------------------------
+
+    fun testReturnsCacheNotReadyWhenInitialScanPending() {
+        // Fresh ApiIndex: cacheReady has not been completed, so isReady() == false.
+        val result = runBlocking { ListProjectEndpointsTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue("expected Text result", result is ToolResult.Text)
+        Assert.assertEquals(
+            "cache not ready",
+            (result as ToolResult.Text).value
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // HTTP endpoints path
+    // ------------------------------------------------------------------
+
+    fun testReturnsHttpEndpointSummaries() {
+        registerPopulatedIndex(
+            ApiEndpoint(
+                name = "getUser",
+                className = "com.example.UserController",
+                metadata = HttpMetadata(path = "/users/{id}", method = HttpMethod.GET)
+            ),
+            ApiEndpoint(
+                name = "createUser",
+                className = "com.example.UserController",
+                metadata = HttpMetadata(path = "/users", method = HttpMethod.POST)
+            )
+        )
+
+        val result = runBlocking { ListProjectEndpointsTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        @Suppress("UNCHECKED_CAST")
+        val summaries = GsonUtils.fromJson<List<Map<String, Any?>>>(
+            (result as ToolResult.Text).value
+        )
+        Assert.assertEquals("should return both HTTP endpoints", 2, summaries.size)
+
+        val first = summaries[0]
+        Assert.assertEquals("com.example.UserController", first["className"])
+        Assert.assertEquals("getUser", first["name"])
+        Assert.assertEquals("GET", first["httpMethod"])
+        Assert.assertEquals("/users/{id}", first["path"])
+
+        val second = summaries[1]
+        Assert.assertEquals("com.example.UserController", second["className"])
+        Assert.assertEquals("createUser", second["name"])
+        Assert.assertEquals("POST", second["httpMethod"])
+        Assert.assertEquals("/users", second["path"])
+    }
+
+    fun testEmptyCacheReturnsEmptyArray() {
+        // A ready but empty cache yields an empty JSON array, not "cache not ready".
+        registerPopulatedIndex()
+
+        val result = runBlocking { ListProjectEndpointsTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        Assert.assertEquals("[]", text)
+    }
+
+    // ------------------------------------------------------------------
+    // gRPC filtering
+    // ------------------------------------------------------------------
+
+    fun testGrpcEndpointsAreFilteredOut() {
+        registerPopulatedIndex(
+            ApiEndpoint(
+                name = "getUser",
+                className = "com.example.UserController",
+                metadata = HttpMetadata(path = "/users/{id}", method = HttpMethod.GET)
+            ),
+            ApiEndpoint(
+                name = "SayHello",
+                className = "com.example.GreeterService",
+                metadata = GrpcMetadata(
+                    path = "/com.example.Greeter/SayHello",
+                    serviceName = "Greeter",
+                    methodName = "SayHello",
+                    packageName = "com.example",
+                    streamingType = GrpcStreamingType.UNARY
+                )
+            )
+        )
+
+        val result = runBlocking { ListProjectEndpointsTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        @Suppress("UNCHECKED_CAST")
+        val summaries = GsonUtils.fromJson<List<Map<String, Any?>>>(
+            (result as ToolResult.Text).value
+        )
+        Assert.assertEquals(
+            "gRPC endpoint should be filtered out, only HTTP remains",
+            1,
+            summaries.size
+        )
+        Assert.assertEquals("getUser", summaries[0]["name"])
+        Assert.assertEquals("/users/{id}", summaries[0]["path"])
+    }
+
+    fun testOnlyGrpcEndpointsYieldsEmptyArray() {
+        // A cache containing only gRPC endpoints should yield an empty
+        // array, not "cache not ready" (the cache IS ready, just empty of HTTP).
+        registerPopulatedIndex(
+            ApiEndpoint(
+                name = "SayHello",
+                className = "com.example.GreeterService",
+                metadata = GrpcMetadata(
+                    path = "/com.example.Greeter/SayHello",
+                    serviceName = "Greeter",
+                    methodName = "SayHello",
+                    packageName = "com.example",
+                    streamingType = GrpcStreamingType.UNARY
+                )
+            )
+        )
+
+        val result = runBlocking { ListProjectEndpointsTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+        Assert.assertEquals("[]", (result as ToolResult.Text).value)
+    }
+
+    // ------------------------------------------------------------------
+    // Tool metadata
+    // ------------------------------------------------------------------
+
+    fun testToolKindIsPerception() {
+        Assert.assertEquals(ToolKind.PERCEPTION, ListProjectEndpointsTool().kind)
+    }
+
+    fun testToolDoesNotRequireApproval() {
+        Assert.assertFalse(ListProjectEndpointsTool().requiresApproval)
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Replaces the registered [ApiIndex] with one pre-populated via
+     * [ApiIndex.updateEndpoints] (which completes `cacheReady`, flipping
+     * `isReady()` to `true`).
+     */
+    private fun registerPopulatedIndex(vararg endpoints: ApiEndpoint) {
+        val index = ApiIndex()
+        runBlocking { index.updateEndpoints(endpoints.toList()) }
+        project.registerServiceInstance(
+            serviceInterface = ApiIndex::class.java,
+            instance = index
+        )
+    }
+
+    private class NoOpApprovalGate : ApprovalGate {
+        override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/PerceptionToolsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/PerceptionToolsTest.kt
@@ -377,6 +377,7 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertTrue("get_psi_method_info", names.contains("get_psi_method_info"))
         Assert.assertTrue("find_classes_by_annotation", names.contains("find_classes_by_annotation"))
         Assert.assertTrue("find_classes_by_supertype", names.contains("find_classes_by_supertype"))
+        Assert.assertTrue("find_classes_by_name", names.contains("find_classes_by_name"))
         Assert.assertTrue("get_existing_rules_for_key", names.contains("get_existing_rules_for_key"))
         Assert.assertTrue("get_module_dependency_graph", names.contains("get_module_dependency_graph"))
         Assert.assertTrue("propose_rule_content", names.contains("propose_rule_content"))
@@ -384,7 +385,7 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
             "write_rule_file must NOT be registered in v1",
             names.contains("write_rule_file")
         )
-        Assert.assertEquals("exactly 12 tools in v1", 12, tools.size)
+        Assert.assertEquals("exactly 13 tools in v1", 13, tools.size)
     }
 
     // --- helpers ---

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/PsiNameResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/PsiNameResolverTest.kt
@@ -1,0 +1,215 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiFile
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import java.io.File
+
+/**
+ * Tests for [PsiNameResolver].
+ *
+ * Covers the three resolution paths (FQN, simple-name single-match,
+ * simple-name ambiguous) and the `resolveContextElement` normalization
+ * (class FQN, absolute path, project-relative path, unresolvable input).
+ *
+ * Uses the light fixture's VFS to provide source classes — the resolver
+ * uses [com.intellij.psi.JavaPsiFacade.findClass] and
+ * [com.intellij.psi.search.PsiShortNamesCache] which rely on the PSI index.
+ */
+class PsiNameResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun addClasses() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/AuthResponse.java",
+                """
+                package com.example;
+                public class AuthResponse {
+                    public String token;
+                }
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/Order.java",
+                """
+                package com.example;
+                public class Order {
+                    public AuthResponse auth;
+                }
+                """.trimIndent()
+            )
+            // Two classes with the same simple name "Duplicate" — ambiguous
+            // when resolved without context.
+            myFixture.addFileToProject(
+                "com/example/dup/Duplicate.java",
+                "package com.example.dup; public class Duplicate {}"
+            )
+            myFixture.addFileToProject(
+                "com/example/other/Duplicate.java",
+                "package com.example.other; public class Duplicate {}"
+            )
+        }
+    }
+
+    // --- resolveClass ---
+
+    fun testFqnResolves() {
+        addClasses()
+        val psiClass = runBlocking {
+            PsiNameResolver.resolveClass("com.example.AuthResponse", project)
+        }
+        Assert.assertNotNull("FQN should resolve", psiClass)
+        Assert.assertEquals("com.example.AuthResponse", psiClass!!.qualifiedName)
+    }
+
+    fun testFqnReturnsNullForUnknown() {
+        addClasses()
+        val psiClass = runBlocking {
+            PsiNameResolver.resolveClass("com.example.DoesNotExist", project)
+        }
+        Assert.assertNull("unknown FQN should return null", psiClass)
+    }
+
+    fun testSimpleNameSingleMatchResolves() {
+        addClasses()
+        val psiClass = runBlocking {
+            PsiNameResolver.resolveClass("AuthResponse", project)
+        }
+        Assert.assertNotNull("single-match simple name should resolve", psiClass)
+        Assert.assertEquals("com.example.AuthResponse", psiClass!!.qualifiedName)
+    }
+
+    fun testSimpleNameZeroMatchReturnsNull() {
+        addClasses()
+        val psiClass = runBlocking {
+            PsiNameResolver.resolveClass("DoesNotExist", project)
+        }
+        Assert.assertNull("zero-match simple name should return null", psiClass)
+    }
+
+    fun testSimpleNameMultiMatchReturnsNull() {
+        addClasses()
+        val psiClass = runBlocking {
+            PsiNameResolver.resolveClass("Duplicate", project)
+        }
+        Assert.assertNull("ambiguous simple name should return null", psiClass)
+    }
+
+    fun testBlankNameReturnsNull() {
+        val psiClass = runBlocking {
+            PsiNameResolver.resolveClass("   ", project)
+        }
+        Assert.assertNull("blank name should return null", psiClass)
+    }
+
+    fun testResolveClassWithContextResolvesSimpleName() {
+        addClasses()
+        // Use Order.java's containing file as context — AuthResponse is
+        // in the same package, so TypeResolver should resolve it.
+        val orderFile = runBlocking {
+            PsiNameResolver.resolveContextElement("com.example.Order", project)
+        }
+        Assert.assertNotNull(orderFile)
+        val psiClass = runBlocking {
+            PsiNameResolver.resolveClass("AuthResponse", project, orderFile)
+        }
+        Assert.assertNotNull("context should help resolve simple name", psiClass)
+        Assert.assertEquals("com.example.AuthResponse", psiClass!!.qualifiedName)
+    }
+
+    // --- resolveAllClasses ---
+
+    fun testResolveAllClassesFqnReturnsSingleOrEmpty() {
+        addClasses()
+        val present = runBlocking {
+            PsiNameResolver.resolveAllClasses("com.example.AuthResponse", project)
+        }
+        Assert.assertEquals(1, present.size)
+        Assert.assertEquals("com.example.AuthResponse", present[0].qualifiedName)
+
+        val absent = runBlocking {
+            PsiNameResolver.resolveAllClasses("com.example.Missing", project)
+        }
+        Assert.assertTrue("missing FQN should return empty list", absent.isEmpty())
+    }
+
+    fun testResolveAllClassesSimpleNameReturnsAllMatches() {
+        addClasses()
+        val all = runBlocking {
+            PsiNameResolver.resolveAllClasses("Duplicate", project)
+        }
+        Assert.assertEquals("ambiguous simple name should return all matches", 2, all.size)
+    }
+
+    fun testResolveAllClassesBlankReturnsEmpty() {
+        val all = runBlocking {
+            PsiNameResolver.resolveAllClasses("  ", project)
+        }
+        Assert.assertTrue("blank name should return empty list", all.isEmpty())
+    }
+
+    // --- resolveContextElement ---
+
+    fun testResolveContextElementAcceptsClassFqn() {
+        addClasses()
+        val element = runBlocking {
+            PsiNameResolver.resolveContextElement("com.example.Order", project)
+        }
+        Assert.assertNotNull("class FQN context should resolve to containing file", element)
+        Assert.assertTrue("expected PsiFile, got $element", element is PsiFile)
+    }
+
+    fun testResolveContextElementAcceptsProjectRelativePath() {
+        addClasses()
+        // The light fixture uses an in-memory VFS, so files added via
+        // myFixture.addFileToProject are not on the local file system.
+        // Create a real file within the project's base path so the
+        // project-relative path resolution (LocalFileSystem + basePath)
+        // can locate it.
+        val basePath = project.basePath
+        Assert.assertNotNull("project base path should be set", basePath)
+        val ioFile = File(basePath!!, "TestProjectRelative.java")
+        ioFile.parentFile?.mkdirs()
+        ioFile.writeText("package com.example; public class TestProjectRelative {}")
+        try {
+            // Register the file in the VFS.
+            VfsUtil.findFileByIoFile(ioFile, true)
+            val element = runBlocking {
+                PsiNameResolver.resolveContextElement("TestProjectRelative.java", project)
+            }
+            Assert.assertNotNull("project-relative path should resolve", element)
+            Assert.assertTrue("expected PsiFile, got $element", element is PsiFile)
+        } finally {
+            ioFile.delete()
+        }
+    }
+
+    fun testResolveContextElementAcceptsAbsolutePath() {
+        addClasses()
+        // The light fixture uses an in-memory VFS, so LocalFileSystem won't
+        // find fixture-added files by path. Create a real temp file on disk
+        // so LocalFileSystem.findFileByPath can locate it.
+        val ioFile = File.createTempFile("TestContext", ".java")
+        ioFile.writeText("package com.example; public class TestContext {}")
+        ioFile.deleteOnExit()
+        // Ensure the file is registered in the VFS before the resolver looks
+        // it up.
+        VfsUtil.findFileByIoFile(ioFile, true)
+        val element = runBlocking {
+            PsiNameResolver.resolveContextElement(ioFile.absolutePath, project)
+        }
+        Assert.assertNotNull("absolute path should resolve", element)
+        Assert.assertTrue("expected PsiFile, got $element", element is PsiFile)
+    }
+
+    fun testResolveContextElementReturnsNullForUnresolvable() {
+        addClasses()
+        val element = runBlocking {
+            PsiNameResolver.resolveContextElement("does/not/exist/Anywhere.java", project)
+        }
+        Assert.assertNull("unresolvable context should return null", element)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/PsiSignatureBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/PsiSignatureBuilderTest.kt
@@ -1,0 +1,555 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiType
+import com.intellij.psi.search.GlobalSearchScope
+import com.itangcent.easyapi.core.threading.readSync
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert
+
+/**
+ * Tests for [PsiSignatureBuilder].
+ *
+ * Covers:
+ * - Each row of the design's type-handling matrix: primitive, array, resolved
+ *   class, parameterized type, raw type, type-parameter argument, unresolved
+ *   `PsiClassType`, and the context path.
+ * - The JSON output shape of [PsiSignatureBuilder.fieldToMap] /
+ *   [PsiSignatureBuilder.paramToMap].
+ * - The class / method signature builders: [PsiSignatureBuilder.classToMap],
+ *   [PsiSignatureBuilder.methodToSignatureMap],
+ *   [PsiSignatureBuilder.methodToInfoMap], and
+ *   [PsiSignatureBuilder.methodSignatureString].
+ *
+ * [PsiSignatureBuilder.resolve] returns `String?` — the
+ * [com.itangcent.easyapi.psi.type.ResolvedType.qualifiedName] for class types
+ * (with type arguments encoded inline, e.g.
+ * `"com.example.Result<com.example.AuthResponse>"`), or `null` for
+ * primitives, arrays, wildcards, type parameters, and unresolved types.
+ */
+class PsiSignatureBuilderTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        // List and Map are needed for the raw/parameterized type fixtures.
+        loadJDKClass("java.util.List")
+        loadJDKClass("java.util.Map")
+    }
+
+    private fun addClasses() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/AuthResponse.java",
+                "package com.example; public class AuthResponse {}"
+            )
+            myFixture.addFileToProject(
+                "com/example/Result.java",
+                "package com.example; public class Result<T> {}"
+            )
+            myFixture.addFileToProject(
+                "com/example/Types.java",
+                """
+                package com.example;
+                import java.util.List;
+                import java.util.Map;
+                import com.example.AuthResponse;
+                import com.example.Result;
+                public class Types<T> {
+                    public int age;
+                    public String name;
+                    public String[] aliases;
+                    public AuthResponse simple;
+                    public Result<AuthResponse> data;
+                    public Map rawMap;
+                    public List<T> items;
+                }
+                """.trimIndent()
+            )
+            // Holder in a DIFFERENT package — AuthResponse is not imported
+            // and is in a different package, so it is truly unresolved here.
+            // DoesNotExist is a type that doesn't exist anywhere in the VFS.
+            myFixture.addFileToProject(
+                "com/other/Holder.java",
+                """
+                package com.other;
+                public class Holder {
+                    public AuthResponse contextResolvable;
+                    public DoesNotExist trulyUnresolved;
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun fieldType(className: String, fieldName: String): PsiType = readSync {
+        val psiClass = JavaPsiFacade.getInstance(project)
+            .findClass(className, GlobalSearchScope.allScope(project))
+            ?: error("class not found: $className")
+        psiClass.findFieldByName(fieldName, false)?.type
+            ?: error("field not found: $className.$fieldName")
+    }
+
+    private fun contextFile(className: String): PsiElement = readSync {
+        val psiClass = JavaPsiFacade.getInstance(project)
+            .findClass(className, GlobalSearchScope.allScope(project))
+            ?: error("class not found: $className")
+        psiClass.containingFile
+    }
+
+    private fun resolveClass(className: String): PsiClass = readSync {
+        JavaPsiFacade.getInstance(project)
+            .findClass(className, GlobalSearchScope.allScope(project))
+            ?: error("class not found: $className")
+    }
+
+    private fun resolveMethod(className: String, methodName: String, paramCount: Int? = null): PsiMethod = readSync {
+        val psiClass = JavaPsiFacade.getInstance(project)
+            .findClass(className, GlobalSearchScope.allScope(project))
+            ?: error("class not found: $className")
+        psiClass.methods.firstOrNull { m ->
+            m.name == methodName &&
+                (paramCount == null || m.parameterList.parameters.size == paramCount)
+        } ?: error("method not found: $className.$methodName")
+    }
+
+    // ------------------------------------------------------------------
+    // Non-class types ⇒ null
+    // ------------------------------------------------------------------
+
+    fun testPrimitiveTypeFqnIsNull() {
+        addClasses()
+        val type = fieldType("com.example.Types", "age")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project) }
+        Assert.assertNull("primitive typeFqn should be null", fqn)
+    }
+
+    fun testArrayTypeFqnIsNull() {
+        addClasses()
+        val type = fieldType("com.example.Types", "aliases")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project) }
+        Assert.assertNull("array typeFqn should be null", fqn)
+    }
+
+    fun testUnresolvedClassTypeFqnIsNull() {
+        addClasses()
+        // DoesNotExist is a type that doesn't exist anywhere — truly unresolved.
+        val type = fieldType("com.other.Holder", "trulyUnresolved")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project) }
+        Assert.assertNull("unresolved typeFqn should be null", fqn)
+    }
+
+    fun testNullTypeReturnsNullFqn() {
+        val fqn = readSync { PsiSignatureBuilder.resolve(null, project) }
+        Assert.assertNull(fqn)
+    }
+
+    // ------------------------------------------------------------------
+    // Class types ⇒ ResolvedType.qualifiedName()
+    // ------------------------------------------------------------------
+
+    fun testResolvedClassTypeFqn() {
+        addClasses()
+        // Use a project class (AuthResponse) — the mock JDK's String may
+        // not expose a resolvable qualifiedName in the light fixture.
+        val type = fieldType("com.example.Types", "simple")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project) }
+        Assert.assertEquals("com.example.AuthResponse", fqn)
+    }
+
+    fun testParameterizedTypeWithClassArg() {
+        addClasses()
+        val type = fieldType("com.example.Types", "data")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project) }
+        // Type arguments are encoded inline in the qualified name.
+        Assert.assertEquals(
+            "com.example.Result<com.example.AuthResponse>",
+            fqn
+        )
+    }
+
+    fun testRawTypeReturnsBareFqn() {
+        addClasses()
+        val type = fieldType("com.example.Types", "rawMap")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project) }
+        // Raw type has no type args — qualifiedName is just the bare FQN.
+        Assert.assertEquals("java.util.Map", fqn)
+    }
+
+    fun testTypeParameterArgEncodedInline() {
+        addClasses()
+        val type = fieldType("com.example.Types", "items")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project) }
+        // List<T> — the type parameter T is unresolved, so its qualifiedName
+        // is its canonical text "T", encoded inline in the outer FQN.
+        Assert.assertEquals("java.util.List<T>", fqn)
+    }
+
+    // ------------------------------------------------------------------
+    // Context path
+    // ------------------------------------------------------------------
+
+    fun testContextResolvesUnresolvedType() {
+        addClasses()
+        // AuthResponse is unresolved in com.other.Holder (different package,
+        // no import). Use Types.java (which imports AuthResponse) as context.
+        val type = fieldType("com.other.Holder", "contextResolvable")
+        val ctxFile = contextFile("com.example.Types")
+        val fqn = readSync { PsiSignatureBuilder.resolve(type, project, ctxFile) }
+        Assert.assertEquals(
+            "context should resolve AuthResponse via Types.java imports",
+            "com.example.AuthResponse",
+            fqn
+        )
+    }
+
+    /**
+     * JDK types (e.g. `java.lang.String`) may not resolve via the context
+     * element's import scope — verify the fallback to the no-context path
+     * returns the resolvable FQN.
+     */
+    fun testFallbackToNoContextForJdkType() {
+        addClasses()
+        loadJDKClass("java.lang.String")
+        val ctxFile = contextFile("com.example.Types")
+        val fqn = readSync {
+            PsiSignatureBuilder.resolve(
+                fieldType("com.example.Types", "name"),
+                project,
+                ctxFile
+            )
+        }
+        Assert.assertEquals("java.lang.String", fqn)
+    }
+
+    // ------------------------------------------------------------------
+    // fieldToMap / paramToMap — JSON output shape
+    // ------------------------------------------------------------------
+
+    /**
+     * Verifies the [PsiSignatureBuilder.fieldToMap] output shape: `name` +
+     * `type` (presentable text) + `typeFqn` (the
+     * [com.itangcent.easyapi.psi.type.ResolvedType.qualifiedName], with type
+     * args encoded inline). No separate `typeArguments` key is emitted.
+     */
+    fun testFieldToMapShapeForClassType() {
+        addClasses()
+        val ctxFile = contextFile("com.example.Types")
+        val map = readSync {
+            val field = JavaPsiFacade.getInstance(project)
+                .findClass("com.example.Types", GlobalSearchScope.allScope(project))!!
+                .findFieldByName("data", false)!!
+            PsiSignatureBuilder.fieldToMap(field, project, ctxFile)
+        }
+        Assert.assertEquals("data", map["name"])
+        Assert.assertEquals("Result<AuthResponse>", map["type"])
+        Assert.assertEquals(
+            "com.example.Result<com.example.AuthResponse>",
+            map["typeFqn"]
+        )
+        Assert.assertFalse(
+            "no typeArguments key — type args are inline in typeFqn",
+            map.containsKey("typeArguments")
+        )
+    }
+
+    /**
+     * Verifies that [PsiSignatureBuilder.fieldToMap] sets `typeFqn` to `null`
+     * for primitive fields, and does not emit a `typeArguments` key.
+     */
+    fun testFieldToMapHasNullTypeFqnForPrimitive() {
+        addClasses()
+        val map = readSync {
+            val field = JavaPsiFacade.getInstance(project)
+                .findClass("com.example.Types", GlobalSearchScope.allScope(project))!!
+                .findFieldByName("age", false)!!
+            PsiSignatureBuilder.fieldToMap(field, project, null)
+        }
+        Assert.assertEquals("age", map["name"])
+        Assert.assertEquals("int", map["type"])
+        Assert.assertNull("primitive typeFqn should be null", map["typeFqn"])
+        Assert.assertFalse(
+            "no typeArguments key for primitive",
+            map.containsKey("typeArguments")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // methodSignatureString
+    // ------------------------------------------------------------------
+
+    /**
+     * Seeds a `Greeter` class with a `greet(String name)` method whose
+     * return type is `String`.
+     */
+    private fun addMethodClasses() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/Greeter.java",
+                """
+                package com.example;
+                public class Greeter {
+                    public String greet(String name) {
+                        return "hello " + name;
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    fun testMethodSignatureStringIncludesModifierReturnTypeNameAndParams() {
+        addMethodClasses()
+        val method = resolveMethod("com.example.Greeter", "greet")
+        val sig = readSync { PsiSignatureBuilder.methodSignatureString(method) }
+        Assert.assertTrue("should contain modifier: $sig", sig.contains("public"))
+        Assert.assertTrue("should contain return type: $sig", sig.contains("String"))
+        Assert.assertTrue("should contain method name: $sig", sig.contains("greet"))
+        Assert.assertTrue("should contain param name: $sig", sig.contains("name"))
+    }
+
+    // ------------------------------------------------------------------
+    // methodToSignatureMap
+    // ------------------------------------------------------------------
+
+    fun testMethodToSignatureMapShape() {
+        addMethodClasses()
+        loadJDKClass("java.lang.String")
+        val method = resolveMethod("com.example.Greeter", "greet")
+        val map = readSync {
+            PsiSignatureBuilder.methodToSignatureMap(method, project, null)
+        }
+        Assert.assertEquals("greet", map["name"])
+        Assert.assertEquals("public", map["modifiers"])
+        Assert.assertEquals("String", map["returnType"])
+        Assert.assertEquals("java.lang.String", map["returnTypeFqn"])
+        val params = map["parameters"] as List<*>
+        Assert.assertEquals("one parameter", 1, params.size)
+        val param = params[0] as Map<*, *>
+        Assert.assertEquals("name", param["name"])
+        Assert.assertEquals("String", param["type"])
+        Assert.assertEquals("java.lang.String", param["typeFqn"])
+        val annotations = map["annotations"] as List<*>
+        Assert.assertTrue("no annotations on greet", annotations.isEmpty())
+    }
+
+    // ------------------------------------------------------------------
+    // methodToInfoMap
+    // ------------------------------------------------------------------
+
+    fun testMethodToInfoMapSignatureDetailOmitsBody() {
+        addMethodClasses()
+        loadJDKClass("java.lang.String")
+        val method = resolveMethod("com.example.Greeter", "greet")
+        val map = readSync {
+            PsiSignatureBuilder.methodToInfoMap(
+                psiMethod = method,
+                className = "com.example.Greeter",
+                project = project,
+                contextElement = null,
+                detail = "signature",
+                maxBodyChars = 4000
+            )
+        }
+        Assert.assertEquals("com.example.Greeter", map["className"])
+        Assert.assertEquals("greet", map["name"])
+        Assert.assertTrue(
+            "signature should contain method name",
+            (map["signature"] as String).contains("greet")
+        )
+        Assert.assertNull("docComment should be null", map["docComment"])
+        Assert.assertEquals("String", map["returnType"])
+        Assert.assertEquals("java.lang.String", map["returnTypeFqn"])
+        Assert.assertFalse(
+            "detail=signature must NOT include body key",
+            map.containsKey("body")
+        )
+    }
+
+    fun testMethodToInfoMapFullDetailIncludesTruncatedBody() {
+        addMethodClasses()
+        loadJDKClass("java.lang.String")
+        val method = resolveMethod("com.example.Greeter", "greet")
+        val map = readSync {
+            PsiSignatureBuilder.methodToInfoMap(
+                psiMethod = method,
+                className = "com.example.Greeter",
+                project = project,
+                contextElement = null,
+                detail = "full",
+                maxBodyChars = 4000
+            )
+        }
+        Assert.assertTrue("detail=full should include body key", map.containsKey("body"))
+        Assert.assertEquals(
+            "body should be the stripped return statement",
+            "return \"hello \" + name;",
+            map["body"]
+        )
+    }
+
+    fun testMethodToInfoMapFullDetailBodyNullForAbstractMethod() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/AbstractClass.java",
+                """
+                package com.example;
+                public abstract class AbstractClass {
+                    public abstract void doStuff();
+                }
+                """.trimIndent()
+            )
+        }
+        val method = resolveMethod("com.example.AbstractClass", "doStuff")
+        val map = readSync {
+            PsiSignatureBuilder.methodToInfoMap(
+                psiMethod = method,
+                className = "com.example.AbstractClass",
+                project = project,
+                contextElement = null,
+                detail = "full",
+                maxBodyChars = 4000
+            )
+        }
+        Assert.assertNull("abstract method body should be null", map["body"])
+    }
+
+    fun testMethodToInfoMapFullDetailBodyEmptyStringForEmptyBody() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/EmptyMethodClass.java",
+                """
+                package com.example;
+                public class EmptyMethodClass {
+                    public void doNothing() {}
+                }
+                """.trimIndent()
+            )
+        }
+        val method = resolveMethod("com.example.EmptyMethodClass", "doNothing")
+        val map = readSync {
+            PsiSignatureBuilder.methodToInfoMap(
+                psiMethod = method,
+                className = "com.example.EmptyMethodClass",
+                project = project,
+                contextElement = null,
+                detail = "full",
+                maxBodyChars = 4000
+            )
+        }
+        Assert.assertEquals(
+            "empty body {} should produce body=\"\"",
+            "",
+            map["body"]
+        )
+    }
+
+    fun testMethodToInfoMapMaxBodyCharsTruncatesBody() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/LongBody.java",
+                """
+                package com.example;
+                public class LongBody {
+                    public void longMethod() {
+                        ${"// padding line\n                        ".repeat(20)}int x = 1;
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+        val method = resolveMethod("com.example.LongBody", "longMethod")
+        val map = readSync {
+            PsiSignatureBuilder.methodToInfoMap(
+                psiMethod = method,
+                className = "com.example.LongBody",
+                project = project,
+                contextElement = null,
+                detail = "full",
+                maxBodyChars = 50
+            )
+        }
+        val body = map["body"] as String
+        Assert.assertTrue(
+            "body should be truncated to ≤ 50 chars: actual length=${body.length}",
+            body.length <= 50
+        )
+        Assert.assertTrue(
+            "body should end with truncation suffix: $body",
+            body.endsWith("... (truncated)")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // classToMap
+    // ------------------------------------------------------------------
+
+    fun testClassToMapShape() {
+        addMethodClasses()
+        loadJDKClass("java.lang.String")
+        val psiClass = resolveClass("com.example.Greeter")
+        val map = readSync {
+            PsiSignatureBuilder.classToMap(psiClass, project, null)
+        }
+        Assert.assertEquals("Greeter", map["name"])
+        Assert.assertEquals("com.example.Greeter", map["fqn"])
+        Assert.assertEquals("public", map["modifiers"])
+        val annotations = map["annotations"] as List<*>
+        Assert.assertTrue("no annotations on Greeter", annotations.isEmpty())
+        val fields = map["fields"] as List<*>
+        Assert.assertTrue("Greeter has no fields", fields.isEmpty())
+        val methods = map["methods"] as List<*>
+        Assert.assertEquals("one method", 1, methods.size)
+        val greetMethod = methods[0] as Map<*, *>
+        Assert.assertEquals("greet", greetMethod["name"])
+        Assert.assertEquals("java.lang.String", greetMethod["returnTypeFqn"])
+    }
+
+    fun testClassToMapFieldsIncludeTypeFqn() {
+        addClasses()
+        loadJDKClass("java.lang.String")
+        val psiClass = resolveClass("com.example.Types")
+        val map = readSync {
+            PsiSignatureBuilder.classToMap(psiClass, project, null)
+        }
+        val fields = map["fields"] as List<*>
+        val dataField = fields.first {
+            (it as Map<*, *>)["name"] == "data"
+        } as Map<*, *>
+        Assert.assertEquals(
+            "Result<AuthResponse> typeFqn encodes type arg inline",
+            "com.example.Result<com.example.AuthResponse>",
+            dataField["typeFqn"]
+        )
+        val ageField = fields.first {
+            (it as Map<*, *>)["name"] == "age"
+        } as Map<*, *>
+        Assert.assertNull("primitive field typeFqn should be null", ageField["typeFqn"])
+    }
+
+    fun testClassToMapMethodsContainSignatureMap() {
+        addMethodClasses()
+        loadJDKClass("java.lang.String")
+        val psiClass = resolveClass("com.example.Greeter")
+        val map = readSync {
+            PsiSignatureBuilder.classToMap(psiClass, project, null)
+        }
+        val methods = map["methods"] as List<*>
+        val greetMethod = methods.first {
+            (it as Map<*, *>)["name"] == "greet"
+        } as Map<*, *>
+        // methodToSignatureMap keys: name, modifiers, returnType,
+        // returnTypeFqn, parameters, annotations.
+        Assert.assertEquals("public", greetMethod["modifiers"])
+        Assert.assertEquals("String", greetMethod["returnType"])
+        Assert.assertEquals("java.lang.String", greetMethod["returnTypeFqn"])
+        val params = greetMethod["parameters"] as List<*>
+        Assert.assertEquals("one parameter", 1, params.size)
+        val param = params[0] as Map<*, *>
+        Assert.assertEquals("name", param["name"])
+        Assert.assertEquals("java.lang.String", param["typeFqn"])
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/WriteRuleFileToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/WriteRuleFileToolTest.kt
@@ -1,0 +1,268 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.itangcent.easyapi.ai.AiProvider
+import com.itangcent.easyapi.ai.AiRuntimeConfig
+import com.itangcent.easyapi.ai.agent.AgentMemory
+import com.itangcent.easyapi.ai.agent.ApprovalGate
+import com.itangcent.easyapi.ai.agent.Proposal
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.source.RuleFileResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import java.nio.file.Files
+
+/**
+ * Tests for [WriteRuleFileTool].
+ *
+ * Although the tool is reserved (not registered in v1's `standardRuleTools()`),
+ * its `execute` is functional and must behave correctly if a future version
+ * registers it. These tests cover the four documented behaviors:
+ * - Writes content to a file inside an allowed rule directory.
+ * - Rejects paths outside the allowed rule directories with an error.
+ * - Rejects missing/blank `path` or `content` parameters.
+ * - Clears any staged proposal in [AgentMemory] after a successful write.
+ */
+class WriteRuleFileToolTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun ctx(workingMemory: AgentMemory = AgentMemory()): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30, maxRequests = 8
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = workingMemory,
+        approvals = NoOpApprovalGate()
+    )
+
+    // ------------------------------------------------------------------
+    // successful write
+    // ------------------------------------------------------------------
+
+    fun testWritesContentToAllowedFile() {
+        val easyapiDir = projectEasyapiDir()
+        try {
+            val targetPath = java.io.File(easyapiDir, "written.rules").absolutePath
+            val content = "api.name=Test\nfield.ignore=id"
+
+            val result = runBlocking {
+                WriteRuleFileTool().execute(
+                    mapOf("path" to targetPath, "content" to content),
+                    ctx()
+                )
+            }
+            Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+            val text = (result as ToolResult.Text).value
+            Assert.assertTrue(
+                "should report chars written: $text",
+                text.contains("Wrote ${content.length} chars")
+            )
+            Assert.assertTrue(
+                "should mention the resolved path: $text",
+                text.contains("written.rules")
+            )
+
+            val onDisk = Files.readString(java.nio.file.Paths.get(targetPath))
+            Assert.assertEquals(content, onDisk)
+        } finally {
+            easyapiDir.deleteRecursively()
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // outside-dir rejection
+    // ------------------------------------------------------------------
+
+    fun testRejectsPathOutsideAllowedDirs() {
+        // /tmp is not an allowed rule directory — resolution returns null.
+        val tmp = Files.createTempFile("easyapi-outside-", ".rules").toFile()
+        try {
+            val result = runBlocking {
+                WriteRuleFileTool().execute(
+                    mapOf("path" to tmp.absolutePath, "content" to "api.name=Nope"),
+                    ctx()
+                )
+            }
+            Assert.assertTrue("expected Error result, got $result", result is ToolResult.Error)
+            val msg = (result as ToolResult.Error).message
+            Assert.assertTrue(
+                "should mention outside allowed",
+                msg.contains("outside allowed")
+            )
+            // The file must not have been written to.
+            Assert.assertEquals(
+                "file should not be modified",
+                "",
+                tmp.readText()
+            )
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    fun testRejectsPathEscapeAttempt() {
+        // A `..` escape from inside the rule dir resolves outside the
+        // allowed dir and must be refused.
+        val easyapiDir = projectEasyapiDir()
+        try {
+            val escapePath = java.io.File(easyapiDir, "../../../etc/passwd").absolutePath
+            val result = runBlocking {
+                WriteRuleFileTool().execute(
+                    mapOf("path" to escapePath, "content" to "api.name=Evil"),
+                    ctx()
+                )
+            }
+            Assert.assertTrue(result is ToolResult.Error)
+            Assert.assertTrue(
+                (result as ToolResult.Error).message.contains("outside allowed")
+            )
+        } finally {
+            easyapiDir.deleteRecursively()
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // missing / blank parameter validation
+    // ------------------------------------------------------------------
+
+    fun testRejectsMissingPath() {
+        val result = runBlocking {
+            WriteRuleFileTool().execute(
+                mapOf("content" to "api.name=Test"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("missing required parameter")
+        )
+    }
+
+    fun testRejectsMissingContent() {
+        val easyapiDir = projectEasyapiDir()
+        try {
+            val targetPath = java.io.File(easyapiDir, "blank.rules").absolutePath
+            val result = runBlocking {
+                WriteRuleFileTool().execute(
+                    mapOf("path" to targetPath),
+                    ctx()
+                )
+            }
+            Assert.assertTrue(result is ToolResult.Error)
+            Assert.assertTrue(
+                (result as ToolResult.Error).message.contains("missing required parameter")
+            )
+        } finally {
+            easyapiDir.deleteRecursively()
+        }
+    }
+
+    fun testRejectsBlankPath() {
+        val result = runBlocking {
+            WriteRuleFileTool().execute(
+                mapOf("path" to "   ", "content" to "api.name=Test"),
+                ctx()
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("missing required parameter")
+        )
+    }
+
+    fun testRejectsBlankContent() {
+        val easyapiDir = projectEasyapiDir()
+        try {
+            val targetPath = java.io.File(easyapiDir, "blank-content.rules").absolutePath
+            val result = runBlocking {
+                WriteRuleFileTool().execute(
+                    mapOf("path" to targetPath, "content" to "   "),
+                    ctx()
+                )
+            }
+            Assert.assertTrue(result is ToolResult.Error)
+            Assert.assertTrue(
+                (result as ToolResult.Error).message.contains("missing required parameter")
+            )
+        } finally {
+            easyapiDir.deleteRecursively()
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // proposal clearing
+    // ------------------------------------------------------------------
+
+    fun testSuccessfulWriteClearsStagedProposal() {
+        val easyapiDir = projectEasyapiDir()
+        try {
+            val targetPath = java.io.File(easyapiDir, "with-proposal.rules").absolutePath
+            val memory = AgentMemory().apply {
+                proposal = Proposal(content = "api.name=Old", suggestedFileName = "old.rules")
+            }
+
+            val result = runBlocking {
+                WriteRuleFileTool().execute(
+                    mapOf("path" to targetPath, "content" to "api.name=New"),
+                    ctx(workingMemory = memory)
+                )
+            }
+            Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+            Assert.assertNull(
+                "proposal should be cleared after successful write",
+                memory.proposal
+            )
+        } finally {
+            easyapiDir.deleteRecursively()
+        }
+    }
+
+    fun testFailedWriteDoesNotClearProposal() {
+        // An outside-dir rejection must leave the staged proposal intact so
+        // the user can retry / inspect the previous draft.
+        val memory = AgentMemory().apply {
+            proposal = Proposal(content = "api.name=Keep", suggestedFileName = "keep.rules")
+        }
+        val result = runBlocking {
+            WriteRuleFileTool().execute(
+                mapOf("path" to "/tmp/not-allowed.rules", "content" to "api.name=New"),
+                ctx(workingMemory = memory)
+            )
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertNotNull(
+            "proposal should be preserved when write fails",
+            memory.proposal
+        )
+        Assert.assertEquals("api.name=Keep", memory.proposal!!.content)
+    }
+
+    // ------------------------------------------------------------------
+    // Tool metadata
+    // ------------------------------------------------------------------
+
+    fun testToolKindIsAction() {
+        Assert.assertEquals(ToolKind.ACTION, WriteRuleFileTool().kind)
+    }
+
+    fun testToolRequiresApproval() {
+        Assert.assertTrue(WriteRuleFileTool().requiresApproval)
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private fun projectEasyapiDir(): java.io.File {
+        val basePath = project.basePath
+            ?: throw IllegalStateException("project base path required")
+        return java.io.File(basePath, ".easyapi").apply { mkdirs() }
+    }
+
+    private class NoOpApprovalGate : ApprovalGate {
+        override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
+    }
+}


### PR DESCRIPTION
## Summary

Closes three tooling gaps in the rule-authoring agent's PSI perception layer that caused it to ask the user questions the source code already answered. All changes are **additive** — no existing JSON field is renamed or reshaped.

## Changes

### 1. New tool: `find_classes_by_name` (REQ-1)
Resolves class simple names to FQN(s) via `PsiShortNamesCache`, with:
- FQN short-circuit (names containing `.` bypass the cache)
- Batch mode (`names` array → JSON object mapping each name to its FQN array)
- `projectScope` to avoid drowning in library matches
- Sorted alphabetically; context-preferred match moved to front

### 2. Type enrichment (REQ-2)
Every type reference in `get_psi_class_info` and `get_psi_method_info` now carries:
- `typeFqn` — the resolved qualified name (or `null` if unresolvable)
- `typeArguments` — array of `{name, fqn}` for parameterized types (omitted when empty)

Resolved via `PsiClassType.resolve()?.qualifiedName` (no context) or `TypeResolver.resolveFromCanonicalText` (with context).

### 3. Method body extraction (REQ-3)
`get_psi_method_info` gains:
- `detail` enum parameter: `"signature"` (default, byte-identical to today) / `"full"`
- `body` field (only when `detail="full"`): method body text with braces stripped
- `maxBodyChars` truncation (default 4000, suffix-inclusive) with ` ... (truncated)` suffix
- Fast path: `detail="signature"` never touches `psiMethod.body`

### 4. Tolerant name resolution (REQ-4, cross-cutting)
All four PSI lookup tools (`get_psi_class_info`, `get_psi_method_info`, `find_classes_by_annotation`, `find_classes_by_supertype`) now:
- Accept both simple names and FQNs interchangeably
- Support an optional `context` argument (file path or class FQN) for import-scope resolution
- Fall back gracefully (warn + no-context path) when context is unresolvable
- Guide the agent to `find_classes_by_name` on ambiguous simple names

### Shared helpers
- `PsiNameResolver` — simple-name/FQN → `PsiClass` + context normalization
- `PsiTypeFqnResolver` — `PsiType` → `{typeFqn, typeArguments}`

### Preamble update
`agent-preamble.md` updated to document the new tool, `typeFqn` chaining, and `detail="full"` opt-in.

## Test plan

- **New tests**: 35+ tests across `FindClassesByNameToolTest` (12), `PsiNameResolverTest` (14), `PsiTypeFqnResolverTest` (9), plus enrichment/tolerance/body tests in the modified tool test classes
- **Existing tests**: all pass unmodified (additive fields, `detail` defaults to `"signature"`)
- **Full suite**: `./gradlew test` — 6105 tests, 0 failures

## Files

**New (6):**
- `src/main/kotlin/.../ai/tools/FindClassesByNameTool.kt`
- `src/main/kotlin/.../ai/tools/PsiNameResolver.kt`
- `src/main/kotlin/.../ai/tools/PsiTypeFqnResolver.kt`
- `src/test/kotlin/.../ai/tools/FindClassesByNameToolTest.kt`
- `src/test/kotlin/.../ai/tools/PsiNameResolverTest.kt`
- `src/test/kotlin/.../ai/tools/PsiTypeFqnResolverTest.kt`

**Modified (12):**
- `GetPsiClassInfoTool.kt`, `GetPsiMethodInfoTool.kt` — type enrichment + tolerance + body/detail
- `FindClassesByAnnotationTool.kt`, `FindClassesBySupertypeTool.kt` — tolerance + context
- `RuleTools.kt` — register `FindClassesByNameTool`
- `agent-preamble.md` — document new capabilities
- 6 test files (extended with new test cases)
- `SystemPromptBuilderTest.kt` — raised token-budget ceiling for preamble growth