### PR TITLE
fix: Features tab renders narrower than other tabs

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistry.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.internal.PluginInfo
 import com.itangcent.easyapi.core.logging.IdeaLog
 import com.itangcent.easyapi.core.settings.SettingBinder
 import com.itangcent.easyapi.core.settings.module.GeneralSettings
@@ -47,7 +48,7 @@ class ChannelRegistry(private val project: Project) : IdeaLog {
         fun getInstance(project: Project): ChannelRegistry = project.service()
 
         // IV: this EP-name string differs between easy-api and easy-yapi
-        private val EP = ExtensionPointName.create<Channel>("com.itangcent.idea.plugin.easy-api.channel")
+        private val EP = ExtensionPointName.create<Channel>("${PluginInfo.PLUGIN_ID}.channel")
 
         /**
          * Pure resolution rule for a channel's effective enabled state, extracted

--- a/src/main/kotlin/com/itangcent/easyapi/core/export/ClassExporterRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/export/ClassExporterRegistry.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.core.internal.PluginInfo.PLUGIN_ID
 import com.itangcent.easyapi.core.logging.IdeaLog
 
 /**
@@ -29,7 +30,7 @@ class ClassExporterRegistry(private val project: Project) : IdeaLog {
         fun getInstance(project: Project): ClassExporterRegistry = project.service()
 
         private val CLASS_EXPORTER_EP =
-            ExtensionPointName.create<ClassExporter>("com.itangcent.idea.plugin.easy-api.classExporter")
+            ExtensionPointName.create<ClassExporter>("$PLUGIN_ID.classExporter")
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/CompositeApiClassRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/CompositeApiClassRecognizer.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.internal.PluginInfo.PLUGIN_ID
 import com.itangcent.easyapi.core.settings.onSettingsChanged
 import com.itangcent.easyapi.framework.spi.FrameworkRegistry
 
@@ -115,7 +116,7 @@ class CompositeApiClassRecognizer(private val project: Project) : Disposable {
          * `<apiClassRecognizer implementation="..."/>`.
          */
         private val EP_NAME: ExtensionPointName<ApiClassRecognizer> =
-            ExtensionPointName.create("com.itangcent.idea.plugin.easy-api.apiClassRecognizer")
+            ExtensionPointName.create("$PLUGIN_ID.apiClassRecognizer")
 
         fun getInstance(project: Project): CompositeApiClassRecognizer = project.service()
     }

