### PR TITLE
docs: add developer extension guides for channel/format/framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,8 @@ The four top-level buckets are named explicitly: `channel`, `format`, `framework
 
 **EP-contract sub-packages.** Each input/output bucket owns a `spi/` sub-package for its EP contract surfaces, which `core.*` may legitimately import (the only sibling imports `core.*` allows): `channel.spi.*` (Channel + ChannelRegistry), `format.spi.*` (FieldFormatChannel + FieldFormatChannelRegistry), `framework.spi.*` (FrameworkRegistry — added by the package-restructure-patch under the broadened CO3 rule). Concrete per-id implementations (`channel.<id>.*`, `format.<id>.*`, `framework.<id>.*`) imported from `core.*` remain forbidden.
 
+Step-by-step guides for adding a new channel/format/framework live in `docs/developer/`.
+
 ## Testing
 
 Tests use JUnit 4 + Mockito/Mockito-Kotlin + the IntelliJ Platform Test Framework. **Always invoke the `write-test-case` skill before writing tests** — it guides test-pattern selection (simple unit, IDE fixture, ResultLoader, action mock, parity test) based on the target class. The brief notes below are only a reminder; the skill is the authoritative guide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,18 +87,13 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 - Use `mockito-kotlin` for mocking
 - Aim for good test coverage
 
+### Extensions
+
+- Adding a new channel, format, or framework? See [`docs/developer/`](docs/developer/README.md) for step-by-step guides (SPI contracts, `plugin.xml` wiring, threading/logging conventions, worked examples).
+
 ## Project Structure
 
-```
-easy-api/
-├── src/main/kotlin/com/itangcent/easyapi/
-│   ├── core/          # Core infrastructure
-│   ├── psi/           # PSI utilities
-│   ├── exporter/      # Export functionality
-│   ├── settings/      # Plugin settings
-│   └── ide/           # IDE integration
-└── src/test/kotlin/   # Tests
-```
+The codebase is organized into four top-level buckets under `src/main/kotlin/com/itangcent/easyapi/`: `channel/` (output destinations), `format/` (field serialization), `framework/` (source framework exporters), and `core/` (shared infrastructure). The four buckets form a directed-acyclic dependency graph — see the [Project Structure section in README](README.md#project-structure) and [AGENTS.md §"Project Structure"](AGENTS.md#project-structure) for the authoritative layout, dependency rules, and package-placement decision rule. Step-by-step guides for adding a new extension live in [`docs/developer/`](docs/developer/README.md).
 
 ## Commit Message Guidelines
 

--- a/README.md
+++ b/README.md
@@ -289,41 +289,35 @@ The four buckets form a directed-acyclic dependency graph: `channel` may import 
 
 ### How to add new support
 
-The plugin is built around three IntelliJ extension points (EPs). Adding support for a new output target, field format, or source framework is a one-package operation plus one `plugin.xml` line.
+The plugin is built around three IntelliJ extension points (EPs). Adding support for a new output target, field format, or source framework is a one-package operation plus one `plugin.xml` line. **Step-by-step guides** for each — SPI reference, optional config/settings/rule-keys, worked examples, import rules, and testing — live in [`docs/developer/`](docs/developer/README.md).
 
 #### Adding a new channel (output destination)
 
-A channel converts `ApiEndpoint` models into a specific output format and handles file write or remote upload (e.g. a Postman variant, or a new target like Insomnia).
+A channel converts `ApiEndpoint` models into a specific output format and handles file write or remote upload (e.g. a Postman variant, or a new target like Insomnia). Create a `channel/<id>/` package with a `Channel` implementation and register it against the `channel` EP:
 
-1. Create a `channel/<id>/` package with a `Channel` implementation.
-2. Register it against the `<extensionPoint name="channel">` EP (interface FQN `com.itangcent.easyapi.channel.spi.Channel`):
-   ```xml
-   <channel implementation="com.itangcent.easyapi.channel.<id>.<ChannelClass>" />
-   ```
-3. The contract surface lives in `channel/spi/` — `Channel`, `ChannelConfig`, `ChannelOptionsPanel`, `ChannelRegistry`, `PlaceholderSyntaxConverter`.
-4. Channels may import from `core.export.*`, `core.psi.model.*`, `core.format.*` (via `format.spi.*`), `core.util.*`, etc. They **MUST NOT** import from `framework.*` or sibling `channel.<id>.*` packages.
+```xml
+<channel implementation="com.itangcent.easyapi.channel.<id>.<ChannelClass>" />
+```
+
+→ Full guide: [docs/developer/channels.md](docs/developer/channels.md) (SPI surface, options panel, settings tab, rule keys, `handleResult`, worked example, import rules).
 
 #### Adding a new format (field serialization)
 
-A format serializes `ObjectModel` to a specific representation (e.g. TOML, XML).
+A format serializes an `ObjectModel` to a specific representation (e.g. TOML, XML). Create a `format/<id>/` package with a pure renderer plus a `FieldFormatChannel` implementation, and register it against the `fieldFormatChannel` EP:
 
-1. Create a `format/<id>/` package with a `FieldFormatChannel` implementation and a serializer.
-2. Register it against the `<extensionPoint name="fieldFormatChannel">` EP (interface FQN `com.itangcent.easyapi.format.spi.FieldFormatChannel`):
-   ```xml
-   <fieldFormatChannel implementation="com.itangcent.easyapi.format.<id>.<FieldFormatChannelClass>" />
-   ```
-3. Add the format's `ObjectModel.to<Format>()` extension function to `format/spi/FieldFormatExtensions.kt` so callers can use the same ergonomic entry point as the built-in formats (`toJson()`, `toJson5()`, `toYaml()`, `toProperties()`).
-4. The contract surface lives in `format/spi/` — `FieldFormatChannel`, `FieldFormatChannelRegistry`, `FieldFormatAction`, `FieldFormatActionGroup`, `FieldFormatExtensions`.
-5. Formats may import from `core.psi.model.*`, `core.util.*`, and the IntelliJ SDK only. They **MUST NOT** import from `channel.*`, `framework.*`, or `core.export.*`.
+```xml
+<fieldFormatChannel implementation="com.itangcent.easyapi.format.<id>.<FieldFormatChannelClass>" />
+```
+
+→ Full guide: [docs/developer/formats.md](docs/developer/formats.md) (two-layer architecture, `ObjectModel` input, cycle safety, entry extension, worked example, import rules).
 
 #### Adding a new framework recognizer (source framework)
 
-A framework recognizer scans PSI for endpoints declared with a specific framework's annotations (e.g. Micronaut).
+A framework scans PSI for endpoints declared with a specific framework's annotations (e.g. Micronaut). Create a `framework/<id>/` package with a `ClassExporter` and an `ApiClassRecognizer`, and register them against **both** EPs (the recognizer drives line markers, index scanning, AI discovery, and enablement — registering only the exporter silently breaks them):
 
-1. Create a `framework/<id>/` package with a `ClassExporter` implementation plus any framework-specific recognizers/resolvers.
-2. Register it against the `<extensionPoint name="classExporter">` EP (interface FQN `com.itangcent.easyapi.core.export.ClassExporter`):
-   ```xml
-   <classExporter implementation="com.itangcent.easyapi.framework.<id>.<ClassExporterClass>" />
-   ```
-3. The contract surface for the pipeline lives in `core/export/` — `ClassExporter`, `ClassExporterRegistry`, `EndpointBuilder`, `ExportOrchestrator`, plus `core.export.recognizer.{ApiClassRecognizer, CompositeApiClassRecognizer, MetaAnnotationResolver}`. To make the framework's recognizer visible to AI/agent code that iterates all recognizers, register it via `CompositeApiClassRecognizer` rather than hard-coding the import (see Decision CO5).
-4. Frameworks may import from `core.export.*`, `core.psi.*`, `core.config.*`, `core.rule.*`, `core.grpc.*` (for `framework.grpc` only), `core.util.*`, `core.logging.*`. They **MUST NOT** import from `channel.*` or `format.*`.
+```xml
+<classExporter implementation="com.itangcent.easyapi.framework.<id>.<ClassExporterClass>" />
+<apiClassRecognizer implementation="com.itangcent.easyapi.framework.<id>.<RecognizerClass>" />
+```
+
+→ Full guide: [docs/developer/frameworks.md](docs/developer/frameworks.md) (two-EP overview, the two SPIs, 4-step guide, rule lifecycle hooks, `ApiEndpoint` shape, worked example, import rules).

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,292 @@
+# EasyApi Developer Guides
+
+Step-by-step guides for contributors adding a new **channel**, **format**, or
+**framework** to the EasyApi IntelliJ plugin. These pages cover the SPI
+contracts, the `plugin.xml` wiring, the enablement model, threading/logging
+conventions, and worked examples — everything you need to ship a new
+extension end-to-end.
+
+> **End user?** The user / rule-author docs live in
+> [`docs/knowledge-base/`](../knowledge-base/README.md) (rule files, settings,
+> usage workflows). This developer suite is for contributors writing Kotlin
+> that extends the plugin itself.
+
+## Pages
+
+| Page | What you'll learn |
+|------|-------------------|
+| [Channels](channels.md) | Add a new output destination (Postman variant, Insomnia, …) — convert `ApiEndpoint` models into a target format and write/upload the result. |
+| [Formats](formats.md) | Add a new field serialization (TOML, XML, …) — render an `ObjectModel` to a target representation and wire a `FieldsTo*` action. |
+| [Frameworks](frameworks.md) | Add a new source framework (Micronaut, …) — scan PSI for endpoints and feed them into the export pipeline. |
+
+## Who this is for
+
+You should already be familiar with:
+
+- Kotlin coroutines (`suspend` functions, structured concurrency).
+- IntelliJ Platform basics — `Project`, `PsiClass`, extension points,
+  `@Service(Service.Level.PROJECT)`.
+- The four-bucket package layout described in
+  [AGENTS.md §"Project Structure"](../../AGENTS.md#project-structure) —
+  `channel/`, `format/`, `framework/`, `core/`.
+
+If you're adding **user-facing rule keys** or **per-project config** (no new
+Kotlin), see the [Rule Authoring Guide](../knowledge-base/rule-guide.md)
+instead.
+
+## The three extension points at a glance
+
+EasyApi exposes **three** IntelliJ extension points (EPs) for plugging in new
+behavior. A framework registers on **two** EPs (`classExporter` +
+`apiClassRecognizer`) — see [Frameworks](frameworks.md) for why.
+
+| EP name (`plugin.xml`) | Interface FQN | Bucket | Scope | What it does |
+|---|---|---|---|---|
+| `channel` | `com.itangcent.easyapi.channel.spi.Channel` | `channel/` | `area="IDEA_PROJECT"` | Convert `ApiEndpoint`s to an output format and write/upload the result. |
+| `fieldFormatChannel` | `com.itangcent.easyapi.format.spi.FieldFormatChannel` | `format/` | application (no `area`) | Serialize an `ObjectModel` to a target representation; auto-registered as a `FieldsTo*` action. |
+| `classExporter` | `com.itangcent.easyapi.core.export.ClassExporter` | `framework/` | `area="IDEA_PROJECT"` | Extract `ApiEndpoint`s from a `PsiClass` for one source framework. |
+| `apiClassRecognizer` | `com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer` | `framework/` | `area="IDEA_PROJECT"` | Cheap "is this an API class?" check; drives line markers, index scanning, AI discovery, and enablement. |
+
+All four EPs are declared `dynamic="true"` so they can be loaded/unloaded
+without a restart. The full declaration block lives at
+[`src/main/resources/META-INF/plugin.xml`](../../src/main/resources/META-INF/plugin.xml#L23-L32):
+
+```xml
+<extensionPoints>
+    <extensionPoint name="classExporter"     interface="com.itangcent.easyapi.core.export.ClassExporter"            area="IDEA_PROJECT" dynamic="true"/>
+    <extensionPoint name="channel"           interface="com.itangcent.easyapi.channel.spi.Channel"                  area="IDEA_PROJECT" dynamic="true"/>
+    <extensionPoint name="fieldFormatChannel" interface="com.itangcent.easyapi.format.spi.FieldFormatChannel"        dynamic="true"/>
+    <extensionPoint name="apiClassRecognizer" interface="com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer" area="IDEA_PROJECT" dynamic="true"/>
+</extensionPoints>
+```
+
+### EP scope: `IDEA_PROJECT` vs application
+
+The `area` attribute is **load-bearing** — getting it wrong produces an
+instantiation failure at startup.
+
+- **`area="IDEA_PROJECT"`** (`channel`, `classExporter`, `apiClassRecognizer`)
+  → IntelliJ creates a separate instance per project and injects `Project` via
+  the constructor. Your constructor signature must be
+  `class MyXxx(private val project: Project)`.
+- **Application scope** (`fieldFormatChannel`, no `area` attribute) → IntelliJ
+  constructs the instance with a **no-arg constructor**. `Project` arrives via
+  the `format(project, psiClass)` parameter on each call.
+
+Each topic page's "Step 1" repeats the required constructor signature for its
+EP — don't skip it.
+
+## The dependency DAG
+
+The four top-level buckets form a directed-acyclic dependency graph:
+
+```
+                 ┌────────────────────────────────────────┐
+                 │                  core/                   │
+                 │  (export pipeline, psi, rule, settings, │
+                 │   ide, logging, util, …)                │
+                 └────┬───────────┬───────────┬────────────┘
+                      │           │           │
+        EP-contract   │           │           │   EP-contract
+        seams only    │           │           │   seams only
+                      ▼           ▼           ▼
+                 ┌─────────┐ ┌─────────┐ ┌─────────────┐
+                 │ format/ │ │framework/│ │  channel/   │
+                 │         │ │          │ │             │
+                 │  JSON   │ │  Spring  │ │  Markdown   │
+                 │  YAML   │ │  JAX-RS  │ │  Postman    │
+                 │  …      │ │  Feign   │ │  cURL       │
+                 │         │ │  gRPC    │ │  Hoppscotch │
+                 └─────────┘ └──────────┘ └─────────────┘
+                      │                       │
+                      └─────► channel ◄──────┘
+                       (channel may import format)
+```
+
+**Import rules** (authoritative in
+[AGENTS.md §"Project Structure"](../../AGENTS.md#project-structure)):
+
+- `channel/` may import from `format`, `framework`, and `core` (via the
+  `*.spi.*` seams — never concrete `format.<id>.*` / `framework.<id>.*`).
+- `format/` and `framework/` may import from `core` (and `core.grpc/` for
+  `framework.grpc`).
+- `core/` imports **only** EP-contract seams from its siblings:
+  `channel.spi.*`, `format.spi.*`, `framework.spi.*`, `core.export.*`.
+  Concrete per-id packages (`channel.<id>.*`, `format.<id>.*`,
+  `framework.<id>.*`) imported from `core.*` are **forbidden** — this is
+  CI-enforced.
+
+The DAG rule is the single most common review feedback on a new extension.
+Each topic page restates the per-bucket import allow-list so you don't have to
+flip back here.
+
+## Package-layout decision rule
+
+When adding a new package, apply this **first-match-wins** rule to pick the
+bucket (mirrors [AGENTS.md §"Package Layout"](../../AGENTS.md#package-layout)):
+
+1. **One output destination** (Postman, Markdown, cURL, Hoppscotch, IntelliJ
+   HTTP Client, …) → `channel/<id>/`
+2. **One field serialization format** (JSON, JSON5, YAML, Properties, TOML, …)
+   → `format/<id>/`
+3. **One source framework** (Spring MVC, JAX-RS, Feign, gRPC, Micronaut, …)
+   → `framework/<id>/`
+4. **Else** — shared by ≥2 buckets, or runtime/IDE plumbing with no extension
+   target → `core/<sub-package>/`
+
+Each input/output bucket also owns a `spi/` sub-package for its EP contract
+surfaces, which `core.*` may legitimately import (the only sibling imports
+`core.*` allows).
+
+## `plugin.xml` basics
+
+Each EP has **two** appearances in
+[`plugin.xml`](../../src/main/resources/META-INF/plugin.xml):
+
+1. **`<extensionPoints>`** (~L23-32) — declares the EP name, interface FQN,
+   scope, and `dynamic="true"`. This block is owned by EasyApi core; you
+   should not need to add a new entry here unless you're inventing a brand-new
+   EP category.
+2. **`<extensions defaultExtensionNs="com.itangcent.idea.plugin.easy-api">`**
+   (~L34-56) — registers concrete implementations against the EPs declared
+   above. **This is where your `<channel ... />`,
+   `<fieldFormatChannel ... />`, `<classExporter ... />`, or
+   `<apiClassRecognizer ... />` line goes.**
+
+A new channel/format/framework needs exactly one (or, for frameworks, two)
+`<… implementation="…"/>` line(s) here — no `<action>`, no
+`<applicationService>`, no other XML wiring. The action menu entry, settings
+tab, and registry discovery are all auto-wired by the SPI.
+
+## Shared concerns
+
+The following cross-cutting rules apply to **all three** extension kinds.
+They're written once here and linked from each topic page so they don't
+drift.
+
+### Threading
+
+All PSI/VFS access must run on the correct IntelliJ dispatcher. Use
+[`IdeDispatchers`](../../src/main/kotlin/com/itangcent/easyapi/core/internal/threading/IdeDispatchers.kt):
+
+| Dispatcher | Purpose |
+|-----------|---------|
+| `IdeDispatchers.ReadAction` | PSI/VFS read operations |
+| `IdeDispatchers.WriteAction` | PSI/VFS write operations |
+| `IdeDispatchers.Swing` | UI operations on EDT (non-modal) |
+| `IdeDispatchers.Background` | General background work (network, CPU) |
+
+Convenience wrappers (defined on `IdeDispatchers`):
+
+```kotlin
+suspend fun <T> read(block: suspend () -> T): T      // ReadAction
+suspend fun <T> write(block: suspend () -> T): T    // WriteAction
+suspend fun <T> swing(block: suspend () -> T): T    // EDT
+suspend fun <T> background(block: suspend () -> T): T // Background
+fun backgroundAsync(block: suspend () -> Unit)       // fire-and-forget
+```
+
+**Rule of thumb:** every method on your SPI that touches `PsiClass` /
+`PsiMethod` should be `suspend` and wrap PSI reads in `read { … }`. Network
+and file I/O belongs in `background { … }`; modal dialogs and file choosers
+belong in `swing { … }`.
+
+The full threading model — including the IntelliJ context-propagation warning
+for `StartupActivity` and the `@requires` KDoc convention — is normative in
+[AGENTS.md §"Threading Model"](../../AGENTS.md#threading-model). Link to it;
+don't paraphrase.
+
+### Logging
+
+Implement [`IdeaLog`](../../src/main/kotlin/com/itangcent/easyapi/core/logging/IdeaLog.kt)
+to get a `LOG` property; do **not** call `Logger.getLogger()` directly.
+
+Hard rules (CI-enforced by `AntiPatternGateTest`):
+
+- **`LOG.error(...)` is forbidden** — IntelliJ treats it as a test failure
+  and pops an error dialog. Use `LOG.warn(msg, t)` instead.
+- **`LOG.debug(...)` / `LOG.trace(...)` are forbidden** — IntelliJ filters
+  them out of `idea.log` by default. `LOG.info` is the floor.
+- **No `println(...)` / `printStackTrace()`.**
+- **No `runCatching{}.getOrNull()`** on a meaningful operation without a
+  `.onFailure { LOG.warn(...) }`. No empty `catch` blocks.
+- **Pass the throwable as the last arg** — never stringify it into the
+  message.
+
+Three output channels exist; pick **one** by first-match-wins:
+
+1. `NotificationUtils` — terminal user-visible outcome (export success/failure).
+2. `IdeaConsole` (via `IdeaConsoleProvider.getInstance(project).getConsole()`)
+   — what the plugin is doing/decided, per-item batch failures,
+   user-fixable conditions.
+3. `IdeaLog` (`LOG` via `IdeaLog`) — developer-facing diagnostic detail, or
+   code running with no `Project` context.
+
+The full channel-selection rule, anti-pattern list, and placement rules are
+normative in [AGENTS.md §"Logging"](../../AGENTS.md#logging). Defer to it.
+
+### Enablement model
+
+All three EPs share an identical enablement pattern. A new extension is
+enabled/disabled by the user via Settings → General → "Export Channels" /
+"Field Format Channels" / "Framework Support". The plumbing is identical in
+all three cases:
+
+1. **`enabledByDefault`** on the SPI (a `val` with `get() = true` default) —
+   the compile-time default.
+2. **Two arrays on `GeneralSettings`** — `enabledX` / `disabledX`
+   (e.g. `enabledChannels` / `disabledChannels`,
+   `enabledFieldFormatChannels` / `disabledFieldFormatChannels`,
+   `enabledFrameworks` / `disabledFrameworks`).
+3. **A `*Registry.isEnabled(...)`** method on the corresponding registry
+   (`ChannelRegistry`, `FieldFormatChannelRegistry`, `FrameworkRegistry`)
+   that overlays the stored preference on `enabledByDefault`.
+
+The resolution truth table is the same in all three registries — extracted as
+a pure `internal companion fun resolveEnabled(...)` so unit tests can exercise
+it without a `Project`:
+
+```kotlin
+internal fun resolveEnabled(
+    ext: /* Channel | FieldFormatChannel | ApiClassRecognizer */,
+    enabledIds: Array<String>,
+    disabledIds: Array<String>
+): Boolean =
+    ext.id in enabledIds ||
+        (ext.enabledByDefault && ext.id !in disabledIds)
+```
+
+> **Explicit-on wins.** If the id is in `enabledIds`, the extension is on
+> regardless of `enabledByDefault`. If the id is in `disabledIds`, the
+> extension is off unless explicitly enabled. Absence in both arrays falls
+> back to `enabledByDefault`.
+
+**Recipe for an experimental extension:** override
+`val enabledByDefault: Boolean get() = false`. The extension is hidden from
+all surfaces until the user opts in via Settings; no other wiring is needed.
+See `HoppscotchChannel` (`enabledByDefault = false`) and the Feign / Actuator /
+gRPC recognizers for examples.
+
+### Testing
+
+- **JUnit 4 + mockito-kotlin** for all tests.
+- **Pure registry rules** (e.g. `ChannelRegistry.resolveEnabled`) are
+  extracted as `internal companion fun` so they can be unit-tested without
+  a `Project` / `plugin.xml`.
+- **PSI / Project-aware tests** extend `EasyApiLightCodeInsightFixtureTestCase`
+  (the project's base class for `LightCodeInsightFixtureTestCase`).
+- **Cross-platform golden-file rule:** never read expected-output resources
+  with `File.readText()`. Use `ResultLoader.load()` (trailing-trimmed) or
+  `ResourceLoader.readRaw()` (strict byte parity) — both collapse CRLF→LF so
+  snapshot tests pass on Windows CI.
+
+**Always invoke the `write-test-case` skill before writing tests** — it
+guides test-pattern selection (simple unit, IDE fixture, ResultLoader,
+action mock, parity test) based on the target class. See
+[AGENTS.md §"Testing"](../../AGENTS.md#testing) for the brief reminder.
+
+## Table of contents
+
+- [Channels — adding a new output destination](channels.md)
+- [Formats — adding a new field serialization](formats.md)
+- [Frameworks — adding a new source framework](frameworks.md)

--- a/docs/developer/channels.md
+++ b/docs/developer/channels.md
@@ -1,0 +1,384 @@
+# Adding a new channel
+
+A **channel** converts `ApiEndpoint` models into a specific output format and
+handles file write or remote upload. Adding a new one is a one-package
+operation plus one `plugin.xml` line.
+
+> **Shared concerns** (threading, logging, enablement, testing) are in the
+> [developer README](README.md). This page covers channel-specific concerns
+> only.
+
+## When to write a channel
+
+Write a channel when you have a new **output destination** for `ApiEndpoint`
+models. The 5 built-in channels:
+
+| Channel | HTTP | gRPC | Output |
+|---------|:----:|:----:|--------|
+| [MarkdownChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownChannel.kt) | ✓ | ✓ | `.md` documentation file |
+| [PostmanChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/postman/PostmanChannel.kt) | ✓ | — | JSON file or direct upload to Postman |
+| [CurlChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/curl/CurlChannel.kt) | ✓ | ✓ | Executable shell script |
+| [HttpClientChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/httpclient/HttpClientChannel.kt) | ✓ | ✓ | IntelliJ HTTP Client scratch file |
+| [HoppscotchChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/hoppscotch/HoppscotchChannel.kt) | ✓ | — | JSON file or direct upload to Hoppscotch |
+
+If you just need to *serialize fields* of a `PsiClass` to a new representation
+(JSON, YAML, …), that's a [format](formats.md), not a channel.
+
+## The `Channel` SPI
+
+The full contract lives in
+[`channel/spi/Channel.kt`](../../src/main/kotlin/com/itangcent/easyapi/channel/spi/Channel.kt).
+The EP is `area="IDEA_PROJECT"`, but in-tree channels use a **no-arg
+constructor** and receive `Project` via the `ExportContext` parameter (see
+`MarkdownChannel`, `CurlChannel`, etc.).
+
+| Member | Type | Default | Purpose |
+|---|---|---|---|
+| `id` | `String` | — | Unique identifier (`"markdown"`, `"postman"`, …). |
+| `displayName` | `String` | — | Human-readable name shown in UI. |
+| `supportsHttp` | `Boolean` | `true` | Whether HTTP/REST endpoints are supported. |
+| `supportsGrpc` | `Boolean` | `false` | Whether gRPC endpoints are supported. |
+| `exposeAsAction` | `Boolean` | `false` | Add a top-level IDE action menu entry. |
+| `actionText` | `String?` | `null` | Action menu text (only when `exposeAsAction = true`). |
+| `enabledByDefault` | `Boolean` | `true` | Compile-time enablement default. Set `false` for experimental. |
+| `settingsTabOrder` | `Int` | `100` | Hint for settings-tab ordering (lower = earlier). |
+| `settingsType` | `KClass<out Settings>?` | `null` | Optional: the settings module type this channel owns. |
+| `export(context)` | `suspend fun` | — | Performs the export. Required. |
+| `handleResult(project, result, config)` | `suspend fun → Boolean` | `false` | Post-export hook (file write, browser open, …). Return `true` to suppress default handling. |
+| `createOptionsPanel(project)` | `fun → ChannelOptionsPanel?` | `null` | Per-export options panel (shown in export dialog). |
+| `createSettingsPanel(project)` | `fun → SettingsPanel<*>?` | `null` | Persistent settings tab (Settings → EasyApi → <Channel>). |
+| `configFiles()` | `fun → List<String>` | `emptyList()` | Config-file names contributed to the extension-config fallback list. |
+| `ruleKeys()` | `fun → List<RuleKey<*>>` | `emptyList()` | Channel-specific `RuleKey`s (consumed by the AI agent). |
+| `isAvailableFor(endpoints)` | `fun → Boolean` | derived | Whether this channel can handle the given endpoints. |
+
+## Step-by-step
+
+### Step 1 — Package + `Channel` class
+
+Create `channel/<id>/` with a `Channel` implementation. **Constructor must be
+no-arg** (the EP doesn't inject `Project`); you receive `Project` via
+`ExportContext.project` inside `export()`.
+
+Minimal skeleton (mirrors
+[`MarkdownChannel`](../../src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownChannel.kt#L57-L67)):
+
+```kotlin
+package com.itangcent.easyapi.channel.example
+
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.channel.spi.Channel
+import com.itangcent.easyapi.channel.spi.ChannelConfig
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.logging.IdeaLog
+
+class ExampleChannel : Channel, IdeaLog {
+    override val id: String = "example"
+    override val displayName: String = "Example"
+    override val supportsGrpc: Boolean = false
+    override val exposeAsAction: Boolean = false
+
+    override suspend fun export(context: ExportContext): ExportResult {
+        LOG.info("ExampleChannel.export: endpoints=${context.endpointsToExport.size}")
+        val content = buildContent(context.endpointsToExport)
+        return ExportResult.Success(
+            count = context.endpointsToExport.size,
+            target = "Example",
+            metadata = ExampleExportMetadata(content = content)
+        )
+    }
+}
+```
+
+### Step 2 — `plugin.xml` line
+
+Add one line under `<extensions defaultExtensionNs="...">` in
+[`plugin.xml`](../../src/main/resources/META-INF/plugin.xml#L48-L52):
+
+```xml
+<channel implementation="com.itangcent.easyapi.channel.example.ExampleChannel"/>
+```
+
+That's the minimum — the channel is now discoverable via `ChannelRegistry`,
+auto-listed in Settings → General → "Export Channels", and offered as an
+output in the export dialog.
+
+### Step 3 — Config + options panel (optional)
+
+`ChannelConfig` is **`open`, not `sealed`** (see
+[`channel/spi/ChannelConfig.kt`](../../src/main/kotlin/com/itangcent/easyapi/channel/spi/ChannelConfig.kt)).
+Declare a `data class` subtype in your channel's own package — zero core
+edits. Consumers use `as?` casts (a `when`-exhaustive switch would be a
+compile error).
+
+```kotlin
+package com.itangcent.easyapi.channel.example
+
+import com.itangcent.easyapi.channel.spi.ChannelConfig
+
+data class ExampleConfig(
+    val outputDir: String? = null,
+    val fileName: String? = null,
+    val includeComments: Boolean = true,
+) : ChannelConfig()
+```
+
+For channels that need only file output, reuse the SPI's
+`ChannelConfig.FileConfig` / `ChannelConfig.Empty` — no subclass needed.
+
+The options panel lives in the same package and implements
+[`ChannelOptionsPanel`](../../src/main/kotlin/com/itangcent/easyapi/channel/spi/ChannelOptionsPanel.kt):
+
+```kotlin
+interface ChannelOptionsPanel {
+    val component: JComponent
+    fun buildConfig(): ChannelConfig
+    fun onShown() {}  // optional — initialize defaults / refresh state
+}
+```
+
+Wire it via `override fun createOptionsPanel(project: Project): ChannelOptionsPanel?`.
+References: [`CurlOptionsPanel`](../../src/main/kotlin/com/itangcent/easyapi/channel/curl/CurlOptionsPanel.kt)
+(uses `FormBuilder`), `MarkdownOptionsPanel` (uses `BorderLayout`).
+
+### Step 4 — Settings tab (optional)
+
+Persistent settings live in a `data class ... : Settings` with
+`@StorageScope(Scope.APPLICATION)` on every `var` (all defaulted). Read via
+`project.settings<XxxSettings>()`, write via
+`SettingBinder.getInstance(project).update(XxxSettings::class) { }`.
+
+```kotlin
+package com.itangcent.easyapi.channel.example
+
+import com.itangcent.easyapi.core.settings.Scope
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.StorageScope
+
+data class ExampleSettings(
+    @StorageScope(Scope.APPLICATION) var host: String = "https://api.example.com",
+    @StorageScope(Scope.APPLICATION) var includeComments: Boolean = true,
+) : Settings
+```
+
+The settings panel **must be typed as `SettingsPanel<Settings>`** (not
+`SettingsPanel<XxxSettings>`) so the configurable's `ChannelPanelEntry.panel`
+cast works (see
+[`CurlSettingsPanel`](../../src/main/kotlin/com/itangcent/easyapi/channel/curl/CurlSettingsPanel.kt#L40)):
+
+```kotlin
+class ExampleSettingsPanel(private val project: Project) : SettingsPanel<Settings> {
+    // ...fields seeded from project.settings<ExampleSettings>()...
+}
+```
+
+On the `Channel` side, override three members:
+
+```kotlin
+override val settingsType: KClass<out Settings> = ExampleSettings::class
+override val settingsTabOrder: Int = 120
+override fun createSettingsPanel(project: Project): SettingsPanel<*>? = ExampleSettingsPanel(project)
+```
+
+`EasyApiSettingsConfigurable` discovers the panel via `settingsType` and
+hosts it as a Settings tab. **No `plugin.xml` `<applicationService>` or
+`<projectConfigurable>` line needed** — the unified `UnifiedAppSettingsState`
+storage handles persistence automatically.
+
+**Contrast:** cURL owns a settings tab (`CurlSettings` /
+`CurlSettingsPanel`); Markdown does not (just a per-export options panel).
+
+### Step 5 — Rule keys + config files (optional)
+
+If your channel exposes user-configurable rule keys (e.g. Hoppscotch's
+`hopp.prerequest`), declare them in a dedicated `object`:
+
+```kotlin
+object ExampleRuleKeys {
+    val EXAMPLE_HOST = RuleKey.string("example.host")
+    val EXAMPLE_FORMAT_AFTER = RuleKey.event("example.format.after", EventRuleMode.THROW_IN_ERROR)
+}
+```
+
+Return them from `ruleKeys()`:
+
+```kotlin
+override fun ruleKeys(): List<RuleKey<*>> = RuleKey.collectFrom(ExampleRuleKeys)
+```
+
+`RuleKey.collectFrom(...)` reflects over the object's properties — no need to
+list each key by name, and adding a new key is just a property declaration.
+
+**Critical:** return only the keys that live in your channel's package. Keys
+already declared in `core.rule.RuleKeys` (the shared general set) must NOT be
+repeated — that would create duplicate lookups and confuse the AI agent.
+
+Reference: [`HoppscotchRuleKeys`](../../src/main/kotlin/com/itangcent/easyapi/channel/hoppscotch/HoppscotchRuleKeys.kt)
+(canonical). [`PostmanChannel`](../../src/main/kotlin/com/itangcent/easyapi/channel/postman/PostmanChannel.kt)
+intentionally doesn't declare any (its rules reuse the general set).
+
+`configFiles()` returns the channel-specific config-file names contributed to
+the extension-config fallback list (e.g. `"yapi"`, `"hoppscotch"`). Return
+`emptyList()` (the default) if you have none.
+
+### Step 6 — Export result + `handleResult`
+
+Return an `ExportResult.Success` with a channel-defined `ExportMetadata`
+subtype so `handleResult` can recover the typed payload:
+
+```kotlin
+import com.itangcent.easyapi.core.export.ExportMetadata
+
+data class ExampleExportMetadata(val content: String) : ExportMetadata {
+    override fun formatDisplay(): String? = null
+}
+```
+
+Override `handleResult` to write the file / open the browser / copy to
+clipboard. Return `true` to suppress the default "export succeeded" toast.
+
+The threading pattern from
+[`MarkdownChannel.handleResult`](../../src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownChannel.kt#L150-L173)
+is canonical:
+
+```kotlin
+override suspend fun handleResult(
+    project: Project,
+    result: ExportResult.Success,
+    config: ChannelConfig
+): Boolean {
+    val metadata = result.metadata as? ExampleExportMetadata ?: return false
+    val targetFile = resolveTargetFile(project, config, "example.txt")
+        ?: throw CancellationException("User cancelled file selection")
+
+    background { targetFile.writeText(metadata.content) }     // file I/O
+    LOG.info("Example exported to ${targetFile.absolutePath}")
+
+    swing {                                                    // UI on EDT
+        Messages.showInfoMessage(
+            project,
+            "Successfully exported ${result.count} endpoints to ${targetFile.absolutePath}",
+            "Export API"
+        )
+    }
+    return true
+}
+```
+
+Throw `CancellationException` if the user cancels a file-chooser — the
+orchestrator translates it into `ExportResult.Cancelled`.
+
+## What you get for free
+
+A channel implementation gets substantial auto-wiring with **no extra code**:
+
+- **Discovery** — `ChannelRegistry` (`project.service()`) iterates every
+  registered `Channel` via the `channel` EP.
+- **Options-panel hosting** — `ExportDialog` renders the active channel's
+  `createOptionsPanel` result in a `CardLayout` keyed by `channel.id`. No
+  per-channel dialog code needed.
+- **Enablement toggle** — Settings → General → "Export Channels" is
+  auto-built from `ChannelRegistry.allChannels()`. A disabled channel is
+  hidden from every consumer (export dialog, quick-export action, etc.).
+- **Top-level action (opt-in)** — set `exposeAsAction = true` and
+  `actionText = "..."` to get a menu entry in `ChannelQuickExportGroup`.
+- **Settings tab (opt-in)** — set `settingsType` and override
+  `createSettingsPanel` to get a dedicated Settings → EasyApi → <Channel>
+  tab, ordered by `settingsTabOrder`, persisted via `UnifiedAppSettingsState`.
+
+No `<action>`, no `<applicationService>`, no `<projectConfigurable>` —
+nothing beyond the single `<channel implementation="…"/>` line.
+
+## Worked example — "echo to file" channel
+
+A ~30-line channel that writes endpoint names to a file:
+
+```kotlin
+package com.itangcent.easyapi.channel.echo
+
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.channel.spi.Channel
+import com.itangcent.easyapi.channel.spi.ChannelConfig
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportMetadata
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.internal.threading.background
+import com.itangcent.easyapi.core.logging.IdeaLog
+import java.io.File
+
+class EchoChannel : Channel, IdeaLog {
+    override val id: String = "echo"
+    override val displayName: String = "Echo (demo)"
+
+    override suspend fun export(context: ExportContext): ExportResult {
+        val names = context.endpointsToExport.joinToString("\n") { it.name ?: "(unnamed)" }
+        return ExportResult.Success(
+            count = context.endpointsToExport.size,
+            target = "Echo",
+            metadata = EchoMetadata(content = names)
+        )
+    }
+
+    override suspend fun handleResult(
+        project: Project,
+        result: ExportResult.Success,
+        config: ChannelConfig
+    ): Boolean {
+        val metadata = result.metadata as? EchoMetadata ?: return false
+        val target = File(project.basePath ?: ".", "echo.txt")
+        background { target.writeText(metadata.content) }
+        LOG.info("Echo wrote ${result.count} endpoints to ${target.absolutePath}")
+        return true
+    }
+}
+
+data class EchoMetadata(val content: String) : ExportMetadata {
+    override fun formatDisplay(): String? = null
+}
+```
+
+`plugin.xml`:
+
+```xml
+<channel implementation="com.itangcent.easyapi.channel.echo.EchoChannel"/>
+```
+
+That's the entire integration — no other wiring.
+
+## Import rules
+
+A channel may import from:
+
+- `core.export.*` (`ApiEndpoint`, `ExportContext`, `ExportResult`,
+  `EndpointBuilder`, …)
+- `core.psi.model.*` (`ObjectModel`, `FieldModel`, …)
+- `core.psi.*` (`PsiClassHelper`, helpers, type system)
+- `core.util.*`, `core.rule.*`, `core.config.*`, `core.settings.*`
+- `format.spi.*` (if you call `ObjectModel.toJson()` etc.)
+- `core.internal.threading.*` (`IdeDispatchers`, `read`/`swing`/`background`)
+- `core.logging.*` (`IdeaLog`, `IdeaConsole`)
+- IntelliJ SDK
+- Your own `channel.<id>.*` package
+
+A channel **MUST NOT** import from:
+
+- `framework.*` (frameworks produce endpoints, channels consume them — they
+  don't know about each other)
+- Sibling `channel.<other-id>.*` packages
+
+## Testing
+
+- **Unit-test `export()`** by constructing an `ExportContext` with mocked
+  `ApiEndpoint`s and a fake `Project`. Assert on the returned
+  `ExportResult.Success.count` / `target` / `metadata` shape.
+- **Round-trip `buildConfig()`** for your `ChannelOptionsPanel` — set
+  fields, call `buildConfig()`, assert each property round-trips.
+- **Pure helpers** (e.g. content builders with no `Project` dependency) get
+  plain JUnit tests.
+- **PSI-aware tests** extend `EasyApiLightCodeInsightFixtureTestCase`.
+
+Reference: [`DummyChannelTest`](../../src/test/kotlin/com/itangcent/easyapi/channel/dummy/DummyChannelTest.kt),
+[`CurlConfigTest`](../../src/test/kotlin/com/itangcent/easyapi/channel/curl/CurlConfigTest.kt).
+
+See [shared testing concerns](README.md#testing) in the developer README,
+and **invoke the `write-test-case` skill before writing tests**.

--- a/docs/developer/formats.md
+++ b/docs/developer/formats.md
@@ -1,0 +1,467 @@
+# Adding a new format
+
+A **format** serializes an `ObjectModel` to a specific representation (JSON,
+YAML, Properties, …) and exposes a `FieldsTo<Format>` action on `PsiClass`.
+Adding a new one is a one-package operation plus one `plugin.xml` line.
+
+> **Shared concerns** (threading, logging, enablement, testing) are in the
+> [developer README](README.md). This page covers format-specific concerns
+> only.
+
+## When to write a format
+
+Write a format when you have a new **field serialization** for `ObjectModel`.
+The 4 built-in formats:
+
+| Format | Layer | Honors `properties.prefix`? |
+|--------|-------|------------------------------|
+| [JSON](../../src/main/kotlin/com/itangcent/easyapi/format/json/JsonFieldFormatChannel.kt) | Pure renderer | No |
+| [JSON5](../../src/main/kotlin/com/itangcent/easyapi/format/json5/Json5FieldFormatChannel.kt) | Pure renderer (subset of JSON) | No |
+| [Properties](../../src/main/kotlin/com/itangcent/easyapi/format/properties/PropertiesFieldFormatChannel.kt) | Project-scoped | Yes |
+| [YAML](../../src/main/kotlin/com/itangcent/easyapi/format/yaml/YamlFieldFormatChannel.kt) | Project-scoped | Yes (renders as nested keys) |
+
+If you need to *export `ApiEndpoint`s* (request/response shapes, headers,
+paths, …) to a target destination, that's a [channel](channels.md), not a
+format.
+
+## The two-layer architecture
+
+Formats have a deliberate two-layer split:
+
+- **Pure renderer** — `ObjectModel → String`. Takes no `Project`, no
+  `RuleEngine`, no PSI. Lives in a single `object` (or class) in your
+  package. JSON, JSON5, and (the core of) Properties/YAML all live here.
+- **Project-scoped channel** — `FieldFormatChannel.format(project, psiClass)`
+  builds the `ObjectModel` (via `PsiClassHelper`), optionally resolves
+  project-scoped rules (e.g. `properties.prefix` from
+  `@ConfigurationProperties(prefix=…)`), then calls the pure renderer.
+
+JSON / JSON5 are pure-renderer-only: their channel builds the model inline
+and calls the renderer directly. Properties / YAML are prefix-sensitive:
+their channel delegates to `PropertiesService`, which resolves the prefix
+via `RuleEngine` and then calls the pure renderer.
+
+Pick the layer based on whether you need `RuleEngine`. If you don't, your
+channel can be a 5-line delegation to the pure renderer.
+
+## The `FieldFormatChannel` SPI
+
+The full contract lives in
+[`format/spi/FieldFormatChannel.kt`](../../src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannel.kt).
+The EP is **application-scoped** (no `area` attribute in `plugin.xml`), so
+your constructor must be **no-arg** — `Project` arrives via the
+`format(project, psiClass)` parameter on each call.
+
+| Member | Type | Default | Purpose |
+|---|---|---|---|
+| `id` | `String` | — | Unique identifier (`"json"`, `"yaml"`, …). |
+| `displayName` | `String` | — | Human-readable name in notifications. |
+| `actionText` | `String` | — | Menu text (`"ToJson"`, `"ToYaml"`, …). |
+| `enabledByDefault` | `Boolean` | `true` | Compile-time enablement default. Set `false` for experimental. |
+| `format(project, psiClass)` | `suspend fun → String` | — | Build the model and render it. Required. |
+
+That's the whole SPI — much smaller than `Channel`. The action menu entry,
+settings toggle, and registry are all auto-wired.
+
+## The `ObjectModel` input
+
+[`ObjectModel`](../../src/main/kotlin/com/itangcent/easyapi/core/psi/model/ObjectModel.kt)
+is a sealed class with four variants:
+
+| Variant | Fields | Meaning |
+|---|---|---|
+| `ObjectModel.Single(type)` | `type: String` | Primitive / scalar. `type` is a `JsonType` name string. |
+| `ObjectModel.Object(fields)` | `fields: Map<String, FieldModel>` | Object with named fields. Each `Object` instance has a unique `id` (used by `ObjectModelVisitTracker`). |
+| `ObjectModel.Array(item)` | `item: ObjectModel` | Array of items. |
+| `ObjectModel.MapModel(keyType, valueType)` | `keyType`, `valueType` | Map / dictionary. |
+
+`FieldModel` carries per-field metadata:
+
+```kotlin
+data class FieldModel(
+    val model: ObjectModel,
+    val comment: String? = null,
+    val required: Boolean = false,
+    val defaultValue: String? = null,
+    val options: List<FieldOption>? = null,
+    val demo: String? = null,
+    val advanced: Map<String, Any?>? = null,
+    val generic: Boolean = false,
+    val extensions: Extension = Extension.EMPTY
+)
+```
+
+### `Single.type` is a `JsonType` name string
+
+`ObjectModel.Single.type` is **not** an arbitrary type — it's one of the
+constants in
+[`JsonType`](../../src/main/kotlin/com/itangcent/easyapi/core/psi/type/JsonType.kt)
+(`STRING`, `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BOOLEAN`, `ARRAY`, `OBJECT`,
+`FILE`, `DATE`, `DATETIME`). Default values come from
+`JsonType.defaultValueForType(type)`:
+
+| `type` | Default |
+|---|---|
+| `STRING` | `""` |
+| `INT` / `SHORT` / `int32` | `0` |
+| `LONG` / `int64` | `0L` |
+| `FLOAT` | `0.0f` |
+| `DOUBLE` | `0.0` |
+| `BOOLEAN` / `bool` | `false` |
+| `bytes` | `""` |
+| anything else | `null` |
+
+### Cycle safety (load-bearing)
+
+A naive recursive walker stack-overflows on self-referential models. Every
+renderer must pair
+[`ObjectModelVisitTracker.tryEnter`](../../src/main/kotlin/com/itangcent/easyapi/core/psi/model/ObjectModelVisitTracker.kt#L31-L36)
+/ `exit` in a `finally`:
+
+```kotlin
+val tracker = ObjectModelVisitTracker()
+if (!tracker.tryEnter(model)) {
+    // visit limit (DEFAULT_MAX_VISITS = 2) reached — emit placeholder
+    sb.append("{}")
+    return
+}
+try {
+    for ((name, field) in model.fields) {
+        // recurse into field.model
+    }
+} finally {
+    tracker.exit(model)  // restores count so sibling fields can re-enter
+}
+```
+
+Or use the `withVisit` helper which encapsulates the `try/finally`:
+
+```kotlin
+tracker.withVisit(model) {
+    // expand model.fields ...
+} ?: run { sb.append("{}") }
+```
+
+`ObjectModel.DEFAULT_MAX_VISITS = 2` — an object is expanded up to twice
+across the whole traversal; on the third attempt, `tryEnter` returns `false`
+and the caller emits a placeholder (`{}`, `[]`). The count is restored on
+`exit`, so sibling fields that reference the same instance each get their
+own expansions.
+
+The Properties, YAML, and JSON formatters all do this. Skipping it is the
+single most common bug in a hand-written renderer.
+
+## Step-by-step
+
+### Step 1 — Pure renderer
+
+Create `format/<id>/<Id>Formatter.kt`. Walk the `ObjectModel`, branch on
+the four variants, read `JsonType.defaultValueForType` for scalar defaults,
+read `FieldModel.comment` / `options` for comments. Use
+`ObjectModelVisitTracker` for cycles.
+
+Minimal structure (mirrors
+[`YamlFormatter`](../../src/main/kotlin/com/itangcent/easyapi/format/yaml/YamlFormatter.kt)):
+
+```kotlin
+object TomlFormatter {
+    fun format(model: ObjectModel, prefix: String = ""): String {
+        val sb = StringBuilder()
+        val tracker = ObjectModelVisitTracker()
+        render(model, sb, tracker, indent = 0)
+        return sb.toString().trimEnd()
+    }
+
+    private fun render(
+        model: ObjectModel,
+        sb: StringBuilder,
+        tracker: ObjectModelVisitTracker,
+        indent: Int
+    ) {
+        when (model) {
+            is ObjectModel.Single -> {
+                sb.append(JsonType.defaultValueForType(model.type) ?: "null")
+            }
+            is ObjectModel.Object -> {
+                if (!tracker.tryEnter(model)) { sb.append("{}"); return }
+                try {
+                    for ((name, field) in model.fields) {
+                        sb.append("  ".repeat(indent))
+                            .append(name).append(" = ")
+                        render(field.model, sb, tracker, indent + 1)
+                        sb.appendLine()
+                    }
+                } finally {
+                    tracker.exit(model)
+                }
+            }
+            is ObjectModel.Array -> { /* render array */ }
+            is ObjectModel.MapModel -> { /* render map */ }
+        }
+    }
+}
+```
+
+Reference implementations:
+[`PropertiesFormatter`](../../src/main/kotlin/com/itangcent/easyapi/format/properties/PropertiesFormatter.kt)
+(simplest — flattens to `key=value`), [`YamlFormatter`](../../src/main/kotlin/com/itangcent/easyapi/format/yaml/YamlFormatter.kt)
+(block style, 2-space indent).
+
+### Step 2 — Entry extension
+
+Add a top-level extension function in
+[`format/spi/FieldFormatExtensions.kt`](../../src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatExtensions.kt)
+so callers can use the same ergonomic entry point as the built-in formats
+(`toJson()`, `toJson5()`, `toYaml()`, `toProperties()`):
+
+```kotlin
+fun ObjectModel.toToml(prefix: String = ""): String =
+    TomlFormatter.format(this, prefix)
+```
+
+> **Nullable-receiver convention:** the JSON/JSON5 extensions use a nullable
+> receiver (`fun ObjectModel?.toJson(): String = ObjectModelJsonConverter.toJson(this)`)
+> because they forward to a null-tolerant converter. If your formatter
+> requires a non-null model, declare the receiver non-nullable.
+
+### Step 3 — Channel
+
+Create `format/<id>/<Id>FieldFormatChannel.kt`:
+
+```kotlin
+package com.itangcent.easyapi.format.toml
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.format.spi.FieldFormatChannel
+import com.itangcent.easyapi.format.spi.toToml
+import com.itangcent.easyapi.core.psi.JsonOption
+import com.itangcent.easyapi.core.psi.PsiClassHelper
+
+class TomlFieldFormatChannel : FieldFormatChannel {
+    override val id: String = "toml"
+    override val displayName: String = "TOML"
+    override val actionText: String = "ToToml"
+
+    override suspend fun format(project: Project, psiClass: PsiClass): String =
+        PsiClassHelper.getInstance(project)
+            .buildObjectModel(psiClass, JsonOption.READ_GETTER_OR_SETTER)
+            ?.toToml() ?: ""
+}
+```
+
+If your format needs `RuleEngine` (e.g. for `properties.prefix`), delegate to
+a project service instead — see
+[`YamlFieldFormatChannel`](../../src/main/kotlin/com/itangcent/easyapi/format/yaml/YamlFieldFormatChannel.kt)
+(the minimal project-scoped example):
+
+```kotlin
+class YamlFieldFormatChannel : FieldFormatChannel {
+    override val id: String = "yaml"
+    override val displayName: String = "YAML"
+    override val actionText: String = "ToYaml"
+
+    override suspend fun format(project: Project, psiClass: PsiClass): String =
+        PropertiesService.getInstance(project).toYaml(psiClass)
+}
+```
+
+`PropertiesService.toYaml` / `toProperties` resolve the `properties.prefix`
+rule via `RuleEngine`, then call the pure renderer (`ObjectModel.toYaml` /
+`ObjectModel.toProperties`).
+
+### Step 4 — `plugin.xml` line
+
+Add one line under `<extensions defaultExtensionNs="...">` in
+[`plugin.xml`](../../src/main/resources/META-INF/plugin.xml#L53-L56):
+
+```xml
+<fieldFormatChannel implementation="com.itangcent.easyapi.format.toml.TomlFieldFormatChannel"/>
+```
+
+**No `<action>` entry, no group entry** — the "FieldsTo*" menu item
+auto-registers via `FieldFormatActionGroup` (see below).
+
+### Step 5 — Experimental (optional)
+
+If your format is experimental, override `enabledByDefault = false`. The
+format is hidden from the action menu until the user enables it in Settings
+→ General → "Field Format Channels". No further wiring needed.
+
+## What you get for free
+
+A format implementation gets substantial auto-wiring with **no extra code**:
+
+- **Action auto-registration** — `FieldFormatActionGroup.ensureActionsRegistered`
+  iterates `FieldFormatChannelRegistry.getEnabledChannels()` at startup (via
+  `ChannelActionInitActivity`) and registers one
+  [`FieldFormatAction`](../../src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatAction.kt)
+  per format with `ActionManager`, using a stable ID
+  (`com.itangcent.easy_api.actions.fieldformat.<id>`) and the plugin's
+  `PluginId` for keymap categorization. No `<action>` XML needed.
+- **Enablement toggle** — `FieldFormatChannelRegistry` mirrors the channel
+  enablement machinery: Settings → General → "Field Format Channels" is
+  auto-built from `allChannels()`. A disabled format's action is hidden
+  (presentation `visible=false` per-context) but **not** unregistered —
+  keymap IDs stay stable across enable/disable cycles.
+- **Re-active on settings change** — `EasyApiSettingsConfigurable.apply()`
+  calls `FieldFormatActionGroup.refreshActions(project)` after a settings
+  write; newly-enabled formats get their action registered, disabled
+  formats' actions are hidden on the next menu show.
+- **AI-visible** — `FieldFormatChannelRegistry.allChannels()` is consumed
+  by the in-IDE AI assistant so the model knows what formats exist.
+
+Reference:
+[`FieldFormatActionGroup`](../../src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatActionGroup.kt)
+(action registration),
+[`FieldFormatChannelRegistry`](../../src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistry.kt)
+(enablement).
+
+## Worked example — minimal TOML format
+
+`TomlFormatter.kt`:
+
+```kotlin
+package com.itangcent.easyapi.format.toml
+
+import com.itangcent.easyapi.core.psi.model.ObjectModel
+import com.itangcent.easyapi.core.psi.model.ObjectModelVisitTracker
+import com.itangcent.easyapi.core.psi.type.JsonType
+
+object TomlFormatter {
+    fun format(model: ObjectModel): String {
+        val sb = StringBuilder()
+        val tracker = ObjectModelVisitTracker()
+        when (model) {
+            is ObjectModel.Object -> renderObject(model, sb, tracker, indent = 0)
+            else -> sb.append("# unsupported top-level model")
+        }
+        return sb.toString().trimEnd()
+    }
+
+    private fun renderObject(
+        model: ObjectModel.Object,
+        sb: StringBuilder,
+        tracker: ObjectModelVisitTracker,
+        indent: Int
+    ) {
+        if (!tracker.tryEnter(model)) return
+        try {
+            for ((name, field) in model.fields) {
+                sb.append("  ".repeat(indent)).append(name).append(" = ")
+                when (val m = field.model) {
+                    is ObjectModel.Single ->
+                        sb.append(JsonType.defaultValueForType(m.type) ?: "null")
+                    is ObjectModel.Object -> {
+                        sb.appendLine()
+                        renderObject(m, sb, tracker, indent + 1)
+                    }
+                    is ObjectModel.Array -> sb.append("[]")
+                    is ObjectModel.MapModel -> sb.append("{}")
+                }
+                sb.appendLine()
+            }
+        } finally {
+            tracker.exit(model)
+        }
+    }
+}
+```
+
+Extension in `format/spi/FieldFormatExtensions.kt`:
+
+```kotlin
+fun ObjectModel.toToml(): String = TomlFormatter.format(this)
+```
+
+`TomlFieldFormatChannel.kt`:
+
+```kotlin
+class TomlFieldFormatChannel : FieldFormatChannel {
+    override val id: String = "toml"
+    override val displayName: String = "TOML"
+    override val actionText: String = "ToToml"
+
+    override suspend fun format(project: Project, psiClass: PsiClass): String =
+        PsiClassHelper.getInstance(project)
+            .buildObjectModel(psiClass, JsonOption.READ_GETTER_OR_SETTER)
+            ?.toToml() ?: ""
+}
+```
+
+`plugin.xml`:
+
+```xml
+<fieldFormatChannel implementation="com.itangcent.easyapi.format.toml.TomlFieldFormatChannel"/>
+```
+
+## Non-trivial formats
+
+For anything beyond "walk the model and emit text", look at
+[`format/json/`](../../src/main/kotlin/com/itangcent/easyapi/format/json/):
+
+- [`ObjectModelJsonConverter`](../../src/main/kotlin/com/itangcent/easyapi/format/json/ObjectModelJsonConverter.kt)
+  — entry point; delegates to a builder with a pluggable handler.
+- [`ObjectModelJsonBuilder`](../../src/main/kotlin/com/itangcent/easyapi/format/json/ObjectModelJsonBuilder.kt)
+  — walks the model and dispatches to a handler.
+- [`ObjectModelJsonHandler`](../../src/main/kotlin/com/itangcent/easyapi/format/json/ObjectModelJsonHandler.kt)
+  — strategy interface for per-variant rendering.
+- [`RawJsonHandler`](../../src/main/kotlin/com/itangcent/easyapi/format/json/RawJsonHandler.kt)
+  — standard JSON.
+- [`Json5Handler`](../../src/main/kotlin/com/itangcent/easyapi/format/json5/Json5Handler.kt)
+  — JSON5 (subset of the JSON package; just another handler).
+
+JSON5 is illustrative: it's not a separate package-walk implementation, just
+another `ObjectModelJsonHandler` plugged into the same builder.
+
+> **`core.util.FormatterHelper` is NOT for format authors.** It's a UI
+> pretty-printer (used by the export dialog and dashboard to format
+> already-rendered JSON/XML/HTML for display). Format authors should never
+> import it — your pure renderer is the source of truth for the output.
+
+## Import rules
+
+A format may import from:
+
+- `core.psi.model.*` (`ObjectModel`, `FieldModel`, `FieldOption`,
+  `ObjectModelVisitTracker`, `ObjectModelUtils`)
+- `core.psi.type.*` (`JsonType`, special-case handlers — for type-default
+  lookup only)
+- `core.util.*` (text helpers — but NOT `FormatterHelper`; see above)
+- `core.psi.*` (`PsiClassHelper`, `JsonOption`) — only in the
+  `FieldFormatChannel` layer, not the pure renderer
+- `core.ide.*` (`PropertiesService` — for prefix-sensitive formats)
+- `core.rule.*` (only if your channel needs to evaluate rules directly)
+- `format.spi.*` (the entry extensions and registry)
+- IntelliJ SDK
+- Your own `format.<id>.*` package
+
+A format **MUST NOT** import from:
+
+- `channel.*` (channels consume endpoints; formats consume field models)
+- `framework.*` (formats don't know about source frameworks)
+- `core.export.*` (formats don't touch `ApiEndpoint` / `ExportContext`)
+
+The pure renderer specifically should import only `core.psi.model.*`,
+`core.psi.type.JsonType`, and your own package — it must be testable with no
+`Project` / no PSI.
+
+## Testing
+
+- **Pure renderer** — plain JUnit. Build an `ObjectModel` with
+  `ObjectModelBuilder` (or `ObjectModel.Object(mapOf(...))`),
+  call `TomlFormatter.format(model)`, assert on the string. Test
+  self-referential models (build two `Object`s that point at each other) to
+  confirm `ObjectModelVisitTracker` prevents stack overflow.
+- **Channel** — extend `EasyApiLightCodeInsightFixtureTestCase`, load a
+  fixture `.java` / `.kt`, call `format(project, psiClass)`, snapshot the
+  output via `ResultLoader.load(...)` (never `File.readText()` — see
+  [shared testing concerns](README.md#testing)).
+- **Round-trip the extension** — call `ObjectModel.toToml()` on a known
+  model and assert it equals `TomlFormatter.format(model)`.
+
+Reference: [`YamlFormatterTest`](../../src/test/kotlin/com/itangcent/easyapi/format/yaml/YamlFormatterTest.kt),
+[`Json5HandlerTest`](../../src/test/kotlin/com/itangcent/easyapi/format/json5/Json5HandlerTest.kt).
+
+See [shared testing concerns](README.md#testing) in the developer README,
+and **invoke the `write-test-case` skill before writing tests**.

--- a/docs/developer/frameworks.md
+++ b/docs/developer/frameworks.md
@@ -1,0 +1,495 @@
+# Adding a new framework
+
+A **framework** scans PSI for `ApiEndpoint`s declared with a specific
+framework's annotations (Spring MVC, JAX-RS, Feign, gRPC, Micronaut, …).
+Adding a new one is a one-package operation plus **two** `plugin.xml` lines.
+
+> **Shared concerns** (threading, logging, enablement, testing) are in the
+> [developer README](README.md). This page covers framework-specific concerns
+> only.
+
+## When to write a framework
+
+Write a framework when you have a new **source framework** that declares API
+endpoints in source code. The 5 built-in frameworks:
+
+| Framework | Recognizer | Exporter | `enabledByDefault` |
+|-----------|------------|-----------|--------------------|
+| Spring MVC | [`SpringControllerRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/springmvc/SpringControllerRecognizer.kt) | [`SpringMvcClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/springmvc/SpringMvcClassExporter.kt) | `true` |
+| Actuator | [`ActuatorEndpointRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/springmvc/ActuatorEndpointRecognizer.kt) | [`ActuatorEndpointExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/springmvc/ActuatorEndpointExporter.kt) | `false` |
+| JAX-RS | [`JaxRsResourceRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsResourceRecognizer.kt) | [`JaxRsClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsClassExporter.kt) | `true` |
+| Feign | [`FeignClientRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/feign/FeignClientRecognizer.kt) | [`FeignClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/feign/FeignClassExporter.kt) | `false` |
+| gRPC | [`GrpcServiceRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/grpc/GrpcServiceRecognizer.kt) | [`GrpcClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/grpc/GrpcClassExporter.kt) | `true` |
+
+If you need to *export `ApiEndpoint`s* (already extracted by a framework
+exporter) to a new destination, that's a [channel](channels.md).
+
+## The two EPs
+
+A framework registers on **two** IntelliJ extension points — this is the
+single most common contributor mistake (registering only the exporter and
+silently breaking line markers, index scanning, and AI discovery).
+
+| EP name | Interface FQN | Purpose |
+|---|---|---|
+| `classExporter` | [`com.itangcent.easyapi.core.export.ClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/core/export/ClassExporter.kt) | Extract `ApiEndpoint`s from a `PsiClass`. Heavy; called per recognized class during a scan. |
+| `apiClassRecognizer` | [`com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizer.kt) | Cheap "is this an API class?" check. Drives line markers, `AnnotatedElementsSearch` index scanning, and AI discovery. **`FrameworkRegistry` keys enablement off this EP.** |
+
+Both EPs are `area="IDEA_PROJECT"` → IntelliJ injects `Project` via the
+constructor (one instance per project). The `frameworkName` you set on the
+recognizer **is the join key** that ties the exporter, the recognizer, and
+`FrameworkRegistry.isEnabled(frameworkName)` together — and is what the user
+sees in Settings → General → "Framework Support". A mismatch between the two
+silently disables the framework.
+
+## The two SPIs
+
+### `ClassExporter`
+
+The full contract lives in
+[`core/export/ClassExporter.kt`](../../src/main/kotlin/com/itangcent/easyapi/core/export/ClassExporter.kt).
+
+| Member | Type | Default | Purpose |
+|---|---|---|---|
+| `frameworkName` | `String` | — | Join key — MUST match the recognizer's `frameworkName`. |
+| `isEnabled()` | `suspend fun → Boolean` | `true` | One-liner: `FrameworkRegistry.getInstance(project).isEnabled(frameworkName)`. |
+| `export(psiClass)` | `suspend fun → List<ApiEndpoint>` | — | Extract endpoints from a `PsiClass`. Called only when `isEnabled` is `true`. |
+
+Constructor signature (required by `IDEA_PROJECT` area):
+
+```kotlin
+class XxxClassExporter(private val project: Project) : ClassExporter { … }
+```
+
+### `ApiClassRecognizer`
+
+The full contract lives in
+[`core/export/recognizer/ApiClassRecognizer.kt`](../../src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizer.kt).
+
+| Member | Type | Default | Purpose |
+|---|---|---|---|
+| `frameworkName` | `String` | — | Join key — MUST match the exporter's `frameworkName`. |
+| `targetAnnotations` | `Set<String>` | — | Annotation FQNs for `AnnotatedElementsSearch` (index scanning). |
+| `isApiClass(psiClass)` | `suspend fun → Boolean` | — | Slow / accurate check; may consult `RuleEngine` + `MetaAnnotationResolver`. |
+| `isEnabled(project)` | `fun → Boolean` | `true` | Per-project state gate (e.g. annotation presence); AND-combined with `FrameworkRegistry`. |
+| `enabledByDefault` | `Boolean` | `true` | Compile-time enablement default. |
+| `matchesClass(psiClass)` | `fun → Boolean` | `false` | Per-class fast-path for line markers. **MUST NOT consult the rule engine.** |
+
+Constructor signature (EP instantiates with no-arg — recognizers receive
+their dependencies via constructor parameters with defaults):
+
+```kotlin
+class XxxResourceRecognizer(
+    private val ruleEngine: RuleEngine? = null,
+    private val enabled: Boolean = true
+) : ApiClassRecognizer { … }
+```
+
+The CompositeApiClassRecognizer discovers recognizers via the EP and filters
+by `FrameworkRegistry.isEnabled(it) && it.isEnabled(project)`. The filter is
+re-evaluated whenever settings change (the composite subscribes to
+settings-change events and rebuilds its cache).
+
+### `matchesClass` contract — load-bearing
+
+`matchesClass` is a **fast-path** used by line-marker providers — it must
+NOT consult the rule engine (which is consulted only in `isApiClass`).
+Default `false` is correct for annotation-driven frameworks (Spring MVC,
+JAX-RS, Feign, Actuator — `isApiClass` already returns `false` quickly for
+non-matching classes). Only gRPC overrides this, because its
+`extends BindableService` walk is a per-class fast-path the line marker
+needs. See
+[`GrpcServiceRecognizer.matchesClass`](../../src/main/kotlin/com/itangcent/easyapi/framework/grpc/GrpcServiceRecognizer.kt#L52-L55).
+
+Getting this wrong regresses line-marker behavior — rule-engine overrides
+would otherwise cause non-gRPC classes to be marked as gRPC services by the
+line marker.
+
+## Step-by-step
+
+JAX-RS is the canonical mirror — its four-resolver split is the layout to
+copy.
+
+### Step 1 — Recognizer
+
+Create `framework/<id>/<Id>ResourceRecognizer.kt`. Set `frameworkName`,
+`targetAnnotations` (FQNs for `AnnotatedElementsSearch`), `enabledByDefault`.
+Implement `isApiClass` (may consult `RuleEngine` +
+[`MetaAnnotationResolver`](../../src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/MetaAnnotationResolver.kt)).
+Override `matchesClass` only if your framework needs an expensive
+non-annotation fast-path (gRPC does; annotation-driven frameworks don't).
+
+```kotlin
+package com.itangcent.easyapi.framework.micronaut
+
+import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer
+import com.itangcent.easyapi.core.export.recognizer.MetaAnnotationResolver
+import com.itangcent.easyapi.core.rule.RuleKeys
+import com.itangcent.easyapi.core.rule.engine.RuleEngine
+
+class MicronautControllerRecognizer(
+    private val ruleEngine: RuleEngine? = null,
+    private val enabled: Boolean = true
+) : ApiClassRecognizer {
+
+    override val frameworkName: String = "Micronaut"
+    override val targetAnnotations: Set<String> = CONTROLLER_ANNOTATIONS
+    override val enabledByDefault: Boolean = false
+
+    override suspend fun isApiClass(psiClass: PsiClass): Boolean {
+        if (!enabled) return false
+        if (ruleEngine?.evaluate(RuleKeys.CLASS_IS_MICRONAUT_CTRL, psiClass) == true) return true
+        return MetaAnnotationResolver.hasMetaAnnotation(psiClass, CONTROLLER_ANNOTATIONS)
+    }
+
+    companion object {
+        val CONTROLLER_ANNOTATIONS = setOf(
+            "io.micronaut.http.annotation.Controller"
+        )
+    }
+}
+```
+
+Reference: [`JaxRsResourceRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsResourceRecognizer.kt).
+
+### Step 2 — Exporter
+
+Create `framework/<id>/<Id>ClassExporter.kt`. Constructor takes `Project`;
+`frameworkName` matches the recognizer; `isEnabled` is one line:
+`FrameworkRegistry.getInstance(project).isEnabled(frameworkName)`. In
+`export(psiClass)` iterate `ResolvedType.suitableMethods()`, fire rule
+lifecycle hooks (see below), and build `ApiEndpoint`s via `EndpointBuilder`.
+
+```kotlin
+package com.itangcent.easyapi.framework.micronaut
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.export.*
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.psi.helper.DocMetadataResolver
+import com.itangcent.easyapi.core.psi.type.ResolvedType
+import com.itangcent.easyapi.core.internal.threading.read
+import com.itangcent.easyapi.core.rule.engine.RuleEngine
+import com.itangcent.easyapi.framework.spi.FrameworkRegistry
+
+class MicronautClassExporter(
+    private val project: Project
+) : ClassExporter {
+
+    override val frameworkName: String = "Micronaut"
+
+    override suspend fun isEnabled(): Boolean =
+        FrameworkRegistry.getInstance(project).isEnabled("Micronaut")
+
+    private val engine = RuleEngine.getInstance(project)
+    private val recognizer = MicronautControllerRecognizer(engine)
+    private val pathResolver = MicronautPathResolver(/* annotationHelper */)
+    private val methodResolver = MicronautHttpMethodResolver(/* annotationHelper */)
+    private val parameterResolver = MicronautParameterResolver(/* annotationHelper */)
+    private val metadataResolver = DocMetadataResolver.getInstance(project)
+    private val endpointBuilder = EndpointBuilder.getInstance(project)
+
+    override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
+        if (!recognizer.isApiClass(psiClass)) return emptyList()
+        // ... iterate suitableMethods(), fire rule hooks, build ApiEndpoint ...
+    }
+}
+```
+
+Reference: [`JaxRsClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsClassExporter.kt)
+(4-resolver split, full rule lifecycle, the canonical "annotation-driven
+framework" template).
+
+### Step 3 — Resolvers (optional, plain classes)
+
+Split per-concern logic into plain Kotlin classes taking an
+`AnnotationHelper` (or similar), wired into the exporter at construction:
+
+| Resolver | Concern |
+|---|---|
+| `*PathResolver` | Combine class-level and method-level path annotations. |
+| `*HttpMethodResolver` | Map framework annotations to `HttpMethod`. |
+| `*ParameterResolver` | Map framework parameter annotations (`@QueryParam`, `@PathParam`, …) to `ApiParameter` + `ParameterBinding`. |
+| `*ContentTypeResolver` | Extract `@Consumes` / `@Produces` or equivalent. |
+
+These are **not registered anywhere** — they're construction-time
+dependencies of the exporter. Reference the JAX-RS 4-resolver split:
+[`JaxRsPathResolver`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsPathResolver.kt),
+[`JaxRsHttpMethodResolver`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsHttpMethodResolver.kt),
+[`JaxRsParameterResolver`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsParameterResolver.kt),
+[`JaxRsContentTypeResolver`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsContentTypeResolver.kt).
+
+### Step 4 — `plugin.xml` (two lines)
+
+Add **two** lines under `<extensions defaultExtensionNs="...">` in
+[`plugin.xml`](../../src/main/resources/META-INF/plugin.xml#L35-L47):
+
+```xml
+<classExporter implementation="com.itangcent.easyapi.framework.micronaut.MicronautClassExporter"/>
+<apiClassRecognizer implementation="com.itangcent.easyapi.framework.micronaut.MicronautControllerRecognizer"/>
+```
+
+Both EPs are `area="IDEA_PROJECT"` → `Project` is injected via the
+exporter's constructor. (The recognizer's no-arg constructor builds the
+default `ruleEngine = null` / `enabled = true` shape; the
+`CompositeApiClassRecognizer` re-evaluates enablement on each access via
+`FrameworkRegistry`.)
+
+## What core gives you
+
+A framework implementation has substantial shared infrastructure to lean
+on:
+
+- [`EndpointBuilder`](../../src/main/kotlin/com/itangcent/easyapi/core/export/EndpointBuilder.kt)
+  — shared utility for building endpoint components:
+  - `buildHeaders(contentType, paramHeaders, additionalHeaders, additionalResponseHeaders)` — header dedup + merge
+  - `buildResponseBody(method, resolvedReturnType)` — response model with `method.return` / `method.return.main` rule overrides
+  - `expandBodyParam(resolvedParamType)` — request body model from a `@Body` parameter
+  - `mergePathParameters(...)` — path-param enrichment (enum / default / description)
+  - `applyReturnMain(...)` — apply `@return` doc to a specific field
+- [`DocMetadataResolver`](../../src/main/kotlin/com/itangcent/easyapi/core/psi/helper/DocMetadataResolver.kt)
+  — rule-aware resolvers for `api.name`, `method.doc`, folders,
+  param defaults, additional headers, additional response headers, ignored
+  params.
+- [`TypeResolver`](../../src/main/kotlin/com/itangcent/easyapi/core/psi/type/ResolvedTypes.kt)
+  / `ResolvedType` — type resolution with generics substitution; iterate
+  methods via `ResolvedType.ClassType.suitableMethods()`.
+- [`UnifiedAnnotationHelper`](../../src/main/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedAnnotationHelper.kt)
+  — language-agnostic annotation lookup (works for Java, Kotlin, Groovy,
+  Scala).
+- `RuleEngine` + `RuleKeys` — rule evaluation for per-class / per-method
+  overrides (`class.is.spring.controller`, `method.content.type`,
+  `method.return`, …).
+- [`FrameworkRegistry`](../../src/main/kotlin/com/itangcent/easyapi/framework/spi/FrameworkRegistry.kt)
+  — the single enablement chokepoint. `isEnabled(frameworkId)` returns
+  `true` if the user has explicitly enabled it (its id is in
+  `GeneralSettings.enabledFrameworks`), OR it is `enabledByDefault` and not
+  explicitly disabled.
+
+[`CompositeApiClassRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/CompositeApiClassRecognizer.kt)
+discovers recognizers via the EP, filters by `isEnabled`, caches, and
+rebuilds on settings change. It exposes `recognizers()`,
+`allTargetAnnotations`, and `isApiClass(psiClass)` to AI tools and other
+core consumers — so **don't** hard-import your recognizer elsewhere. The
+composite is the only legitimate way for `core.*` to reach a framework
+recognizer (the `framework.spi.*` carve-out in the DAG rule).
+
+## Rule lifecycle hooks
+
+A framework exporter MUST fire the rule lifecycle hooks around its
+parse loop so user rules (`api_class.parse.before`, `method.doc`,
+`api.after`, …) can run. The exact `engine.evaluate(...)` calls (from
+[`JaxRsClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsClassExporter.kt)):
+
+```kotlin
+// before iterating methods:
+withContext(IdeDispatchers.Background) {
+    engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
+}
+
+try {
+    for (resolvedMethod in resolvedType.suitableMethods()) {
+        // before each method:
+        withContext(IdeDispatchers.Background) {
+            engine.evaluate(RuleKeys.API_METHOD_PARSE_BEFORE, resolvedMethod)
+        }
+        try {
+            // ... build the ApiEndpoint ...
+            withContext(IdeDispatchers.Background) {
+                for (endpoint in endpoints) {
+                    engine.evaluate(RuleKeys.EXPORT_AFTER, resolvedMethod) { ctx ->
+                        ctx.setExt("api", endpoint)
+                    }
+                }
+            }
+        } finally {
+            // after each method (success or failure):
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, resolvedMethod)
+            }
+        }
+    }
+} finally {
+    // after the whole class:
+    withContext(IdeDispatchers.Background) {
+        engine.evaluate(RuleKeys.API_CLASS_PARSE_AFTER, psiClass)
+    }
+}
+```
+
+`API_METHOD_PARSE_AFTER` and `API_CLASS_PARSE_AFTER` go in `finally` blocks
+so they fire even when a method throws. `EXPORT_AFTER` runs after the
+endpoint is built and sets the `api` extension on the rule context so user
+rules can mutate the endpoint before it leaves the exporter.
+
+## The `ApiEndpoint` shape
+
+The full contract lives in
+[`core/export/ApiModels.kt`](../../src/main/kotlin/com/itangcent/easyapi/core/export/ApiModels.kt).
+
+```kotlin
+data class ApiEndpoint(
+    val name: String? = null,
+    val folder: String? = null,
+    var description: String? = null,
+    val sourceClass: PsiClass? = null,
+    val sourceMethod: PsiMethod? = null,
+    val className: String? = null,
+    val classDescription: String? = null,
+    val metadata: ApiMetadata,                  // HttpMetadata or GrpcMetadata
+    val extensions: Extension = Extension.EMPTY
+)
+```
+
+Build HTTP endpoints via the
+[`httpMetadata(...)`](../../src/main/kotlin/com/itangcent/easyapi/core/export/ApiModels.kt#L316)
+factory:
+
+```kotlin
+val endpoint = ApiEndpoint(
+    name = name,
+    folder = folder,
+    description = description,
+    sourceClass = psiClass,
+    sourceMethod = method,
+    className = classQualifiedName,
+    classDescription = classFolder.description,
+    metadata = httpMetadata(
+        path = path,
+        method = httpMethod,
+        parameters = params + additionalParams,
+        headers = headers,
+        contentType = contentType,
+        body = body,
+        responseBody = responseBody,
+        responseType = responseTypeName
+    )
+)
+```
+
+`HttpMetadata` fields: `path`, `method`, `parameters`, `headers`,
+`contentType`, `bodyAttr`, `alternativePaths`, `body`, `responseBody`,
+`responseType`. The `ParameterBinding` sealed class is what binds each
+parameter to a request location:
+
+| `ParameterBinding` | HTTP location |
+|---|---|
+| `Query` | Query string (`?name=value`) |
+| `Path` | URL path (`/users/{id}`) |
+| `Header` | HTTP header |
+| `Cookie` | Cookie value |
+| `Body` | Request body |
+| `Form` | Form data |
+| `Ignored` | Framework-injected (skip in output) |
+
+For gRPC, build a `GrpcMetadata` instead (`path`, `serviceName`,
+`methodName`, `packageName`, `streamingType`, `protoFile`, `body`,
+`responseBody`, `responseType`).
+
+## Worked example — minimal Micronaut framework skeleton
+
+Recognizer + exporter + 2 resolvers + 2 `plugin.xml` lines:
+
+`MicronautControllerRecognizer.kt` — see Step 1 above.
+
+`MicronautPathResolver.kt`:
+
+```kotlin
+class MicronautPathResolver(private val annotationHelper: AnnotationHelper) {
+    suspend fun resolve(psiClass: PsiClass, psiMethod: PsiMethod): String {
+        val classPath = annotationHelper.findAttrAsString(psiClass, "io.micronaut.http.annotation.Controller", "value")
+            ?.trim('/') ?: ""
+        val methodPath = annotationHelper.findAttrAsString(psiMethod, "io.micronaut.http.annotation.Get", "value")
+            ?: annotationHelper.findAttrAsString(psiMethod, "io.micronaut.http.annotation.Post", "value")
+            ?: ""
+        return "/" + listOf(classPath, methodPath.trim('/')).filter { it.isNotEmpty() }.joinToString("/")
+    }
+}
+```
+
+`MicronautHttpMethodResolver.kt`:
+
+```kotlin
+class MicronautHttpMethodResolver(private val annotationHelper: AnnotationHelper) {
+    suspend fun resolve(psiMethod: PsiMethod): HttpMethod? {
+        for ((ann, method) in ANNOTATION_TO_METHOD) {
+            if (annotationHelper.findAnnotation(psiMethod, ann) != null) return method
+        }
+        return null
+    }
+
+    companion object {
+        private val ANNOTATION_TO_METHOD = listOf(
+            "io.micronaut.http.annotation.Get" to HttpMethod.GET,
+            "io.micronaut.http.annotation.Post" to HttpMethod.POST,
+            "io.micronaut.http.annotation.Put" to HttpMethod.PUT,
+            "io.micronaut.http.annotation.Delete" to HttpMethod.DELETE,
+            "io.micronaut.http.annotation.Patch" to HttpMethod.PATCH,
+        )
+    }
+}
+```
+
+`MicronautClassExporter.kt` — see Step 2 above; follow
+[`JaxRsClassExporter.exportMethod`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsClassExporter.kt#L100-L197)
+for the per-method parse + endpoint-build pattern.
+
+`plugin.xml`:
+
+```xml
+<classExporter implementation="com.itangcent.easyapi.framework.micronaut.MicronautClassExporter"/>
+<apiClassRecognizer implementation="com.itangcent.easyapi.framework.micronaut.MicronautControllerRecognizer"/>
+```
+
+That's the entire integration. The recognizer drives line markers, index
+scanning, AI discovery, and Settings → General → "Framework Support"; the
+exporter drives the actual endpoint extraction.
+
+## Import rules
+
+A framework may import from:
+
+- `core.export.*` (`ClassExporter`, `ApiEndpoint`, `EndpointBuilder`,
+  `ExportContext`, `Extension`, `ParameterBinding`, `HttpMethod`,
+  `HttpMetadata`, …)
+- `core.export.recognizer.*` (`ApiClassRecognizer`,
+  `MetaAnnotationResolver`)
+- `core.psi.*` (`PsiClassHelper`, `ResolvedType`, `TypeResolver`,
+  `UnifiedAnnotationHelper`, `DocMetadataResolver`, `ObjectModel`)
+- `core.config.*`, `core.rule.*`, `core.settings.*`
+- `core.grpc.*` (only for `framework.grpc` — descriptor reflection, proto)
+- `core.util.*`, `core.logging.*`, `core.internal.threading.*`
+- `framework.spi.*` (`FrameworkRegistry` — the only `framework.*` sibling
+  import allowed for `core.*`; frameworks may of course import it too)
+- IntelliJ SDK
+- Your own `framework.<id>.*` package
+
+A framework **MUST NOT** import from:
+
+- `channel.*` (channels consume endpoints; frameworks produce them)
+- `format.*` (formats consume field models; frameworks produce endpoints)
+- Sibling `framework.<other-id>.*` packages
+
+## Testing
+
+- **Recognizer unit tests** — plain JUnit; build a `PsiClass` from a
+  fixture, assert `isApiClass` returns the expected value. Test
+  meta-annotations (a custom annotation annotated with `@Controller`).
+- **Exporter integration tests** — extend
+  `EasyApiLightCodeInsightFixtureTestCase`, load a fixture `.java` / `.kt`,
+  call `export(psiClass)`, snapshot the resulting `ApiEndpoint` list via
+  `ResultLoader.load(...)`. Test rule-lifecycle hooks by configuring a rule
+  that mutates the endpoint and asserting the mutation landed.
+- **Enablement tests** — `FrameworkRegistry.resolveEnabled` is extracted as
+  a pure `internal companion fun`; unit-test the truth table without a
+  `Project`.
+
+Reference tests:
+[`ApiEndpointTest`](../../src/test/kotlin/com/itangcent/easyapi/core/export/ApiEndpointTest.kt),
+[`FrameworkRegistryTest`](../../src/test/kotlin/com/itangcent/easyapi/framework/spi)
+(if present).
+
+See [shared testing concerns](README.md#testing) in the developer README,
+and **invoke the `write-test-case` skill before writing tests**.


### PR DESCRIPTION
## Summary

Adds a new **developer / extension-author** documentation suite under `docs/developer/`, and rewires the existing top-level docs so the suite is discoverable.

The README's `### How to add new support` section was recipe-only and lacked the depth a real contributor needs (SPI surface details, config subtypes, options/settings panels, enablement model, threading, logging, testing, worked examples). This PR produces the full guides and turns that section into pointers.

## What's new

- **`docs/developer/README.md`** — orientation + shared concerns (the three EPs at a glance, dependency DAG, package-layout decision rule, `plugin.xml` basics, threading, logging, enablement, testing). Linked from each topic page so nothing is duplicated.
- **`docs/developer/channels.md`** — full `Channel` SPI reference, step-by-step (package + `Channel` class → `plugin.xml` → config + options panel → settings tab → rule keys → export result + `handleResult`), "what you get for free", worked example, import rules, testing.
- **`docs/developer/formats.md`** — two-layer architecture (pure renderer vs project-scoped channel), `FieldFormatChannel` SPI, the `ObjectModel` input (incl. cycle safety with `ObjectModelVisitTracker`), step-by-step, "what you get for free", worked example, non-trivial formats, import rules.
- **`docs/developer/frameworks.md`** — **two-EP** overview (`classExporter` + `apiClassRecognizer`), the two SPIs, 4-step guide (JAX-RS as the mirror), what core gives you, rule lifecycle hooks, `ApiEndpoint` shape, worked example, import rules.

## Rewired top-level docs

- **`README.md` §"How to add new support"** — each subsection trimmed to a 2-sentence teaser + the one `plugin.xml` line + a deep-link to the corresponding topic page. No information lost — the prior content is a strict subset of the new guides.
- **`CONTRIBUTING.md` §"Project Structure"** — the stale/wrong body (v2-style packages, broken `.kiro/steering/project.md` link) replaced with a one-sentence four-bucket summary + pointers to README and AGENTS.md. A new `### Extensions` bullet points at `docs/developer/`.
- **`AGENTS.md` §"Package Layout"** — appended a one-line pointer to `docs/developer/`. No other AGENTS.md changes; its DAG / import-rule / threading / logging content remains the authority and is linked from the new README.

## Scope

Docs-only change — **no Kotlin, `plugin.xml`, or test code touched.**

## Checklist

- [x] `docs/developer/{README,channels,formats,frameworks}.md` created
- [x] `README.md` §"How to add new support" rewritten into teasers + deep-links
- [x] `CONTRIBUTING.md` `## Project Structure` fixed + `### Extensions` bullet added
- [x] `AGENTS.md` §"Package Layout" pointer appended
- [x] All code excerpts sourced verbatim from real source files (no invented APIs)
- [x] Deep-links point at real paths; AGENTS.md remains the authority for DAG/threading/logging