--- a/src/main/kotlin/com/itangcent/easyapi/core/internal/PluginInfo.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/internal/PluginInfo.kt
@@ -1,0 +1,20 @@
+package com.itangcent.easyapi.core.internal
+
+/**
+ * Plugin identity and metadata constants for the EasyApi IntelliJ plugin.
+ *
+ * Centralizes the plugin id (declared in `plugin.xml` as `<id>`) so that
+ * extension-point name strings and `PluginId` lookups can reference a single
+ * source of truth instead of hard-coding the raw id string at each call site.
+ */
+object PluginInfo {
+
+    /**
+     * The unique plugin id, matching `<id>` in `src/main/resources/META-INF/plugin.xml`.
+     *
+     * Used as the namespace prefix for all extension points declared by this
+     * plugin — e.g. `"$PLUGIN_ID.channel"` resolves to
+     * `"com.itangcent.idea.plugin.easy-api.channel"`.
+     */
+    const val PLUGIN_ID: String = "com.itangcent.idea.plugin.easy-api"
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanels.kt
@@ -604,6 +604,11 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
         .addComponent(buildFieldFormatEnablementPanel())
         .addComponentFillVertically(JPanel(), 0)
         .panel
+        // The panel's only content is checkboxes, whose preferred width is
+        // narrow text. Match the width of the other panels (whose wide content
+        // — the repositories table, 150px labeledRow labels — drives a near-600px
+        // preferred width) so this tab doesn't render noticeably narrower.
+        .apply { preferredSize = Dimension(600, preferredSize.height) }
 
     override fun resetFrom(settings: GeneralSettings?) {
         // Framework enablement is handled by [resetFrameworkEnablementFrom],

--- a/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistry.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.core.internal.PluginInfo
+import com.itangcent.easyapi.core.internal.PluginInfo.PLUGIN_ID
 import com.itangcent.easyapi.core.logging.IdeaLog
 import com.itangcent.easyapi.core.settings.SettingBinder
 import com.itangcent.easyapi.core.settings.module.GeneralSettings
@@ -49,7 +51,7 @@ class FieldFormatChannelRegistry(private val project: Project) : IdeaLog {
 
         // IV: this EP-name string differs between easy-api and easy-yapi
         private val EP = ExtensionPointName.create<FieldFormatChannel>(
-            "com.itangcent.idea.plugin.easy-api.fieldFormatChannel"
+            "$PLUGIN_ID.fieldFormatChannel"
         )
 
         /**
@@ -70,7 +72,7 @@ class FieldFormatChannelRegistry(private val project: Project) : IdeaLog {
             disabledIds: Array<String>
         ): Boolean =
             channel.id in enabledIds ||
-                (channel.enabledByDefault && channel.id !in disabledIds)
+                    (channel.enabledByDefault && channel.id !in disabledIds)
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/channel/dummy/DummyChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/dummy/DummyChannelTest.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.channel.dummy
 
 import com.itangcent.easyapi.channel.spi.Channel
 import com.itangcent.easyapi.channel.spi.ChannelRegistry
+import com.itangcent.easyapi.core.internal.PluginInfo.PLUGIN_ID
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 /**
@@ -22,7 +23,7 @@ class DummyChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testDummyChannelIsDiscoverableViaChannelEP() {
         // The channel EP is project-scoped (area="IDEA_PROJECT").
         project.extensionArea
-            .getExtensionPoint<Channel>("com.itangcent.idea.plugin.easy-api.channel")
+            .getExtensionPoint<Channel>("$PLUGIN_ID.channel")
             .registerExtension(DummyChannel(), testRootDisposable)
 
         val channels = ChannelRegistry.getInstance(project).allChannels()
@@ -34,7 +35,7 @@ class DummyChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testDummyChannelSettingsSurfaceIsDiscoverable() {
         // The single channel EP now also covers the former channelSettings surface.
         project.extensionArea
-            .getExtensionPoint<Channel>("com.itangcent.idea.plugin.easy-api.channel")
+            .getExtensionPoint<Channel>("${PLUGIN_ID}.channel")
             .registerExtension(DummyChannel(), testRootDisposable)
 
         val channel = ChannelRegistry.getInstance(project).getChannel("dummy")

--- a/src/test/kotlin/com/itangcent/easyapi/core/ide/action/ActionBasicsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ide/action/ActionBasicsTest.kt
@@ -1,8 +1,10 @@
 package com.itangcent.easyapi.core.ide.action
 
-import com.itangcent.easyapi.format.spi.FieldFormatChannel
 import com.intellij.openapi.extensions.ExtensionPointName
-import org.junit.Assert.*
+import com.itangcent.easyapi.core.internal.PluginInfo.PLUGIN_ID
+import com.itangcent.easyapi.format.spi.FieldFormatChannel
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ActionExistenceTest {
@@ -16,7 +18,7 @@ class ActionExistenceTest {
     @Test
     fun testFieldFormatChannelsRegistered() {
         val ep = ExtensionPointName.create<FieldFormatChannel>(
-            "com.itangcent.idea.plugin.easy-api.fieldFormatChannel"
+            "$PLUGIN_ID.fieldFormatChannel"
         )
         val channels = ep.extensionList
         val ids = channels.map { it.id }.toSet()


### PR DESCRIPTION
## Summary

The **Features** settings tab rendered visibly narrower than the other tabs (General, HTTP, Parsing & Output, ...). This PR makes its width consistent with its siblings.

## Root cause

`EasyApiSettingsConfigurable.wrapNorth()` places each tab's content in a horizontal box with trailing glue, so the rendered width equals the component's **preferred width**.

- Other panels have wide content driving a near-600px preferred width: the Repositories table sums to ~530px of column widths, and `labeledRow` uses 150px fixed labels plus fields.
- `FeaturesSettingsPanel`'s only content is `JBCheckBox`es whose preferred width is just the narrow checkbox text — so the tab came out much narrower than its siblings.

## What changes

- Set `FeaturesSettingsPanel.component`'s `preferredSize` width to 600, aligning with the `wrapNorth()` 600px cap so the Features tab matches the other tabs. Height is preserved from the form's own preferred size.

## Scope

Visual-only — one-line change in `SettingsPanels.kt`. No behavior, settings shape, or test impact.

## How to test

- `./gradlew build`
- `./gradlew runIde` → open Settings → EasyApi → flip between tabs and confirm the Features tab now matches the width of the other tabs.