### PR TITLE
feat(channel): add OpenAPI 3.0.3 export channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,7 @@ com.itangcent.easyapi/
 │   ├── hoppscotch/  (+ model/)
 │   ├── httpclient/
 │   ├── markdown/    (+ template/)
+│   ├── openapi/
 │   └── postman/     (+ model/)
 │
 ├── format/                          # FIELD/OBJECT SERIALIZATION

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Export API endpoints from your source code to multiple formats:
 | **Hoppscotch** *(Beta)* | ✓ | — | JSON file or direct upload to Hoppscotch |
 | **cURL** | ✓ | ✓ | Executable shell script |
 | **HTTP Client** | ✓ | ✓ | IntelliJ HTTP Client scratch file |
+| **OpenAPI** *(Beta)* | ✓ | — | `.json` or `.yaml` OpenAPI 3.0.3 document |
 
 ### API Dashboard
 
@@ -120,7 +121,7 @@ Support for gRPC service implementations:
 
 1. Right-click on a controller file, class, or method in the editor or project view
 2. Select **EasyApi → Export** (or press `Ctrl+E` on macOS / `Alt+Shift+E`)
-3. Choose the target format (Postman / Hoppscotch *(Beta)* / Markdown / cURL / HTTP Client)
+3. Choose the target format (Postman / Hoppscotch *(Beta)* / Markdown / cURL / HTTP Client / OpenAPI *(Beta)*)
 4. The APIs will be exported automatically
 
 ### Call an API
@@ -233,7 +234,7 @@ graph TB
 
 - **ExportOrchestrator** — Coordinates the full export pipeline: scans endpoints via `ApiScanner`, then hands them to the selected `Channel` for output
 - **ClassExporter** *(extension point)* — Extracts `ApiEndpoint` models from PSI classes; built-in implementations: Spring MVC, Spring Cloud OpenFeign, JAX-RS, Spring Actuator, gRPC
-- **Channel** *(extension point)* — Converts `ApiEndpoint` models to an output format and handles file write / remote upload; built-in channels: Markdown, Postman, cURL, HTTP Client, Hoppscotch *(Beta)*. Adding a new output target only requires implementing `Channel` — no core edits
+- **Channel** *(extension point)* — Converts `ApiEndpoint` models to an output format and handles file write / remote upload; built-in channels: Markdown, Postman, cURL, HTTP Client, Hoppscotch *(Beta)*, OpenAPI *(Beta)*. Adding a new output target only requires implementing `Channel` — no core edits
 - **ApiIndex** — Caches discovered endpoints for fast search and dashboard access
 - **RuleEngine** — Evaluates rule expressions (Groovy, regex, annotation, tag) to customize parsing behavior
 - **AI Assistant** — Optional built-in agent that inspects the project via PSI tools and authors rule files; see the [Skills](#skills) section for the external-skill equivalent
@@ -244,12 +245,13 @@ The plugin's source tree is organized into four top-level buckets under `src/mai
 
 ```
 com.itangcent.easyapi/
-├── channel/      # OUTPUT — export destinations (Postman, Markdown, cURL, Hoppscotch, HTTP Client)
+├── channel/      # OUTPUT — export destinations (Postman, Markdown, cURL, Hoppscotch, HTTP Client, OpenAPI)
 │   ├── spi/      #   Channel EP contract: Channel, ChannelConfig, ChannelRegistry, …
 │   ├── curl/
 │   ├── hoppscotch/  (+ model/)
 │   ├── httpclient/
 │   ├── markdown/    (+ template/)
+│   ├── openapi/
 │   └── postman/     (+ model/)
 │
 ├── format/       # FIELD/OBJECT SERIALIZATION (JSON, JSON5, YAML, Properties)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2")
     implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.2")
     implementation("com.fasterxml.jackson.core:jackson-core:2.12.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.2")
+    implementation("org.yaml:snakeyaml:1.33")
     implementation("org.xerial:sqlite-jdbc:3.34.0")
 
     // LangChain4j — AI agent substrate

--- a/docs/developer/channels.md
+++ b/docs/developer/channels.md
@@ -11,7 +11,7 @@ operation plus one `plugin.xml` line.
 ## When to write a channel
 
 Write a channel when you have a new **output destination** for `ApiEndpoint`
-models. The 5 built-in channels:
+models. The 6 built-in channels:
 
 | Channel | HTTP | gRPC | Output |
 |---------|:----:|:----:|--------|
@@ -20,6 +20,7 @@ models. The 5 built-in channels:
 | [CurlChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/curl/CurlChannel.kt) | ✓ | ✓ | Executable shell script |
 | [HttpClientChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/httpclient/HttpClientChannel.kt) | ✓ | ✓ | IntelliJ HTTP Client scratch file |
 | [HoppscotchChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/hoppscotch/HoppscotchChannel.kt) | ✓ | — | JSON file or direct upload to Hoppscotch |
+| [OpenApiChannel](../../src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiChannel.kt) | ✓ | — | `.json` or `.yaml` OpenAPI 3.0.3 document |
 
 If you just need to *serialize fields* of a `PsiClass` to a new representation
 (JSON, YAML, …), that's a [format](formats.md), not a channel.

--- a/src/main/kotlin/com/itangcent/easyapi/channel/curl/CurlRendererService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/curl/CurlRendererService.kt
@@ -8,7 +8,7 @@ import com.itangcent.easyapi.core.script.ScriptScope
 import com.itangcent.easyapi.core.settings.settings
 
 /**
- * Application-scoped implementation of [CurlRenderer] (Decision CO8).
+ * Application-scoped implementation of [CurlRenderer].
  *
  * Bridges the `core.*` callers (`ScriptApiEndpoint.toCurl`,
  * `ApiDashboardPanel` copy-as-cURL action) to the concrete `channel.curl.*`

--- a/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownChannel.kt
@@ -178,7 +178,7 @@ class MarkdownChannel : Channel, IdeaLog {
      * Accepts either a [MarkdownConfig] (channel-specific) or a
      * [ChannelConfig.FileConfig] (SPI base) for the [outputDir][MarkdownConfig.outputDir]
      * / [fileName][MarkdownConfig.fileName] fields — so callers that don't want
-     * to import `channel.markdown.*` can use the SPI base class (Decision CO3).
+     * to import `channel.markdown.*` can use the SPI base class.
      */
     private suspend fun resolveTargetFile(
         project: Project,

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiChannel.kt
@@ -1,0 +1,377 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.fileChooser.FileSaverDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileWrapper
+import com.itangcent.easyapi.channel.spi.Channel
+import com.itangcent.easyapi.channel.spi.ChannelConfig
+import com.itangcent.easyapi.channel.spi.ChannelOptionsPanel
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.export.isHttp
+import com.itangcent.easyapi.core.internal.threading.background
+import com.itangcent.easyapi.core.internal.threading.swing
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.rule.RuleKey
+import com.itangcent.easyapi.core.rule.engine.RuleEngine
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.settings
+import com.itangcent.easyapi.core.settings.ui.SettingsPanel
+import kotlinx.coroutines.CancellationException
+import java.io.File
+import kotlin.reflect.KClass
+
+/**
+ * [Channel] implementation for exporting HTTP API endpoints to an OpenAPI 3.0.3
+ * document.
+ *
+ * HTTP-only: gRPC endpoints are filtered out before formatting and a
+ * per-endpoint skip is logged at `info`. When the filtered set is empty,
+ * `export` returns `ExportResult.Error("No HTTP endpoints to export")`.
+ *
+ * Disabled by default — the user must opt in via Settings → General →
+ * "Export Channels". Marked as **beta**: the channel is functional but may
+ * have rough edges; `displayName` carries a "(Beta)" suffix to signal this
+ * to the user.
+ *
+ * ## Export flow
+ *
+ * 1. Partition `endpointsToExport` into HTTP / gRPC. Log each gRPC skip at
+ *    `info`. Error out if no HTTP endpoints remain.
+ * 2. Resolve the effective [OpenApiOutputFormat]. Precedence:
+ *    options-panel > persistent settings > built-in default (`ALWAYS_ASK`).
+ *    When `ALWAYS_ASK` is selected, [promptFormat] prompts the user on EDT
+ *    — throws [CancellationException] on cancel.
+ * 3. Resolve the rule-resolved [OpenApiEnvelope] via
+ *    [resolveRuleBasedEnvelope] — document-level metadata (`info.title`,
+ *    `info.version`, `info.description`, `server.url`) come from rule scripts
+ *    only. Built-in defaults: `infoTitle = projectName ?: "API"`,
+ *    `infoVersion = "1.0.0"`, others `null`.
+ * 4. Build the [OpenApiDocument] via [OpenApiFormatter] (pure).
+ * 5. Fire the `openapi.format.after` event — scripts can
+ *    mutate the in-memory document before serialization. The document is
+ *    exposed via the rule context extension `"document"`.
+ * 6. Serialize via [OpenApiSerializer] — JSON (Gson) or YAML (Jackson
+ *    `YAMLMapper`) depending on the effective format.
+ * 7. Wrap the document + format + pre-serialized content in
+ *    [OpenApiExportMetadata] and return `ExportResult.Success`.
+ *
+ * ## handleResult
+ *
+ * Writes the pre-serialized content to the user-chosen file using
+ * `background { }` for the I/O and `swing { }` for the success dialog (mirrors
+ * [com.itangcent.easyapi.channel.markdown.MarkdownChannel.handleResult] and
+ * [com.itangcent.easyapi.channel.hoppscotch.HoppscotchChannel.handleFileExport]).
+ *
+ * Default file name is `openapi.json` or `openapi.yaml` based on the format.
+ * Throws [CancellationException] when the user cancels the save dialog so the
+ * orchestrator can propagate the cancellation.
+ *
+ * ## Logging
+ *
+ * Implements [IdeaLog]; uses `LOG.info` for entry / per-skip / completion
+ * milestones and `LOG.warn` for recoverable failures. No `LOG.error` /
+ * `LOG.debug` / `LOG.trace` (AGENTS.md §"Logging" → Anti-patterns).
+ *
+ * @see OpenApiFormatter for the conversion core (pure)
+ * @see OpenApiSerializer for the JSON + YAML serializers (pure, channel-local)
+ * @see OpenApiOptionsPanel for the per-export options panel
+ * @see OpenApiSettingsPanel for the persistent settings tab
+ * @see OpenApiEnvelope for the rule-resolved envelope data carrier
+ */
+class OpenApiChannel : Channel, IdeaLog {
+
+    override val id: String = "openapi"
+    override val displayName: String = "OpenAPI (Beta)"
+    override val supportsGrpc: Boolean = false
+    override val exposeAsAction: Boolean = true
+    override val actionText: String = "Export to OpenAPI"
+    override val enabledByDefault: Boolean = false
+    override val beta: Boolean = true
+    override val settingsType: KClass<out Settings> = OpenApiSettings::class
+
+    override fun createOptionsPanel(project: Project): ChannelOptionsPanel? =
+        OpenApiOptionsPanel(project)
+
+    override fun createSettingsPanel(project: Project): SettingsPanel<*>? =
+        OpenApiSettingsPanel(project)
+
+    override fun configFiles(): List<String> = emptyList()
+
+    override fun ruleKeys(): List<RuleKey<*>> = RuleKey.collectFrom(OpenApiRuleKeys)
+
+    override suspend fun export(context: ExportContext): ExportResult {
+        LOG.info("OpenApiChannel.export: endpoints=${context.endpointsToExport.size}")
+        val project = context.project
+
+        // 1. Filter — keep HTTP only, log gRPC skips at info.
+        val (httpEndpoints, grpcEndpoints) = context.endpointsToExport.partition { it.isHttp }
+        grpcEndpoints.forEach { ep ->
+            LOG.info(
+                "Skipping gRPC endpoint (OpenAPI does not represent gRPC): " +
+                        (ep.name ?: ep.sourceMethod?.name ?: "<unknown>")
+            )
+        }
+        if (httpEndpoints.isEmpty()) {
+            return ExportResult.Error("No HTTP endpoints to export")
+        }
+
+        // 2. Resolve the effective output format.
+        //    Precedence: options-panel > settings > built-in default (ALWAYS_ASK).
+        //    When ALWAYS_ASK is selected, prompt the user on EDT — throws
+        //    CancellationException on cancel.
+        val settings = project.settings<OpenApiSettings>()
+        val typed = (context.channelConfig as? OpenApiConfig) ?: OpenApiConfig()
+        val typedFormat = typed.outputFormat
+        val effectiveFormat = when (typedFormat) {
+            OpenApiOutputFormat.ALWAYS_ASK -> {
+                // If the typed config is ALWAYS_ASK, defer to the settings; if
+                // settings is ALSO ALWAYS_ASK, prompt the user.
+                val settingsFormat = OpenApiConfig.parseOutputFormat(settings.outputFormat)
+                when (settingsFormat) {
+                    OpenApiOutputFormat.ALWAYS_ASK -> promptFormat(project)
+                    else -> settingsFormat
+                }
+            }
+            else -> typedFormat
+        }
+
+        // 3. Resolve envelope metadata from rules only.
+        //    No settings/options-panel fallback for these fields.
+        val envelope = resolveRuleBasedEnvelope(project, project.name)
+
+        // 4. Build the document (pure — no rule engine, no I/O).
+        val formatter = OpenApiFormatter(project)
+        val document = formatter.format(httpEndpoints, envelope)
+
+        // 5. Fire openapi.format.after event.
+        //    Scripts can mutate the in-memory document before serialization.
+        fireFormatAfterEvent(project, httpEndpoints, document)
+
+        // 6. Serialize. ALWAYS_ASK is already resolved above.
+        val content = when (effectiveFormat) {
+            OpenApiOutputFormat.JSON -> OpenApiSerializer.toJson(document)
+            OpenApiOutputFormat.YAML -> OpenApiSerializer.toYaml(document)
+            OpenApiOutputFormat.ALWAYS_ASK -> error("unreachable — ALWAYS_ASK resolved at step 2")
+        }
+
+        return ExportResult.Success(
+            count = httpEndpoints.size,
+            target = "OpenAPI",
+            metadata = OpenApiExportMetadata(document, effectiveFormat, content),
+        )
+    }
+
+    // ─── ALWAYS_ASK prompt ────────────────────────────────────────────
+
+    /**
+     * Shows a `Messages.showChooseDialog` on EDT prompting the user to pick
+     * JSON / YAML. Throws [CancellationException] on cancel.
+     * Mirrors `CurlExportResolver.resolveRenderMode` `ALWAYS_ASK` pattern.
+     *
+     * @requires EDT (called via [swing]); the caller is responsible for
+     *  wrapping with `swing { ... }`.
+     */
+    private suspend fun promptFormat(project: Project): OpenApiOutputFormat = swing {
+        val choice = Messages.showChooseDialog(
+            project,
+            "Select output format for OpenAPI export:",
+            "OpenAPI Export - Format",
+            Messages.getQuestionIcon(),
+            arrayOf("JSON", "YAML"),
+            "JSON",
+        )
+        when (choice) {
+            -1 -> throw CancellationException("User cancelled format selection")
+            0 -> OpenApiOutputFormat.JSON
+            else -> OpenApiOutputFormat.YAML
+        }
+    }
+
+    // ─── Rule evaluation (envelope, not config) ─────────────────────
+
+    /**
+     * Evaluates the document-metadata rule keys ONCE per export operation
+     * (without an element context) and returns the resolved envelope.
+     *
+     * Document-level rule keys
+     * (`openapi.info.title`, `openapi.info.version`, `openapi.info.description`,
+     * `openapi.server.url`, `openapi.host`) describe the WHOLE document —
+     * there is only one `info` block and one `servers` array per OpenAPI
+     * document. Evaluating them per `sourceClass` (the previous behaviour)
+     * was incorrect because:
+     *
+     * 1. The extension config files (`swagger3-openapi.config`,
+     *    `swagger-openapi.config`, `springfox-openapi.config`) now use
+     *    `helper.findClassesByAnnotation(...)` / `helper.findMethodsByAnnotation(...)`
+     *    to locate document-level annotations (`@OpenAPIDefinition`,
+     *    `@SwaggerDefinition`, Springfox `@Bean Docket`) GLOBALLY — they do
+     *    NOT reference `it` (the current element) at all. Evaluating them
+     *    once is both correct and sufficient.
+     * 2. Per-class evaluation produced redundant `helper.findClassesByAnnotation`
+     *    calls (one per controller class) for the same global result.
+     *
+     * The no-arg `ruleEngine.evaluate(key)` overload uses
+     * `RuleContext.withoutElement(project)` — the scripts still have access to
+     * the `helper` binding (which resolves the project from the rule context)
+     * and to `logger`/`LOG`. The `it` binding is an empty `ScriptItContext`
+     * with no PSI element; scripts that relied on `it.annMap(...)` (the old
+     * swagger3/swagger config files) would return null — but those files were
+     * rewritten to use `helper.findClassesByAnnotation(...)` instead,
+     * so this is no longer a concern.
+     *
+     * - `openapi.host` is evaluated first (legacy alias, parity with
+     *   `hopp.host` / `postman.host`), then `openapi.server.url` as the
+     *   OAS-native fallback.
+     * - Built-in defaults: `infoTitle = projectName ?: "API"`,
+     *   `infoVersion = "1.0.0"`, `infoDescription = null`, `serverUrl = null`.
+     *
+     * @requires ReadAction context (rule engine may access PSI via `helper.*`)
+     */
+    private suspend fun resolveRuleBasedEnvelope(
+        project: Project,
+        projectName: String?,
+    ): OpenApiEnvelope {
+        val ruleEngine = RuleEngine.getInstance(project)
+
+        // Document-level keys: evaluated once (no element context).
+        // The extension config scripts use `helper.findClassesByAnnotation(...)`
+        // / `helper.findMethodsByAnnotation(...)` which resolve the project
+        // from the rule context — they do not need an `it` element.
+        var infoTitle: String? = ruleEngine.evaluate(OpenApiRuleKeys.OPENAPI_INFO_TITLE)
+            ?.takeIf { it.isNotBlank() }
+        if (infoTitle != null) LOG.info("openapi.info.title resolved by rule")
+
+        var infoVersion: String? = ruleEngine.evaluate(OpenApiRuleKeys.OPENAPI_INFO_VERSION)
+            ?.takeIf { it.isNotBlank() }
+        if (infoVersion != null) LOG.info("openapi.info.version resolved by rule")
+
+        var infoDescription: String? = ruleEngine.evaluate(OpenApiRuleKeys.OPENAPI_INFO_DESCRIPTION)
+            ?.takeIf { it.isNotBlank() }
+        if (infoDescription != null) LOG.info("openapi.info.description resolved by rule")
+
+        // openapi.host is evaluated first (parity with hopp.host / postman.host),
+        // then openapi.server.url as the OAS-native fallback.
+        var serverUrl: String? = ruleEngine.evaluate(OpenApiRuleKeys.OPENAPI_HOST)
+            ?.takeIf { it.isNotBlank() }
+            ?: ruleEngine.evaluate(OpenApiRuleKeys.OPENAPI_SERVER_URL)
+                ?.takeIf { it.isNotBlank() }
+        if (serverUrl != null) LOG.info("openapi.server.url resolved by rule")
+
+        return OpenApiEnvelope(
+            infoTitle = infoTitle ?: projectName ?: "API",
+            infoVersion = infoVersion ?: "1.0.0",
+            infoDescription = infoDescription,
+            serverUrl = serverUrl,
+        )
+    }
+
+    /**
+     * Fires the `openapi.format.after` event against the first available
+     * `ApiEndpoint.sourceMethod`. The built [OpenApiDocument] is exposed to
+     * scripts via the rule context extension `"document"` — scripts can
+     * mutate it in place (e.g. inject vendor extensions, sort tags, scrub
+     * fields) before serialization.
+     *
+     * No-op when no `sourceMethod` is available or when no rules are defined
+     * for the key (the rule engine returns early in that case).
+     */
+    private suspend fun fireFormatAfterEvent(
+        project: Project,
+        httpEndpoints: List<ApiEndpoint>,
+        document: OpenApiDocument,
+    ) {
+        val firstMethod = httpEndpoints.firstNotNullOfOrNull { it.sourceMethod } ?: return
+        val ruleEngine = RuleEngine.getInstance(project)
+        ruleEngine.evaluate(OpenApiRuleKeys.OPENAPI_FORMAT_AFTER, firstMethod) { ctx ->
+            ctx.setExt("document", document)
+        }
+    }
+
+    override suspend fun handleResult(
+        project: Project,
+        result: ExportResult.Success,
+        config: ChannelConfig,
+    ): Boolean {
+        val metadata = result.metadata as? OpenApiExportMetadata ?: return false
+
+        val defaultFileName = defaultFileName(metadata.outputFormat)
+        val targetFile = resolveTargetFile(project, config, defaultFileName)
+            ?: throw CancellationException("User cancelled file selection")
+
+        background {
+            targetFile.writeText(metadata.content)
+        }
+        LOG.info("OpenAPI exported to ${targetFile.absolutePath}")
+
+        swing {
+            Messages.showInfoMessage(
+                project,
+                "Successfully exported ${result.count} endpoints to ${targetFile.absolutePath}",
+                "Export API",
+            )
+        }
+        return true
+    }
+
+    /**
+     * Default output file name for the given [format].
+     */
+    private fun defaultFileName(format: OpenApiOutputFormat): String = when (format) {
+        OpenApiOutputFormat.JSON -> "openapi.json"
+        OpenApiOutputFormat.YAML -> "openapi.yaml"
+        OpenApiOutputFormat.ALWAYS_ASK -> error("unreachable — ALWAYS_ASK resolved at export step 2")
+    }
+
+    /**
+     * Resolves the target output file from the channel config.
+     *
+     * Accepts a [ChannelConfig.FileConfig] (SPI base) for the
+     * [outputDir][ChannelConfig.FileConfig.outputDir] /
+     * [fileName][ChannelConfig.FileConfig.fileName] fields. When `fileName` has
+     * no extension, the format-specific extension (`.json` / `.yaml`) is
+     * appended; when `fileName` already carries an extension, it is used as-is.
+     *
+     * Returns `null` to signal "user must be prompted" — the caller then
+     * invokes [selectTargetFile] which throws [CancellationException] on
+     * cancel.
+     */
+    private suspend fun resolveTargetFile(
+        project: Project,
+        config: ChannelConfig?,
+        defaultFileName: String,
+    ): File? {
+        val fileConfig = config as? ChannelConfig.FileConfig
+        val outputDir = fileConfig?.outputDir
+        val fileName = fileConfig?.fileName
+        if (!outputDir.isNullOrBlank()) {
+            val dir = File(outputDir)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            val name = when {
+                fileName.isNullOrBlank() -> defaultFileName
+                fileName.contains('.') -> fileName
+                else -> "$fileName.${defaultFileName.substringAfterLast('.')}"
+            }
+            return File(dir, name)
+        }
+        return selectTargetFile(project, defaultFileName)
+    }
+
+    private suspend fun selectTargetFile(project: Project, defaultFileName: String): File? {
+        return swing {
+            val descriptor = FileSaverDescriptor(
+                "Save OpenAPI Document",
+                "Choose where to save the OpenAPI document",
+            )
+            val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
+            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, defaultFileName)
+            wrapper?.file
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiConfig.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiConfig.kt
@@ -1,0 +1,58 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.channel.spi.ChannelConfig
+import com.itangcent.easyapi.core.logging.IdeaLog
+
+/**
+ * Selected output format for the OpenAPI channel.
+ *
+ * - `JSON` — serialize via Gson (default-of-defaults when stored values are
+ *   unrecognized, see [parseOutputFormat]).
+ * - `YAML` — serialize via Jackson `YAMLMapper`.
+ * - `ALWAYS_ASK` — prompt the user on EDT with a `Messages.showChooseDialog`
+ *   for JSON / YAML at export time. Default for both `OpenApiConfig` and
+ *   `OpenApiSettings`.
+ *
+ * Defined early so that the formatter / channel can already reference a
+ * stable type.
+ */
+enum class OpenApiOutputFormat { JSON, YAML, ALWAYS_ASK }
+
+/**
+ * Per-export configuration for the OpenAPI channel.
+ *
+ * Built by `OpenApiOptionsPanel` from the export dialog. For the quick-export
+ * path (no options panel shown), the effective config is built directly from
+ * `OpenApiSettings.outputFormat` via [parseOutputFormat].
+ *
+ * The v1 `infoTitle` / `infoVersion` /
+ * `infoDescription` / `serverUrl` fields were removed — those values vary
+ * per project and belong in rule scripts (see `swagger3-openapi.config` /
+ * `swagger-openapi.config` / `springfox-openapi.config`). The channel now
+ * carries rule-resolved envelope metadata in an internal [OpenApiEnvelope]
+ * between channel and formatter.
+ *
+ * `outputFormat` is the only field here — it is consumed by
+ * `OpenApiChannel.export` to pick the serializer. `OpenApiFormatter` does not
+ * read it.
+ */
+data class OpenApiConfig(
+    val outputFormat: OpenApiOutputFormat = OpenApiOutputFormat.ALWAYS_ASK,
+) : ChannelConfig() {
+
+    companion object : IdeaLog {
+
+        /**
+         * Parses the persistent [OpenApiSettings.outputFormat] string into the
+         * enum. Falls back to JSON and logs a warning when the stored value is
+         * unrecognized (e.g. corrupted state or a future format name).
+         *
+         * Note: `ALWAYS_ASK` is a valid stored value (default for new
+         * installations); only truly unrecognized values fall back.
+         */
+        internal fun parseOutputFormat(value: String): OpenApiOutputFormat =
+            runCatching { OpenApiOutputFormat.valueOf(value.uppercase()) }
+                .onFailure { LOG.warn("Unrecognized outputFormat '$value', defaulting to JSON", it) }
+                .getOrDefault(OpenApiOutputFormat.JSON)
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiDocument.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiDocument.kt
@@ -1,0 +1,154 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.google.gson.annotations.SerializedName
+import com.itangcent.easyapi.core.export.HttpMethod
+
+/**
+ * OpenAPI 3.0.3 document tree (data-class subset emitted by EasyApi's
+ * OpenAPI export channel).
+ *
+ * Designed for clean serialization via both Gson (JSON output) and Jackson
+ * `YAMLMapper` (YAML output). All fields are nullable except the OAS-required
+ * ones; optional fields are suppressed on the wire via
+ * `serializeNulls()` off (Gson) and `@JsonInclude(NON_NULL)` (Jackson).
+ *
+ * [paths], [OperationObject.responses], [RequestBodyObject.content],
+ * [MediaTypeObject.content]-less shapes, [ComponentsObject.schemas], and
+ * [SchemaObject.properties] use [LinkedHashMap] to preserve insertion order
+ * for byte-stable output across runs.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OpenApiDocument(
+    val openapi: String = "3.0.3",
+    val info: InfoObject,
+    val servers: List<ServerObject>? = null,
+    val tags: List<TagObject>? = null,
+    val paths: LinkedHashMap<String, PathItemObject>,
+    val components: ComponentsObject? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class InfoObject(
+    val title: String,
+    val version: String,
+    val description: String? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ServerObject(
+    val url: String,
+    val description: String? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class TagObject(
+    val name: String,
+    val description: String? = null,
+)
+
+/**
+ * OAS Path Item Object. Each HTTP method is a nullable field; absent methods
+ * are omitted from serialized output (with `serializeNulls()` off / NON_NULL).
+ *
+ * `withMethod` returns a `copy(...)` so the [PathItemObject] is effectively
+ * immutable from the formatter's perspective.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class PathItemObject(
+    val get: OperationObject? = null,
+    val post: OperationObject? = null,
+    val put: OperationObject? = null,
+    val delete: OperationObject? = null,
+    val patch: OperationObject? = null,
+    val head: OperationObject? = null,
+    val options: OperationObject? = null,
+) {
+    /** Returns a copy of this [PathItemObject] with [method] set to [op]. */
+    fun withMethod(method: HttpMethod, op: OperationObject): PathItemObject = when (method) {
+        HttpMethod.GET -> copy(get = op)
+        HttpMethod.POST -> copy(post = op)
+        HttpMethod.PUT -> copy(put = op)
+        HttpMethod.DELETE -> copy(delete = op)
+        HttpMethod.PATCH -> copy(patch = op)
+        HttpMethod.HEAD -> copy(head = op)
+        HttpMethod.OPTIONS -> copy(options = op)
+        HttpMethod.NO_METHOD -> this
+    }
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OperationObject(
+    val tags: List<String>? = null,
+    val summary: String? = null,
+    val description: String? = null,
+    val operationId: String,
+    val parameters: List<ParameterObject>? = null,
+    val requestBody: RequestBodyObject? = null,
+    val responses: LinkedHashMap<String, ResponseObject>,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ParameterObject(
+    val name: String,
+    @param:JsonProperty("in") @get:JsonProperty("in") val `in`: String,
+    val description: String? = null,
+    val required: Boolean = false,
+    val schema: SchemaObject,
+    val example: Any? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class RequestBodyObject(
+    val description: String? = null,
+    val content: LinkedHashMap<String, MediaTypeObject>,
+    val required: Boolean = false,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class MediaTypeObject(
+    val schema: SchemaObject,
+    val example: Any? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ResponseObject(
+    val description: String,
+    val content: LinkedHashMap<String, MediaTypeObject>? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ComponentsObject(
+    val schemas: LinkedHashMap<String, SchemaObject>? = null,
+)
+
+/**
+ * OAS Schema Object. Holds EITHER a `$ref` OR inline fields — never both.
+ *
+ * Field-name workaround:
+ * - `$ref`, `enum`, `x-enumDescriptions` contain characters that are illegal
+ *   in plain Kotlin identifiers; they are stored under Kotlin-safe source
+ *   names (`ref` / `enumValues` / `xEnumDescriptions`) and aliased to their
+ *   OAS wire names via `@SerializedName` (Gson) and `@JsonProperty` (Jackson).
+ *
+ * Note: Kotlin data-class constructor parameters don't auto-propagate
+ * `@JsonProperty` to the getter without `jackson-module-kotlin` registered.
+ * The `@get:JsonProperty(...)` use-site target is added alongside so Jackson
+ * serialization picks up the OAS wire names (`$ref`/`enum`/`x-enumDescriptions`)
+ * rather than the Kotlin-safe source identifiers.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class SchemaObject(
+    @SerializedName("\$ref") @get:JsonProperty("\$ref") val `$ref`: String? = null,
+    val type: String? = null,
+    val format: String? = null,
+    val description: String? = null,
+    val properties: LinkedHashMap<String, SchemaObject>? = null,
+    val additionalProperties: SchemaObject? = null,
+    val items: SchemaObject? = null,
+    val required: List<String>? = null,
+    @SerializedName("enum") @get:JsonProperty("enum") val enumValues: List<Any>? = null,
+    val example: Any? = null,
+    @SerializedName("x-enumDescriptions") @get:JsonProperty("x-enumDescriptions") val xEnumDescriptions: Map<String, String>? = null,
+)

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiEnvelope.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiEnvelope.kt
@@ -1,0 +1,33 @@
+package com.itangcent.easyapi.channel.openapi
+
+/**
+ * Resolved envelope metadata for the document (info + servers). Built by
+ * `OpenApiChannel.resolveRuleBasedEnvelope` from rule evaluation; consumed
+ * by [OpenApiFormatter.format].
+ *
+ * NOT a [com.itangcent.easyapi.channel.spi.ChannelConfig] subtype — it is
+ * `internal` to the channel package and not exposed through the SPI.
+ *
+ * Replaces the v1 `OpenApiConfig.infoTitle` /
+ * `infoVersion` / `infoDescription` / `serverUrl` fields that were removed.
+ * Those values vary per project and belong in rule scripts (see
+ * `swagger3-openapi.config` / `swagger-openapi.config` /
+ * `springfox-openapi.config`); the channel resolves them via the rule engine
+ * into this envelope, then hands the envelope to the pure formatter.
+ *
+ * @param infoTitle resolved from `openapi.info.title` rules; falls back to
+ *   the project name (or `"API"` when the project is unnamed) when no rule
+ *   produces a value — never `null`.
+ * @param infoVersion resolved from `openapi.info.version` rules; falls back
+ *   to `"1.0.0"` when no rule produces a value — never `null`.
+ * @param infoDescription resolved from `openapi.info.description` rules;
+ *   `null` when no rule produces a value (formatter omits the field).
+ * @param serverUrl resolved from `openapi.server.url` / `openapi.host`
+ *   rules; `null` when no rule produces a value (formatter omits `servers`).
+ */
+internal data class OpenApiEnvelope(
+    val infoTitle: String,
+    val infoVersion: String,
+    val infoDescription: String?,
+    val serverUrl: String?,
+)

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiExportMetadata.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiExportMetadata.kt
@@ -1,0 +1,36 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.export.ExportMetadata
+
+/**
+ * Export metadata for the OpenAPI channel.
+ *
+ * Carried inside `ExportResult.Success` by `OpenApiChannel.export`. The
+ * `document` and `content` are pre-computed in `export` so that
+ * `handleResult` can write the file without re-serializing — this keeps
+ * `handleResult` free of `OpenApiSerializer` / `OpenApiDocument` awareness
+ * (it just sees a String).
+ *
+ * `formatDisplay()` is shown to the user via the export-result notification
+ * — it returns a short label identifying which format was produced, so the
+ * user can tell at a glance whether they got JSON or YAML.
+ *
+ * @property document the in-memory [OpenApiDocument] — preserved so future
+ *   channel extensions (e.g., a "preview in editor" action) can re-serialize
+ *   to a different format without re-running the formatter.
+ * @property outputFormat the format that was produced (drives `formatDisplay`
+ *   and the file-name extension in `handleResult`).
+ * @property content the already-serialized document string (JSON or YAML).
+ *   `handleResult` writes this verbatim to the output file.
+ */
+data class OpenApiExportMetadata(
+    val document: OpenApiDocument,
+    val outputFormat: OpenApiOutputFormat,
+    val content: String,
+) : ExportMetadata {
+    override fun formatDisplay(): String? = when (outputFormat) {
+        OpenApiOutputFormat.JSON -> "Format: JSON"
+        OpenApiOutputFormat.YAML -> "Format: YAML"
+        OpenApiOutputFormat.ALWAYS_ASK -> error("unreachable — ALWAYS_ASK is resolved to JSON/YAML at OpenApiChannel.export step 2 before this metadata is constructed")
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiFormatter.kt
@@ -1,0 +1,404 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ApiParameter
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.HttpMetadata
+import com.itangcent.easyapi.core.export.ParameterBinding
+import com.itangcent.easyapi.core.export.ParameterType
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.intellij.openapi.project.Project
+
+/**
+ * Pure `List<ApiEndpoint> → OpenApiDocument` converter.
+ *
+ * Holds [project] only for future rule hooks; v1 ignores it inside [format]
+ * (the `openapi.host` rule is evaluated in `OpenApiChannel.export`).
+ *
+ * The formatter is non-`suspend` and pure — no rule-engine lookup, no I/O, no
+ * PSI access. This makes it unit-testable with plain JUnit + mockito-kotlin.
+ *
+ * Logging follows AGENTS.md §"Logging": per-endpoint skips log at `info`;
+ * collisions / path-normalization failures at `warn`. The class
+ * implements [IdeaLog] so `LOG.info` / `LOG.warn` mirror to `idea.log` and the
+ * CI `AntiPatternGateTest` accepts it.
+ */
+class OpenApiFormatter(private val project: Project) : IdeaLog {
+
+    /**
+     * Builds an [OpenApiDocument] from [endpoints] using the rule-resolved
+     * [envelope] for the document envelope (`info`, `servers`).
+     *
+     * Signature takes [OpenApiEnvelope]
+     * (rule-resolved, internal to the channel package) instead of
+     * [OpenApiConfig]. The formatter is no longer concerned with
+     * `outputFormat` — that's consumed by `OpenApiChannel.export`.
+     *
+     * Iterates endpoints once. Path collapse is via
+     * `PathItemObject.withMethod` (copy-based). gRPC endpoints
+     * are defensively skipped here even though `OpenApiChannel.export`
+     * filters them first.
+     */
+    internal fun format(endpoints: List<ApiEndpoint>, envelope: OpenApiEnvelope): OpenApiDocument {
+        val usedOperationIds = mutableSetOf<String>()
+        val paths = linkedMapOf<String, PathItemObject>()
+        val tagOrder = linkedSetOf<String>()
+        val schemaConverter = OpenApiSchemaConverter()
+
+        for (endpoint in endpoints) {
+            // Defensively skip non-HTTP endpoints. OpenApiChannel.export
+            // filters first, but the formatter must be robust to a gRPC endpoint
+            // slipping through.
+            val meta = endpoint.httpMetadata
+            if (meta == null) {
+                LOG.info("Skipping non-HTTP endpoint (OpenAPI represents HTTP only): ${endpoint.name ?: "<unknown>"}")
+                continue
+            }
+
+            // Normalize the path before grouping / emission.
+            val normalizedPath = PathNormalizer.normalize(meta.path)
+            if (normalizedPath == null) {
+                LOG.warn("Skipping endpoint with un-normalizable path: ${meta.path}")
+                continue
+            }
+
+            // Resolve a document-unique operationId.
+            val opIdResult = OperationIdResolver.resolve(meta, endpoint.sourceMethod, usedOperationIds)
+
+            val operation = buildOperation(endpoint, meta, opIdResult.operationId, schemaConverter, tagOrder)
+
+            // Collapse by normalized path (one PathItem per path).
+            // PathItemObject is val-only; withMethod returns a copy.
+            val existing = paths.getOrPut(normalizedPath) { PathItemObject() }
+            paths[normalizedPath] = existing.withMethod(meta.method, operation)
+        }
+
+        return OpenApiDocument(
+            info = InfoObject(
+                title = envelope.infoTitle,
+                version = envelope.infoVersion,
+                description = envelope.infoDescription,
+            ),
+            servers = envelope.serverUrl?.let { listOf(ServerObject(it)) },
+            tags = tagOrder.takeIf { it.isNotEmpty() }?.map { TagObject(it) },
+            paths = paths,
+            components = schemaConverter.buildComponents().takeIf { it.schemas?.isNotEmpty() == true },
+        )
+    }
+
+    // ─── Operation assembly ────────────────────────────────────────────────
+
+    /**
+     * Wires parameters, request body, responses, tags, summary/description,
+     * and operationId into a single [OperationObject].
+     */
+    private fun buildOperation(
+        endpoint: ApiEndpoint,
+        meta: HttpMetadata,
+        opId: String,
+        schemaConverter: OpenApiSchemaConverter,
+        tagOrder: MutableSet<String>,
+    ): OperationObject {
+        val tag = resolveTag(endpoint, tagOrder)
+        val parameters = buildParameters(meta)
+        val requestBody = buildRequestBody(meta, schemaConverter)
+        val responses = buildResponses(meta, schemaConverter)
+
+        return OperationObject(
+            tags = tag?.let { listOf(it) },
+            summary = endpoint.name,
+            description = endpoint.description,
+            operationId = opId,
+            parameters = parameters.takeIf { it.isNotEmpty() },
+            requestBody = requestBody,
+            responses = responses,
+        )
+    }
+
+    /**
+     * Resolves the operation's tag: `endpoint.folder` when
+     * present and non-blank, else the simple name of `endpoint.className`
+     * (last `.`-segment). Returns `null` when neither is available — the
+     * operation's `tags` field is then `null` (omitted on the wire).
+     *
+     * Resolved tags are also added to [tagOrder] so the document-level
+     * `tags` array preserves first-appearance order and is
+     * deduplicated by name (LinkedHashSet semantics).
+     */
+    private fun resolveTag(endpoint: ApiEndpoint, tagOrder: MutableSet<String>): String? {
+        val tag = endpoint.folder?.takeIf { it.isNotBlank() }
+            ?: endpoint.className?.substringAfterLast('.')?.takeIf { it.isNotBlank() }
+        if (tag != null) {
+            tagOrder.add(tag)
+        }
+        return tag
+    }
+
+    // ─── Parameter mapping ─────────────────────────────────────────
+
+    /**
+     * Builds the OAS Parameter Object list for one operation.
+     *
+     * - Query → `in: query`
+     * - Path → `in: path`, `required: true` (OAS mandates path params are required)
+     * - Header → `in: header`
+     * - Cookie → `in: cookie`
+     * - Body / Form / Ignored → dropped — body/form are covered by
+     *   the request body; ignored is dropped silently.
+     *
+     * `ApiHeader` (request headers) are added as `in: header` parameters
+     * after the typed parameters, deduplicated by name against any
+     * header-typed `ApiParameter` already emitted for the same operation.
+     *
+     * `example` is populated from `ApiParameter.example` (or `defaultValue`
+     * as fallback) when present. `enum` is populated when
+     * `ApiParameter.enumValues` is non-empty.
+     */
+    private fun buildParameters(meta: HttpMetadata): List<ParameterObject> {
+        val parameters = mutableListOf<ParameterObject>()
+        val seenHeaderNames = mutableSetOf<String>()
+
+        for (param in meta.parameters) {
+            val binding = param.binding ?: continue
+            val parameterObject = when (binding) {
+                is ParameterBinding.Query -> ParameterObject(
+                    name = param.name,
+                    `in` = "query",
+                    required = param.required,
+                    description = param.description,
+                    schema = schemaForParameter(param),
+                    example = param.example ?: param.defaultValue,
+                )
+                is ParameterBinding.Path -> ParameterObject(
+                    name = param.name,
+                    `in` = "path",
+                    required = true,
+                    description = param.description,
+                    schema = schemaForParameter(param),
+                    example = param.example ?: param.defaultValue,
+                )
+                is ParameterBinding.Header -> {
+                    seenHeaderNames.add(param.name)
+                    ParameterObject(
+                        name = param.name,
+                        `in` = "header",
+                        required = param.required,
+                        description = param.description,
+                        schema = schemaForParameter(param),
+                        example = param.example ?: param.defaultValue,
+                    )
+                }
+                is ParameterBinding.Cookie -> ParameterObject(
+                    name = param.name,
+                    `in` = "cookie",
+                    required = param.required,
+                    description = param.description,
+                    schema = schemaForParameter(param),
+                    example = param.example ?: param.defaultValue,
+                )
+                is ParameterBinding.Body,
+                is ParameterBinding.Form,
+                is ParameterBinding.Ignored -> continue
+            }
+            parameters.add(parameterObject)
+        }
+
+        // ApiHeader (request headers) become header-typed Parameters,
+        // deduplicated against header-typed ApiParameters already emitted.
+        for (header in meta.headers) {
+            if (header.name in seenHeaderNames) continue
+            parameters.add(
+                ParameterObject(
+                    name = header.name,
+                    `in` = "header",
+                    required = header.required,
+                    description = header.description,
+                    schema = SchemaObject(type = "string"),
+                    example = header.example ?: header.value,
+                ),
+            )
+        }
+
+        return parameters
+    }
+
+    /**
+     * Builds the OAS Schema for a parameter. Defaults to `(string, null)`;
+     * file-typed parameters use `(string, binary)` — used
+     * when an array-of-files needs `items` with the binary shape.
+     * `enumValues` is forwarded as the schema's `enum`.
+     */
+    private fun schemaForParameter(param: ApiParameter): SchemaObject {
+        val base = if (param.type == ParameterType.FILE) {
+            SchemaObject(type = "string", format = "binary")
+        } else {
+            SchemaObject(type = "string")
+        }
+        val enumValues = param.enumValues?.takeIf { it.isNotEmpty() }
+        return if (enumValues != null) base.copy(enumValues = enumValues) else base
+    }
+
+    // ─── Request body mapping ──────────────────────────────────────
+
+    /**
+     * Builds the OAS Request Body Object for one operation. Returns `null`
+     * when no body should be emitted.
+     *
+     * - GET / HEAD / DELETE never carry a request body.
+     * - `multipart/form-data` (or any `ParameterType.FILE` param)
+     *   → multipart schema with `type: string, format: binary` per file.
+     * - `application/x-www-form-urlencoded` with form params →
+     *   form-urlencoded schema built from form parameters.
+     * - `application/json` with a non-null `HttpMetadata.body` →
+     *   JSON schema derived via [OpenApiSchemaConverter].
+     * - Body-capable method but no body model and no form params
+     *   → `null` (no request body emitted).
+     */
+    private fun buildRequestBody(
+        meta: HttpMetadata,
+        schemaConverter: OpenApiSchemaConverter,
+    ): RequestBodyObject? {
+        // GET / HEAD / DELETE never carry a request body.
+        if (meta.method in BODY_SUPPRESSED_METHODS) return null
+
+        val contentType = meta.contentType ?: "application/json"
+        val formParams = meta.parameters.filter { it.binding == ParameterBinding.Form }
+        val hasFileParam = meta.parameters.any { it.type == ParameterType.FILE }
+        val required = formParams.any { it.required }
+
+        // Multipart for files.
+        if (contentType.contains("multipart/form-data") || hasFileParam) {
+            val schema = buildMultipartSchema(meta)
+            return RequestBodyObject(
+                content = linkedMapOf("multipart/form-data" to MediaTypeObject(schema = schema)),
+                required = required,
+            )
+        }
+
+        // Form-urlencoded.
+        if (contentType.contains("application/x-www-form-urlencoded") && formParams.isNotEmpty()) {
+            val schema = buildFormSchema(formParams)
+            return RequestBodyObject(
+                content = linkedMapOf(
+                    "application/x-www-form-urlencoded" to MediaTypeObject(schema = schema),
+                ),
+                required = required,
+            )
+        }
+
+        // JSON body.
+        if (meta.body != null) {
+            val schema = schemaConverter.convert(meta.body, nameHint = meta.bodyAttr)
+                ?: SchemaObject(type = "object")
+            return RequestBodyObject(
+                content = linkedMapOf("application/json" to MediaTypeObject(schema = schema)),
+                required = false,
+            )
+        }
+
+        // Body-capable method but no body / form params.
+        return null
+    }
+
+    /**
+     * Builds the multipart schema from form parameters. Each file-typed
+     * parameter emits `type: string, format: binary`.
+     */
+    private fun buildMultipartSchema(meta: HttpMetadata): SchemaObject {
+        val properties = linkedMapOf<String, SchemaObject>()
+        val required = mutableListOf<String>()
+        for (param in meta.parameters) {
+            if (param.binding != ParameterBinding.Form) continue
+            val schema = if (param.type == ParameterType.FILE) {
+                SchemaObject(type = "string", format = "binary")
+            } else {
+                SchemaObject(type = "string")
+            }
+            properties[param.name] = schema
+            if (param.required) required.add(param.name)
+        }
+        return SchemaObject(
+            type = "object",
+            properties = properties.takeIf { it.isNotEmpty() },
+            required = required.takeIf { it.isNotEmpty() },
+        )
+    }
+
+    /**
+     * Builds the form-urlencoded schema from form parameters. Each form
+     * parameter becomes a `type: string` property.
+     */
+    private fun buildFormSchema(formParams: List<ApiParameter>): SchemaObject {
+        val properties = linkedMapOf<String, SchemaObject>()
+        val required = mutableListOf<String>()
+        for (param in formParams) {
+            properties[param.name] = SchemaObject(type = "string")
+            if (param.required) required.add(param.name)
+        }
+        return SchemaObject(
+            type = "object",
+            properties = properties.takeIf { it.isNotEmpty() },
+            required = required.takeIf { it.isNotEmpty() },
+        )
+    }
+
+    // ─── Response mapping ──────────────────────────────────────────
+
+    /**
+     * Builds the `responses` map for one operation.
+     *
+     * - `responseBody` present → `200` with `application/json`
+     *   schema derived via [OpenApiSchemaConverter] (using `responseType`
+     *   as the name hint so the schema is registered under its simple class
+     *   name in components).
+     * - `responseType` only, no `responseBody` → `200` with
+     *   `description` naming the type, no inline schema.
+     * - Neither → `204` "No content", no `content` field.
+     *
+     * No error responses are synthesized. Every emitted Response
+     * Object includes a non-empty `description`.
+     */
+    private fun buildResponses(
+        meta: HttpMetadata,
+        schemaConverter: OpenApiSchemaConverter,
+    ): LinkedHashMap<String, ResponseObject> {
+        val responses = linkedMapOf<String, ResponseObject>()
+
+        when {
+            meta.responseBody != null -> {
+                // nameHint from responseType so the schema
+                // is registered under its simple class name in components.
+                val schema = schemaConverter.convert(meta.responseBody, nameHint = meta.responseType)
+                    ?: SchemaObject(type = "object")
+                responses["200"] = ResponseObject(
+                    description = "OK",
+                    content = linkedMapOf("application/json" to MediaTypeObject(schema = schema)),
+                )
+            }
+            meta.responseType != null -> {
+                // Description naming the type, no inline schema.
+                responses["200"] = ResponseObject(
+                    description = "Response type: ${meta.responseType}",
+                )
+            }
+            else -> {
+                // Void → 204 No content.
+                responses["204"] = ResponseObject(
+                    description = "No content",
+                )
+            }
+        }
+
+        return responses
+    }
+
+    private companion object {
+        /** HTTP methods that MUST NOT carry a request body. */
+        private val BODY_SUPPRESSED_METHODS = setOf(
+            HttpMethod.GET,
+            HttpMethod.HEAD,
+            HttpMethod.DELETE,
+        )
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiOptionsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiOptionsPanel.kt
@@ -1,0 +1,89 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.intellij.openapi.project.Project
+import com.intellij.util.ui.FormBuilder
+import com.itangcent.easyapi.channel.spi.ChannelOptionsPanel
+import com.itangcent.easyapi.core.logging.IdeaLog
+import java.awt.FlowLayout
+import javax.swing.ButtonGroup
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JRadioButton
+
+/**
+ * Per-export options panel for the OpenAPI channel.
+ *
+ * The v1 envelope fields (`infoTitle` / `infoVersion` / `infoDescription` /
+ * `serverUrl`) were removed — those values vary per project and belong in
+ * rule scripts. The options panel now exposes ONLY a two-way format
+ * selector:
+ *
+ *  - **JSON** (radio, default-selected)
+ *  - **YAML** (radio)
+ *
+ * The "Always Ask" option is NOT exposed here — the panel itself is the
+ * per-export prompt, so offering "Always Ask" would be redundant (it would
+ * just trigger a second `Messages.showChooseDialog` inside `export()`).
+ * "Always Ask" remains available in [OpenApiSettings] as the persistent
+ * default: when the quick-export path is used (no options panel shown) and
+ * the setting is `ALWAYS_ASK`, `OpenApiChannel.export` prompts the user at
+ * export time.
+ *
+ * Mirrors the shape of
+ * [com.itangcent.easyapi.channel.hoppscotch.HoppscotchOptionsPanel] and
+ * [com.itangcent.easyapi.channel.curl.CurlOptionsPanel] (the latter uses
+ * a similar radio group for render-mode selection, including an
+ * `ALWAYS_ASK`-equivalent).
+ *
+ * @param project the IntelliJ project context (unused today but kept for
+ *  future rule-context lookups; consistent with the ChannelOptionsPanel SPI).
+ * @see OpenApiChannel
+ * @see OpenApiConfig
+ */
+class OpenApiOptionsPanel(@Suppress("UNUSED_PARAMETER") private val project: Project) :
+    ChannelOptionsPanel, IdeaLog {
+
+    private val jsonRadio = JRadioButton("JSON", true)
+    private val yamlRadio = JRadioButton("YAML", false)
+
+    init {
+        ButtonGroup().apply {
+            add(jsonRadio)
+            add(yamlRadio)
+        }
+    }
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addLabeledComponent(
+            "Format:",
+            JPanel(FlowLayout(FlowLayout.LEFT)).apply {
+                add(jsonRadio)
+                add(yamlRadio)
+            },
+        )
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    override fun buildConfig(): OpenApiConfig = OpenApiConfig(
+        outputFormat = if (yamlRadio.isSelected) OpenApiOutputFormat.YAML
+        else OpenApiOutputFormat.JSON,
+    )
+
+    /**
+     * Populates the radio selection from a pre-built [OpenApiConfig].
+     *
+     * Resets every radio so the panel reflects [cfg]. When [cfg.outputFormat]
+     * is `ALWAYS_ASK` (only reachable from [OpenApiSettings] — the panel
+     * itself never produces it), the panel falls back to JSON (the
+     * default-of-defaults) since there is no "Always Ask" radio to select.
+     */
+    fun applyConfig(cfg: OpenApiConfig) {
+        jsonRadio.isSelected = cfg.outputFormat != OpenApiOutputFormat.YAML
+        yamlRadio.isSelected = cfg.outputFormat == OpenApiOutputFormat.YAML
+    }
+
+    /** Test-visible setter for the format radio. */
+    internal fun setFormat(format: OpenApiOutputFormat) {
+        applyConfig(OpenApiConfig(outputFormat = format))
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiRuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiRuleKeys.kt
@@ -1,0 +1,99 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.rule.EventRuleMode
+import com.itangcent.easyapi.core.rule.RuleKey
+
+/**
+ * OpenAPI channel-specific rule keys.
+ *
+ * These rule keys allow users to customize OpenAPI export behavior via the
+ * rule engine (e.g., in `.easy.api.yml` files):
+ *
+ * | Rule Key | Purpose |
+ * |----------|---------|
+ * | `openapi.host` | Base URL override for the `servers` array (legacy; mirrored to `openapi.server.url`) |
+ * | `openapi.server.url` | Base URL override for the `servers` array (preferred OAS name) |
+ * | `openapi.info.title` | Document `info.title` override |
+ * | `openapi.info.version` | Document `info.version` override |
+ * | `openapi.info.description` | Document `info.description` override |
+ * | `openapi.format.after` | Post-format hook (fires after `OpenApiFormatter.format` completes, before serialization) |
+ *
+ * Channel-specific keys live in the channel package (DAG compliance —
+ * `core.rule.RuleKeys` owns the shared keys; channels own their own).
+ *
+ * Mirrors the [com.itangcent.easyapi.channel.hoppscotch.HoppscotchRuleKeys]
+ * pattern — `object` with `RuleKey.string(...)` / `RuleKey.event(...)` vals;
+ * `RuleKey.collectFrom(OpenApiRuleKeys)` enumerates them via reflection.
+ *
+ * Document-metadata rule keys
+ * (`OPENAPI_INFO_TITLE` / `OPENAPI_INFO_VERSION` / `OPENAPI_INFO_DESCRIPTION`
+ * / `OPENAPI_SERVER_URL`) are evaluated once per export operation (without
+ * an element context) inside `OpenApiChannel.export` — the first non-blank
+ * result wins. The `openapi.host` key is kept as a legacy alias and is
+ * consulted as a fallback for `openapi.server.url`.
+ *
+ * @see com.itangcent.easyapi.core.rule.RuleKeys for general (shared) rule keys
+ */
+object OpenApiRuleKeys {
+    /**
+     * Base URL override for the OpenAPI `servers` array (legacy key).
+     *
+     * Evaluated against the PSI class/method context. When set, the value
+     * populates `servers[0].url` in the emitted document. Kept for backwards
+     * compatibility — new configs should prefer [OPENAPI_SERVER_URL]
+     * (the OAS-spec-aligned name). `OpenApiChannel.export` consults this key
+     * as a fallback when [OPENAPI_SERVER_URL] is blank.
+     */
+    val OPENAPI_HOST = RuleKey.string("openapi.host")
+
+    /**
+     * Base URL override for the OpenAPI `servers` array (preferred OAS name).
+     *
+     * Evaluated once per export operation inside `OpenApiChannel.export`.
+     * First non-blank result wins. Falls back to [OPENAPI_HOST], then to
+     * settings/options-panel values, then to the built-in default (no
+     * `servers` array emitted).
+     */
+    val OPENAPI_SERVER_URL = RuleKey.string("openapi.server.url")
+
+    /**
+     * Document `info.title` override.
+     *
+     * Evaluated once per export operation inside `OpenApiChannel.export`.
+     * First non-blank result wins. Precedence: options-panel > this rule >
+     * persistent settings > project name > `"API"` default.
+     */
+    val OPENAPI_INFO_TITLE = RuleKey.string("openapi.info.title")
+
+    /**
+     * Document `info.version` override.
+     *
+     * Evaluated once per export operation inside `OpenApiChannel.export`.
+     * First non-blank result wins. Precedence: options-panel > this rule >
+     * persistent settings > `"1.0.0"` default.
+     */
+    val OPENAPI_INFO_VERSION = RuleKey.string("openapi.info.version")
+
+    /**
+     * Document `info.description` override.
+     *
+     * Evaluated once per export operation inside `OpenApiChannel.export`.
+     * First non-blank result wins. Precedence: options-panel > this rule >
+     * persistent settings > `null` (omitted on the wire).
+     */
+    val OPENAPI_INFO_DESCRIPTION = RuleKey.string("openapi.info.description")
+
+    /**
+     * Post-format hook.
+     *
+     * Fires after `OpenApiFormatter.format(...)` completes and before
+     * `OpenApiSerializer.toJson`/`toYaml` serializes the document —
+     * scripts can mutate the in-memory `OpenApiDocument` (e.g., inject
+     * vendor extensions, scrub a field, sort tags).
+     *
+     * Uses [EventRuleMode.THROW_IN_ERROR] so a failing script surfaces
+     * the exception instead of being silently swallowed (matches the
+     * `hopp.format.after` / `postman.format.after` semantics).
+     */
+    val OPENAPI_FORMAT_AFTER = RuleKey.event("openapi.format.after", EventRuleMode.THROW_IN_ERROR)
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSchemaConverter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSchemaConverter.kt
@@ -1,0 +1,296 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.psi.model.FieldModel
+import com.itangcent.easyapi.core.psi.model.FieldOption
+import com.itangcent.easyapi.core.psi.model.ObjectModel
+
+/**
+ * Cycle-safe converter from EasyApi's [ObjectModel] to an OAS [SchemaObject]
+ * tree.
+ *
+ * The converter is pure and project-independent — it accumulates named
+ * schemas in an internal [components] map and exposes them via
+ * [buildComponents]. Cycles in the input [ObjectModel.Object] graph are
+ * detected via an immutable `seenIds` set passed by copy;
+ * on revisit, the converter returns a `$ref` rather than recursing infinitely.
+ *
+ * Schema-name resolution:
+ * - When a [nameHint] is provided, the FIRST occurrence registers the full
+ *   inlined schema in `components.schemas[<name>]` and the caller receives a
+ *   `$ref` to it. Subsequent calls with the same [nameHint] and matching
+ *   shape return the existing `$ref`.
+ * - When the shape differs, a `_2`, `_3`, … suffix is appended and a `warn`
+ *   is logged.
+ * - When no [nameHint] is available (anonymous body), the schema is inlined
+ *   at the call site; only on recursion (cycle) does it get a
+ *   `GeneratedSchemaN` name and a `$ref`.
+ */
+class OpenApiSchemaConverter : IdeaLog {
+
+    /** Mutable accumulator of named schemas → emitted as `components.schemas`. */
+    private val components: LinkedHashMap<String, SchemaObject> = linkedMapOf()
+
+    /** Tracks the resolved schema name (if any) for each visited [ObjectModel.Object] id. */
+    private val idToName: MutableMap<Int, String> = mutableMapOf()
+
+    /** Counter for `GeneratedSchemaN` synthesis. */
+    private var generatedCounter: Int = 0
+
+    /**
+     * Converts [model] into a [SchemaObject]. Returns `null` if [model] is null.
+     *
+     * - [nameHint]: hint for the schema name (typically the simple class name
+     *   from `responseType` / `bodyAttr`); package and generic args are
+     *   stripped. When provided, the schema is registered under that name in
+     *   `components.schemas` and the caller receives a `$ref`.
+     * - [seenIds]: immutable-by-copy cycle-detection set. Each
+     *   recursive call passes `LinkedHashSet(seenIds).apply { add(model.id) }`.
+     */
+    fun convert(
+        model: ObjectModel?,
+        nameHint: String? = null,
+        seenIds: LinkedHashSet<Int> = linkedSetOf(),
+    ): SchemaObject? {
+        if (model == null) return null
+
+        return when (model) {
+            is ObjectModel.Object -> {
+                // Cycle: the same Object.id has been visited along the current path.
+                if (model.id in seenIds) {
+                    val name = idToName[model.id] ?: allocateGeneratedName(model, seenIds)
+                    return SchemaObject(`$ref` = "#/components/schemas/$name")
+                }
+
+                // Same model already registered under a name → reuse $ref.
+                val existingName = idToName[model.id]
+                if (existingName != null) {
+                    return SchemaObject(`$ref` = "#/components/schemas/$existingName")
+                }
+
+                // First visit.
+                if (nameHint != null) {
+                    val simpleName = stripPackageAndGenerics(nameHint)
+                    registerWithShapeCheck(model, simpleName, seenIds)
+                } else {
+                    // Anonymous first visit — inline at the call site.
+                    buildObjectSchema(model, LinkedHashSet(seenIds).apply { add(model.id) })
+                }
+            }
+            is ObjectModel.Single -> primitiveSchema(model.type)
+            is ObjectModel.Array -> SchemaObject(
+                type = "array",
+                items = convert(model.item, nameHint = null, seenIds = seenIds),
+            )
+            is ObjectModel.MapModel -> SchemaObject(
+                type = "object",
+                additionalProperties = convert(model.valueType, nameHint = null, seenIds = seenIds),
+            )
+        }
+    }
+
+    /** Returns the accumulated named schemas as a [ComponentsObject]. */
+    fun buildComponents(): ComponentsObject =
+        ComponentsObject(schemas = components.takeIf { it.isNotEmpty() })
+
+    // ─── Name resolution ──────────────────────────────────────────
+
+    /**
+     * Registers [model] under [simpleName], after checking the existing entry
+     * (if any) for a shape match. On shape mismatch, finds the first free
+     * `_N` suffix (N ≥ 2), logs a `warn`, and registers under the new name.
+     *
+     * Sets `idToName[model.id]` BEFORE building the schema so recursive
+     * cycle-$refs pick up the correct name. If the name turns out to clash,
+     * `idToName` is updated to the resolved `_N` name and the schema is
+     * rebuilt so its internal $refs point to the correct name.
+     */
+    private fun registerWithShapeCheck(
+        model: ObjectModel.Object,
+        simpleName: String,
+        seenIds: LinkedHashSet<Int>,
+    ): SchemaObject {
+        // Tentatively assign so cycle recursion picks up `simpleName`.
+        idToName[model.id] = simpleName
+        val nextSeen = LinkedHashSet(seenIds).apply { add(model.id) }
+        val newSchema = buildObjectSchema(model, nextSeen)
+
+        val existing = components[simpleName]
+        if (existing == null) {
+            // Name is free → register and return $ref.
+            components[simpleName] = newSchema
+            return SchemaObject(`$ref` = "#/components/schemas/$simpleName")
+        }
+        if (existing == newSchema) {
+            // Same shape → reuse. Discard the freshly-built schema.
+            return SchemaObject(`$ref` = "#/components/schemas/$simpleName")
+        }
+
+        // Shape mismatch → find first free `_N` slot.
+        var n = 2
+        while (true) {
+            val candidate = "${simpleName}_$n"
+            val existingN = components[candidate]
+            if (existingN == null) {
+                // Free slot — rebuild with the correct name so cycle $refs
+                // point to `candidate`, not the tentative `simpleName`.
+                idToName[model.id] = candidate
+                val rebuilt = buildObjectSchema(model, nextSeen)
+                components[candidate] = rebuilt
+                LOG.warn("Schema name clash: '$simpleName' already used with a different shape; registering as '$candidate'")
+                return SchemaObject(`$ref` = "#/components/schemas/$candidate")
+            }
+            if (existingN == newSchema) {
+                // `_N` entry matches → reuse.
+                idToName[model.id] = candidate
+                return SchemaObject(`$ref` = "#/components/schemas/$candidate")
+            }
+            n++
+        }
+    }
+
+    /**
+     * Allocates a fresh `GeneratedSchemaN` name for an anonymous cyclic model.
+     * Registers the inline schema under the new name so future
+     * cycle-$refs resolve correctly.
+     */
+    private fun allocateGeneratedName(
+        model: ObjectModel.Object,
+        seenIds: LinkedHashSet<Int>,
+    ): String {
+        val name = "GeneratedSchema${++generatedCounter}"
+        idToName[model.id] = name
+        val nextSeen = LinkedHashSet(seenIds).apply { add(model.id) }
+        components[name] = buildObjectSchema(model, nextSeen)
+        return name
+    }
+
+    /**
+     * Strips package prefix and generic args from [name].
+     * `com.acme.Result<User>` → `Result`. `Result` → `Result`.
+     */
+    private fun stripPackageAndGenerics(name: String): String {
+        val noGenerics = name.substringBefore('<').trim()
+        val simple = noGenerics.substringAfterLast('.').trim()
+        return simple.ifBlank { name }
+    }
+
+    // ─── Inline schema construction ──────────────────────────────────────────
+
+    /**
+     * Builds an inline [SchemaObject] for [model]. Recurses into fields via
+     * [convert] so cycle detection applies. The caller must have added
+     * [model.id] to [seenIds] before calling.
+     */
+    private fun buildObjectSchema(
+        model: ObjectModel.Object,
+        seenIds: LinkedHashSet<Int>,
+    ): SchemaObject {
+        val properties = linkedMapOf<String, SchemaObject>()
+        val required = mutableListOf<String>()
+        for ((fieldName, fieldModel) in model.fields) {
+            val fieldSchema = convert(fieldModel.model, nameHint = null, seenIds = seenIds)
+                ?: continue
+            properties[fieldName] = enrichWithFieldMetadata(fieldSchema, fieldModel)
+            if (fieldModel.required) required.add(fieldName)
+        }
+        return SchemaObject(
+            type = "object",
+            properties = properties.takeIf { it.isNotEmpty() },
+            required = required.takeIf { it.isNotEmpty() },
+        )
+    }
+
+    /**
+     * Applies field-level enrichments (comment → description,
+     * options → enum + x-enumDescriptions, demo → example)
+     * to [base]. Returns [base] unchanged if no enrichment applies; otherwise
+     * returns a copy with the enriched fields populated.
+     */
+    private fun enrichWithFieldMetadata(base: SchemaObject, field: FieldModel): SchemaObject {
+        if (field.comment == null && field.options.isNullOrEmpty() && field.demo == null) {
+            return base
+        }
+        val description = field.comment ?: base.description
+        val enumValues: List<Any>? = field.options
+            ?.mapNotNull { it.value }
+            ?.takeIf { it.isNotEmpty() }
+            ?: base.enumValues
+        val enumDescs: Map<String, String>? = field.options
+            ?.mapNotNull { opt ->
+                val v = opt.value ?: return@mapNotNull null
+                opt.desc?.let { v.toString() to it }
+            }
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { pairs -> linkedMapOf<String, String>().apply { putAll(pairs) } }
+            ?: base.xEnumDescriptions
+        val example = field.demo ?: base.example
+        return base.copy(
+            description = description,
+            enumValues = enumValues,
+            xEnumDescriptions = enumDescs,
+            example = example,
+        )
+    }
+
+    /** Converts an option [value] of arbitrary type to its wire form. */
+    private fun FieldOption.wireValue(): Any? = value
+
+    // ─── Primitive type table ─────────────────────────────────────
+
+    /**
+     * Maps a Java/Kotlin type name to its OAS `(type, format)` pair. Match is
+     * case-insensitive substring. Unknown types default to
+     * `(string, null)`.
+     */
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun primitiveSchema(type: String): SchemaObject {
+        val t = type.lowercase()
+        return when {
+            // `byte[]` must be checked before `byte` (the latter → integer/int32).
+            t.contains("byte[]") || t.contains("binary") ->
+                SchemaObject(type = "string", format = "binary")
+
+            // datetime-family → string/date-time. Checked before `date` so that
+            // "datetime"/"date-time"/"zoneddatetime" all land here.
+            t.contains("datetime") || t.contains("date-time") ||
+                t.contains("timestamp") || t.contains("instant") ||
+                t.contains("zoneddatetime") ->
+                SchemaObject(type = "string", format = "date-time")
+
+            // Plain `date` (not `date-time`) → string/date.
+            t.contains("date") ->
+                SchemaObject(type = "string", format = "date")
+
+            t.contains("uuid") ->
+                SchemaObject(type = "string", format = "uuid")
+
+            // `char` / `character` → string/null. Must be checked before default.
+            t.contains("char") ->
+                SchemaObject(type = "string", format = null)
+
+            // `long` must be checked before `int` (no substring overlap, but
+            // explicit for clarity).
+            t.contains("long") ->
+                SchemaObject(type = "integer", format = "int64")
+
+            t.contains("int") ->
+                SchemaObject(type = "integer", format = "int32")
+
+            t.contains("short") || t.contains("byte") ->
+                SchemaObject(type = "integer", format = "int32")
+
+            t.contains("float") ->
+                SchemaObject(type = "number", format = "float")
+
+            t.contains("double") || t.contains("decimal") || t.contains("number") ->
+                SchemaObject(type = "number", format = "double")
+
+            t.contains("boolean") ->
+                SchemaObject(type = "boolean", format = null)
+
+            // Explicit `string` and unknown types default to (string, null).
+            else -> SchemaObject(type = "string", format = null)
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSerializer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSerializer.kt
@@ -1,0 +1,54 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+
+/**
+ * Channel-local serializer for [OpenApiDocument].
+ *
+ * JSON output uses a channel-local [Gson] instance with `setPrettyPrinting()`,
+ * `disableHtmlEscaping()`, `serializeNulls()` OFF so optional
+ * fields are omitted, not nulled. The instance is NOT the shared `GsonUtils`
+ * — channel isolation prevents formatting drift across channels (mirrors
+ * `PostmanGson.pretty` / `hoppscotchGson()`).
+ *
+ * YAML output uses Jackson's [YAMLMapper] with
+ * `serializationInclusion(NON_NULL)` so optional fields vanish,
+ * and `WRITE_DOC_START_MARKER` disabled so the output begins with
+ * `openapi: "3.0.3"` on line 1 (no leading `---`). Jackson auto-quotes
+ * strings that would otherwise parse as a number, so `openapi: "3.0.3"`
+ * is emitted with quotes.
+ *
+ * Both mappers are lazily initialized
+ * — the YAML mapper is not built when the user picks JSON, and vice versa.
+ *
+ * Determinism: both mappers preserve `LinkedHashMap` insertion
+ * order for `paths`, `components.schemas`, `tags`, `properties`,
+ * `responses`, `content` — see [OpenApiDocument] and the formatter.
+ */
+object OpenApiSerializer {
+
+    private val gson: Gson by lazy {
+        GsonBuilder()
+            .setPrettyPrinting()
+            .disableHtmlEscaping()
+            .create() // serializeNulls() OFF → optional fields omitted, not nulled
+    }
+
+    private val yamlMapper: ObjectMapper by lazy {
+        YAMLMapper.builder()
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+            .build()
+    }
+
+    /** Serializes [doc] to a pretty-printed JSON string. */
+    fun toJson(doc: OpenApiDocument): String = gson.toJson(doc)
+
+    /** Serializes [doc] to a YAML string with no leading `---`. */
+    fun toYaml(doc: OpenApiDocument): String = yamlMapper.writeValueAsString(doc)
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettings.kt
@@ -1,0 +1,45 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.settings.Scope
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.StorageScope
+
+/**
+ * Persistent defaults for the OpenAPI channel.
+ *
+ * Stored at APPLICATION scope via the unified
+ * [com.itangcent.easyapi.core.settings.state.UnifiedAppSettingsState] —
+ * no per-module state class or `plugin.xml` registration required.
+ *
+ * Read/written via [com.itangcent.easyapi.core.settings.SettingBinder]:
+ * ```kotlin
+ * val binder = SettingBinder.getInstance(project)
+ * val settings = binder.read<OpenApiSettings>()
+ * settings.outputFormat = "YAML"
+ * binder.save(settings)
+ * ```
+ *
+ * ## Refactor
+ *
+ * The v1 `infoTitle` / `infoVersion` / `infoDescription` / `serverUrl`
+ * fields were removed — those values vary per project and belong in rule
+ * scripts. The settings layer now persists **only** the default
+ * [outputFormat] (default `"ALWAYS_ASK"`).
+ *
+ * ## Field semantics
+ *
+ * - [outputFormat] — stored as a String (`"JSON"` / `"YAML"` / `"ALWAYS_ASK"`)
+ *   because the unified settings state serializes to primitives; the channel
+ *   layer parses it back to [OpenApiOutputFormat] at use time via
+ *   [OpenApiConfig.parseOutputFormat].
+ *
+ * All fields are `var` (not `val`) because the SettingBinder mutates the
+ * instance in place when loading from persistent state. All fields carry
+ * `@StorageScope(Scope.APPLICATION)` — fields without the annotation are
+ * silently skipped by the binder.
+ *
+ * @see OpenApiConfig for the per-export counterpart (in-memory only).
+ */
+data class OpenApiSettings(
+    @StorageScope(Scope.APPLICATION) var outputFormat: String = "ALWAYS_ASK",
+) : Settings

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettingsPanel.kt
@@ -1,0 +1,98 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.util.ui.FormBuilder
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.settings
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.core.settings.ui.SettingsPanel
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Persistent settings panel for the OpenAPI channel.
+ *
+ * The v1 envelope fields (`infoTitle` / `infoVersion` / `infoDescription` /
+ * `serverUrl`) were removed — those values vary per project and belong in
+ * rule scripts. The settings panel now exposes ONLY the default
+ * [outputFormat] combo with three options: `JSON`, `YAML`, `Always Ask`
+ * (default).
+ *
+ * Edits the [OpenApiSettings] module via [SettingBinder] — never touching
+ * state components directly. Mirrors
+ * [com.itangcent.easyapi.channel.curl.CurlSettingsPanel] and
+ * [com.itangcent.easyapi.channel.hoppscotch.HoppscotchSettingsPanel].
+ *
+ * ## `SettingsPanel<Settings>` typing
+ *
+ * Typed against the [Settings] base (NOT `SettingsPanel<OpenApiSettings>`) so
+ * the configurable's `ChannelPanelEntry.panel` unchecked cast at
+ * `EasyApiSettingsConfigurable` works for every channel without per-channel
+ * `Settings` subtype awareness. The panel still reads/writes its own
+ * [OpenApiSettings] module internally via [SettingBinder].
+ *
+ * @param project the IntelliJ project context
+ * @see OpenApiSettings for the persisted module
+ * @see OpenApiOptionsPanel for the per-export counterpart
+ */
+class OpenApiSettingsPanel(private val project: Project) : SettingsPanel<Settings> {
+
+    /**
+     * The three UI strings shown in the combo. The mapping to/from the
+     * persistent [OpenApiSettings.outputFormat] string is via
+     * [toUiFormat] / [fromUiFormat].
+     */
+    private val outputFormatCombo = ComboBox(arrayOf("JSON", "YAML", "Always Ask"))
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addLabeledComponent("Default Output Format:", outputFormatCombo)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    override fun resetFrom(settings: Settings?) {
+        // Always read fresh from the binder — the passed-in `settings` is the
+        // shared `Settings` umbrella, not an OpenApiSettings
+        // instance. Mirrors CurlSettingsPanel.resetFrom.
+        val s = project.settings<OpenApiSettings>()
+        outputFormatCombo.selectedItem = toUiFormat(s.outputFormat)
+    }
+
+    override fun applyTo(settings: Settings) {
+        // Persist via SettingBinder.update so the unified state component is
+        // the single source of truth (mirrors CurlSettingsPanel.applyTo).
+        SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+            outputFormat = fromUiFormat((outputFormatCombo.selectedItem as? String) ?: "Always Ask")
+        }
+    }
+
+    override fun isModified(settings: Settings?): Boolean {
+        val s = project.settings<OpenApiSettings>()
+        val uiFormat = (outputFormatCombo.selectedItem as? String) ?: "Always Ask"
+        return uiFormat != toUiFormat(s.outputFormat)
+    }
+
+    // --- Test-visible accessors (mirror the CurlSettingsPanel internal-accessor pattern) ---
+
+    internal fun outputFormatText(): String =
+        (outputFormatCombo.selectedItem as? String) ?: "Always Ask"
+
+    internal fun setOutputFormat(value: String) {
+        outputFormatCombo.selectedItem = value
+    }
+
+    private fun toUiFormat(stored: String): String = when (stored.uppercase()) {
+        "JSON" -> "JSON"
+        "YAML" -> "YAML"
+        "ALWAYS_ASK" -> "Always Ask"
+        else -> "Always Ask"
+    }
+
+    private fun fromUiFormat(ui: String): String = when (ui) {
+        "JSON" -> "JSON"
+        "YAML" -> "YAML"
+        "Always Ask" -> "ALWAYS_ASK"
+        else -> "ALWAYS_ASK"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OperationIdResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/OperationIdResolver.kt
@@ -1,0 +1,98 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.HttpMetadata
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.intellij.psi.PsiMethod
+
+/**
+ * Outcome of [OperationIdResolver.resolve] — carries both the resolved
+ * operation id and a flag signalling whether the resolution had to break a
+ * collision (which the resolver logs at `warn`).
+ *
+ * Exposing [collisionDetected] lets tests assert the warn-log side effect
+ * without capturing an IntelliJ `Logger` test fake.
+ */
+data class ResolutionResult(
+    val operationId: String,
+    val collisionDetected: Boolean,
+)
+
+/**
+ * Resolves a stable, document-unique `operationId` for an OAS Operation
+ * Object.
+ *
+ * Resolution order:
+ * 1. `sourceMethod.name` when the method is available (e.g. `getUser`).
+ * 2. `{method}_{path_slug}` slug fallback, where `path_slug` is the
+ *    normalized path with `{`/`}`/`/` collapsed to `_`, trimmed and
+ *    lowercased (e.g. `/users/{id}` → `users_id`, giving `get_users_id`).
+ *    When the path slug is empty (e.g. root `/`), the operationId is just
+ *    the lowercased method name.
+ * 3. On collision with an id already in [used], a numeric `-N` suffix
+ *    (N ≥ 2) is appended; the first free slot wins, so `getUser` →
+ *    `getUser-2` → `getUser-3`. The collision is logged at `warn`
+ *    and flagged in the returned [ResolutionResult].
+ *
+ * The resolved id is added to [used] before returning so the next caller
+ * sees it. The object is stateless and pure — all mutable state is supplied
+ * by the caller via [used].
+ */
+object OperationIdResolver : IdeaLog {
+
+    fun resolve(
+        meta: HttpMetadata,
+        sourceMethod: PsiMethod?,
+        used: MutableSet<String>,
+    ): ResolutionResult {
+        val baseName = pickBaseName(meta, sourceMethod)
+
+        // First use — no collision.
+        if (baseName !in used) {
+            used.add(baseName)
+            return ResolutionResult(operationId = baseName, collisionDetected = false)
+        }
+
+        // Collision — find the first free `-N` slot (N ≥ 2).
+        var suffix = 2
+        while ("$baseName-$suffix" in used) {
+            suffix++
+        }
+        val finalId = "$baseName-$suffix"
+        LOG.warn("operationId collision: '$baseName' already used; suffixing as '$finalId'")
+        used.add(finalId)
+        return ResolutionResult(operationId = finalId, collisionDetected = true)
+    }
+
+    /**
+     * Picks the base name (before any collision suffixing) per the
+     * resolution order: `sourceMethod.name` → `{method}_{path_slug}`.
+     */
+    private fun pickBaseName(meta: HttpMetadata, sourceMethod: PsiMethod?): String {
+        val methodName = sourceMethod?.name
+        if (!methodName.isNullOrBlank()) return methodName
+
+        return buildSlug(meta.method, meta.path)
+    }
+
+    /**
+     * Builds the `{method}_{path_slug}` fallback. Path slashes, `{` and `}`
+     * collapse to a single `_`; consecutive `_` runs collapse to one; the
+     * result is trimmed of leading/trailing `_` and lowercased. If the path
+     * slug is empty (root path `/`, or empty path), the result is just the
+     * lowercased method name.
+     */
+    private fun buildSlug(method: HttpMethod, path: String): String {
+        val methodSlug = method.name.lowercase()
+        val pathSlug = path
+            .replace('/', '_')
+            .replace('{', '_')
+            .replace('}', '_')
+            .split('_')
+            .filter { it.isNotEmpty() }
+            .joinToString("_")
+            .lowercase()
+
+        return if (pathSlug.isEmpty()) methodSlug else "${methodSlug}_$pathSlug"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/openapi/PathNormalizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/openapi/PathNormalizer.kt
@@ -1,0 +1,86 @@
+package com.itangcent.easyapi.channel.openapi
+
+/**
+ * Normalizes EasyApi HTTP paths into OpenAPI Path Template syntax.
+ *
+ * Handles two Spring-specific input forms:
+ * - **Spring colon form:** `/users/:id` → `/users/{id}` (only when the `:`
+ *   appears at the start of a segment).
+ * - **Spring regex form:** `/users/{id:\\d+}` → `/users/{id}` (the trailing
+ *   `:regex` portion inside braces is stripped; nested braces inside the
+ *   regex are tolerated, e.g. quantifiers `{8,}` in `{id:[0-9a-f]{8,}}`).
+ *
+ * After the two rewrites, the path is validated against the OAS Path
+ * Template grammar (segments separated by `/`; each segment is either a
+ * literal or a `{name}` parameter with a name matching
+ * `[a-zA-Z_][a-zA-Z0-9_.-]*`). Paths that still violate the grammar
+ * (e.g. unclosed braces, query strings, empty parameter names) return
+ * `null` so the caller can skip-with-warn.
+ *
+ * The object is stateless and pure.
+ */
+object PathNormalizer {
+
+    /**
+     * Matches Spring's `:name` colon form, but only when the colon is at the
+     * start of a segment — either at the start of the string or immediately
+     * after a `/`. Group 1 captures the segment-start anchor (empty string
+     * if at start of input, or `/`); group 2 captures the parameter name.
+     */
+    private val COLON_FORM = Regex("""(^|/):([a-zA-Z_][a-zA-Z0-9_]*)""")
+
+    /**
+     * Validates a path parameter name (the substring between `{` and the
+     * first `:` or `}`). Allows letters, digits, underscore, dot, and dash;
+     * must start with a letter or underscore.
+     */
+    private val PARAM_NAME = Regex("^[a-zA-Z_][a-zA-Z0-9_.-]*$")
+
+    /**
+     * Validates that the post-normalization path is a valid OAS 3.0.3 Path
+     * Template: a leading `/`, followed by zero or more segments separated
+     * by `/`, where each segment is either a literal (`[^/{}?#]+`) or a
+     * path parameter (`{[a-zA-Z0-9_.-]+}`). The root path `/` is also valid.
+     */
+    private val VALID_PATH_TEMPLATE =
+        Regex("""^/(?:\{[a-zA-Z0-9_.-]+\}|[^/{}?#]+)(?:/(?:\{[a-zA-Z0-9_.-]+\}|[^/{}?#]+))*$|^/$""")
+
+    /**
+     * Normalizes [path] to OAS Path Template syntax, or returns `null` if the
+     * post-normalization path still violates the OAS grammar.
+     */
+    fun normalize(path: String): String? {
+        if (path.isBlank()) return null
+
+        // Step 1: Spring colon form `:name` → `{name}` (segment-start only)
+        val step1 = COLON_FORM.replace(path) { match ->
+            "${match.groupValues[1]}{${match.groupValues[2]}}"
+        }
+
+        // Step 2: Spring regex form `{name:regex}` → `{name}` (per segment).
+        // Splitting by `/` lets each segment be inspected in isolation —
+        // nested braces inside the regex (e.g. quantifiers `{8,}`) don't
+        // confuse a balanced-brace matcher because the segment boundaries
+        // are already known.
+        val step2 = step1.split("/").joinToString("/") { seg ->
+            stripRegexFromSegment(seg)
+        }
+
+        // Step 3: Validate the post-normalization path against the OAS grammar
+        if (!VALID_PATH_TEMPLATE.matches(step2)) return null
+        return step2
+    }
+
+    /**
+     * If [seg] is a `{name:regex}` segment, returns `{name}`; otherwise
+     * returns [seg] unchanged.
+     */
+    private fun stripRegexFromSegment(seg: String): String {
+        if (!seg.startsWith("{") || !seg.endsWith("}") || seg.length < 4) return seg
+        val colonIdx = seg.indexOf(':')
+        if (colonIdx !in 1 until seg.length - 1) return seg
+        val name = seg.substring(1, colonIdx)
+        if (!PARAM_NAME.matches(name)) return seg
+        return "{$name}"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/channel/postman/sync/EnvironmentSyncDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/postman/sync/EnvironmentSyncDialog.kt
@@ -27,7 +27,7 @@ import javax.swing.*
  * - **Push**: Select local environments to push to Postman
  * - **Pull**: Select Postman environments to pull into local, with conflict resolution
  *
- * **Decision CO7**: Lives in `channel.postman.sync` alongside
+ * Lives in `channel.postman.sync` alongside
  * [EnvironmentSyncService] (Postman-specific — no abstraction extracted).
  */
 class EnvironmentSyncDialog(

--- a/src/main/kotlin/com/itangcent/easyapi/channel/postman/sync/EnvironmentSyncLogic.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/postman/sync/EnvironmentSyncLogic.kt
@@ -12,9 +12,9 @@ import com.itangcent.easyapi.core.script.env.EnvironmentScope
  *
  * Contains conflict resolution and error message conversion — logic that is
  * specific to the sync service layer. Pure data mapping functions live in
- * [PostmanApiClient.Companion] per spec tasks 2.5 and 2.6.
+ * [PostmanApiClient.Companion].
  *
- * **Decision CO7**: Lives in `channel.postman.sync` alongside
+ * Lives in `channel.postman.sync` alongside
  * [EnvironmentSyncService] (Postman-specific — no abstraction extracted).
  *
  * @see EnvironmentSyncService for the service that uses this logic
@@ -26,8 +26,7 @@ internal object EnvironmentSyncLogic {
     /**
      * Maps an EasyAPI [Environment] to a [PostmanEnvironmentDetail].
      *
-     * Delegates the variable mapping to [PostmanApiClient.environmentToVariables]
-     * (spec task 2.5).
+     * Delegates the variable mapping to [PostmanApiClient.environmentToVariables].
      *
      * @see EnvironmentSyncService.pushToPostman
      */
@@ -41,7 +40,7 @@ internal object EnvironmentSyncLogic {
     /**
      * Maps EasyAPI variables to a list of [PostmanEnvironmentValue] entries.
      *
-     * Delegates to [PostmanApiClient.variablesToPostmanValues] (spec task 2.5).
+     * Delegates to [PostmanApiClient.variablesToPostmanValues].
      */
     fun variablesToPostmanValues(variables: Map<String, String>): List<PostmanEnvironmentValue> {
         return PostmanApiClient.variablesToPostmanValues(variables)
@@ -52,7 +51,7 @@ internal object EnvironmentSyncLogic {
     /**
      * Maps Postman environment values to a simple key-value map.
      *
-     * Delegates to [PostmanApiClient.postmanVariablesToMap] (spec task 2.6).
+     * Delegates to [PostmanApiClient.postmanVariablesToMap].
      *
      * @param values Postman variable list
      * @param includeDisabled Whether to include disabled variables

--- a/src/main/kotlin/com/itangcent/easyapi/channel/postman/sync/EnvironmentSyncService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/postman/sync/EnvironmentSyncService.kt
@@ -30,7 +30,7 @@ import javax.swing.SwingUtilities
  *
  * Uses [PostmanApiClient] for API calls and [EnvironmentService] for local persistence.
  *
- * **Decision CO7**: Implements [EnvironmentSyncSupport] (the SPI in
+ * Implements [EnvironmentSyncSupport] (the SPI in
  * `channel.spi`) so `core.*` callers can depend on the abstraction rather than
  * this concrete class. Registered in `plugin.xml` as a project service with
  * `serviceInterface="...EnvironmentSyncSupport"`. Callers MUST look it up via

--- a/src/main/kotlin/com/itangcent/easyapi/channel/spi/Channel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/spi/Channel.kt
@@ -70,6 +70,20 @@ interface Channel {
      */
     val enabledByDefault: Boolean get() = true
 
+    /**
+     * Whether this channel is in beta status.
+     *
+     * Beta channels are functional but may have rough edges, incomplete
+     * features, or breaking changes in future releases. UI surfaces MAY
+     * append a "(Beta)" indicator to the [displayName] and MAY warn the
+     * user on first use. Beta channels are typically `enabledByDefault = false`
+     * so the user opts in explicitly.
+     *
+     * Default is `false` (stable). Override to `true` for channels that
+     * are not yet production-ready.
+     */
+    val beta: Boolean get() = false
+
     /** Hint for settings-tab ordering; lower = earlier. Default 100. */
     val settingsTabOrder: Int get() = 100
 

--- a/src/main/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistry.kt
@@ -73,14 +73,14 @@ class ChannelRegistry(private val project: Project) : IdeaLog {
      *  project area (e.g. in lightweight unit tests that do not load `plugin.xml`).
      *
      *  Unfiltered by design — returns every registered channel regardless of
-     *  enabled state (Req 4.5). Consumers that need only enabled channels must
+     *  enabled state. Consumers that need only enabled channels must
      *  use [getAvailableChannels], [getActionChannels], or [channelsForSettings]. */
     fun allChannels(): List<Channel> = extensionListSafe()
 
     /** Finds a channel by its unique [id], or `null` if not found.
      *
-     *  Unfiltered by design — returns the channel regardless of enabled state
-     *  (Req 4.5, design Decision 3). The export boundary refuses disabled
+     *  Unfiltered by design — returns the channel regardless of enabled state.
+     *  The export boundary refuses disabled
      *  channels; this lookup stays a pure registry primitive. */
     fun getChannel(id: String): Channel? =
         allChannels().firstOrNull { it.id == id }
@@ -94,7 +94,7 @@ class ChannelRegistry(private val project: Project) : IdeaLog {
      * [com.itangcent.easyapi.core.settings.DefaultSettingBinder]).
      *
      * If the settings storage cannot be read, falls back to
-     * [Channel.enabledByDefault] for every channel and does not throw (Req 2.6).
+     * [Channel.enabledByDefault] for every channel and does not throw.
      */
     fun isEnabled(channel: Channel): Boolean {
         val settings = try {

--- a/src/main/kotlin/com/itangcent/easyapi/channel/spi/CurlRenderer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/spi/CurlRenderer.kt
@@ -9,11 +9,11 @@ import com.itangcent.easyapi.core.script.ScriptScope
 /**
  * SPI for cURL rendering operations needed by `core.*` callers.
  *
- * Decisions CO3 + CO8: `core.rule.context.ScriptApiEndpoint.toCurl` and
+ * `core.rule.context.ScriptApiEndpoint.toCurl` and
  * `core.dashboard.ApiDashboardPanel` (copy-as-cURL action, scope resolution)
  * MUST NOT import concrete `channel.curl.*` types. They go through this SPI
  * instead; the implementation lives in `channel.curl.CurlRendererService` and
- * is registered in `plugin.xml` as an `<applicationService>` (Decision CO8).
+ * is registered in `plugin.xml` as an `<applicationService>`.
  *
  * ## Why application-scoped (not project-scoped)
  *

--- a/src/main/kotlin/com/itangcent/easyapi/channel/spi/EnvironmentSyncSupport.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/spi/EnvironmentSyncSupport.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.project.Project
  * SPI for channels that support bidirectional environment synchronization
  * (push local environments to a remote, pull remote environments into local).
  *
- * **Decision CO7**: Extracted to break the `core.dashboard` →
+ * Extracted to break the `core.dashboard` →
  * `channel.postman.sync` concrete-impl dependency. The Postman channel
  * provides the implementation; `core.*` callers (dashboard panels) depend
  * only on this SPI.

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AmbientPerception.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AmbientPerception.kt
@@ -88,12 +88,12 @@ object AmbientPerception : IdeaLog {
      * ≥1 hit, its owning recognizer's framework label is collected into
      * [ApiPerception.frameworkHints] (deduped).
      *
-     * Settings gates (Req 9.3) are respected automatically: disabled
+     * Settings gates are respected automatically: disabled
      * recognizers are excluded from [CompositeApiClassRecognizer.allTargetAnnotations],
      * so their annotations are never searched and their framework labels never
      * surface.
      *
-     * Decision CO5: the annotation→framework map is built per call from
+     * The annotation→framework map is built per call from
      * [CompositeApiClassRecognizer.recognizers] — the EP-respecting service
      * seam — instead of hard-coding concrete framework recognizer imports.
      * The map covers exactly the enabled recognizers (the same set whose
@@ -111,7 +111,7 @@ object AmbientPerception : IdeaLog {
         val composite = CompositeApiClassRecognizer.getInstance(project)
         val annotationFqns = composite.allTargetAnnotations
         if (annotationFqns.isEmpty()) return@readSync ApiPerception(emptyList(), emptyList())
-        // Decision CO5: build the annotation→framework map per call from the
+        // Build the annotation→framework map per call from the
         // EP-respecting seam rather than hard-coding 5 concrete recognizer
         // imports. The map covers exactly the enabled recognizers, which is
         // the same set whose annotations appear in `annotationFqns` above.

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuard.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuard.kt
@@ -201,7 +201,7 @@ class LoopGuard(private val cfg: LoopSafetyConfig) {
 }
 
 // ------------------------------------------------------------------
-// Normalization & fingerprinting helpers (Phase 2, task 9)
+// Normalization & fingerprinting helpers
 // ------------------------------------------------------------------
 
 /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgent.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgent.kt
@@ -78,7 +78,7 @@ class RuleAuthoringAgent(
             "budget=${ctx.aiSettings.maxRequests}")
 
         // Fresh per-turn loop guard + retry policy so detection state never
-        // leaks across turns (REQ-1 AC-4).
+        // leaks across turns.
         val guard = LoopGuard(ctx.aiSettings.loopSafety)
         val retry = ChatRetry(ctx.aiSettings.loopSafety)
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByNameTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByNameTool.kt
@@ -22,8 +22,7 @@ import com.itangcent.easyapi.core.util.json.GsonUtils
  * Resolution strategy:
  * - **FQN short-circuit** (input contains `.`): direct
  *   [JavaPsiFacade.findClass] in [GlobalSearchScope.projectScope]. Returns a
- *   single-element or empty array. Does NOT invoke [PsiShortNamesCache]
- *   (per REQ-1 AC-6).
+ *   single-element or empty array. Does NOT invoke [PsiShortNamesCache].
  * - **Simple name**: [PsiShortNamesCache.getClassesByName] in
  *   [GlobalSearchScope.projectScope], sorted alphabetically. When a
  *   `context` is supplied, a context-reachable match (resolved via

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetModuleDependencyGraphTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetModuleDependencyGraphTool.kt
@@ -51,7 +51,7 @@ class GetModuleDependencyGraphTool : AiTool, IdeaLog {
                     val deps = ModuleRootManager.getInstance(module).orderEntries
                         .asSequence()
                         .filterIsInstance<ModuleOrderEntry>()
-                        // Req 8.1: restrict to workspace (non-external) modules —
+                        // Restrict to workspace (non-external) modules —
                         // a ModuleOrderEntry whose Module is null is an external /
                         // unloaded reference, not a structural workspace edge.
                         .filter { it.module != null }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoTool.kt
@@ -76,8 +76,8 @@ class GetPsiClassInfoTool : AiTool, IdeaLog {
     /**
      * Builds the error message for a missing class. When the lookup was a
      * simple name without context and `PsiNameResolver` found multiple
-     * matches, the message guides the agent to `find_classes_by_name`
-     * (Design Decision 4). Otherwise a plain "class not found" is returned.
+     * matches, the message guides the agent to `find_classes_by_name`.
+     * Otherwise a plain "class not found" is returned.
      */
     private suspend fun buildNotFoundMessage(
         fqn: String,
@@ -106,7 +106,7 @@ class GetPsiClassInfoTool : AiTool, IdeaLog {
         val psiClass = PsiNameResolver.resolveClass(fqn, ctx.project, contextElement)
             ?: return@read null
         // Implicit contextElement for type enrichment: when no explicit context
-        // was supplied, use the resolved class's containing file (REQ-4 AC-9).
+        // was supplied, use the resolved class's containing file.
         val enrichmentContext = contextElement ?: psiClass.containingFile
         PsiSignatureBuilder.classToMap(psiClass, ctx.project, enrichmentContext)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoTool.kt
@@ -89,7 +89,7 @@ class GetPsiMethodInfoTool : AiTool, IdeaLog {
         // All PSI access (name, signature, annotations, parameters, docComment,
         // body) must happen inside the read action — PSI element getters
         // require one. The detail="signature" fast path does NOT touch
-        // psiMethod.body?.text (REQ-3 AC-9).
+        // psiMethod.body?.text.
         val info = read {
             val psiClass = PsiNameResolver.resolveClass(fqn, ctx.project, contextElement)
                 ?: return@read null
@@ -98,8 +98,7 @@ class GetPsiMethodInfoTool : AiTool, IdeaLog {
                     (paramCount == null || m.parameterList.parameters.size == paramCount)
             } ?: return@read null
             // Implicit contextElement for type enrichment: when no explicit
-            // context was supplied, use the resolved class's containing file
-            // (REQ-4 AC-9).
+            // context was supplied, use the resolved class's containing file.
             val enrichmentContext = contextElement ?: psiClass.containingFile
             PsiSignatureBuilder.methodToInfoMap(
                 psiMethod = psiMethod,
@@ -117,8 +116,7 @@ class GetPsiMethodInfoTool : AiTool, IdeaLog {
     /**
      * Builds the error message for a missing class or method. When the
      * lookup was a simple name without context and `PsiNameResolver` found
-     * multiple matches, the message guides the agent to `find_classes_by_name`
-     * (Design Decision 4).
+     * multiple matches, the message guides the agent to `find_classes_by_name`.
      */
     private suspend fun buildNotFoundMessage(
         fqn: String,

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/PsiNameResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/PsiNameResolver.kt
@@ -27,8 +27,8 @@ import com.itangcent.easyapi.core.psi.type.TypeResolver
  *   [GlobalSearchScope.allScope]. Returns the single match, or `null` with a
  *   `LOG.info` decision log when zero or >1 matches are found.
  *
- * All PSI access is performed inside a read action (NFR-1). Logging follows
- * NFR-2 — `LOG.info` is the floor; no arguments or result bodies are logged
+ * All PSI access is performed inside a read action. Logging follows
+ * the convention that `LOG.info` is the floor; no arguments or result bodies are logged
  * beyond the identifier needed to explain a decision.
  */
 internal object PsiNameResolver : IdeaLog {
@@ -174,7 +174,7 @@ internal object PsiNameResolver : IdeaLog {
     /**
      * Resolves the optional `context` argument supplied by AI tools to a
      * [PsiElement] for import-scope resolution. Non-string values are logged
-     * and treated as `null` (per REQ-4 AC-5).
+     * and treated as `null`.
      *
      * Shared by tools that accept a `context` parameter
      * ([GetPsiClassInfoTool], [GetPsiMethodInfoTool], [FindClassesByAnnotationTool],

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanel.kt
@@ -949,7 +949,7 @@ class AiChatPanel(
      *
      * The dialog names the offending tool (captured from
      * [AgentEvent.LoopDetected]) when available. Continuing injects a
-     * user-style anti-repetition hint (design Decision 5) and re-runs the
+     * user-style anti-repetition hint and re-runs the
      * turn — a fresh `LoopGuard` starts automatically (it is per-turn).
      * Recovery is user-initiated; there is no auto-retry.
      */
@@ -972,7 +972,7 @@ class AiChatPanel(
             options[0]
         )
         if (choice == JOptionPane.YES_OPTION) {
-            // User-style anti-repetition hint (design Decision 5) — same
+            // User-style anti-repetition hint — same
             // injection channel as the "(continue)" nudge in offerContinueOrCancel.
             val hint = "The previous turn repeated without progress. " +
                 "Try a different tool, change the arguments, or communicate your conclusion."

--- a/src/main/kotlin/com/itangcent/easyapi/core/config/parser/ConfigTextParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/config/parser/ConfigTextParser.kt
@@ -82,7 +82,7 @@ class ConfigTextParser(
         val http = project.settings<HttpSettings>()
         val ruleFile = project.settings<RuleFileSettings>()
         // postmanToken is read via string-based lookup to avoid importing
-        // channel.postman.PostmanSettings (concrete-impl) from core.* (Decision CO3).
+        // channel.postman.PostmanSettings (concrete-impl) from core.*.
         val postmanModuleKey = "com.itangcent.easyapi.channel.postman.PostmanSettings"
         return { key ->
             when (key) {

--- a/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiDashboardPanel.kt
@@ -712,7 +712,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
     }
 
     fun resolveScriptScopesForEndpoint(endpoint: ApiEndpoint): List<ScriptScope> {
-        // Delegates to the CurlRenderer SPI (Decision CO8) — folder + class
+        // Delegates to the CurlRenderer SPI — folder + class
         // scopes only, matching the dashboard's prior behavior. The cURL
         // single-endpoint path (CurlRenderer.formatForCopy → CurlExportResolver)
         // additionally appends the Endpoint scope.

--- a/src/main/kotlin/com/itangcent/easyapi/core/export/ClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/export/ClassExporter.kt
@@ -35,7 +35,7 @@ interface ClassExporter {
     /**
      * Checks whether this exporter is enabled for the current project.
      *
-     * After the framework-enablement unification (Item 2), the canonical
+     * After the framework-enablement unification, the canonical
      * implementation delegates to
      * [com.itangcent.easyapi.framework.spi.FrameworkRegistry.isEnabled]:
      * ```kotlin

--- a/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizer.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiClass
  * Each framework (Spring MVC, JAX-RS, Feign, etc.) provides its own implementation.
  * Use [CompositeApiClassRecognizer] to combine them.
  *
- * ## Extension Point (Decision CO9)
+ * ## Extension Point
  *
  * Implementations are discovered via the `com.itangcent.idea.plugin.easy-api.apiClassRecognizer`
  * extension point (declared in `plugin.xml`). The [CompositeApiClassRecognizer] iterates

--- a/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/CompositeApiClassRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/CompositeApiClassRecognizer.kt
@@ -17,7 +17,7 @@ import com.itangcent.easyapi.framework.spi.FrameworkRegistry
  * across any supported framework. All code that needs to check "is this an API class?"
  * should use this class instead of checking annotations directly.
  *
- * ## EP-based discovery (Decision CO9)
+ * ## EP-based discovery
  *
  * Recognizer instances are discovered via the `com.itangcent.idea.plugin.easy-api.apiClassRecognizer`
  * extension point (declared in `plugin.xml`). Each framework registers its recognizer
@@ -49,10 +49,10 @@ class CompositeApiClassRecognizer(private val project: Project) : Disposable {
     private fun buildRecognizers(): List<ApiClassRecognizer> {
         // EP-discovered recognizers are constructed with no-arg constructors.
         // Framework enablement is resolved by FrameworkRegistry (the single
-        // chokepoint — PR4), overlaying the stored user preference on each
+        // chokepoint), overlaying the stored user preference on each
         // recognizer's `enabledByDefault`. The `&& it.isEnabled(project)`
         // clause preserves the per-recognizer project-state gate (default
-        // `true` for all 5 in-tree recognizers after task 26 — they no longer
+        // `true` for all 5 in-tree recognizers — they no longer
         // override). This composite never imports concrete framework.* classes.
         return EP_NAME.getExtensions(project).toList()
             .filter { FrameworkRegistry.getInstance(project).isEnabled(it) && it.isEnabled(project) }
@@ -80,7 +80,7 @@ class CompositeApiClassRecognizer(private val project: Project) : Disposable {
         get() = cachedRecognizers.flatMap { it.targetAnnotations }.toSet()
 
     /**
-     * Returns the cached list of enabled [ApiClassRecognizer]s (Decision CO5).
+     * Returns the cached list of enabled [ApiClassRecognizer]s.
      *
      * Exposes the existing private [cachedRecognizers] field so callers can
      * iterate the EP-respecting seam rather than hard-coding imports of the
@@ -108,7 +108,7 @@ class CompositeApiClassRecognizer(private val project: Project) : Disposable {
 
     companion object {
         /**
-         * EP name for framework recognizers (Decision CO9).
+         * EP name for framework recognizers.
          *
          * Declared in `plugin.xml` as `<extensionPoint name="apiClassRecognizer"
          * interface="...ApiClassRecognizer" area="IDEA_PROJECT" dynamic="true"/>`.

--- a/src/main/kotlin/com/itangcent/easyapi/core/http/HttpClientScriptInterceptor.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/http/HttpClientScriptInterceptor.kt
@@ -31,7 +31,7 @@ class HttpClientScriptInterceptor(
     private val ruleEngine: RuleEngine?
 ) : HttpClient {
     override suspend fun execute(request: HttpRequest): HttpResponse {
-        // Recursion guard (Spec: ai-workflow-patterns, D3 / review Issue #3).
+        // Recursion guard.
         // `depth` is a per-thread counter incremented at the top of execute() and
         // decremented in `finally`. It prevents infinite re-entry when a script
         // running in `http.call.before`/`after` issues a sub-request via
@@ -51,7 +51,7 @@ class HttpClientScriptInterceptor(
                     }
                 }
                 // Send the (possibly mutated) wrapper state, not the original request,
-                // so retries carry script-applied header changes (Spec: D2).
+                // so retries carry script-applied header changes.
                 val response = delegate.execute(wrappedRequest.toHttpRequest())
                 val wrappedResponse = HttpResponseWrapper(response, wrappedRequest)
                 if (d < MAX_HOOK_DEPTH) {
@@ -95,7 +95,7 @@ class HttpClientScriptInterceptor(
  * Used in rule scripts to inspect and modify request properties. Header mutation
  * (via [setHeader] / [removeHeader]) is reflected in [headers] and materialized
  * into a fresh [HttpRequest] by [toHttpRequest], so retries carry script-applied
- * header changes (Spec: ai-workflow-patterns, D2 — 401-refresh sets a new
+ * header changes — 401-refresh sets a new
  * `Authorization` header on the wrapper, then `response.discard()` triggers a
  * retry that sends the mutated headers).
  *

--- a/src/main/kotlin/com/itangcent/easyapi/core/http/ScriptHttpClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/http/ScriptHttpClient.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.runBlocking
  * Synchronous adapter exposing the suspend-only [HttpClient] API at the blocking
  * JSR-223 script boundary.
  *
- * ## Why this exists (Spec: ai-workflow-patterns, D1 / Req 5.5)
+ * ## Why this exists
  * The 401-refresh recipe runs inside an `http.call.after` rule value. That script is
  * evaluated by [com.itangcent.easyapi.core.rule.parser.Jsr223ScriptParser] via the JSR-223
  * Groovy engine, which is a **blocking** evaluator (`ScriptEngine.eval`). Groovy scripts

--- a/src/main/kotlin/com/itangcent/easyapi/core/ide/action/ChannelExportAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ide/action/ChannelExportAction.kt
@@ -29,7 +29,7 @@ class ChannelExportAction(
         if (project != null) {
             // Re-evaluate visibility per-display-context (NOT templatePresentation,
             // which the platform forbids mutating — Presentation.assertNotTemplatePresentation).
-            // This is the chokepoint for "hide not unregister" (Decision 4): a
+            // This is the chokepoint for "hide not unregister": a
             // disabled channel's action stays registered (keymap IDs remain
             // stable) but is hidden from the menu because isVisible resolves to false.
             val registry = ChannelRegistry.getInstance(project)

--- a/src/main/kotlin/com/itangcent/easyapi/core/ide/action/ChannelQuickActionGroup.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ide/action/ChannelQuickActionGroup.kt
@@ -59,7 +59,7 @@ class ChannelQuickActionGroup : DefaultActionGroup(), IdeaLog {
          * change. Newly-enabled channels get their action registered (via
          * [ensureActionsRegistered]); disabled channels' actions are hidden
          * (presentation visible=false) without unregistering, so keymap IDs
-         * remain stable across enable/disable cycles (Req 5.1, 5.2, Decision 4).
+         * remain stable across enable/disable cycles.
          *
          * Visibility for existing actions is re-evaluated by each
          * [ChannelExportAction]'s `update(AnActionEvent)` method (per-context
@@ -67,7 +67,7 @@ class ChannelQuickActionGroup : DefaultActionGroup(), IdeaLog {
          * mutate `templatePresentation.isVisible` here — the IntelliJ Platform
          * forbids direct template-presentation mutation
          * (Presentation.assertNotTemplatePresentation). This achieves the same
-         * "hide not unregister" semantics (Decision 4) while respecting the
+         * "hide not unregister" semantics while respecting the
          * platform's presentation contract.
          *
          * Safe to call when the group is not registered (no-op) and idempotent.

--- a/src/main/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProvider.kt
@@ -106,10 +106,10 @@ class ApiMethodLineMarkerProvider : LineMarkerProvider {
      * - Unary/server-streaming: (Req, StreamObserver<Resp>) -> void
      * - Client/bidirectional: (StreamObserver<Resp>) -> StreamObserver<Req>
      *
-     * Uses the `apiClassRecognizer` EP seam (Decision CO9) to verify the
+     * Uses the `apiClassRecognizer` EP seam to verify the
      * containing class is claimed by at least one recognizer's
      * [ApiClassRecognizer.matchesClass] fast-path — without consulting the
-     * rule engine (PR1 contract). Only then is the more expensive
+     * rule engine. Only then is the more expensive
      * [GrpcMethodResolver.resolveStreamingType] invoked.
      */
     private suspend fun isGrpcRpcMethod(method: PsiMethod): Boolean {

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/AnnotatedElementsHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/AnnotatedElementsHelper.kt
@@ -1,0 +1,217 @@
+package com.itangcent.easyapi.core.psi.helper
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import com.itangcent.easyapi.core.internal.threading.readSync
+import com.itangcent.easyapi.core.logging.IdeaLog
+
+/**
+ * Finds [PsiClass] / [PsiMethod] instances by annotation FQN.
+ *
+ * Wraps [AnnotatedElementsSearch.searchPsiClasses] /
+ * [AnnotatedElementsSearch.searchPsiMethods] with annotation resolution via
+ * [JavaPsiFacade.findClass] (all-scope) + an `isAnnotationType` guard. The
+ * search itself runs in [GlobalSearchScope.projectScope] so only project
+ * sources are returned (matching the existing
+ * [com.itangcent.easyapi.core.ai.tools.FindClassesByAnnotationTool] behavior).
+ *
+ * ## Why a separate helper
+ *
+ * Previously the lookup logic lived directly on
+ * [com.itangcent.easyapi.core.rule.parser.ScriptHelper], which made it
+ * unreachable from non-script code and untestable in isolation. This class
+ * splits the responsibilities:
+     * - **`AnnotatedElementsHelper`** (this class) — pure PSI lookup, returns
+     *   `List<PsiClass>` / `List<PsiMethod>` (or a single `PsiClass?` via the
+     *   singular `findClassByAnnotation`). Project-scoped `@Service`, no
+     *   dependency on rule-script context.
+     * - **`ScriptHelper.findClassByAnnotation` /
+     *   `ScriptHelper.findClassesByAnnotation` / `findMethodsByAnnotation`** —
+     *   thin wrappers that call this helper and wrap each result in a
+     *   [com.itangcent.easyapi.core.rule.context.ScriptPsiClassContext] /
+     *   [com.itangcent.easyapi.core.rule.context.ScriptPsiMethodContext] for the
+     *   `helper` / `H` script binding.
+ *
+ * This mirrors the existing `SourceHelper` pattern (project service, plain
+ * PSI return type, suspend + sync variants) and the
+ * [com.itangcent.easyapi.core.ai.tools.FindClassesByAnnotationTool] AI-tool
+ * pattern (same `AnnotatedElementsSearch` API + `isAnnotationType` filter).
+ *
+ * ## Threading
+ *
+ * All public methods run inside [readSync] so they can be called from any
+ * rule-script context (the JSR-223 boundary is non-suspending). Callers
+ * already inside a read action incur no nested read action cost (IntelliJ
+ * re-entrant read actions are essentially free).
+ *
+ * ## Error handling
+ *
+     * Every public method returns an empty value on any failure (empty list
+     * for the plural variants, `null` for `findClassByAnnotation`; unresolvable
+     * annotation FQN, non-annotation type, read-action failure). Errors are
+     * logged at `warn` with the throwable as the last arg — per AGENTS.md
+     * §"Logging" → "Anti-patterns" (no silent `runCatching{}.getOrNull()`).
+ *
+ * @see ScriptHelper for the script-binding surface
+ * @see com.itangcent.easyapi.core.ai.tools.FindClassesByAnnotationTool for the AI-tool equivalent
+ */
+@Service(Service.Level.PROJECT)
+class AnnotatedElementsHelper(private val project: Project) : IdeaLog {
+
+    companion object {
+        /**
+         * Get the [AnnotatedElementsHelper] instance for a project.
+         *
+         * @param project the IntelliJ project
+         * @return the project-scoped service instance
+         */
+        fun getInstance(project: Project): AnnotatedElementsHelper = project.service()
+    }
+
+    /**
+     * Finds the first class annotated with the given annotation FQN.
+     *
+     * Singular counterpart of [findClassesByAnnotation]: it stops at the
+     * first match instead of collecting all hits, so it is cheaper when the
+     * caller only needs one result. This covers the common case where a
+     * document-level annotation (e.g. `@SwaggerDefinition`,
+     * `@OpenAPIDefinition`) is declared on a single config class — the rule
+     * scripts previously wrote `findClassesByAnnotation(...)[0]`, which still
+     * paid for the full scan.
+     *
+     * Returns `null` when:
+     * - [annotationFqn] is blank
+     * - the annotation cannot be resolved via [JavaPsiFacade.findClass] in
+     *   [GlobalSearchScope.allScope]
+     * - the resolved class is NOT an annotation type (e.g., the FQN points at
+     *   a regular class)
+     * - the read action throws
+     * - no class is annotated
+     *
+     * @param annotationFqn fully-qualified annotation name (e.g.,
+     *   `"org.springframework.stereotype.Service"`). Simple names are NOT
+     *   supported here — the script-binding layer (`ScriptHelper`) keeps that
+     *   flexibility for AI tools via `PsiNameResolver`. Production rule
+     *   scripts always pass FQNs.
+     * @return the first matching [PsiClass] in project scope, or `null` on
+     *   any error or when no class is annotated (never throws).
+     * @see findClassesByAnnotation for the all-matches variant
+     */
+    fun findClassByAnnotation(annotationFqn: String): PsiClass? {
+        if (annotationFqn.isBlank()) return null
+        return runCatching {
+            readSync {
+                val annotationClass = resolveAnnotation(annotationFqn) ?: return@readSync null
+                val scope = GlobalSearchScope.projectScope(project)
+                AnnotatedElementsSearch
+                    .searchPsiClasses(annotationClass, scope)
+                    .findFirst()
+            }
+        }.onFailure {
+            LOG.warn("AnnotatedElementsHelper.findClassByAnnotation failed for '$annotationFqn'", it)
+        }.getOrNull()
+    }
+
+    /**
+     * Finds all classes annotated with the given annotation FQN.
+     *
+     * Returns an empty list when:
+     * - [annotationFqn] is blank
+     * - the annotation cannot be resolved via [JavaPsiFacade.findClass] in
+     *   [GlobalSearchScope.allScope]
+     * - the resolved class is NOT an annotation type (e.g., the FQN points at
+     *   a regular class)
+     * - the read action throws
+     *
+     * When only the first match is needed, prefer the cheaper
+     * [findClassByAnnotation], which stops the search early.
+     *
+     * @param annotationFqn fully-qualified annotation name (e.g.,
+     *   `"org.springframework.stereotype.Service"`). Simple names are NOT
+     *   supported here — the script-binding layer (`ScriptHelper`) keeps that
+     *   flexibility for AI tools via `PsiNameResolver`. Production rule
+     *   scripts always pass FQNs.
+     * @return matching [PsiClass] instances in project scope (empty on any
+     *   error; never throws).
+     */
+    fun findClassesByAnnotation(annotationFqn: String): List<PsiClass> {
+        if (annotationFqn.isBlank()) return emptyList()
+        return runCatching {
+            readSync {
+                val annotationClass = resolveAnnotation(annotationFqn) ?: return@readSync emptyList<PsiClass>()
+                val scope = GlobalSearchScope.projectScope(project)
+                val hits = AnnotatedElementsSearch
+                    .searchPsiClasses(annotationClass, scope)
+                    .findAll()
+                LOG.info("AnnotatedElementsHelper: found ${hits.size} class(es) annotated with $annotationFqn")
+                hits.toList()
+            }
+        }.onFailure {
+            LOG.warn("AnnotatedElementsHelper.findClassesByAnnotation failed for '$annotationFqn'", it)
+        }.getOrDefault(emptyList())
+    }
+
+    /**
+     * Finds all methods annotated with the given annotation FQN.
+     *
+     * Returns an empty list when:
+     * - [annotationFqn] is blank
+     * - the annotation cannot be resolved via [JavaPsiFacade.findClass]
+     * - the resolved class is NOT an annotation type
+     * - the read action throws
+     *
+     * @param annotationFqn fully-qualified annotation name (e.g.,
+     *   `"org.springframework.context.annotation.Bean"`).
+     * @return matching [PsiMethod] instances in project scope (empty on any
+     *   error; never throws).
+     */
+    fun findMethodsByAnnotation(annotationFqn: String): List<PsiMethod> {
+        if (annotationFqn.isBlank()) return emptyList()
+        return runCatching {
+            readSync {
+                val annotationClass = resolveAnnotation(annotationFqn) ?: return@readSync emptyList<PsiMethod>()
+                val scope = GlobalSearchScope.projectScope(project)
+                val hits = AnnotatedElementsSearch
+                    .searchPsiMethods(annotationClass, scope)
+                    .findAll()
+                LOG.info("AnnotatedElementsHelper: found ${hits.size} method(s) annotated with $annotationFqn")
+                hits.toList()
+            }
+        }.onFailure {
+            LOG.warn("AnnotatedElementsHelper.findMethodsByAnnotation failed for '$annotationFqn'", it)
+        }.getOrDefault(emptyList())
+    }
+
+    /**
+     * Resolves [annotationFqn] to a [PsiClass] and verifies it is an
+     * annotation type.
+     *
+     * Returns `null` and logs at `info` when:
+     * - the FQN cannot be resolved (no such class on the project classpath)
+     * - the resolved class is not `isAnnotationType` (e.g., the FQN points at
+     *   a regular class/interface/enum)
+     *
+     * `info` (not `warn`) is correct here because "user passed a non-existent
+     * FQN" is a routine rule-script condition, not a recoverable failure —
+     * the caller returns an empty list and the rule engine falls through.
+     */
+    private fun resolveAnnotation(annotationFqn: String): PsiClass? {
+        val annotationClass = JavaPsiFacade.getInstance(project)
+            .findClass(annotationFqn, GlobalSearchScope.allScope(project))
+        if (annotationClass == null) {
+            LOG.info("AnnotatedElementsHelper: annotation not resolvable: $annotationFqn")
+            return null
+        }
+        if (!annotationClass.isAnnotationType) {
+            LOG.info("AnnotatedElementsHelper: not an annotation type: $annotationFqn")
+            return null
+        }
+        return annotationClass
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedAnnotationHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedAnnotationHelper.kt
@@ -95,6 +95,7 @@ class UnifiedAnnotationHelper : AnnotationHelper, com.itangcent.easyapi.core.log
 
     private fun normalizeValue(value: PsiAnnotationMemberValue, project: Project): Any? {
         return when (value) {
+            is PsiAnnotation -> normalizeAttributes(value, project)
             is PsiLiteralExpression -> value.value
             is PsiClassObjectAccessExpression -> value.operand.type.canonicalText
             is PsiArrayInitializerMemberValue -> value.initializers.mapNotNull { normalizeValue(it, project) }

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptApiEndpoint.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptApiEndpoint.kt
@@ -112,7 +112,7 @@ class ScriptApiEndpoint(
      * - When [project] is null (e.g. unit tests, headless rule eval), falls back to
      *   the pure format path — no settings, no scripts.
      *
-     * ## SPI indirection (Decision CO8)
+     * ## SPI indirection
      *
      * Delegates to [CurlRenderer] (application-scoped SPI in `channel.spi`),
      * never to concrete `channel.curl.*` types — keeps the CO3 DAG rule

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptParser.kt
@@ -8,6 +8,8 @@ import com.itangcent.easyapi.core.internal.threading.readSync
 import com.itangcent.easyapi.core.http.HttpClientProvider
 import com.itangcent.easyapi.core.http.ScriptHttpClient
 import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.psi.LinkResolver
+import com.itangcent.easyapi.core.psi.helper.AnnotatedElementsHelper
 import com.itangcent.easyapi.core.psi.helper.SourceHelper
 import com.itangcent.easyapi.core.psi.type.JsonType
 import com.itangcent.easyapi.core.rule.RuleKey
@@ -128,7 +130,7 @@ abstract class Jsr223ScriptParser(
         // executeSync(...) (the suspend HttpClient.execute is not callable from the
         // blocking JSR-223 boundary). Scope: bound ONLY here (groovy: rule values +
         // http.call.before/after events), NOT in PmScriptExecutor (postman.* scripts
-        // use pm.sendRequest for sub-requests if ever needed). Spec: ai-workflow-patterns T2.3.
+        // use pm.sendRequest for sub-requests if ever needed).
         val rawHttpClient = runCatching {
             HttpClientProvider.getInstance(context.project).getClient()
         }.onFailure { LOG.warn("Jsr223ScriptParser: failed to get httpClient", it) }
@@ -164,10 +166,10 @@ abstract class Jsr223ScriptParser(
  *
  * @param context The rule context
  */
-class ScriptHelper(private val context: RuleContext) {
+class ScriptHelper(private val context: RuleContext) : IdeaLog {
 
-    private val linkResolver: com.itangcent.easyapi.core.psi.LinkResolver? by lazy {
-        com.itangcent.easyapi.core.psi.LinkResolver.getInstance(context.project)
+    private val linkResolver: LinkResolver? by lazy {
+        LinkResolver.getInstance(context.project)
     }
 
     /**
@@ -250,6 +252,128 @@ class ScriptHelper(private val context: RuleContext) {
                 else -> null
             }
         }
+    }
+
+    /**
+     * Finds the first class annotated with the given annotation FQN.
+     *
+     * Singular counterpart of [findClassesByAnnotation]. Returns a
+     * [ScriptPsiClassContext] wrapper for the first match, or `null` when no
+     * class is annotated or the annotation is not resolvable. Never throws —
+     * any error is logged at `warn` and `null` is returned.
+     *
+     * This is the idiomatic form for document-level annotations (e.g.
+     * `@SwaggerDefinition`, `@OpenAPIDefinition`) that live on a single config
+     * class — the rule scripts previously wrote
+     * `findClassesByAnnotation(...)[0]` with a redundant `isEmpty()` guard,
+     * which still paid for the full scan.
+     *
+     * The actual PSI lookup lives in
+     * [AnnotatedElementsHelper.findClassByAnnotation]; this wrapper is a thin
+     * context adapter that wraps the raw [com.intellij.psi.PsiClass] result in
+     * a [ScriptPsiClassContext] for the `helper` / `H` script binding.
+     *
+     * ## Usage in Scripts
+     * ```
+     * // Find the single @SwaggerDefinition config class
+     * def cls = helper.findClassByAnnotation("io.swagger.annotations.SwaggerDefinition")
+     * if (cls == null) return null
+     * return cls.annMap("io.swagger.annotations.SwaggerDefinition")?.info?.title
+     *
+     * // Short alias
+     * def cls = H.findClassByAnnotation("io.swagger.annotations.SwaggerDefinition")
+     * ```
+     *
+     * @param annotationFqn fully-qualified annotation name (e.g.
+     *   `"io.swagger.annotations.SwaggerDefinition"`). Simple names are NOT
+     *   supported — pass the FQN.
+     * @return a [ScriptPsiClassContext] for the first match, or `null`.
+     * @see findClassesByAnnotation for the all-matches variant
+     */
+    fun findClassByAnnotation(annotationFqn: String): Any? {
+        if (annotationFqn.isBlank()) return null
+        val hit = AnnotatedElementsHelper.getInstance(context.project)
+            .findClassByAnnotation(annotationFqn) ?: return null
+        return ScriptPsiClassContext(context.withElement(hit))
+    }
+
+    /**
+     * Finds all classes annotated with the given annotation FQN.
+     *
+     * Returns a list of [ScriptPsiClassContext] wrappers (empty list if no
+     * matches or the annotation is not resolvable). Never throws — any error
+     * is logged at `warn` and an empty list is returned.
+     *
+     * When only the first match is needed, prefer [findClassByAnnotation],
+     * which stops the search early and returns `null` instead of an empty list.
+     *
+     * The actual PSI lookup was
+     * extracted to [AnnotatedElementsHelper] so it can be reused by non-script
+     * callers and unit-tested in isolation (see
+     * `AnnotatedElementsHelperTest`). This wrapper is now a thin context
+     * adapter — it delegates the lookup to the helper and wraps each raw
+     * [com.intellij.psi.PsiClass] result in a [ScriptPsiClassContext] for the
+     * `helper` / `H` script binding.
+     *
+     * ## Usage in Scripts
+     * ```
+     * // Find all classes annotated with @Service
+     * def services = helper.findClassesByAnnotation("org.springframework.stereotype.Service")
+     *
+     * // Short alias
+     * def services = H.findClassesByAnnotation("org.springframework.stereotype.Service")
+     * ```
+     *
+     * Added for the `springfox-openapi.config`
+     * Springfox `Docket` extractor and any rule script that needs to locate
+     * annotated code.
+     *
+     * @param annotationFqn fully-qualified annotation name (e.g.
+     *   `"org.springframework.context.annotation.Bean"`). Simple names are NOT
+     *   supported — pass the FQN.
+     */
+    fun findClassesByAnnotation(annotationFqn: String): List<Any> {
+        if (annotationFqn.isBlank()) return emptyList()
+        val hits = AnnotatedElementsHelper.getInstance(context.project)
+            .findClassesByAnnotation(annotationFqn)
+        return hits.map { ScriptPsiClassContext(context.withElement(it)) }
+    }
+
+    /**
+     * Finds all methods annotated with the given annotation FQN.
+     *
+     * Returns a list of [ScriptPsiMethodContext] wrappers (empty list if no
+     * matches or the annotation is not resolvable). Never throws — any error
+     * is logged at `warn` and an empty list is returned.
+     *
+     * The actual PSI lookup was
+     * extracted to [AnnotatedElementsHelper] (see `findClassesByAnnotation`
+     * above). This wrapper delegates the lookup to the helper and wraps each
+     * raw [com.intellij.psi.PsiMethod] result in a [ScriptPsiMethodContext]
+     * for the `helper` / `H` script binding.
+     *
+     * ## Usage in Scripts
+     * ```
+     * // Find all @Bean methods (Springfox Docket beans)
+     * def beanMethods = helper.findMethodsByAnnotation("org.springframework.context.annotation.Bean")
+     *
+     * // Short alias
+     * def beanMethods = H.findMethodsByAnnotation("org.springframework.context.annotation.Bean")
+     * ```
+     *
+     * Added for the `springfox-openapi.config`
+     * Springfox `Docket` extractor (locates `@Bean` methods returning
+     * `springfox.documentation.spring.web.plugins.Docket`).
+     *
+     * @param annotationFqn fully-qualified annotation name (e.g.
+     *   `"org.springframework.context.annotation.Bean"`). Simple names are NOT
+     *   supported — pass the FQN.
+     */
+    fun findMethodsByAnnotation(annotationFqn: String): List<Any> {
+        if (annotationFqn.isBlank()) return emptyList()
+        val hits = AnnotatedElementsHelper.getInstance(context.project)
+            .findMethodsByAnnotation(annotationFqn)
+        return hits.map { ScriptPsiMethodContext(context.withElement(it)) }
     }
 }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/migration/SettingsMigrationActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/migration/SettingsMigrationActivity.kt
@@ -72,7 +72,7 @@ class SettingsMigrationActivity : StartupActivity {
      * Reads legacy [ApplicationSettingsState] and writes to [UnifiedAppSettingsState]
      * under each module's qualified-name key.
      *
-     * v4 branch (PR7) translates the legacy per-framework booleans
+     * v4 branch translates the legacy per-framework booleans
      * (`feignEnable`, `jaxrsEnable`, `actuatorEnable`, `grpcEnable`) to the unified
      * `enabledFrameworks`/`disabledFrameworks` arrays in `GeneralSettings`. The
      * translation is idempotent (uses [MutableSet] semantics) and only adds an
@@ -149,14 +149,14 @@ class SettingsMigrationActivity : StartupActivity {
         appState.setValue(ruleFileKey, "disabledGlobalRuleFiles", GsonUtils.toJson(legacy.disabledGlobalRuleFiles))
 
         // PostmanSettings (APP) — postmanToken standardized to APP only
-        // FQN used as string literal to avoid concrete-impl import from core.* (Decision CO3)
+        // FQN used as string literal to avoid concrete-impl import from core.*.
         val postmanKey = "com.itangcent.easyapi.channel.postman.PostmanSettings"
         appState.setValue(postmanKey, "postmanToken", legacy.postmanToken)
         appState.setValue(postmanKey, "wrapCollection", legacy.wrapCollection.toString())
         appState.setValue(postmanKey, "autoMergeScript", legacy.autoMergeScript.toString())
         appState.setValue(postmanKey, "postmanJson5FormatType", legacy.postmanJson5FormatType)
 
-        // v4 (PR7): translate legacy per-framework booleans to the unified
+        // v4: translate legacy per-framework booleans to the unified
         // enabledFrameworks/disabledFrameworks arrays in GeneralSettings.
         // Idempotent — initialized from existing arrays so re-running migration
         // does not duplicate entries. Only non-default legacy values produce an
@@ -203,7 +203,7 @@ class SettingsMigrationActivity : StartupActivity {
         projState.setValue(envKey, "projectEnvironments", legacy.projectEnvironments)
         projState.setValue(envKey, "disabledAutoRuleFiles", GsonUtils.toJson(legacy.disabledAutoRuleFiles))
 
-        // PostmanSettings (PROJ) — FQN as string literal (Decision CO3)
+        // PostmanSettings (PROJ) — FQN as string literal
         val postmanKey = "com.itangcent.easyapi.channel.postman.PostmanSettings"
         projState.setValue(postmanKey, "postmanWorkspace", legacy.postmanWorkspace)
         projState.setValue(postmanKey, "postmanExportMode", legacy.postmanExportMode)

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/EasyApiSettingsConfigurable.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/EasyApiSettingsConfigurable.kt
@@ -219,10 +219,10 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
 
         // Re-apply the enablement filter to the quick-action group so newly
         // enabled channels appear and disabled channels are hidden without an
-        // IDE restart (Req 5.1, 5.2). Safe to call when no group is registered.
+        // IDE restart. Safe to call when no group is registered.
         ChannelQuickActionGroup.refreshActions(project)
         // Mirror for field-format actions: re-register newly-enabled formats and
-        // let per-context update() hide disabled ones (Req A4, Decision A5).
+        // let per-context update() hide disabled ones.
         FieldFormatActionGroup.refreshActions(project)
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanels.kt
@@ -486,15 +486,15 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
  * - **Framework support** (Feign, JAX-RS, Actuator) — moved here from
  *   [GeneralSettingsPanel] so all enable/disable checkboxes share a tab.
  * - **Export Channels** — one checkbox per registered [Channel], built
- *   dynamically from [ChannelRegistry.allChannels] (Req 3.1, 3.4).
+ *   dynamically from [ChannelRegistry.allChannels].
  * - **Field Format Channels** — one checkbox per registered
  *   [FieldFormatChannel], built from
- *   [FieldFormatChannelRegistry.allChannels] (Req A3.1, A3.4).
+ *   [FieldFormatChannelRegistry.allChannels].
  *
  * Typed by [GeneralSettings] (the same module [GeneralSettingsPanel] reads),
  * so a panel touching a module it doesn't "own" follows the existing
  * `grpcRepositories` precedent. The channel/format checkbox logic is isolated
- * in cross-module helpers that mirror that pattern (design Decision 5 / A3).
+ * in cross-module helpers that mirror that pattern.
  */
 class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Project) : SettingsPanel<GeneralSettings> {
 
@@ -502,9 +502,9 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
      * Dynamic checkbox→recognizer mapping for the "Framework Support" section.
      *
      * Built once from [CompositeApiClassRecognizer.allRecognizers] (deliberately
-     * **unfiltered**, so disabled frameworks are listed and can be re-enabled —
-     * Req 4.5). Empty when no recognizers are registered, in which case the
-     * section is skipped gracefully (Req 4.6).
+     * **unfiltered**, so disabled frameworks are listed and can be re-enabled).
+     * Empty when no recognizers are registered, in which case the
+     * section is skipped gracefully.
      */
     private val frameworkEnablementCheckboxes = mutableListOf<Pair<ApiClassRecognizer, JBCheckBox>>()
 
@@ -512,31 +512,30 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
      * Dynamic checkbox→channel mapping for the "Export Channels" section.
      *
      * Built once from [ChannelRegistry.allChannels] (deliberately **unfiltered**,
-     * so disabled channels are listed and can be re-enabled — Req 3.4). Empty
+     * so disabled channels are listed and can be re-enabled). Empty
      * when no channels are registered, in which case the section is skipped
-     * gracefully (Req 3.7).
+     * gracefully.
      */
     private val channelEnablementCheckboxes = mutableListOf<Pair<Channel, JBCheckBox>>()
 
     /**
-     * Dynamic checkbox→format mapping for the "Field Format Channels" section
-     * (Req A3.1, A3.4).
+     * Dynamic checkbox→format mapping for the "Field Format Channels" section.
      *
      * Built once from [FieldFormatChannelRegistry.allChannels] (deliberately
-     * **unfiltered**, so disabled formats are listed and can be re-enabled —
-     * Req A3.4). Empty when no formats are registered, in which case the
-     * section is skipped gracefully (Req A3.7).
+     * **unfiltered**, so disabled formats are listed and can be re-enabled).
+     * Empty when no formats are registered, in which case the
+     * section is skipped gracefully.
      */
     private val fieldFormatEnablementCheckboxes = mutableListOf<Pair<FieldFormatChannel, JBCheckBox>>()
 
     /**
      * Builds the "Framework Support" titled panel containing one [JBCheckBox]
-     * per registered recognizer (Req 4.1, 4.3, 4.5). Uses
+     * per registered recognizer. Uses
      * [CompositeApiClassRecognizer.allRecognizers] (unfiltered) so disabled
      * frameworks remain listed and re-enableable.
      *
-     * Returns an empty panel when no recognizers are registered (Req 4.6 —
-     * graceful skip, no error).
+     * Returns an empty panel when no recognizers are registered
+     * (graceful skip, no error).
      */
     private fun buildFrameworkEnablementPanel(): JComponent {
         val allRecognizers = CompositeApiClassRecognizer.getInstance(project).allRecognizers()
@@ -555,10 +554,10 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
 
     /**
      * Builds the "Export Channels" titled panel containing one [JBCheckBox] per
-     * registered channel (Req 3.1, 3.4). Uses [ChannelRegistry.allChannels]
+     * registered channel. Uses [ChannelRegistry.allChannels]
      * (unfiltered) so disabled channels remain listed and re-enableable.
      *
-     * Returns an empty panel when no channels are registered (Req 3.7 — graceful
+     * Returns an empty panel when no channels are registered (graceful
      * skip, no error).
      */
     private fun buildChannelEnablementPanel(): JComponent {
@@ -577,11 +576,11 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
 
     /**
      * Builds the "Field Format channels" titled panel containing one [JBCheckBox]
-     * per registered format (Req A3.1, A3.4). Uses
+     * per registered format. Uses
      * [FieldFormatChannelRegistry.allChannels] (unfiltered) so disabled formats
      * remain listed and re-enableable.
      *
-     * Returns an empty panel when no formats are registered (Req A3.7 — graceful
+     * Returns an empty panel when no formats are registered (graceful
      * skip, no error).
      */
     private fun buildFieldFormatEnablementPanel(): JComponent {
@@ -638,9 +637,9 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
      * Resets the "Framework Support" checkboxes to the effective enabled state
      * derived from [GeneralSettings.enabledFrameworks] /
      * [GeneralSettings.disabledFrameworks] overlaid on each recognizer's
-     * [ApiClassRecognizer.enabledByDefault] (Req 4.4).
+     * [ApiClassRecognizer.enabledByDefault].
      *
-     * No-op when no recognizers are registered (Req 4.6).
+     * No-op when no recognizers are registered.
      */
     fun resetFrameworkEnablementFrom(recognizers: List<ApiClassRecognizer>, settings: GeneralSettings) {
         frameworkEnablementCheckboxes.forEach { (recognizer, cb) ->
@@ -677,7 +676,7 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
     /**
      * Returns `true` if any "Framework Support" checkbox differs from the
      * effective enabled state in [settings]. No-op (returns `false`) when no
-     * recognizers are registered (Req 4.6).
+     * recognizers are registered.
      */
     fun isFrameworkEnablementModified(recognizers: List<ApiClassRecognizer>, settings: GeneralSettings): Boolean {
         frameworkEnablementCheckboxes.forEach { (recognizer, cb) ->
@@ -701,14 +700,14 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
     // --- Channel enablement (cross-module methods, mirror the *Repositories* pattern) ---
     // The data lives on [GeneralSettings] (enabledChannels / disabledChannels),
     // but the UI is built from [ChannelRegistry.allChannels]. These three methods
-    // keep the checkbox-list logic isolated and testable (design Decision 5).
+    // keep the checkbox-list logic isolated and testable.
 
     /**
      * Resets the "Export Channels" checkboxes to the effective enabled state
      * derived from [GeneralSettings.enabledChannels] / [GeneralSettings.disabledChannels]
-     * overlaid on each channel's [Channel.enabledByDefault] (Req 3.6).
+     * overlaid on each channel's [Channel.enabledByDefault].
      *
-     * No-op when no channels are registered (Req 3.7).
+     * No-op when no channels are registered.
      */
     fun resetChannelEnablementFrom(channels: List<Channel>, settings: GeneralSettings) {
         channelEnablementCheckboxes.forEach { (channel, cb) ->
@@ -745,7 +744,7 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
     /**
      * Returns `true` if any "Export Channels" checkbox differs from the effective
      * enabled state in [settings]. No-op (returns `false`) when no channels are
-     * registered (Req 3.7).
+     * registered.
      */
     fun isChannelEnablementModified(channels: List<Channel>, settings: GeneralSettings): Boolean {
         channelEnablementCheckboxes.forEach { (channel, cb) ->
@@ -770,15 +769,15 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
     // The data lives on [GeneralSettings] (enabledFieldFormatChannels /
     // disabledFieldFormatChannels), but the UI is built from
     // [FieldFormatChannelRegistry.allChannels]. These three methods keep the
-    // checkbox-list logic isolated and testable (Decision A3).
+    // checkbox-list logic isolated and testable.
 
     /**
      * Resets the "Field Format Channels" checkboxes to the effective enabled
      * state derived from [GeneralSettings.enabledFieldFormatChannels] /
      * [GeneralSettings.disabledFieldFormatChannels] overlaid on each format's
-     * [FieldFormatChannel.enabledByDefault] (Req A3.6).
+     * [FieldFormatChannel.enabledByDefault].
      *
-     * No-op when no formats are registered (Req A3.7).
+     * No-op when no formats are registered.
      */
     fun resetFieldFormatEnablementFrom(channels: List<FieldFormatChannel>, settings: GeneralSettings) {
         fieldFormatEnablementCheckboxes.forEach { (channel, cb) ->
@@ -816,7 +815,7 @@ class FeaturesSettingsPanel(private val project: com.intellij.openapi.project.Pr
     /**
      * Returns `true` if any "Field Format Channels" checkbox differs from the
      * effective enabled state in [settings]. No-op (returns `false`) when no
-     * formats are registered (Req A3.7).
+     * formats are registered.
      */
     fun isFieldFormatEnablementModified(channels: List<FieldFormatChannel>, settings: GeneralSettings): Boolean {
         fieldFormatEnablementCheckboxes.forEach { (channel, cb) ->
@@ -1816,7 +1815,7 @@ class BackupSettingsPanel(private val project: com.intellij.openapi.project.Proj
                 ?.toTypedArray()?.let { enabledFieldFormatChannels = it }
             obj.get("disabledFieldFormatChannels")?.takeIf { it.isJsonArray }?.asJsonArray?.map { it.asString }
                 ?.toTypedArray()?.let { disabledFieldFormatChannels = it }
-            // Legacy per-framework booleans → unified arrays (mirrors PR7 migration).
+            // Legacy per-framework booleans → unified arrays.
             // A legacy `true` for a default-off framework (Feign, Actuator) adds it
             // to enabledFrameworks; a legacy `false` for a default-on framework
             // (JAX-RS, gRPC) adds it to disabledFrameworks. Default-matching legacy

--- a/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatAction.kt
@@ -35,7 +35,7 @@ class FieldFormatAction(
     override fun update(e: AnActionEvent) {
         // Re-evaluate visibility per-display-context (NOT templatePresentation,
         // which the platform forbids mutating — Presentation.assertNotTemplatePresentation).
-        // This is the chokepoint for "hide not unregister" (Decision A5): a
+        // This is the chokepoint for "hide not unregister": a
         // disabled format's action stays registered (keymap IDs remain stable)
         // but is hidden from the menu because isVisible resolves to false.
         e.presentation.isVisible = e.project?.let {

--- a/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatActionGroup.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatActionGroup.kt
@@ -23,7 +23,7 @@ import com.itangcent.easyapi.core.logging.IdeaLog
  * [getChildren] as a fallback. Enablement is filtered through
  * [FieldFormatChannelRegistry.getEnabledChannels] so disabled formats do not
  * get an action registered; visibility of already-registered actions is
- * re-evaluated per-context by [FieldFormatAction.update] (Decision A5).
+ * re-evaluated per-context by [FieldFormatAction.update].
  *
  * ## Adding a new format
  *
@@ -67,7 +67,7 @@ class FieldFormatActionGroup : DefaultActionGroup(), IdeaLog {
          * change. Newly-enabled formats get their action registered (via
          * [ensureActionsRegistered]); disabled formats' actions are hidden
          * (presentation visible=false) without unregistering, so keymap IDs
-         * remain stable across enable/disable cycles (Req A4.1–A4.3, Decision A5).
+         * remain stable across enable/disable cycles.
          *
          * Visibility for existing actions is re-evaluated by each
          * [FieldFormatAction]'s `update(AnActionEvent)` method (per-context
@@ -75,7 +75,7 @@ class FieldFormatActionGroup : DefaultActionGroup(), IdeaLog {
          * mutate `templatePresentation.isVisible` here — the IntelliJ Platform
          * forbids direct template-presentation mutation
          * (Presentation.assertNotTemplatePresentation). This achieves the same
-         * "hide not unregister" semantics (Decision A5) while respecting the
+         * "hide not unregister" semantics while respecting the
          * platform's presentation contract.
          *
          * Safe to call when the group is not registered (no-op) and idempotent.

--- a/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannel.kt
@@ -44,14 +44,14 @@ interface FieldFormatChannel {
      *
      * Mirrors [com.itangcent.easyapi.channel.spi.Channel.enabledByDefault].
      * All four shipping formats (JSON, JSON5, Properties, YAML) keep the default
-     * `true` (Decision A2 — none is experimental). A future experimental format
+     * `true` (none is experimental). A future experimental format
      * overrides this to `false` and the enablement machinery handles it with no
      * further work. The effective enabled state is resolved against the stored
      * user preference by
      * [FieldFormatChannelRegistry.isEnabled].
      *
      * This is a static (compile-time) declaration; it is not user-editable or
-     * persisted directly (Req A1.3).
+     * persisted directly.
      */
     val enabledByDefault: Boolean get() = true
 

--- a/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistry.kt
@@ -31,7 +31,7 @@ import com.itangcent.easyapi.core.settings.read
  * [SettingBinder.getInstance] requires a [Project] to read the
  * APPLICATION-scoped [GeneralSettings] (mirroring how `ChannelRegistry` reads
  * the same settings). Query methods take no project parameter — the registry
- * holds the project internally (Decision A1).
+ * holds the project internally.
  *
  * ## Usage
  *
@@ -86,8 +86,8 @@ class FieldFormatChannelRegistry(private val project: Project) : IdeaLog {
      * the project-scoped `channel` EP).
      *
      * Unfiltered by design — returns every registered format regardless of
-     * enabled state (Req A3.4 — so a disabled format can be re-enabled in the
-     * Settings UI). Consumers that need only enabled formats must use
+     * enabled state — so a disabled format can be re-enabled in the
+     * Settings UI. Consumers that need only enabled formats must use
      * [getEnabledChannels].
      */
     fun allChannels(): List<FieldFormatChannel> =
@@ -104,7 +104,7 @@ class FieldFormatChannelRegistry(private val project: Project) : IdeaLog {
      *
      * If the settings storage cannot be read, falls back to
      * [FieldFormatChannel.enabledByDefault] for every format and does not throw
-     * (Req A2.6; AGENTS.md forbids silent `runCatching`).
+     * (AGENTS.md forbids silent `runCatching`).
      */
     fun isEnabled(channel: FieldFormatChannel): Boolean {
         val settings = try {

--- a/src/main/kotlin/com/itangcent/easyapi/framework/spi/FrameworkRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/spi/FrameworkRegistry.kt
@@ -13,7 +13,7 @@ import com.itangcent.easyapi.core.settings.read
 /**
  * Project-level service that resolves the effective enabled state of every
  * registered [ApiClassRecognizer] — the single chokepoint for framework
- * enablement (PR4).
+ * enablement.
  *
  * Mirrors [com.itangcent.easyapi.channel.spi.ChannelRegistry] structurally:
  * a pure [resolveEnabled] companion rule (testable without a [Project]),
@@ -24,7 +24,7 @@ import com.itangcent.easyapi.core.settings.read
  *
  * ## Why this lives in `framework/spi/`
  *
- * Per the broadened CO3 rule (Decision PR4 / Spec Reconciliation PR10), `core.*`
+ * Per the broadened CO3 rule, `core.*`
  * may import the `framework.spi.*` contract surface — mirroring the existing
  * allowance for `channel.spi.*` and `format.spi.*`. Concrete framework
  * implementations (`framework.<id>.*`) remain off-limits to `core.*`.
@@ -36,14 +36,14 @@ import com.itangcent.easyapi.core.settings.read
  * - [GeneralSettings.disabledFrameworks] — explicit-off overrides
  *
  * A framework id is the recognizer's [ApiClassRecognizer.frameworkName]
- * (PR5 — reuse, no new SPI member).
+ * (reuse, no new SPI member).
  *
  * ## Fallback
  *
  * If [SettingBinder] cannot read [GeneralSettings] (e.g. storage not yet
  * initialized during startup), [isEnabled] falls back to
  * [ApiClassRecognizer.enabledByDefault] and does not throw (mirrors
- * [com.itangcent.easyapi.channel.spi.ChannelRegistry.isEnabled] Req 2.6).
+ * [com.itangcent.easyapi.channel.spi.ChannelRegistry.isEnabled]).
  *
  * @see ApiClassRecognizer
  * @see CompositeApiClassRecognizer
@@ -90,7 +90,7 @@ class FrameworkRegistry(private val project: Project) : IdeaLog {
      *
      * If the settings storage cannot be read, falls back to
      * [ApiClassRecognizer.enabledByDefault] for the recognizer and does not
-     * throw (Req 2.6 — mirrors ChannelRegistry fallback).
+     * throw (mirrors ChannelRegistry fallback).
      */
     fun isEnabled(recognizer: ApiClassRecognizer): Boolean {
         val settings = try {
@@ -116,7 +116,7 @@ class FrameworkRegistry(private val project: Project) : IdeaLog {
      * registered (which is also the correct answer when the framework is
      * disabled — its recognizer is filtered out of the cache).
      *
-     * PR5: [frameworkId] must match [ApiClassRecognizer.frameworkName].
+     * [frameworkId] must match [ApiClassRecognizer.frameworkName].
      */
     fun isEnabled(frameworkId: String): Boolean {
         val recognizer = CompositeApiClassRecognizer.getInstance(project).recognizers()

--- a/src/main/kotlin/com/itangcent/easyapi/framework/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/springmvc/SpringMvcClassExporter.kt
@@ -183,7 +183,7 @@ class SpringMvcClassExporter(
                             contentType = contentType,
                             body = body,
                             responseBody = responseBody,
-                            responseType = response.toString()
+                            responseType = response.qualifiedName()
                         )
                     )
                 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,10 +24,10 @@
         <extensionPoint name="classExporter" interface="com.itangcent.easyapi.core.export.ClassExporter" area="IDEA_PROJECT" dynamic="true"/>
         <extensionPoint name="channel" interface="com.itangcent.easyapi.channel.spi.Channel" area="IDEA_PROJECT" dynamic="true"/>
         <extensionPoint name="fieldFormatChannel" interface="com.itangcent.easyapi.format.spi.FieldFormatChannel" dynamic="true"/>
-        <!-- Decision CO9: EP-based discovery for framework recognizers.
+        <!-- EP-based discovery for framework recognizers.
              CompositeApiClassRecognizer iterates EP-discovered instances and
              filters by ApiClassRecognizer.isEnabled(project) — so core.*
-             no longer hard-imports framework.<id>.* recognizer classes (DAG rule CO3). -->
+             no longer hard-imports framework.<id>.* recognizer classes (DAG rule). -->
         <extensionPoint name="apiClassRecognizer" interface="com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer" area="IDEA_PROJECT" dynamic="true"/>
     </extensionPoints>
 
@@ -37,7 +37,7 @@
         <classExporter implementation="com.itangcent.easyapi.framework.jaxrs.JaxRsClassExporter"/>
         <classExporter implementation="com.itangcent.easyapi.framework.springmvc.ActuatorEndpointExporter"/>
         <classExporter implementation="com.itangcent.easyapi.framework.grpc.GrpcClassExporter"/>
-        <!-- Decision CO9: register framework recognizers via EP.
+        <!-- register framework recognizers via EP.
              CompositeApiClassRecognizer discovers these via ExtensionPointName
              and filters by isEnabled(project) (settings-driven). -->
         <apiClassRecognizer implementation="com.itangcent.easyapi.framework.springmvc.SpringControllerRecognizer"/>
@@ -50,6 +50,7 @@
         <channel implementation="com.itangcent.easyapi.channel.curl.CurlChannel"/>
         <channel implementation="com.itangcent.easyapi.channel.httpclient.HttpClientChannel"/>
         <channel implementation="com.itangcent.easyapi.channel.hoppscotch.HoppscotchChannel"/>
+        <channel implementation="com.itangcent.easyapi.channel.openapi.OpenApiChannel"/>
         <fieldFormatChannel implementation="com.itangcent.easyapi.format.json.JsonFieldFormatChannel"/>
         <fieldFormatChannel implementation="com.itangcent.easyapi.format.json5.Json5FieldFormatChannel"/>
         <fieldFormatChannel implementation="com.itangcent.easyapi.format.properties.PropertiesFieldFormatChannel"/>
@@ -64,7 +65,7 @@
         <!-- Migration flag + activity -->
         <applicationService serviceImplementation="com.itangcent.easyapi.core.settings.migration.MigrationFlag"/>
         <applicationService serviceImplementation="com.itangcent.easyapi.core.cache.AppCacheRepository"/>
-        <!-- Decision CO8: register CurlRenderer SPI → cURL impl.
+        <!-- register CurlRenderer SPI → cURL impl.
              core.* callers (ScriptApiEndpoint.toCurl, ApiDashboardPanel copy-as-cURL)
              look up via CurlRenderer.getInstance(); never import the concrete
              CurlBuilder/CurlExportResolver/CurlScriptScopes/CurlSettings from core
@@ -96,7 +97,7 @@
         <projectService serviceImplementation="com.itangcent.easyapi.core.export.ClassExporterRegistry"/>
         <projectService serviceImplementation="com.itangcent.easyapi.channel.spi.ChannelRegistry"/>
         <projectService serviceImplementation="com.itangcent.easyapi.framework.spi.FrameworkRegistry"/>
-        <!-- Decision CO7: register EnvironmentSyncSupport SPI → Postman impl.
+        <!-- register EnvironmentSyncSupport SPI → Postman impl.
              core.* callers look up via EnvironmentSyncSupport.getInstance(project);
              never import the concrete EnvironmentSyncService from core (DAG rule CO3). -->
         <projectService serviceInterface="com.itangcent.easyapi.channel.spi.EnvironmentSyncSupport"

--- a/src/main/resources/extensions/springfox-openapi.config
+++ b/src/main/resources/extensions/springfox-openapi.config
@@ -1,0 +1,164 @@
+---
+code: springfox-openapi
+description: OpenAPI channel document-level extraction from Springfox Docket beans
+on-class: springfox.documentation.spring.web.plugins.Docket
+default-enabled: true
+---
+
+# ─── Springfox Docket extraction ───────────────────────────────────────────
+# Springfox Docket is configured via Java code (Spring @Bean methods returning
+# springfox.documentation.spring.web.plugins.Docket), NOT via annotations on
+# the controller class. The extraction uses the script helper
+# `helper.findMethodsByAnnotation("org.springframework.context.annotation.Bean")`
+# to locate @Bean methods, then filters by return type = Docket, then walks
+# the method body for `.apiInfo(...)` / `.pathMapping(...)` / `.host(...)`
+# calls.
+#
+# Returns null when no Docket @Bean is found — rule engine returns blank —
+# channel falls through to the built-in defaults
+# (infoTitle=projectName|"API", infoVersion="1.0.0", etc.).
+#
+# The previous version of this file used `${find_docket_bean}` placeholders
+# to share groovy logic across rule keys. That is BROKEN —
+# `PropertyResolver` (core/config/parser/PropertyResolver.kt) performs RAW
+# TEXT SUBSTITUTION: it replaces `${find_docket_bean}` with the literal text
+# value of the `find_docket_bean` property (the entire groovy block),
+# producing invalid nested code like `def m = def methods = helper.findMethodsByAnnotation(...)`.
+# Each rule key's groovy script MUST be self-contained — no cross-rule
+# `${...}` references. The find-Docket logic is inlined into each script.
+#
+# Method-name corrections: the previous version called `m.text()` and
+# `ret.qualifiedName()` which do NOT exist on the script contexts.
+# Correct calls (see core/rule/context/ScriptItContext.kt#sourceCode and
+# ScriptPsiContexts.kt#ScriptTypeContext.name):
+#   - `m.sourceCode()` returns the PsiMethod's text (inherited from
+#     ScriptItContext#sourceCode).
+#   - `ret.name()` returns the return type's qualified name (ScriptTypeContext
+#     already exposes the FQN via name()).
+#
+# The script helpers are exposed via `helper.findMethodsByAnnotation` and
+# `helper.findClassesByAnnotation` (bound as `H` alias too). The lookup
+# logic lives in `core/psi/helper/AnnotatedElementsHelper.kt`;
+# `ScriptHelper` is a thin context-adapter wrapper.
+
+# ─── Rule keys ────────────────────────────────────────────────────────────
+# Each rule key is evaluated by OpenApiChannel.resolveRuleBasedEnvelope
+# against each endpoint's sourceClass. When no Docket @Bean is found, the
+# script returns null — the rule engine returns blank — the channel falls
+# through to the built-in defaults.
+#
+# Each script block is SELF-CONTAINED (no `${...}` cross-references) and
+# follows the same pattern:
+#   1. find @Bean methods via helper.findMethodsByAnnotation(...)
+#   2. filter by return type name ending in "Docket"
+#   3. read the method body via m.sourceCode()
+#   4. extract the relevant string via regex
+
+openapi.info.title=groovy:```
+    def methods = helper.findMethodsByAnnotation("org.springframework.context.annotation.Bean")
+    if (methods == null || methods.isEmpty()) return null
+    for (m in methods) {
+        def ret = m.returnType()
+        if (ret == null) continue
+        def retName = ret.name()
+        if (retName == null || !retName.endsWith("Docket")) continue
+        def body = m.sourceCode()
+        if (body == null) return null
+        // Try constructor form: new ApiInfo("title", ...)
+        def ctor = body =~ /new\s+ApiInfo\s*\(\s*"([^"]+)"/
+        if (ctor.find()) return ctor.group(1)
+        // Try builder form: .title("...")
+        def builder = body =~ /\.title\s*\(\s*"([^"]+)"/
+        if (builder.find()) return builder.group(1)
+        return null
+    }
+    return null
+```
+
+openapi.info.version=groovy:```
+    def methods = helper.findMethodsByAnnotation("org.springframework.context.annotation.Bean")
+    if (methods == null || methods.isEmpty()) return null
+    for (m in methods) {
+        def ret = m.returnType()
+        if (ret == null) continue
+        def retName = ret.name()
+        if (retName == null || !retName.endsWith("Docket")) continue
+        def body = m.sourceCode()
+        if (body == null) return null
+        // Constructor form: new ApiInfo("title", "desc", "version", ...)
+        def ctor = body =~ /new\s+ApiInfo\s*\(\s*"[^"]+"\s*,\s*"[^"]+"\s*,\s*"([^"]+)"/
+        if (ctor.find()) return ctor.group(1)
+        // Builder form: .version("...")
+        def builder = body =~ /\.version\s*\(\s*"([^"]+)"/
+        if (builder.find()) return builder.group(1)
+        return null
+    }
+    return null
+```
+
+openapi.info.description=groovy:```
+    def methods = helper.findMethodsByAnnotation("org.springframework.context.annotation.Bean")
+    if (methods == null || methods.isEmpty()) return null
+    for (m in methods) {
+        def ret = m.returnType()
+        if (ret == null) continue
+        def retName = ret.name()
+        if (retName == null || !retName.endsWith("Docket")) continue
+        def body = m.sourceCode()
+        if (body == null) return null
+        // Constructor form: new ApiInfo("title", "description", ...)
+        def ctor = body =~ /new\s+ApiInfo\s*\(\s*"[^"]+"\s*,\s*"([^"]+)"/
+        if (ctor.find()) return ctor.group(1)
+        // Builder form: .description("...")
+        def builder = body =~ /\.description\s*\(\s*"([^"]+)"/
+        if (builder.find()) return builder.group(1)
+        return null
+    }
+    return null
+```
+
+# Server URL: combine .host(...) and .pathMapping(...) when both present.
+# When only .host(...) is present, use "https://{host}".
+# When only .pathMapping(...) is present, treat it as the full URL.
+# Returns null when neither is present.
+#
+# The groovy script below uses groovy string
+# interpolation `${scheme}${host}${path}` which collides with
+# `PropertyResolver`'s `${key}` placeholder syntax. `PropertyResolver` performs
+# RAW TEXT SUBSTITUTION during config loading — it would try to resolve
+# `scheme`, `host`, `path` as property keys and replace them with their
+# (likely empty) values, corrupting the groovy script. We wrap the rule with
+# `###set resolveProperty=false` / `###set resolveProperty=true` to disable
+# property resolution for this block, then re-enable it for the rest of the file.
+###set resolveProperty=false
+openapi.server.url=groovy:```
+    def methods = helper.findMethodsByAnnotation("org.springframework.context.annotation.Bean")
+    if (methods == null || methods.isEmpty()) return null
+    def host = null
+    def path = null
+    for (m in methods) {
+        def ret = m.returnType()
+        if (ret == null) continue
+        def retName = ret.name()
+        if (retName == null || !retName.endsWith("Docket")) continue
+        def body = m.sourceCode()
+        if (body == null) continue
+        def hostMatcher = body =~ /\.host\s*\(\s*"([^"]+)"/
+        if (hostMatcher.find()) host = hostMatcher.group(1)
+        def pathMatcher = body =~ /\.pathMapping\s*\(\s*"([^"]+)"/
+        if (pathMatcher.find()) path = pathMatcher.group(1)
+        // First Docket bean wins — stop after we have scanned it.
+        break
+    }
+    if (host == null && path == null) return null
+    if (host != null && path != null) {
+        def scheme = host.startsWith("http://") || host.startsWith("https://") ? "" : "https://"
+        return "${scheme}${host}${path}"
+    }
+    if (host != null) {
+        def scheme = host.startsWith("http://") || host.startsWith("https://") ? "" : "https://"
+        return "${scheme}${host}"
+    }
+    return path
+```
+###set resolveProperty=true

--- a/src/main/resources/extensions/swagger-openapi.config
+++ b/src/main/resources/extensions/swagger-openapi.config
@@ -1,0 +1,74 @@
+---
+code: swagger-openapi
+description: OpenAPI channel document-level extraction from Swagger v2 annotations
+on-class: io.swagger.annotations.SwaggerDefinition
+default-enabled: true
+---
+
+# ─── Swagger v2 document-level extraction ───────────────────────────────────
+# `@SwaggerDefinition` is a document-level annotation declared on a SEPARATE
+# config class, NOT on the controller. The scripts use
+# `helper.findClassByAnnotation(...)` to locate the annotated config class
+# globally, then read the annotation from the found class via `.annMap(...)`.
+#
+# These rule keys are DOCUMENT-LEVEL — evaluated ONCE per export operation
+# (without an element context), not per controller class. The scripts do not
+# reference `it` at all; they rely solely on `helper.*`.
+#
+# Supported annotations:
+#   - @SwaggerDefinition(host, basePath, schemes, info=@Info(title, version, description))
+#   - @Info — nested in @SwaggerDefinition; carries title / version / description
+#   - @SwaggerDefinition.Scheme — enum array (HTTP, HTTPS, WS, WSS); take first
+#     and lowercase for the server URL scheme
+#
+# `annMap` returns the full annotation as a Map<String, Any?>; groovy
+# safe-navigation (?.info?.title) walks into nested annotations.
+#
+# Returns null when no class annotated with @SwaggerDefinition is found — the
+# rule engine returns blank — the channel falls through to the built-in defaults.
+openapi.info.title=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.annotations.SwaggerDefinition")
+    if (cls == null) return null
+    return cls.annMap("io.swagger.annotations.SwaggerDefinition")?.info?.title
+```
+openapi.info.version=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.annotations.SwaggerDefinition")
+    if (cls == null) return null
+    return cls.annMap("io.swagger.annotations.SwaggerDefinition")?.info?.version
+```
+openapi.info.description=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.annotations.SwaggerDefinition")
+    if (cls == null) return null
+    return cls.annMap("io.swagger.annotations.SwaggerDefinition")?.info?.description
+```
+
+# Server URL: Swagger 2 uses host + basePath + schemes (not @Server).
+# Combine them into a single OAS server URL: "{scheme}://{host}{basePath}".
+# @SwaggerDefinition#schemes is an array of Scheme enum values; take the
+# first and lowercase it (HTTP -> http). Defaults to https when absent.
+# Returns null when host is absent (channel falls through to next tier).
+# Note: `annMap` normalizes annotation arrays to Lists, so use `schemes.size()`
+# (not `schemes.length` which only works on Java arrays).
+#
+# The groovy script below uses groovy string
+# interpolation `${scheme}://...` which collides with `PropertyResolver`'s
+# `${key}` placeholder syntax. `PropertyResolver` performs RAW TEXT
+# SUBSTITUTION during config loading — it would try to resolve `scheme`,
+# `host`, `basePath` as property keys and replace them with their (likely
+# empty) values, corrupting the groovy script. We wrap the rule with
+# `###set resolveProperty=false` / `###set resolveProperty=true` to disable
+# property resolution for this block, then re-enable it for the rest of the file.
+###set resolveProperty=false
+openapi.server.url=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.annotations.SwaggerDefinition")
+    if (cls == null) return null
+    def defn = cls.annMap("io.swagger.annotations.SwaggerDefinition")
+    if (defn == null) return null
+    def host = defn.host
+    def basePath = defn.basePath ?: ""
+    def schemes = defn.schemes
+    def scheme = (schemes != null && !schemes.isEmpty()) ? schemes[0].toString().toLowerCase() : "https"
+    if (host == null || host.toString().isBlank()) return null
+    return "${scheme}://${host}${basePath}"
+```
+###set resolveProperty=true

--- a/src/main/resources/extensions/swagger3-openapi.config
+++ b/src/main/resources/extensions/swagger3-openapi.config
@@ -1,0 +1,58 @@
+---
+code: swagger3-openapi
+description: OpenAPI channel document-level extraction from Swagger v3 / OpenAPI 3.0 annotations
+on-class: io.swagger.v3.oas.annotations.OpenAPIDefinition
+default-enabled: true
+---
+
+# ─── Swagger v3 / OpenAPI 3.0 document-level extraction ─────────────────────
+# `@OpenAPIDefinition` is a document-level annotation declared on a SEPARATE
+# config class (typically `@Configuration`), NOT on the controller. The
+# scripts use `helper.findClassByAnnotation(...)` to locate the annotated
+# config class globally, then read the annotation from the found class via
+# `.annMap(...)`.
+#
+# These rule keys are DOCUMENT-LEVEL — evaluated ONCE per export operation
+# (without an element context), not per controller class. The scripts do not
+# reference `it` at all; they rely solely on `helper.*`.
+#
+# Supported annotations:
+#   - @OpenAPIDefinition(info=@Info(title, version, description), servers=[@Server(url)])
+#   - @Info — nested in @OpenAPIDefinition; carries title / version / description
+#   - @Server — nested in @OpenAPIDefinition#servers; carries url
+#   - @SecurityScheme — declared at the document level (NOT extracted here yet;
+#       a future extension could populate components.securitySchemes)
+#   - @Tag — declared at the document level (NOT extracted here yet; future
+#       extension could pre-populate the document's `tags` array)
+#
+# `annMap` returns the full annotation as a Map<String, Any?>; groovy
+# safe-navigation (?.info?.title) walks into nested annotations. This is the
+# same pattern the existing swagger3.config uses for @Parameter extraction.
+#
+# Returns null when no class annotated with @OpenAPIDefinition is found — the
+# rule engine returns blank — the channel falls through to the built-in
+# defaults (infoTitle=projectName|"API", infoVersion="1.0.0", etc.).
+openapi.info.title=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.v3.oas.annotations.OpenAPIDefinition")
+    if (cls == null) return null
+    return cls.annMap("io.swagger.v3.oas.annotations.OpenAPIDefinition")?.info?.title
+```
+openapi.info.version=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.v3.oas.annotations.OpenAPIDefinition")
+    if (cls == null) return null
+    return cls.annMap("io.swagger.v3.oas.annotations.OpenAPIDefinition")?.info?.version
+```
+openapi.info.description=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.v3.oas.annotations.OpenAPIDefinition")
+    if (cls == null) return null
+    return cls.annMap("io.swagger.v3.oas.annotations.OpenAPIDefinition")?.info?.description
+```
+
+# Server URL: take the first @Server entry's url. When multiple servers are
+# declared, only the first is used (OAS supports multiple, but the envelope
+# carries a single serverUrl — a v2 enhancement could extend this).
+openapi.server.url=groovy:```
+    def cls = helper.findClassByAnnotation("io.swagger.v3.oas.annotations.OpenAPIDefinition")
+    if (cls == null) return null
+    return cls.annMap("io.swagger.v3.oas.annotations.OpenAPIDefinition")?.servers?.first()?.url
+```

--- a/src/test/kotlin/com/itangcent/easyapi/channel/hoppscotch/HoppHeaderVarConversionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/hoppscotch/HoppHeaderVarConversionTest.kt
@@ -17,10 +17,8 @@ import org.junit.Test
  * Formatter-level test for unresolved `${...}` placeholder conversion in Hoppscotch
  * header values (`${x}` → `<<x>>`).
  *
- * Symmetric to `PostmanHeaderVarConversionTest` (Task 4.1) but targets the
+ * Symmetric to `PostmanHeaderVarConversionTest` but targets the
  * Hoppscotch `<<...>>` variable syntax via [HoppscotchFormatter.buildHeaders].
- *
- * - _Requirements: Req 5.2, 5.3, 5.4; NFR-3_
  */
 class HoppHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -47,7 +45,7 @@ class HoppHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
         return method.invoke(formatter(), meta) as List<HoppKeyValue>
     }
 
-    // ==================== Req 5.2: unresolved ${x} → <<x>> ====================
+    // ==================== unresolved ${x} → <<x>> ====================
 
     @Test
     fun testUnresolvedPlaceholderConvertsToAngleBrackets() {
@@ -64,7 +62,7 @@ class HoppHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertEquals("Bearer <<order-service-token>>", headers[0].value)
     }
 
-    // ==================== Req 5.3: resolved ${x} left untouched ====================
+    // ==================== resolved ${x} left untouched ====================
 
     @Test
     fun testResolvedPlaceholderLeftUntouched() {
@@ -80,7 +78,7 @@ class HoppHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertEquals("\${baseUrl}", headers[0].value)
     }
 
-    // ==================== Req 5.4: regex-capture ${1} left untouched ====================
+    // ==================== regex-capture ${1} left untouched ====================
 
     @Test
     fun testRegexCaptureReferenceLeftUntouched() {
@@ -96,7 +94,7 @@ class HoppHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertEquals("Basic \${1}", headers[0].value)
     }
 
-    // ==================== NFR-3: byte-parity golden (placeholder-free) ====================
+    // ==================== byte-parity golden (placeholder-free) ====================
 
     /**
      * A placeholder-free header set must serialize byte-identically to the

--- a/src/test/kotlin/com/itangcent/easyapi/channel/hoppscotch/HoppscotchChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/hoppscotch/HoppscotchChannelTest.kt
@@ -26,13 +26,13 @@ class HoppscotchChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testHoppscotchChannelIsDefaultOff() {
-        // Req 1.3: HoppscotchChannel ships disabled by default — users opt in via Settings.
+        // HoppscotchChannel ships disabled by default — users opt in via Settings.
         assertFalse(HoppscotchChannel().enabledByDefault)
     }
 
     fun testChannelRegistered() {
         val registry = ChannelRegistry.getInstance(project)
-        // allChannels() is the unfiltered registry primitive (Req 4.5) — a
+        // allChannels() is the unfiltered registry primitive — a
         // registration check must use it because hoppscotch is default-off and
         // therefore excluded from the filtered getAvailableChannels.
         val channels = registry.allChannels()

--- a/src/test/kotlin/com/itangcent/easyapi/channel/httpclient/HttpClientChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/httpclient/HttpClientChannelTest.kt
@@ -14,7 +14,7 @@ class HttpClientChannelTest {
 
     @Test
     fun testHttpClientChannelIsDefaultOff() {
-        // Req 1.4: HttpClientChannel ships disabled by default — users opt in via Settings.
+        // HttpClientChannel ships disabled by default — users opt in via Settings.
         assertFalse(HttpClientChannel().enabledByDefault)
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/ExtensionParsingTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/ExtensionParsingTest.kt
@@ -1,0 +1,486 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * Verifies each of the three OpenAPI-channel extension
+ * config files (`swagger3-openapi.config`, `swagger-openapi.config`,
+ * `springfox-openapi.config`) correctly extracts document-level metadata from
+ * a SEPARATE config class (NOT from the controller being exported).
+ *
+ * This mirrors how real projects declare OpenAPI metadata — on a dedicated
+ * `@Configuration` class, not on every controller. The fixes rewrote the
+ * extension configs to use `helper.findClassesByAnnotation(...)`
+ * / `helper.findMethodsByAnnotation(...)` instead of `it.annMap(...)` (which
+ * read the annotation from the current controller — always null in real
+ * projects where the annotation lives elsewhere).
+ *
+ * ## Structure
+ *
+ * Three inner test classes, one per extension. Each inner class:
+ *  - Overrides [createConfigReader] to load ONLY its extension's config file
+ *    (isolation — avoids cross-extension interference when multiple extensions
+ *    define the same rule key, e.g. `openapi.info.title`).
+ *  - Loads ONLY its extension's cross-class fixtures (a separate `@Configuration`
+ *    class carrying the document-level annotation + a plain `@RestController`
+ *    with no document-level annotation).
+ *  - Exports the PLAIN controller and asserts the document-level metadata
+ *    (title / version / description / server URL) is picked up from the
+ *    SEPARATE config class via the global `helper.findClassesByAnnotation(...)`
+ *    / `helper.findMethodsByAnnotation(...)` lookup.
+ *
+ * ## Fixtures (`api/extension/`)
+ *
+ * - `swagger3/OpenApiConfig.java` — `@Configuration @OpenAPIDefinition(info=...)`
+ * - `swagger3/PingController.java` — plain `@RestController` (no `@OpenAPIDefinition`)
+ * - `swagger2/SwaggerConfig.java` — `@Configuration @SwaggerDefinition(host=..., info=...)`
+ * - `swagger2/PingController.java` — plain `@RestController`
+ * - `springfox/DocketConfig.java` — `@Configuration` with `@Bean Docket api()` method
+ * - `springfox/PingController.java` — plain `@RestController`
+ *
+ * JUnit 3-style `testXxx()` naming is required because
+ * [EasyApiLightCodeInsightFixtureTestCase] extends
+ * `LightJavaCodeInsightFixtureTestCase` (a JUnit 3 `TestCase` subclass).
+ */
+class ExtensionParsingTest {
+
+    /**
+     * Shared base class for the three extension-specific inner test classes.
+     * Provides common setup (channel instance, JSON output format pin) and
+     * the `exportChannel` / `loadConfigFromResource` helpers.
+     */
+    abstract class Base : EasyApiLightCodeInsightFixtureTestCase() {
+
+        protected lateinit var channel: OpenApiChannel
+
+        override fun setUp() {
+            super.setUp()
+            channel = OpenApiChannel()
+            // Pin JSON output format so the ALWAYS_ASK prompt (which would
+            // block on EDT) is bypassed.
+            SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                outputFormat = "JSON"
+            }
+            // Load common Spring annotation stubs needed by all fixture
+            // controllers (@RestController, @RequestMapping, @GetMapping).
+            loadSpringStubs()
+        }
+
+        override fun tearDown() {
+            try {
+                SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                    outputFormat = "ALWAYS_ASK"
+                }
+            } finally {
+                super.tearDown()
+            }
+        }
+
+        /**
+         * Loads the common Spring annotation stubs needed by all fixture
+         * controllers (`@RestController`, `@RequestMapping`, `@GetMapping`).
+         * Extension-specific annotation stubs are loaded by each inner
+         * class's `setUp()`.
+         */
+        protected fun loadSpringStubs() {
+            loadFile("spring/RestController.java")
+            loadFile("spring/RequestMapping.java")
+            loadFile("spring/GetMapping.java")
+        }
+
+        /**
+         * Exports an endpoint whose `sourceClass` is the given [psiClass],
+         * using an explicit JSON [OpenApiConfig] to bypass the ALWAYS_ASK
+         * prompt. The endpoint's path/method are synthetic — the rule scripts
+         * use `helper.findClassesByAnnotation(...)` (global lookup, not
+         * per-element) so the sourceClass only matters for the `it` binding
+         * which the new scripts do not reference.
+         */
+        protected suspend fun exportChannel(psiClass: PsiClass): ExportResult {
+            val endpoint = endpointWithSourceClass(psiClass, methodName = "ping")
+            return channel.export(
+                ExportContext(
+                    project = project,
+                    endpoints = listOf(endpoint),
+                    channelId = "openapi",
+                    channelConfig = OpenApiConfig(outputFormat = OpenApiOutputFormat.JSON),
+                )
+            )
+        }
+
+        private fun endpointWithSourceClass(psiClass: PsiClass, methodName: String): ApiEndpoint {
+            val psiMethod = mock<PsiMethod> { on { this.name } doReturn methodName }
+            return ApiEndpoint(
+                name = methodName,
+                metadata = httpMetadata(path = "/ping", method = HttpMethod.GET),
+                sourceMethod = psiMethod,
+                sourceClass = psiClass,
+                className = psiClass.qualifiedName,
+            )
+        }
+
+        protected fun loadConfigFromResource(path: String): String {
+            return javaClass.classLoader.getResourceAsStream(path)
+                ?.bufferedReader(Charsets.UTF_8)
+                ?.use { it.readText() }
+                ?: error("Resource not found: $path")
+        }
+    }
+
+    // ─── swagger3-openapi.config ───────────────────────────────────────
+
+    /**
+     * Verifies `swagger3-openapi.config` extracts `@OpenAPIDefinition`
+     * metadata from a SEPARATE `@Configuration` class (NOT from the exported
+     * controller).
+     *
+     * The config uses
+     * `helper.findClassesByAnnotation("io.swagger.v3.oas.annotations.OpenAPIDefinition")`
+     * to locate the annotated config class globally. Previously it used
+     * `it.annMap(...)` against the current controller, which always returned
+     * null because `@OpenAPIDefinition` is never on the controller in real
+     * projects.
+     */
+    class Swagger3ExtensionTest : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/swagger3-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // Swagger v3 annotation stubs
+            loadFile("io/swagger/v3/oas/annotations/OpenAPIDefinition.java")
+            loadFile("io/swagger/v3/oas/annotations/info/Info.java")
+            loadFile("io/swagger/v3/oas/annotations/servers/Server.java")
+            // Spring @Configuration (OpenApiConfig.java is a @Configuration class)
+            loadFile("org/springframework/context/annotation/Configuration.java")
+            // Cross-class fixtures
+            loadFile("api/extension/swagger3/OpenApiConfig.java")
+            loadFile("api/extension/swagger3/PingController.java")
+        }
+
+        fun testCrossClassOpenApiDefinitionExtractsInfoTitle() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger3.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue("Expected Success, got: $result", result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.title should come from @OpenAPIDefinition on the SEPARATE OpenApiConfig class",
+                "Cross-Class Swagger3 Title",
+                metadata.document.info.title,
+            )
+        }
+
+        fun testCrossClassOpenApiDefinitionExtractsInfoVersion() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger3.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.version should come from @OpenAPIDefinition.info.version on OpenApiConfig",
+                "9.1.0",
+                metadata.document.info.version,
+            )
+        }
+
+        fun testCrossClassOpenApiDefinitionExtractsInfoDescription() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger3.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.description should come from @OpenAPIDefinition.info.description on OpenApiConfig",
+                "Cross-class OpenAPIDefinition description",
+                metadata.document.info.description,
+            )
+        }
+
+        fun testCrossClassOpenApiDefinitionExtractsServerUrl() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger3.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val servers = metadata.document.servers
+            assertNotNull(
+                "servers should be populated when @OpenAPIDefinition declares @Server on OpenApiConfig",
+                servers,
+            )
+            assertEquals("Expected exactly one server entry", 1, servers!!.size)
+            assertEquals(
+                "servers[0].url should come from @OpenAPIDefinition.servers[0].url on OpenApiConfig",
+                "https://cross-class.example.com",
+                servers.first().url,
+            )
+        }
+
+        fun testCrossClassSerializedContentContainsExpectedMetadata() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger3.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val content = metadata.content
+            // Verify the serialized JSON contains all the cross-class metadata.
+            assertTrue("JSON should contain the cross-class title: ${content.take(200)}",
+                content.contains("\"title\": \"Cross-Class Swagger3 Title\""))
+            assertTrue("JSON should contain the cross-class version",
+                content.contains("\"version\": \"9.1.0\""))
+            assertTrue("JSON should contain the cross-class description",
+                content.contains("\"description\": \"Cross-class OpenAPIDefinition description\""))
+            assertTrue("JSON should contain the cross-class server URL",
+                content.contains("\"url\": \"https://cross-class.example.com\""))
+        }
+    }
+
+    // ─── swagger-openapi.config ─────────────────────────────────────────
+
+    /**
+     * Verifies `swagger-openapi.config` extracts `@SwaggerDefinition`
+     * metadata from a SEPARATE `@Configuration` class (NOT from the exported
+     * controller).
+     *
+     * The `openapi.server.url` rule uses groovy
+     * string interpolation `${scheme}://${host}${basePath}` which collides
+     * with `PropertyResolver`'s `${key}` placeholder syntax. The rule is
+     * wrapped with `###set resolveProperty=false` / `###set resolveProperty=true`
+     * to disable property resolution for that block.
+     *
+     * The config uses
+     * `helper.findClassesByAnnotation("io.swagger.annotations.SwaggerDefinition")`
+     * instead of `it.annMap(...)`.
+     */
+    class Swagger2ExtensionTest : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/swagger-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // Swagger v2 annotation stubs
+            loadFile("io/swagger/annotations/SwaggerDefinition.java")
+            loadFile("io/swagger/annotations/Info.java")
+            // Spring @Configuration
+            loadFile("org/springframework/context/annotation/Configuration.java")
+            // Cross-class fixtures
+            loadFile("api/extension/swagger2/SwaggerConfig.java")
+            loadFile("api/extension/swagger2/PingController.java")
+        }
+
+        fun testCrossClassSwaggerDefinitionExtractsInfoTitle() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger2.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue("Expected Success, got: $result", result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.title should come from @SwaggerDefinition.info.title on the SEPARATE SwaggerConfig class",
+                "Cross-Class Swagger2 Title",
+                metadata.document.info.title,
+            )
+        }
+
+        fun testCrossClassSwaggerDefinitionExtractsInfoVersion() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger2.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.version should come from @SwaggerDefinition.info.version on SwaggerConfig",
+                "2.9",
+                metadata.document.info.version,
+            )
+        }
+
+        fun testCrossClassSwaggerDefinitionExtractsInfoDescription() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger2.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.description should come from @SwaggerDefinition.info.description on SwaggerConfig",
+                "Cross-class SwaggerDefinition description",
+                metadata.document.info.description,
+            )
+        }
+
+        fun testCrossClassSwaggerDefinitionCombinesHostBasePathSchemeIntoServerUrl() = runTest {
+            // The groovy script uses ${scheme}://${host}${basePath}
+            // which must be protected from PropertyResolver via ###set resolveProperty=false.
+            val psiClass = findClass("com.itangcent.extension.swagger2.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val servers = metadata.document.servers
+            assertNotNull(
+                "servers should be populated when @SwaggerDefinition declares host on SwaggerConfig",
+                servers,
+            )
+            assertEquals("Expected exactly one server entry", 1, servers!!.size)
+            assertEquals(
+                "servers[0].url should be assembled from scheme + host + basePath (property resolution disabled)",
+                "https://cross-class.example.com/v2",
+                servers.first().url,
+            )
+        }
+
+        fun testCrossClassSerializedContentContainsExpectedMetadata() = runTest {
+            val psiClass = findClass("com.itangcent.extension.swagger2.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val content = metadata.content
+            assertTrue("JSON should contain the cross-class title: ${content.take(200)}",
+                content.contains("\"title\": \"Cross-Class Swagger2 Title\""))
+            assertTrue("JSON should contain the cross-class version",
+                content.contains("\"version\": \"2.9\""))
+            assertTrue("JSON should contain the cross-class description",
+                content.contains("\"description\": \"Cross-class SwaggerDefinition description\""))
+            assertTrue("JSON should contain the assembled server URL (not corrupted by PropertyResolver)",
+                content.contains("\"url\": \"https://cross-class.example.com/v2\""))
+        }
+    }
+
+    // ─── springfox-openapi.config ───────────────────────────────────────
+
+    /**
+     * Verifies `springfox-openapi.config` extracts Springfox `Docket` metadata
+     * from a `@Bean` method on a SEPARATE `@Configuration` class (NOT from the
+     * exported controller).
+     *
+     * The `openapi.server.url` rule uses groovy string
+     * interpolation `${scheme}${host}${path}` which collides with
+     * `PropertyResolver`'s `${key}` placeholder syntax. The rule is wrapped
+     * with `###set resolveProperty=false` / `###set resolveProperty=true`.
+     *
+     * Each rule key's groovy script is self-contained
+     * (no `${...}` cross-references between rule keys) and uses the correct
+     * script-context method names (`m.sourceCode()` not `m.text()`,
+     * `ret.name()` not `ret.qualifiedName()`).
+     */
+    class SpringfoxExtensionTest : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/springfox-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // Spring @Bean / @Configuration (for Springfox Docket extraction)
+            loadFile("org/springframework/context/annotation/Bean.java")
+            loadFile("org/springframework/context/annotation/Configuration.java")
+            // Springfox stubs — only the declared-return-type name is
+            // inspected, plus the method body text; the real classes are
+            // never invoked.
+            loadFile("springfox/documentation/spring/web/plugins/Docket.java")
+            loadFile("springfox/documentation/service/ApiInfo.java")
+            // Cross-class fixtures
+            loadFile("api/extension/springfox/DocketConfig.java")
+            loadFile("api/extension/springfox/PingController.java")
+        }
+
+        fun testCrossClassSpringfoxDocketExtractsInfoTitle() = runTest {
+            val psiClass = findClass("com.itangcent.extension.springfox.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue("Expected Success, got: $result", result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.title should be parsed from `new ApiInfo(\"Cross-Class Springfox Title\", ...)` in the @Bean Docket body",
+                "Cross-Class Springfox Title",
+                metadata.document.info.title,
+            )
+        }
+
+        fun testCrossClassSpringfoxDocketExtractsInfoVersion() = runTest {
+            val psiClass = findClass("com.itangcent.extension.springfox.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.version should be the third positional arg of the ApiInfo constructor",
+                "5.0",
+                metadata.document.info.version,
+            )
+        }
+
+        fun testCrossClassSpringfoxDocketExtractsInfoDescription() = runTest {
+            val psiClass = findClass("com.itangcent.extension.springfox.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.description should be the second positional arg of the ApiInfo constructor",
+                "Cross-class Springfox description",
+                metadata.document.info.description,
+            )
+        }
+
+        fun testCrossClassSpringfoxDocketCombinesHostAndPathMappingIntoServerUrl() = runTest {
+            // The groovy script uses ${scheme}${host}${path}
+            // which must be protected from PropertyResolver via ###set resolveProperty=false.
+            val psiClass = findClass("com.itangcent.extension.springfox.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val servers = metadata.document.servers
+            assertNotNull(
+                "servers should be populated when the @Bean Docket declares .host(...) and .pathMapping(...)",
+                servers,
+            )
+            assertEquals("Expected exactly one server entry", 1, servers!!.size)
+            assertEquals(
+                "servers[0].url should be assembled from scheme + host + pathMapping (property resolution disabled)",
+                "https://cross-class.example.com/v5",
+                servers.first().url,
+            )
+        }
+
+        fun testCrossClassSerializedContentContainsExpectedMetadata() = runTest {
+            val psiClass = findClass("com.itangcent.extension.springfox.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val content = metadata.content
+            assertTrue("JSON should contain the cross-class title: ${content.take(200)}",
+                content.contains("\"title\": \"Cross-Class Springfox Title\""))
+            assertTrue("JSON should contain the cross-class version",
+                content.contains("\"version\": \"5.0\""))
+            assertTrue("JSON should contain the cross-class description",
+                content.contains("\"description\": \"Cross-class Springfox description\""))
+            assertTrue("JSON should contain the assembled server URL (not corrupted by PropertyResolver)",
+                content.contains("\"url\": \"https://cross-class.example.com/v5\""))
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiChannelRegistrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiChannelRegistrationTest.kt
@@ -1,0 +1,126 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.channel.spi.Channel
+import com.itangcent.easyapi.channel.spi.ChannelRegistry
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * Integration smoke test verifying that [OpenApiChannel] is registered in
+ * `plugin.xml` and discoverable via [ChannelRegistry].
+ *
+ * Unlike [com.itangcent.easyapi.channel.dummy.DummyChannelTest] which
+ * programmatically registers a test-only channel via the EP, this test
+ * asserts the production `plugin.xml` registration is live — so a missing
+ * `<channel implementation="...OpenApiChannel"/>` line shows up as a failed
+ * test, not a silent runtime miss.
+ *
+ * Uses [EasyApiLightCodeInsightFixtureTestCase] so the plugin.xml-declared
+ * EPs are registered by the IntelliJ test framework's bootstrap.
+ */
+class OpenApiChannelRegistrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    fun testOpenApiChannelIsRegisteredViaPluginXml() {
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(
+            "OpenApiChannel should be registered via plugin.xml and discoverable via ChannelRegistry",
+            channel
+        )
+        assertEquals("openapi", channel?.id)
+        assertEquals("OpenAPI (Beta)", channel?.displayName)
+    }
+
+    fun testOpenApiChannelAppearsInAllChannelsList() {
+        val channels = ChannelRegistry.getInstance(project).allChannels()
+        val openApi = channels.find { it is OpenApiChannel }
+        assertNotNull(
+            "OpenApiChannel should appear in ChannelRegistry.allChannels() (plugin.xml registration)",
+            openApi
+        )
+    }
+
+    fun testOpenApiChannelExposedAsAction() {
+        // getActionChannels() filters by isEnabled; since OpenApiChannel is
+        // disabled by default, verify the channel's action properties directly
+        // via the unfiltered getChannel() path.
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(channel)
+        assertTrue(
+            "OpenApiChannel should have exposeAsAction=true",
+            channel!!.exposeAsAction
+        )
+        assertEquals("Export to OpenAPI", channel.actionText)
+    }
+
+    fun testOpenApiChannelAvailableForSettings() {
+        // channelsForSettings() filters by isEnabled; since OpenApiChannel is
+        // disabled by default, verify the channel contributes a settings type
+        // directly via the unfiltered getChannel() path.
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(channel)
+        assertNotNull(
+            "OpenApiChannel should contribute a settings type (settings tab)",
+            channel!!.settingsType
+        )
+    }
+
+    fun testOpenApiChannelDisabledByDefault() {
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(channel)
+        assertFalse(
+            "OpenApiChannel should be disabled by default (opt-in channel)",
+            ChannelRegistry.getInstance(project).isEnabled(channel!!)
+        )
+    }
+
+    fun testOpenApiChannelIsAvailableForHttpEndpoints() {
+        // Even with no registered endpoints, isAvailableFor returns true for an empty list.
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(channel)
+        assertTrue(
+            "OpenApiChannel should be available for empty endpoint list",
+            channel!!.isAvailableFor(emptyList())
+        )
+    }
+
+    fun testOpenApiChannelCreatesOptionsPanel() {
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(channel)
+        val panel = channel!!.createOptionsPanel(project)
+        assertNotNull(
+            "OpenApiChannel.createOptionsPanel should return a non-null panel",
+            panel
+        )
+        assertTrue(
+            "OpenApiChannel.createOptionsPanel should return an OpenApiOptionsPanel",
+            panel is OpenApiOptionsPanel
+        )
+    }
+
+    fun testOpenApiChannelCreatesSettingsPanel() {
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(channel)
+        val panel = channel!!.createSettingsPanel(project)
+        assertNotNull(
+            "OpenApiChannel.createSettingsPanel should return a non-null panel",
+            panel
+        )
+        assertTrue(
+            "OpenApiChannel.createSettingsPanel should return an OpenApiSettingsPanel",
+            panel is OpenApiSettingsPanel
+        )
+    }
+
+    fun testOpenApiChannelRuleKeysAreRegistered() {
+        val channel = ChannelRegistry.getInstance(project).getChannel("openapi")
+        assertNotNull(channel)
+        val keys = channel!!.ruleKeys()
+        assertFalse(
+            "OpenApiChannel should contribute OPENAPI_HOST and OPENAPI_FORMAT_AFTER rule keys",
+            keys.isEmpty()
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiChannelTest.kt
@@ -1,0 +1,433 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.channel.spi.ChannelConfig
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.export.GrpcMetadata
+import com.itangcent.easyapi.core.export.GrpcStreamingType
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.intellij.openapi.ui.TestDialog
+import com.intellij.openapi.ui.TestDialogManager
+import com.intellij.psi.PsiMethod
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.io.File
+
+/**
+ * Tests for [OpenApiChannel].
+ *
+ * Covers:
+ *  - Channel metadata contract (id / displayName / supports flags / action text).
+ *  - gRPC filtering inside `export`: empty input → Error; gRPC-only →
+ *    Error; mixed HTTP+gRPC → only HTTP reach the formatter (Success carries
+ *    HTTP count); HTTP-only → Success carrying `OpenApiExportMetadata`.
+ *  - `isAvailableFor`: HTTP-only → true; gRPC-only → false; mixed →
+ *    true; empty → true.
+ *  - `handleResult` writes the file and returns `true`. Uses
+ *    `ChannelConfig.FileConfig` so the file path is deterministic (no dialog).
+ *
+ * Pattern mirrors [com.itangcent.easyapi.channel.postman.PostmanChannelWarnPathTest]
+ * for the project-aware setup and [com.itangcent.easyapi.channel.dummy.DummyChannelTest]
+ * for the channel-metadata assertions.
+ */
+class OpenApiChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var channel: OpenApiChannel
+    private var previousDialog: TestDialog? = null
+
+    override fun setUp() {
+        super.setUp()
+        channel = OpenApiChannel()
+        // Messages.showInfoMessage in handleResult would otherwise block on a
+        // real dialog — replace with a no-op for the file-save test.
+        previousDialog = try {
+            TestDialogManager.setTestDialog(TestDialog { 0 })
+        } catch (_: Exception) {
+            null
+        }
+        // OpenApiSettings defaults to "ALWAYS_ASK", which would cause
+        // `Messages.showChooseDialog` to block tests that don't pass an
+        // explicit `channelConfig`. Pin the persistent `outputFormat` to
+        // "JSON" for the duration of each test so the settings-fallback path
+        // resolves to JSON. Tests that need YAML / BINARY / ALWAYS_ASK
+        // behavior set their own value and reset to "JSON" in their `finally`
+        // blocks.
+        SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+            outputFormat = "JSON"
+        }
+    }
+
+    override fun tearDown() {
+        try {
+            previousDialog?.let { TestDialogManager.setTestDialog(it) }
+            SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                outputFormat = "JSON"
+            }
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    // ─── Channel metadata contract ───────────────────────
+
+    fun testChannelIdIsOpenapi() {
+        assertEquals("openapi", channel.id)
+    }
+
+    fun testChannelDisplayNameIsOpenAPI() {
+        // displayName carries the "(Beta)" suffix.
+        assertEquals("OpenAPI (Beta)", channel.displayName)
+    }
+
+    fun testChannelIsMarkedAsBeta() {
+        // OpenApiChannel is in beta status.
+        assertTrue("OpenApiChannel should be marked as beta", channel.beta)
+    }
+
+    fun testChannelSupportsHttpOnly() {
+        assertTrue(channel.supportsHttp)
+        assertFalse(channel.supportsGrpc)
+    }
+
+    fun testChannelExposedAsActionWithExpectedText() {
+        assertTrue(channel.exposeAsAction)
+        assertEquals("Export to OpenAPI", channel.actionText)
+    }
+
+    fun testChannelDisabledByDefault() {
+        // OpenAPI channel is opt-in — the user must enable it in Settings.
+        assertFalse(channel.enabledByDefault)
+    }
+
+    fun testChannelSettingsTypeIsOpenApiSettings() {
+        assertEquals(OpenApiSettings::class, channel.settingsType)
+    }
+
+    fun testChannelRuleKeysCollectedFromOpenApiRuleKeys() {
+        val keys = channel.ruleKeys()
+        assertEquals(6, keys.size)
+        assertTrue(keys.any { it.name == "openapi.host" })
+        assertTrue(keys.any { it.name == "openapi.server.url" })
+        assertTrue(keys.any { it.name == "openapi.info.title" })
+        assertTrue(keys.any { it.name == "openapi.info.version" })
+        assertTrue(keys.any { it.name == "openapi.info.description" })
+        assertTrue(keys.any { it.name == "openapi.format.after" })
+    }
+
+    // ─── export() — gRPC filtering ───────────────────────
+
+    fun testExportWithEmptyInputReturnsError() = runTest {
+        val context = ExportContext(
+            project = project,
+            endpoints = emptyList(),
+            channelId = "openapi",
+        )
+        val result = channel.export(context)
+        assertTrue("Empty input should yield ExportResult.Error, got: $result", result is ExportResult.Error)
+        assertEquals("No HTTP endpoints to export", (result as ExportResult.Error).message)
+    }
+
+    fun testExportWithGrpcOnlyInputReturnsError() = runTest {
+        val grpcEndpoint = grpcEndpoint()
+        val context = ExportContext(
+            project = project,
+            endpoints = listOf(grpcEndpoint),
+            channelId = "openapi",
+        )
+        val result = channel.export(context)
+        assertTrue("gRPC-only input should yield ExportResult.Error, got: $result", result is ExportResult.Error)
+        assertEquals("No HTTP endpoints to export", (result as ExportResult.Error).message)
+    }
+
+    fun testExportWithMixedHttpAndGrpcFiltersGrpcAndReturnsSuccessWithHttpCount() = runTest {
+        val http1 = httpEndpoint(name = "Get user", path = "/users/{id}", method = HttpMethod.GET, methodName = "getUser")
+        val http2 = httpEndpoint(name = "List users", path = "/users", method = HttpMethod.GET, methodName = "listUsers")
+        val grpc = grpcEndpoint()
+        val context = ExportContext(
+            project = project,
+            endpoints = listOf(http1, http2, grpc),
+            channelId = "openapi",
+        )
+        val result = channel.export(context)
+        assertTrue("Mixed input should yield ExportResult.Success, got: $result", result is ExportResult.Success)
+        val success = result as ExportResult.Success
+        assertEquals("Only HTTP endpoints should be counted", 2, success.count)
+        val metadata = success.metadata
+        assertNotNull("Success should carry OpenApiExportMetadata", metadata)
+        assertTrue("Metadata should be OpenApiExportMetadata, got: ${metadata?.javaClass}", metadata is OpenApiExportMetadata)
+    }
+
+    fun testExportWithHttpOnlyReturnsSuccessWithMetadata() = runTest {
+        val endpoint = httpEndpoint(
+            name = "Get user",
+            path = "/users/{id}",
+            method = HttpMethod.GET,
+            methodName = "getUser",
+        )
+        val context = ExportContext(
+            project = project,
+            endpoints = listOf(endpoint),
+            channelId = "openapi",
+        )
+        val result = channel.export(context)
+        assertTrue("HTTP-only input should yield ExportResult.Success, got: $result", result is ExportResult.Success)
+        val success = result as ExportResult.Success
+        assertEquals(1, success.count)
+        assertEquals("OpenAPI", success.target)
+        val metadata = success.metadata as? OpenApiExportMetadata
+            ?: error("Expected OpenApiExportMetadata, got: ${success.metadata?.javaClass}")
+        // Metadata carries the in-memory document, the format, and the
+        // pre-serialized content string.
+        assertNotNull(metadata.document)
+        assertEquals(OpenApiOutputFormat.JSON, metadata.outputFormat)
+        assertTrue("Content should be non-empty JSON", metadata.content.isNotBlank())
+        // JSON output starts with `{` (the openapi document root object).
+        val trimmed = metadata.content.trim()
+        assertTrue("JSON content should start with '{', got: ${trimmed.take(20)}", trimmed.startsWith("{"))
+        // The serialized content must contain the OAS version constant.
+        assertTrue("Content should embed openapi 3.0.3", metadata.content.contains("\"openapi\": \"3.0.3\""))
+    }
+
+    fun testExportYamlFormatWhenConfigured() = runTest {
+        val endpoint = httpEndpoint(
+            name = "Get user",
+            path = "/users/{id}",
+            method = HttpMethod.GET,
+            methodName = "getUser",
+        )
+        val context = ExportContext(
+            project = project,
+            endpoints = listOf(endpoint),
+            channelId = "openapi",
+            channelConfig = OpenApiConfig(outputFormat = OpenApiOutputFormat.YAML),
+        )
+        val result = channel.export(context)
+        assertTrue(result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        assertEquals(OpenApiOutputFormat.YAML, metadata.outputFormat)
+        // YAML output should not start with `{`; should not contain a leading `---`
+        // marker.
+        val trimmed = metadata.content.trimStart()
+        assertFalse("YAML content should not start with '{', got: ${trimmed.take(20)}", trimmed.startsWith("{"))
+        assertFalse("YAML content should not start with --- marker", trimmed.startsWith("---"))
+        assertTrue("YAML content should embed openapi: \"3.0.3\"", metadata.content.contains("openapi: \"3.0.3\""))
+    }
+
+    // ─── Settings fallback for outputFormat ───────────────────────
+
+    fun testExportUsesSettingsOutputFormatWhenNoTypedConfig() = runTest {
+        // Quick-export path: caller passes ChannelConfig.Empty (no options
+        // panel shown). The channel must fall back to the persistent
+        // OpenApiSettings.outputFormat.
+        SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+            outputFormat = "YAML"
+        }
+        try {
+            val endpoint = httpEndpoint(
+                name = "Get user",
+                path = "/users/{id}",
+                method = HttpMethod.GET,
+                methodName = "getUser",
+            )
+            val context = ExportContext(
+                project = project,
+                endpoints = listOf(endpoint),
+                channelId = "openapi",
+                channelConfig = ChannelConfig.Empty,
+            )
+            val result = channel.export(context)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "Settings outputFormat=YAML should be used when no typed config is provided",
+                OpenApiOutputFormat.YAML,
+                metadata.outputFormat,
+            )
+            assertFalse(
+                "Content should be YAML, not JSON",
+                metadata.content.trimStart().startsWith("{"),
+            )
+        } finally {
+            SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                outputFormat = "JSON"
+            }
+        }
+    }
+
+    fun testExportTypedConfigOverridesSettingsOutputFormat() = runTest {
+        // Options-panel path: typed config from buildConfig() takes precedence
+        // over the persistent settings value.
+        SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+            outputFormat = "YAML"
+        }
+        try {
+            val endpoint = httpEndpoint(
+                name = "Get user",
+                path = "/users/{id}",
+                method = HttpMethod.GET,
+                methodName = "getUser",
+            )
+            val context = ExportContext(
+                project = project,
+                endpoints = listOf(endpoint),
+                channelId = "openapi",
+                channelConfig = OpenApiConfig(outputFormat = OpenApiOutputFormat.JSON),
+            )
+            val result = channel.export(context)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "Typed config JSON should override settings YAML",
+                OpenApiOutputFormat.JSON,
+                metadata.outputFormat,
+            )
+        } finally {
+            SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                outputFormat = "JSON"
+            }
+        }
+    }
+
+    fun testExportFallsBackToJsonForUnrecognizedSettingsOutputFormat() = runTest {
+        SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+            outputFormat = "BINARY"
+        }
+        try {
+            val endpoint = httpEndpoint(
+                name = "Get user",
+                path = "/users/{id}",
+                method = HttpMethod.GET,
+                methodName = "getUser",
+            )
+            val context = ExportContext(
+                project = project,
+                endpoints = listOf(endpoint),
+                channelId = "openapi",
+                channelConfig = ChannelConfig.Empty,
+            )
+            val result = channel.export(context)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "Unrecognized format should fall back to JSON",
+                OpenApiOutputFormat.JSON,
+                metadata.outputFormat,
+            )
+        } finally {
+            SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                outputFormat = "JSON"
+            }
+        }
+    }
+
+    // ─── isAvailableFor ───────────────────────────────────────────
+
+    fun testIsAvailableForEmptyEndpointsReturnsTrue() {
+        // Channel.isAvailableFor returns true for empty input by SPI contract.
+        assertTrue(channel.isAvailableFor(emptyList()))
+    }
+
+    fun testIsAvailableForHttpEndpointsReturnsTrue() {
+        val http = httpEndpoint(path = "/users", method = HttpMethod.GET, methodName = "listUsers")
+        assertTrue(channel.isAvailableFor(listOf(http)))
+    }
+
+    fun testIsAvailableForGrpcOnlyEndpointsReturnsFalse() {
+        val grpc = grpcEndpoint()
+        assertFalse(channel.isAvailableFor(listOf(grpc)))
+    }
+
+    fun testIsAvailableForMixedEndpointsReturnsTrue() {
+        val http = httpEndpoint(path = "/users", method = HttpMethod.GET, methodName = "listUsers")
+        val grpc = grpcEndpoint()
+        assertTrue(channel.isAvailableFor(listOf(http, grpc)))
+    }
+
+    // ─── handleResult ───────────────────────────────────────
+
+    fun testHandleResultWritesFileAndReturnsTrue() = runTest {
+        // Use a temp directory + FileConfig so no save dialog is shown.
+        val tempDir = createTempDir(prefix = "openapi-test").apply { mkdirs() }
+        try {
+            val endpoint = httpEndpoint(
+                name = "Get user",
+                path = "/users/{id}",
+                method = HttpMethod.GET,
+                methodName = "getUser",
+            )
+            val context = ExportContext(
+                project = project,
+                endpoints = listOf(endpoint),
+                channelId = "openapi",
+            )
+            val exportResult = channel.export(context) as ExportResult.Success
+
+            val fileConfig = ChannelConfig.FileConfig(
+                outputDir = tempDir.absolutePath,
+                fileName = "openapi",
+            )
+            val handled = channel.handleResult(project, exportResult, fileConfig)
+
+            assertTrue("handleResult should return true (suppress default toast)", handled)
+            val expectedFile = File(tempDir, "openapi.json")
+            assertTrue("File ${expectedFile.absolutePath} should exist after handleResult", expectedFile.exists())
+            val content = expectedFile.readText()
+            assertTrue("Written file should contain openapi 3.0.3", content.contains("\"openapi\": \"3.0.3\""))
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    fun testHandleResultReturnsFalseForForeignMetadata() = runTest {
+        // When the metadata is not OpenApiExportMetadata, handleResult should
+        // return false so the orchestrator can fall back to default handling.
+        val foreignMetadata = object : com.itangcent.easyapi.core.export.ExportMetadata {
+            override fun formatDisplay(): String? = "Foreign"
+        }
+        val success = ExportResult.Success(
+            count = 1,
+            target = "Foreign",
+            metadata = foreignMetadata,
+        )
+        val handled = channel.handleResult(project, success, ChannelConfig.Empty)
+        assertFalse("handleResult should return false for foreign metadata", handled)
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private fun httpEndpoint(
+        name: String? = null,
+        path: String,
+        method: HttpMethod,
+        methodName: String,
+    ): ApiEndpoint {
+        val psiMethod = mock<PsiMethod> {
+            on { this.name } doReturn methodName
+        }
+        return ApiEndpoint(
+            name = name,
+            metadata = httpMetadata(path = path, method = method),
+            sourceMethod = psiMethod,
+        )
+    }
+
+    private fun grpcEndpoint(): ApiEndpoint = ApiEndpoint(
+        name = "SayHello",
+        metadata = GrpcMetadata(
+            path = "/helloworld.Greeter/SayHello",
+            serviceName = "Greeter",
+            methodName = "SayHello",
+            packageName = "helloworld",
+            streamingType = GrpcStreamingType.UNARY,
+        ),
+    )
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiConfigTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiConfigTest.kt
@@ -1,0 +1,114 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.channel.spi.ChannelConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Plain-JUnit tests for [OpenApiConfig], [OpenApiOutputFormat], and
+ * [OpenApiConfig.parseOutputFormat].
+ *
+ * Pins the contract that `OpenApiConfig` carries **only**
+ * [OpenApiConfig.outputFormat] (default `ALWAYS_ASK`). The v1 `infoTitle` /
+ * `infoVersion` / `infoDescription` / `serverUrl` fields were removed — those
+ * values vary per project and belong in rule scripts.
+ *
+ * The v1 `OpenApiSettings.asOpenApiConfig` extension function was removed
+ * (no fields to merge from settings — settings only carries `outputFormat`).
+ */
+class OpenApiConfigTest {
+
+    @Test
+    fun `default outputFormat is ALWAYS_ASK`() {
+        // ALWAYS_ASK is the default — the user is prompted for
+        // JSON / YAML at export time.
+        val cfg = OpenApiConfig()
+        assertEquals(OpenApiOutputFormat.ALWAYS_ASK, cfg.outputFormat)
+    }
+
+    @Test
+    fun `outputFormat enum has JSON, YAML, and ALWAYS_ASK in declaration order`() {
+        // Pin the enum shape — the settings layer stores the name as a string
+        // ("JSON" / "YAML" / "ALWAYS_ASK"), so adding or reordering entries
+        // would silently break persisted settings.
+        val values = OpenApiOutputFormat.values().toList()
+        assertEquals(
+            listOf(OpenApiOutputFormat.JSON, OpenApiOutputFormat.YAML, OpenApiOutputFormat.ALWAYS_ASK),
+            values,
+        )
+    }
+
+    @Test
+    fun `config is a ChannelConfig subtype`() {
+        // Compile-time check that OpenApiConfig extends ChannelConfig — this
+        // test exists so a refactor that breaks the inheritance is caught by
+        // the test suite, not by a runtime ClassCastException in Channel.export.
+        val cfg: ChannelConfig = OpenApiConfig()
+        assertEquals(OpenApiOutputFormat.ALWAYS_ASK, (cfg as OpenApiConfig).outputFormat)
+    }
+
+    @Test
+    fun `config has only outputFormat property`() {
+        // Removed infoTitle / infoVersion / infoDescription /
+        // serverUrl. The data class should have exactly one declared
+        // property — outputFormat.
+        val properties = OpenApiConfig::class.memberProperties.map { it.name }
+        assertEquals(listOf("outputFormat"), properties)
+    }
+
+    @Test
+    fun `constructed config round-trips outputFormat`() {
+        val cfg = OpenApiConfig(outputFormat = OpenApiOutputFormat.YAML)
+        assertEquals(OpenApiOutputFormat.YAML, cfg.outputFormat)
+    }
+
+    // ─── parseOutputFormat — case-insensitive parsing + fallback ─────────
+
+    @Test
+    fun `parseOutputFormat parses JSON case-insensitively`() {
+        assertEquals(OpenApiOutputFormat.JSON, OpenApiConfig.parseOutputFormat("JSON"))
+        assertEquals(OpenApiOutputFormat.JSON, OpenApiConfig.parseOutputFormat("json"))
+        assertEquals(OpenApiOutputFormat.JSON, OpenApiConfig.parseOutputFormat("Json"))
+    }
+
+    @Test
+    fun `parseOutputFormat parses YAML case-insensitively`() {
+        assertEquals(OpenApiOutputFormat.YAML, OpenApiConfig.parseOutputFormat("YAML"))
+        assertEquals(OpenApiOutputFormat.YAML, OpenApiConfig.parseOutputFormat("yaml"))
+        assertEquals(OpenApiOutputFormat.YAML, OpenApiConfig.parseOutputFormat("Yaml"))
+    }
+
+    @Test
+    fun `parseOutputFormat parses ALWAYS_ASK case-insensitively`() {
+        // ALWAYS_ASK is the default value; it must round-trip
+        // through the string form too.
+        assertEquals(OpenApiOutputFormat.ALWAYS_ASK, OpenApiConfig.parseOutputFormat("ALWAYS_ASK"))
+        assertEquals(OpenApiOutputFormat.ALWAYS_ASK, OpenApiConfig.parseOutputFormat("always_ask"))
+        assertEquals(OpenApiOutputFormat.ALWAYS_ASK, OpenApiConfig.parseOutputFormat("Always_Ask"))
+    }
+
+    @Test
+    fun `parseOutputFormat falls back to JSON for unrecognized values`() {
+        // Matches the historical behavior: a corrupted or future-format name
+        // must not crash the export; it defaults to JSON and emits a warn-level
+        // log.
+        assertEquals(OpenApiOutputFormat.JSON, OpenApiConfig.parseOutputFormat("BINARY"))
+        assertEquals(OpenApiOutputFormat.JSON, OpenApiConfig.parseOutputFormat(""))
+        assertEquals(OpenApiOutputFormat.JSON, OpenApiConfig.parseOutputFormat("garbage"))
+    }
+
+    @Test
+    fun `config has no infoTitle infoVersion infoDescription serverUrl properties`() {
+        // Explicit assertion that the removed fields do NOT
+        // reappear — protects against an accidental re-add.
+        val propertyNames = OpenApiConfig::class.memberProperties.map { it.name }
+        assertTrue("infoTitle should be removed", "infoTitle" !in propertyNames)
+        assertTrue("infoVersion should be removed", "infoVersion" !in propertyNames)
+        assertTrue("infoDescription should be removed", "infoDescription" !in propertyNames)
+        assertTrue("serverUrl should be removed", "serverUrl" !in propertyNames)
+        assertNull("Optional envelope fields no longer exist", OpenApiConfig::class.memberProperties.find { it.name == "infoTitle" })
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiDocumentTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiDocumentTest.kt
@@ -1,0 +1,240 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
+import com.itangcent.easyapi.core.export.HttpMethod
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Smoke test for [OpenApiDocument] and its nested data classes.
+ *
+ * Covers the `openapi` constant, `LinkedHashMap` ordering,
+ * `withMethod` copy-based collapse, and the keyword-alias
+ * workaround (`$ref`/`enum`/`x-enumDescriptions` `@SerializedName` aliases).
+ */
+class OpenApiDocumentTest {
+
+    private val gson: Gson = GsonBuilder()
+        .setPrettyPrinting()
+        .disableHtmlEscaping()
+        .create()
+
+    @Test
+    fun openapiConstantIs303() {
+        val doc = minimalDocument()
+        assertEquals("3.0.3", doc.openapi)
+    }
+
+    @Test
+    fun pathsPreservesInsertionOrder() {
+        val paths = linkedMapOf<String, PathItemObject>()
+        // Insert in deliberately non-alphabetical order.
+        paths["/zebra"] = PathItemObject()
+        paths["/alpha"] = PathItemObject()
+        paths["/middle"] = PathItemObject()
+
+        val doc = OpenApiDocument(
+            info = InfoObject(title = "T", version = "1.0.0"),
+            paths = paths,
+        )
+
+        val keys = doc.paths.keys.toList()
+        assertEquals(listOf("/zebra", "/alpha", "/middle"), keys)
+    }
+
+    @Test
+    fun responsesPreservesInsertionOrder() {
+        val responses = linkedMapOf<String, ResponseObject>()
+        responses["204"] = ResponseObject(description = "No content")
+        responses["200"] = ResponseObject(description = "OK")
+
+        val op = OperationObject(operationId = "x", responses = responses)
+        assertEquals(listOf("204", "200"), op.responses.keys.toList())
+    }
+
+    @Test
+    fun pathItemWithMethodReplacesOnlyTargetMethod() {
+        val original = PathItemObject()
+        val getOp = OperationObject(operationId = "getUser", responses = linkedMapOf())
+        val postOp = OperationObject(operationId = "addUser", responses = linkedMapOf())
+
+        val withGet = original.withMethod(HttpMethod.GET, getOp)
+        assertSame(getOp, withGet.get)
+        assertNull(withGet.post)
+        assertNull(withGet.put)
+
+        val withPost = withGet.withMethod(HttpMethod.POST, postOp)
+        assertSame(getOp, withPost.get)
+        assertSame(postOp, withPost.post)
+        assertNull(withPost.put)
+    }
+
+    @Test
+    fun pathItemWithMethodIsImmutable() {
+        val original = PathItemObject()
+        val getOp = OperationObject(operationId = "getUser", responses = linkedMapOf())
+        val mutated = original.withMethod(HttpMethod.GET, getOp)
+
+        // The original instance should not have been mutated.
+        assertNull(original.get)
+        assertSame(getOp, mutated.get)
+    }
+
+    @Test
+    fun schemaObjectRefFieldSerializesAsDollarRef() {
+        val schema = SchemaObject(`$ref` = "#/components/schemas/User")
+        val json = gson.toJson(schema)
+        val parsed = JsonParser.parseString(json).asJsonObject
+        assertTrue(parsed.has("\$ref"))
+        assertEquals("#/components/schemas/User", parsed.get("\$ref").asString)
+        // The Kotlin-safe identifier `$ref` MUST NOT leak as a field name.
+        assertFalse(parsed.has("ref"))
+    }
+
+    @Test
+    fun schemaObjectEnumValuesSerializesAsEnum() {
+        val schema = SchemaObject(
+            type = "string",
+            enumValues = listOf("ACTIVE", "INACTIVE"),
+        )
+        val json = gson.toJson(schema)
+        val parsed = JsonParser.parseString(json).asJsonObject
+        assertTrue(parsed.has("enum"))
+        assertEquals(listOf("ACTIVE", "INACTIVE"), parsed.get("enum").asJsonArray.map { it.asString })
+        // The Kotlin-safe identifier `enumValues` MUST NOT leak.
+        assertFalse(parsed.has("enumValues"))
+    }
+
+    @Test
+    fun schemaObjectXEnumDescriptionsSerializesAsXEnumDescriptions() {
+        val schema = SchemaObject(
+            type = "string",
+            enumValues = listOf("ACTIVE", "INACTIVE"),
+            xEnumDescriptions = linkedMapOf(
+                "ACTIVE" to "User is active",
+                "INACTIVE" to "User is inactive",
+            ),
+        )
+        val json = gson.toJson(schema)
+        val parsed = JsonParser.parseString(json).asJsonObject
+        assertTrue(parsed.has("x-enumDescriptions"))
+        val descriptions = parsed.getAsJsonObject("x-enumDescriptions")
+        assertEquals("User is active", descriptions.get("ACTIVE").asString)
+        assertEquals("User is inactive", descriptions.get("INACTIVE").asString)
+        // The Kotlin-safe identifier `xEnumDescriptions` MUST NOT leak.
+        assertFalse(parsed.has("xEnumDescriptions"))
+    }
+
+    @Test
+    fun schemaObjectRoundTripsAllKeywordAliasesAtOnce() {
+        val schema = SchemaObject(
+            `$ref` = "#/components/schemas/Status",
+            enumValues = listOf("A", "B"),
+            xEnumDescriptions = linkedMapOf("A" to "alpha"),
+        )
+        val json = gson.toJson(schema)
+        val parsed = JsonParser.parseString(json).asJsonObject
+        assertTrue(parsed.has("\$ref"))
+        assertTrue(parsed.has("enum"))
+        assertTrue(parsed.has("x-enumDescriptions"))
+        assertFalse(parsed.has("ref"))
+        assertFalse(parsed.has("enumValues"))
+        assertFalse(parsed.has("xEnumDescriptions"))
+    }
+
+    @Test
+    fun serializeNullsOffOmitsAbsentOptionalFields() {
+        val schema = SchemaObject(type = "string")
+        val json = gson.toJson(schema)
+        val parsed = JsonParser.parseString(json).asJsonObject
+        assertEquals("string", parsed.get("type").asString)
+        // Optional/nullable fields should be omitted, not `null`.
+        assertFalse(parsed.has("\$ref"))
+        assertFalse(parsed.has("format"))
+        assertFalse(parsed.has("description"))
+        assertFalse(parsed.has("properties"))
+        assertFalse(parsed.has("additionalProperties"))
+        assertFalse(parsed.has("items"))
+        assertFalse(parsed.has("required"))
+        assertFalse(parsed.has("enum"))
+        assertFalse(parsed.has("example"))
+        assertFalse(parsed.has("x-enumDescriptions"))
+    }
+
+    @Test
+    fun fullDocumentSerializesCleanly() {
+        val schema = SchemaObject(
+            type = "object",
+            properties = linkedMapOf(
+                "id" to SchemaObject(type = "integer", format = "int64"),
+                "name" to SchemaObject(type = "string"),
+            ),
+            required = listOf("id"),
+        )
+        val components = ComponentsObject(schemas = linkedMapOf("User" to schema))
+        val op = OperationObject(
+            tags = listOf("users"),
+            summary = "Get user",
+            operationId = "getUser",
+            parameters = listOf(
+                ParameterObject(
+                    name = "id",
+                    `in` = "path",
+                    required = true,
+                    schema = SchemaObject(type = "integer", format = "int64"),
+                ),
+            ),
+            responses = linkedMapOf(
+                "200" to ResponseObject(
+                    description = "OK",
+                    content = linkedMapOf(
+                        "application/json" to MediaTypeObject(
+                            schema = SchemaObject(`$ref` = "#/components/schemas/User"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val doc = OpenApiDocument(
+            info = InfoObject(title = "Demo API", version = "1.0.0"),
+            paths = linkedMapOf("/users/{id}" to PathItemObject(get = op)),
+            components = components,
+        )
+
+        val json = gson.toJson(doc)
+        val parsed = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("3.0.3", parsed.get("openapi").asString)
+        val info = parsed.getAsJsonObject("info")
+        assertEquals("Demo API", info.get("title").asString)
+        assertEquals("1.0.0", info.get("version").asString)
+
+        val paths = parsed.getAsJsonObject("paths")
+        assertTrue(paths.has("/users/{id}"))
+        val getOp = paths.getAsJsonObject("/users/{id}").getAsJsonObject("get")
+        assertEquals("getUser", getOp.get("operationId").asString)
+
+        val componentsJson = parsed.getAsJsonObject("components")
+        val schemas = componentsJson.getAsJsonObject("schemas")
+        val userSchema = schemas.getAsJsonObject("User")
+        assertEquals("object", userSchema.get("type").asString)
+        val required = userObjAsList(userSchema.getAsJsonArray("required"))
+        assertEquals(listOf("id"), required)
+    }
+
+    private fun userObjAsList(arr: com.google.gson.JsonArray): List<String> =
+        arr.map { it.asString }
+
+    private fun minimalDocument(): OpenApiDocument {
+        val op = OperationObject(
+            operationId = "getUser",
+            responses = linkedMapOf("200" to ResponseObject(description = "OK")),
+        )
+        return OpenApiDocument(
+            info = InfoObject(title = "Test", version = "1.0.0"),
+            paths = linkedMapOf("/users/{id}" to PathItemObject(get = op)),
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiExportMetadataTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiExportMetadataTest.kt
@@ -1,0 +1,103 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.export.ExportMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Plain-JUnit tests for [OpenApiExportMetadata].
+ *
+ * Pins the contract:
+ *  - `formatDisplay()` returns `"Format: JSON"` for JSON output and
+ *    `"Format: YAML"` for YAML output.
+ *  - `document` and `content` are stored unmodified (the channel layer
+ *    pre-serializes the content so handleResult doesn't re-serialize).
+ *  - The class implements [ExportMetadata] (carried in ExportResult.Success).
+ *
+ * Mirrors the [com.itangcent.easyapi.channel.hoppscotch.HoppscotchExportMetadata]
+ * pattern (file at `channel/hoppscotch/HoppscotchExportMetadata.kt` is the
+ * reference).
+ */
+class OpenApiExportMetadataTest {
+
+    @Test
+    fun `formatDisplay returns Format JSON for JSON output`() {
+        val metadata = OpenApiExportMetadata(
+            document = minimalDoc(),
+            outputFormat = OpenApiOutputFormat.JSON,
+            content = "{}",
+        )
+        assertEquals("Format: JSON", metadata.formatDisplay())
+    }
+
+    @Test
+    fun `formatDisplay returns Format YAML for YAML output`() {
+        val metadata = OpenApiExportMetadata(
+            document = minimalDoc(),
+            outputFormat = OpenApiOutputFormat.YAML,
+            content = "openapi: \"3.0.3\"",
+        )
+        assertEquals("Format: YAML", metadata.formatDisplay())
+    }
+
+    @Test
+    fun `document is stored unmodified`() {
+        val doc = minimalDoc()
+        val metadata = OpenApiExportMetadata(
+            document = doc,
+            outputFormat = OpenApiOutputFormat.JSON,
+            content = "{}",
+        )
+        // Identity check — the exact same instance is returned, no copy.
+        assertSame(doc, metadata.document)
+    }
+
+    @Test
+    fun `content is stored unmodified`() {
+        val content = """{"openapi":"3.0.3","info":{"title":"T","version":"1.0.0"}}"""
+        val metadata = OpenApiExportMetadata(
+            document = minimalDoc(),
+            outputFormat = OpenApiOutputFormat.JSON,
+            content = content,
+        )
+        // Equality check — content is a String (immutable), so equality is
+        // the strongest guarantee we can give.
+        assertEquals(content, metadata.content)
+    }
+
+    @Test
+    fun `metadata implements ExportMetadata interface`() {
+        // Compile-time + runtime check — ExportResult.Success carries an
+        // ExportMetadata, so the channel layer must produce one.
+        val metadata: ExportMetadata = OpenApiExportMetadata(
+            document = minimalDoc(),
+            outputFormat = OpenApiOutputFormat.JSON,
+            content = "{}",
+        )
+        assertNotNull(metadata.formatDisplay())
+    }
+
+    @Test
+    fun `data class copy preserves all fields`() {
+        // Pin the data-class shape — handleResult reads `document` and
+        // `content` directly. A refactor that drops either field would
+        // break the file-write flow.
+        val doc = minimalDoc()
+        val metadata = OpenApiExportMetadata(
+            document = doc,
+            outputFormat = OpenApiOutputFormat.JSON,
+            content = "{}",
+        )
+        val copy = metadata.copy(outputFormat = OpenApiOutputFormat.YAML)
+        assertEquals(OpenApiOutputFormat.YAML, copy.outputFormat)
+        assertSame(doc, copy.document)
+        assertEquals("{}", copy.content)
+    }
+
+    private fun minimalDoc(): OpenApiDocument = OpenApiDocument(
+        info = InfoObject(title = "T", version = "1.0.0"),
+        paths = linkedMapOf(),
+    )
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiFormatterTest.kt
@@ -1,0 +1,508 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ApiHeader
+import com.itangcent.easyapi.core.export.ApiParameter
+import com.itangcent.easyapi.core.export.GrpcMetadata
+import com.itangcent.easyapi.core.export.GrpcStreamingType
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.export.ParameterBinding
+import com.itangcent.easyapi.core.export.ParameterType
+import com.itangcent.easyapi.core.psi.model.FieldModel
+import com.itangcent.easyapi.core.psi.model.ObjectModel
+import com.itangcent.easyapi.testFramework.ResultLoader
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMethod
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Golden-file tests for [OpenApiFormatter].
+ *
+ * The formatter signature takes [OpenApiEnvelope] (rule-resolved envelope
+ * metadata) instead of [OpenApiConfig]. The default envelope here matches
+ * what the channel produces when no rules fire: `infoTitle="API"`,
+ * `infoVersion="1.0.0"`, `infoDescription=null`, `serverUrl=null`.
+ *
+ * Each test constructs `ApiEndpoint` instances directly (no PSI) — the model
+ * is POJO. A local Gson-pretty instance serializes the produced
+ * [OpenApiDocument] for byte comparison against the golden file
+ * (`OpenApiSerializer.toJson` is not yet available).
+ *
+ * Golden files live at
+ * `src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.<name>.txt`
+ * and are read via [ResultLoader.load] (CRLF→LF normalized).
+ */
+class OpenApiFormatterTest {
+
+    private val project: Project = mock()
+    private val formatter = OpenApiFormatter(project)
+
+    private val gson: Gson = GsonBuilder()
+        .setPrettyPrinting()
+        .disableHtmlEscaping()
+        .create()
+
+    /** Default envelope — mirrors what `OpenApiChannel` produces when no rules fire. */
+    private val defaultEnvelope: OpenApiEnvelope =
+        OpenApiEnvelope(infoTitle = "API", infoVersion = "1.0.0", infoDescription = null, serverUrl = null)
+
+    // ─── simple GET with void response ───────────────────────
+
+    @Test
+    fun simpleGet() {
+        val endpoint = endpoint(
+            name = "List users",
+            path = "/users",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("listUsers"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("simpleGet"), json)
+    }
+
+    // ─── POST with JSON body + response body ───────────
+
+    @Test
+    fun postWithJsonBody() {
+        val userBody = ObjectModel.Object(
+            linkedMapOf(
+                "id" to FieldModel(model = ObjectModel.single("long"), required = true),
+                "name" to FieldModel(model = ObjectModel.single("string")),
+            )
+        )
+        val endpoint = endpoint(
+            name = "Create user",
+            path = "/users",
+            method = HttpMethod.POST,
+            contentType = "application/json",
+            bodyAttr = "com.example.User",
+            body = userBody,
+            responseBody = userBody,
+            responseType = "com.example.User",
+            sourceMethod = mockMethod("createUser"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("postWithJsonBody"), json)
+    }
+
+    // ─── path collapse — two methods on same path ─────────────
+
+    @Test
+    fun pathCollapse() {
+        val getEndpoint = endpoint(
+            name = "List users",
+            path = "/users",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("listUsers"),
+        )
+        val postEndpoint = endpoint(
+            name = "Create user",
+            path = "/users",
+            method = HttpMethod.POST,
+            sourceMethod = mockMethod("createUser"),
+        )
+        val doc = formatter.format(listOf(getEndpoint, postEndpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("pathCollapse"), json)
+    }
+
+    // ─── path normalization — Spring colon form ──────────────
+
+    @Test
+    fun pathNormalization() {
+        val endpoint = endpoint(
+            name = "Get user by id",
+            path = "/users/:id",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("getUser"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("pathNormalization"), json)
+    }
+
+    // ─── operationId collision ─────────────────────────────────────
+
+    @Test
+    fun operationIdCollision() {
+        val first = endpoint(
+            name = "Get user",
+            path = "/users/{id}",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("getUser"),
+        )
+        val second = endpoint(
+            name = "Get user (admin)",
+            path = "/admin/users/{id}",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("getUser"),
+        )
+        val doc = formatter.format(listOf(first, second), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("operationIdCollision"), json)
+    }
+
+    // ─── parameter mapping ─────────────────────────────────────
+
+    @Test
+    fun parameters() {
+        val endpoint = endpoint(
+            name = "Search users",
+            path = "/users/{id}",
+            method = HttpMethod.GET,
+            parameters = listOf(
+                ApiParameter(
+                    name = "id",
+                    binding = ParameterBinding.Path,
+                    required = true,
+                    description = "User ID",
+                    example = "42",
+                ),
+                ApiParameter(
+                    name = "status",
+                    binding = ParameterBinding.Query,
+                    required = false,
+                    description = "Filter by status",
+                    enumValues = listOf("ACTIVE", "INACTIVE"),
+                ),
+                ApiParameter(
+                    name = "X-Custom-Header",
+                    binding = ParameterBinding.Header,
+                    required = true,
+                    description = "Custom header from ApiParameter",
+                ),
+                ApiParameter(
+                    name = "session",
+                    binding = ParameterBinding.Cookie,
+                    description = "Session cookie",
+                ),
+            ),
+            headers = listOf(
+                // Dedup: this header should be skipped because there's already
+                // a header-typed ApiParameter with the same name.
+                ApiHeader(name = "X-Custom-Header", description = "Duplicate header", required = false),
+                // New header — should appear in parameters.
+                ApiHeader(name = "X-Request-Id", value = "abc-123", description = "Request ID", required = false),
+            ),
+            sourceMethod = mockMethod("searchUsers"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("parameters"), json)
+    }
+
+    // ─── multipart with file params ───────────────────────────
+
+    @Test
+    fun requestBodyMultipart() {
+        val endpoint = endpoint(
+            name = "Upload avatar",
+            path = "/users/{id}/avatar",
+            method = HttpMethod.POST,
+            contentType = "multipart/form-data",
+            parameters = listOf(
+                ApiParameter(name = "id", binding = ParameterBinding.Path, required = true),
+                ApiParameter(
+                    name = "avatar",
+                    binding = ParameterBinding.Form,
+                    type = ParameterType.FILE,
+                    required = true,
+                    description = "Avatar image file",
+                ),
+                ApiParameter(
+                    name = "gallery",
+                    binding = ParameterBinding.Form,
+                    type = ParameterType.FILE,
+                    required = false,
+                    description = "Additional gallery images (multiple)",
+                ),
+            ),
+            sourceMethod = mockMethod("uploadAvatar"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("requestBodyMultipart"), json)
+    }
+
+    // ─── form-urlencoded with form params ──────────────────────────
+
+    @Test
+    fun requestBodyFormUrlencoded() {
+        val endpoint = endpoint(
+            name = "Submit form",
+            path = "/forms/{id}",
+            method = HttpMethod.POST,
+            contentType = "application/x-www-form-urlencoded",
+            parameters = listOf(
+                ApiParameter(name = "id", binding = ParameterBinding.Path, required = true),
+                ApiParameter(
+                    name = "username",
+                    binding = ParameterBinding.Form,
+                    required = true,
+                    description = "Username",
+                ),
+                ApiParameter(
+                    name = "email",
+                    binding = ParameterBinding.Form,
+                    required = false,
+                    description = "Email",
+                ),
+            ),
+            sourceMethod = mockMethod("submitForm"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("requestBodyFormUrlencoded"), json)
+    }
+
+    // ─── GET with body model — suppressed ──────────────────────
+
+    @Test
+    fun requestBodySuppressedForGet() {
+        val bodyModel = ObjectModel.Object(
+            linkedMapOf("query" to FieldModel(model = ObjectModel.single("string")))
+        )
+        val endpoint = endpoint(
+            name = "Search",
+            path = "/search",
+            method = HttpMethod.GET,
+            contentType = "application/json",
+            body = bodyModel,
+            bodyAttr = "com.example.SearchQuery",
+            sourceMethod = mockMethod("search"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("requestBodySuppressedForGet"), json)
+    }
+
+    // ─── tags resolution ──────────────────────────────────
+
+    @Test
+    fun tagsResolution() {
+        val usersEndpoint = endpoint(
+            name = "List users",
+            path = "/users",
+            method = HttpMethod.GET,
+            folder = "Users",
+            className = "com.example.UserController",
+            sourceMethod = mockMethod("listUsers"),
+        )
+        val adminEndpoint = endpoint(
+            name = "List admins",
+            path = "/admins",
+            method = HttpMethod.GET,
+            // No folder — falls back to className simple name → "AdminController"
+            className = "com.example.AdminController",
+            sourceMethod = mockMethod("listAdmins"),
+        )
+        // Another endpoint under "Users" — the tag should NOT reappear.
+        val secondUserEndpoint = endpoint(
+            name = "Get user",
+            path = "/users/{id}",
+            method = HttpMethod.GET,
+            folder = "Users",
+            className = "com.example.UserController",
+            sourceMethod = mockMethod("getUser"),
+        )
+        val doc = formatter.format(
+            listOf(usersEndpoint, adminEndpoint, secondUserEndpoint),
+            defaultEnvelope,
+        )
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("tagsResolution"), json)
+    }
+
+    // ─── void response (no responseBody, no responseType) ─────────
+
+    @Test
+    fun voidResponse() {
+        val endpoint = endpoint(
+            name = "Delete user",
+            path = "/users/{id}",
+            method = HttpMethod.DELETE,
+            parameters = listOf(
+                ApiParameter(name = "id", binding = ParameterBinding.Path, required = true),
+            ),
+            sourceMethod = mockMethod("deleteUser"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("voidResponse"), json)
+    }
+
+    // ─── responseType only — no inline schema ──────────────────────
+
+    @Test
+    fun responseTypeOnly() {
+        val endpoint = endpoint(
+            name = "Get config",
+            path = "/config",
+            method = HttpMethod.GET,
+            responseType = "com.example.Config",
+            sourceMethod = mockMethod("getConfig"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("responseTypeOnly"), json)
+    }
+
+    // ─── gRPC skipped ───────────────────────────────────────────────
+
+    @Test
+    fun grpcSkipped() {
+        val httpEndpoint = endpoint(
+            name = "Get user",
+            path = "/users/{id}",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("getUser"),
+        )
+        val grpcEndpoint = ApiEndpoint(
+            name = "SayHello",
+            metadata = GrpcMetadata(
+                path = "/helloworld.Greeter/SayHello",
+                serviceName = "Greeter",
+                methodName = "SayHello",
+                packageName = "helloworld",
+                streamingType = GrpcStreamingType.UNARY,
+            ),
+        )
+        val doc = formatter.format(listOf(httpEndpoint, grpcEndpoint), defaultEnvelope)
+        val json = gson.toJson(doc)
+        assertEquals(ResultLoader.load("grpcSkipped"), json)
+    }
+
+    // ─── Structural assertions (don't depend on golden files) ──────────────
+
+    @Test
+    fun formatProducesDocumentWithOpenApi303Constant() {
+        val endpoint = endpoint(
+            path = "/health",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("health"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        assertEquals("3.0.3", doc.openapi)
+    }
+
+    @Test
+    fun formatIncludesServerWhenConfigured() {
+        val endpoint = endpoint(
+            path = "/health",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("health"),
+        )
+        val doc = formatter.format(
+            listOf(endpoint),
+            OpenApiEnvelope(infoTitle = "API", infoVersion = "1.0.0", infoDescription = null, serverUrl = "https://api.example.com"),
+        )
+        assertNotNull(doc.servers)
+        assertEquals(1, doc.servers!!.size)
+        assertEquals("https://api.example.com", doc.servers!!.first().url)
+    }
+
+    @Test
+    fun formatOmitsServersWhenServerUrlIsNull() {
+        val endpoint = endpoint(
+            path = "/health",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("health"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        assertNull(doc.servers)
+    }
+
+    @Test
+    fun formatUsesEnvelopeInfoTitleVersionAndDescription() {
+        val endpoint = endpoint(
+            path = "/health",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("health"),
+        )
+        val doc = formatter.format(
+            listOf(endpoint),
+            OpenApiEnvelope(
+                infoTitle = "My API",
+                infoVersion = "2.0.0",
+                infoDescription = "A description",
+                serverUrl = null,
+            ),
+        )
+        assertEquals("My API", doc.info.title)
+        assertEquals("2.0.0", doc.info.version)
+        assertEquals("A description", doc.info.description)
+    }
+
+    @Test
+    fun formatDefaultsInfoTitleToApiAndVersionTo100() {
+        val endpoint = endpoint(
+            path = "/health",
+            method = HttpMethod.GET,
+            sourceMethod = mockMethod("health"),
+        )
+        val doc = formatter.format(listOf(endpoint), defaultEnvelope)
+        assertEquals("API", doc.info.title)
+        assertEquals("1.0.0", doc.info.version)
+        assertNull(doc.info.description)
+    }
+
+    @Test
+    fun formatAlwaysEmitsPathsMapEvenWhenEmpty() {
+        val doc = formatter.format(emptyList(), defaultEnvelope)
+        assertNotNull(doc.paths)
+        assertTrue(doc.paths!!.isEmpty())
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private fun endpoint(
+        name: String? = null,
+        path: String,
+        method: HttpMethod,
+        parameters: List<ApiParameter> = emptyList(),
+        headers: List<ApiHeader> = emptyList(),
+        contentType: String? = null,
+        bodyAttr: String? = null,
+        body: ObjectModel? = null,
+        responseBody: ObjectModel? = null,
+        responseType: String? = null,
+        sourceMethod: PsiMethod? = null,
+        folder: String? = null,
+        className: String? = null,
+    ): ApiEndpoint {
+        return ApiEndpoint(
+            name = name,
+            folder = folder,
+            metadata = httpMetadata(
+                path = path,
+                method = method,
+                parameters = parameters,
+                headers = headers,
+                contentType = contentType,
+                bodyAttr = bodyAttr,
+                body = body,
+                responseBody = responseBody,
+                responseType = responseType,
+            ),
+            sourceMethod = sourceMethod,
+            className = className,
+        )
+    }
+
+    private fun mockMethod(name: String): PsiMethod {
+        val method = mock<PsiMethod>()
+        whenever(method.name).thenReturn(name)
+        return method
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiOptionsPanelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiOptionsPanelTest.kt
@@ -1,0 +1,146 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlin.reflect.full.memberProperties
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * Round-trip tests for [OpenApiOptionsPanel].
+ *
+ * The panel exposes a two-way format selector (`JSON` default / `YAML`).
+ * The "Always Ask" option is NOT exposed in the per-export panel — the panel
+ * itself IS the per-export prompt, so "Always Ask" would be redundant (it
+ * would just trigger a second `Messages.showChooseDialog` inside `export()`).
+ * "Always Ask" remains available in [OpenApiSettings] as the persistent
+ * default. The v1 envelope setters (`setTitle` / `setVersion` /
+ * `setDescription` / `setServerUrl`) and the corresponding `OpenApiConfig`
+ * fields were removed — those values vary per project and belong in rule
+ * scripts.
+ *
+ * Pattern: select a radio → call [OpenApiOptionsPanel.buildConfig] →
+ * assert the returned [OpenApiConfig] carries the selected format.
+ * Conversely, call [OpenApiOptionsPanel.applyConfig] with a pre-built
+ * [OpenApiConfig] and assert the radios reflect it.
+ *
+ * Uses [EasyApiLightCodeInsightFixtureTestCase] so Swing components are
+ * properly initialized in an IntelliJ application context (the panel uses
+ * `JRadioButton` which needs the IDEA look-and-feel).
+ */
+class OpenApiOptionsPanelTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var panel: OpenApiOptionsPanel
+
+    override fun setUp() {
+        super.setUp()
+        panel = OpenApiOptionsPanel(project)
+    }
+
+    fun testComponentIsNotNull() {
+        assertNotNull(panel.component)
+    }
+
+    fun testBuildConfigReturnsChannelConfigSubtype() {
+        val config = panel.buildConfig()
+        assertNotNull(config)
+        assertTrue("buildConfig should return OpenApiConfig, got: ${config.javaClass}", config is OpenApiConfig)
+    }
+
+    fun testDefaultBuildConfigReturnsJsonFormat() {
+        // JSON is the default-selected radio.
+        val config = panel.buildConfig() as OpenApiConfig
+        assertEquals(OpenApiOutputFormat.JSON, config.outputFormat)
+    }
+
+    fun testBuildConfigReturnsOnlyOutputFormatProperty() {
+        // The v1 envelope fields (infoTitle / infoVersion / infoDescription /
+        // serverUrl) were removed. Reflection-level guard so
+        // accidental re-introduction is caught by this test.
+        val propertyNames = OpenApiConfig::class.memberProperties.map { it.name }
+        assertEquals(
+            "OpenApiConfig should have only the outputFormat property, got: $propertyNames",
+            listOf("outputFormat"),
+            propertyNames,
+        )
+    }
+
+
+    fun testBuildConfigJsonFormatWhenSet() {
+        panel.setFormat(OpenApiOutputFormat.JSON)
+        val config = panel.buildConfig() as OpenApiConfig
+        assertEquals(OpenApiOutputFormat.JSON, config.outputFormat)
+    }
+
+    fun testBuildConfigYamlFormatWhenSet() {
+        panel.setFormat(OpenApiOutputFormat.YAML)
+        val config = panel.buildConfig() as OpenApiConfig
+        assertEquals(OpenApiOutputFormat.YAML, config.outputFormat)
+    }
+
+    fun testBuildConfigAlwaysAskFallsBackToJson() {
+        // The panel has no "Always Ask" radio. When applyConfig receives an
+        // ALWAYS_ASK config (only reachable from OpenApiSettings), the panel
+        // falls back to JSON (the default-of-defaults).
+        panel.setFormat(OpenApiOutputFormat.ALWAYS_ASK)
+        val config = panel.buildConfig() as OpenApiConfig
+        assertEquals(
+            "ALWAYS_ASK should fall back to JSON in the options panel",
+            OpenApiOutputFormat.JSON,
+            config.outputFormat,
+        )
+    }
+
+    fun testApplyConfigPopulatesRadiosFromConfig() {
+        val cfg = OpenApiConfig(outputFormat = OpenApiOutputFormat.YAML)
+        panel.applyConfig(cfg)
+
+        val built = panel.buildConfig() as OpenApiConfig
+        assertEquals(OpenApiOutputFormat.YAML, built.outputFormat)
+    }
+
+    fun testApplyConfigWithDefaultsSelectsJson() {
+        // First populate, then apply a default config — JSON should be selected.
+        panel.setFormat(OpenApiOutputFormat.YAML)
+        panel.applyConfig(OpenApiConfig())
+
+        val built = panel.buildConfig() as OpenApiConfig
+        assertEquals(
+            "Default OpenApiConfig (ALWAYS_ASK) should select JSON in the panel",
+            OpenApiOutputFormat.JSON,
+            built.outputFormat,
+        )
+    }
+
+    fun testRoundTripFromUItoConfigAndBack() {
+        // Set UI → buildConfig → applyConfig → buildConfig → assert equality.
+        panel.setFormat(OpenApiOutputFormat.YAML)
+
+        val firstConfig = panel.buildConfig() as OpenApiConfig
+        // Apply to a fresh panel and verify the second build matches the first.
+        val freshPanel = OpenApiOptionsPanel(project)
+        freshPanel.applyConfig(firstConfig)
+
+        val secondConfig = freshPanel.buildConfig() as OpenApiConfig
+        assertEquals(firstConfig, secondConfig)
+    }
+
+    fun testRoundTripBothFormats() {
+        // Round-trip each panel-selectable format (JSON, YAML) through a fresh panel.
+        for (format in listOf(OpenApiOutputFormat.JSON, OpenApiOutputFormat.YAML)) {
+            panel.setFormat(format)
+            val config = panel.buildConfig() as OpenApiConfig
+            assertEquals(format, config.outputFormat)
+
+            val freshPanel = OpenApiOptionsPanel(project)
+            freshPanel.applyConfig(config)
+            assertEquals(format, (freshPanel.buildConfig() as OpenApiConfig).outputFormat)
+        }
+    }
+
+    fun testOnShownDoesNotThrow() {
+        // The SPI default is a no-op; the panel may override it to initialize
+        // defaults. Either way, it should not throw.
+        panel.onShown()
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiRuleEvaluationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiRuleEvaluationTest.kt
@@ -1,0 +1,294 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.intellij.testFramework.registerServiceInstance
+import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * Rule evaluation in `OpenApiChannel.export`.
+ *
+ * Pins the contract that `OpenApiChannel.export` evaluates the four
+ * document-metadata rule keys (`openapi.info.title`, `openapi.info.version`,
+ * `openapi.info.description`, `openapi.server.url`) against
+ * `ApiEndpoint.sourceClass`, and fires the `openapi.format.after` event
+ * with the built `OpenApiDocument` exposed via the rule context extension
+ * `"document"`.
+ *
+ * The options-panel / settings tiers for `info.*` / `server.url` were
+ * removed — those values vary per project and belong in rules only.
+ * Precedence is now: **rules > built-in defaults**
+ * (`projectName ?: "API"`, `"1.0.0"`, `null` for description, `null` for
+ * server url). `openapi.host` is a legacy alias for `openapi.server.url`.
+ *
+ * Pattern: each test wires a [TestConfigReader] with literal rule values
+ * (no groovy scripts needed — the [com.itangcent.easyapi.core.rule.parser.LiteralParser]
+ * returns the literal as-is regardless of the context element). The source
+ * class is a mock `PsiClass`; the source method is a mock `PsiMethod` so
+ * `fireFormatAfterEvent` has a target.
+ *
+ * JUnit 3-style `testXxx()` naming is required because
+ * [EasyApiLightCodeInsightFixtureTestCase] extends
+ * `LightJavaCodeInsightFixtureTestCase` (a JUnit 3 `TestCase` subclass) —
+ * `@Test` annotations are not picked up by the JUnit 3 runner.
+ */
+class OpenApiRuleEvaluationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var channel: OpenApiChannel
+
+    override fun setUp() {
+        super.setUp()
+        channel = OpenApiChannel()
+    }
+
+    override fun tearDown() {
+        try {
+            // Reset OpenApiSettings to defaults so tests don't bleed into each other.
+            // Only `outputFormat` is a persisted field — envelope fields
+            // were removed and live only in rules / defaults.
+            runCatching {
+                SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                    outputFormat = "ALWAYS_ASK"
+                }
+            }
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    override fun createConfigReader(): ConfigReader = TestConfigReader.empty(project)
+
+    /**
+     * Builds an [ExportContext] with an explicit JSON [OpenApiConfig] so the
+     * `ALWAYS_ASK` prompt (which would block on EDT) is bypassed — these tests
+     * focus on rule-resolved envelope metadata, not format selection.
+     */
+    private fun exportContext(endpoints: List<ApiEndpoint>): ExportContext = ExportContext(
+        project = project,
+        endpoints = endpoints,
+        channelId = "openapi",
+        channelConfig = OpenApiConfig(outputFormat = OpenApiOutputFormat.JSON),
+    )
+
+    // ─── Rule resolves document metadata ───────────────────────────────────
+
+    fun testInfoTitleRulePopulatesDocument() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "openapi.info.title" to "Rule-Resolved Title",
+            )
+        )
+        val endpoint = httpEndpointWithSourceClass(
+            path = "/users",
+            method = HttpMethod.GET,
+            methodName = "listUsers",
+            className = "com.example.UserController",
+        )
+        val result = channel.export(exportContext(listOf(endpoint)))
+        assertTrue("Expected Success, got: $result", result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        assertEquals("Rule-Resolved Title", metadata.document.info.title)
+    }
+
+    fun testInfoVersionRulePopulatesDocument() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "openapi.info.version" to "9.9.9",
+            )
+        )
+        val endpoint = httpEndpointWithSourceClass(
+            path = "/users",
+            method = HttpMethod.GET,
+            methodName = "listUsers",
+            className = "com.example.UserController",
+        )
+        val result = channel.export(exportContext(listOf(endpoint)))
+        assertTrue(result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        assertEquals("9.9.9", metadata.document.info.version)
+    }
+
+    fun testInfoDescriptionRulePopulatesDocument() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "openapi.info.description" to "Description from rule",
+            )
+        )
+        val endpoint = httpEndpointWithSourceClass(
+            path = "/users",
+            method = HttpMethod.GET,
+            methodName = "listUsers",
+            className = "com.example.UserController",
+        )
+        val result = channel.export(exportContext(listOf(endpoint)))
+        assertTrue(result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        assertEquals("Description from rule", metadata.document.info.description)
+    }
+
+    fun testServerUrlRulePopulatesServers() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "openapi.server.url" to "https://rule.example.com",
+            )
+        )
+        val endpoint = httpEndpointWithSourceClass(
+            path = "/users",
+            method = HttpMethod.GET,
+            methodName = "listUsers",
+            className = "com.example.UserController",
+        )
+        val result = channel.export(exportContext(listOf(endpoint)))
+        assertTrue(result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        assertEquals(
+            "Expected exactly one server entry",
+            1,
+            metadata.document.servers?.size ?: 0,
+        )
+        assertEquals("https://rule.example.com", metadata.document.servers!!.first().url)
+    }
+
+    // ─── Legacy alias: openapi.host → openapi.server.url ──────────────────
+
+    fun testHostRuleServesAsLegacyFallbackForServerUrl() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "openapi.host" to "https://legacy.example.com",
+            )
+        )
+        val endpoint = httpEndpointWithSourceClass(
+            path = "/users",
+            method = HttpMethod.GET,
+            methodName = "listUsers",
+            className = "com.example.UserController",
+        )
+        val result = channel.export(exportContext(listOf(endpoint)))
+        assertTrue(result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        assertEquals(
+            "Expected the legacy openapi.host value to populate servers[0].url",
+            "https://legacy.example.com",
+            metadata.document.servers!!.first().url,
+        )
+    }
+
+    // ─── Built-in defaults (no rules fire) ────────────────────────────────
+
+    fun testNoRulesFallbackToBuiltInDefaults() = runTest {
+        // No rules defined — rule evaluation returns null for every key.
+        // The channel falls back to built-in defaults:
+        //   infoTitle = projectName ?: "API"
+        //   infoVersion = "1.0.0"
+        //   infoDescription = null
+        //   serverUrl = null
+        val endpoint = httpEndpointWithSourceClass(
+            path = "/users",
+            method = HttpMethod.GET,
+            methodName = "listUsers",
+            className = "com.example.UserController",
+        )
+        val result = channel.export(exportContext(listOf(endpoint)))
+        assertTrue(result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        // info.title falls back to project name (or "API" when null).
+        assertNotNull("info.title should have a default even without rules", metadata.document.info.title)
+        assertEquals(
+            "info.version should fall back to default '1.0.0'",
+            "1.0.0",
+            metadata.document.info.version,
+        )
+        assertNull(
+            "info.description should be null when no rule produces a value",
+            metadata.document.info.description,
+        )
+        assertNull(
+            "servers should be null when no rule produces a serverUrl",
+            metadata.document.servers,
+        )
+    }
+
+    // ─── openapi.format.after event ────────────────────────────────────────
+
+    fun testFormatAfterEventFiresWithDocumentExposedInContext() = runTest {
+        // A groovy script that mutates the document's paths map (LinkedHashMap
+        // is mutable even though the property reference is val). If the event
+        // fires and `document` is bound, paths will be cleared before
+        // serialization — so the serialized output will have an empty paths
+        // object `"paths":{}`.
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "openapi.format.after" to "groovy:document.paths.clear()",
+            )
+        )
+        val endpoint = httpEndpointWithSourceClass(
+            path = "/users",
+            method = HttpMethod.GET,
+            methodName = "listUsers",
+            className = "com.example.UserController",
+        )
+        val result = channel.export(exportContext(listOf(endpoint)))
+        assertTrue(result is ExportResult.Success)
+        val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+        assertTrue(
+            "format.after script should have cleared paths; got: ${metadata.document.paths}",
+            metadata.document.paths.isEmpty(),
+        )
+        // The serialized content should contain an empty paths object.
+        assertTrue(
+            "Serialized output should contain empty paths after format.after cleared them; got: ${metadata.content}",
+            metadata.content.contains("\"paths\"") && !metadata.content.contains("\"/users\""),
+        )
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * Builds an [ApiEndpoint] with both a mock [PsiMethod] (so `fireFormatAfterEvent`
+     * has a target) and a mock [PsiClass] (so `resolveRuleBasedEnvelope` has a
+     * source class to evaluate rules against).
+     */
+    private fun httpEndpointWithSourceClass(
+        path: String,
+        method: HttpMethod,
+        methodName: String,
+        className: String,
+    ): ApiEndpoint {
+        val psiMethod = mock<PsiMethod> { on { this.name } doReturn methodName }
+        val psiClass = mock<PsiClass> { on { this.qualifiedName } doReturn className }
+        return ApiEndpoint(
+            name = methodName,
+            metadata = httpMetadata(path = path, method = method),
+            sourceMethod = psiMethod,
+            sourceClass = psiClass,
+            className = className,
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiRuleKeysTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiRuleKeysTest.kt
@@ -1,0 +1,141 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.rule.EventRuleMode
+import com.itangcent.easyapi.core.rule.RuleKey
+import com.itangcent.easyapi.core.rule.RuleKeys
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain-JUnit tests for [OpenApiRuleKeys].
+ *
+ * Pins the contract:
+ *  - `RuleKey.collectFrom(OpenApiRuleKeys)` returns exactly six keys:
+ *    `openapi.host`, `openapi.server.url`, `openapi.info.title`,
+ *    `openapi.info.version`, `openapi.info.description` (all string keys),
+ *    plus `openapi.format.after` (event key, `EventRuleMode.THROW_IN_ERROR`).
+ *  - No overlap with [RuleKeys] (the shared core rule keys) — channel-specific
+ *    keys must live in the channel package to keep the DAG clean.
+ *
+ * Mirrors the [com.itangcent.easyapi.channel.hoppscotch.HoppscotchRuleKeys]
+ * pattern (file at `channel/hoppscotch/HoppscotchRuleKeys.kt` is the reference).
+ *
+ * The four document-metadata keys
+ * (`openapi.info.title`, `openapi.info.version`, `openapi.info.description`,
+ * `openapi.server.url`) are evaluated against `ApiEndpoint.sourceClass`
+ * inside `OpenApiChannel.export` — see [OpenApiRuleEvaluationTest].
+ */
+class OpenApiRuleKeysTest {
+
+    @Test
+    fun `collectFrom returns exactly six keys`() {
+        val keys = RuleKey.collectFrom(OpenApiRuleKeys)
+        assertEquals(6, keys.size)
+    }
+
+    @Test
+    fun `openapi host key is a string key with the expected name`() {
+        val keys = RuleKey.collectFrom(OpenApiRuleKeys)
+        val hostKey = keys.firstOrNull { it.name == "openapi.host" }
+        assertTrue(
+            "Expected a key named 'openapi.host', got: ${keys.map { it.name }}",
+            hostKey != null
+        )
+        assertTrue(
+            "openapi.host should be a StringKey, got: ${hostKey?.javaClass?.name}",
+            hostKey is RuleKey.StringKey
+        )
+    }
+
+    @Test
+    fun `openapi format after key is an event key with THROW_IN_ERROR mode`() {
+        val keys = RuleKey.collectFrom(OpenApiRuleKeys)
+        val formatAfterKey = keys.firstOrNull { it.name == "openapi.format.after" }
+        assertTrue(
+            "Expected a key named 'openapi.format.after', got: ${keys.map { it.name }}",
+            formatAfterKey != null
+        )
+        assertTrue(
+            "openapi.format.after should be an EventKey, got: ${formatAfterKey?.javaClass?.name}",
+            formatAfterKey is RuleKey.EventKey
+        )
+        assertEquals(
+            "openapi.format.after should use THROW_IN_ERROR mode",
+            EventRuleMode.THROW_IN_ERROR,
+            (formatAfterKey as RuleKey.EventKey).eventMode
+        )
+    }
+
+    @Test
+    fun `openapi rule keys are disjoint from core RuleKeys`() {
+        // Channel-specific keys must not collide with the shared core keys
+        // (DAG compliance — channel packages own their keys, core.rule owns
+        // the shared ones). A collision would silently override the wrong
+        // behavior in the rule engine.
+        val openApiKeyNames = RuleKey.collectFrom(OpenApiRuleKeys).flatMap { it.allNames }.toSet()
+        val coreKeyNames = RuleKey.collectFrom(RuleKeys).flatMap { it.allNames }.toSet()
+
+        val intersection = openApiKeyNames.intersect(coreKeyNames)
+        assertTrue(
+            "OpenApi rule keys must not overlap with core RuleKeys; overlap: $intersection",
+            intersection.isEmpty()
+        )
+    }
+
+    @Test
+    fun `openapi host key is directly accessible as a property`() {
+        // Pin the property name — Channel.ruleKeys() uses RuleKey.collectFrom,
+        // but tests and the channel layer also reference the constant directly
+        // for readability. Renaming the property would break those call sites.
+        assertEquals("openapi.host", OpenApiRuleKeys.OPENAPI_HOST.name)
+        assertTrue(OpenApiRuleKeys.OPENAPI_HOST is RuleKey.StringKey)
+    }
+
+    @Test
+    fun `openapi format after key is directly accessible as a property`() {
+        assertEquals("openapi.format.after", OpenApiRuleKeys.OPENAPI_FORMAT_AFTER.name)
+        assertTrue(OpenApiRuleKeys.OPENAPI_FORMAT_AFTER is RuleKey.EventKey)
+        assertEquals(
+            EventRuleMode.THROW_IN_ERROR,
+            OpenApiRuleKeys.OPENAPI_FORMAT_AFTER.eventMode
+        )
+    }
+
+    // ─── document-metadata rule keys ───────
+
+    @Test
+    fun `openapi server url key is a string key with the expected name`() {
+        assertEquals("openapi.server.url", OpenApiRuleKeys.OPENAPI_SERVER_URL.name)
+        assertTrue(OpenApiRuleKeys.OPENAPI_SERVER_URL is RuleKey.StringKey)
+    }
+
+    @Test
+    fun `openapi info title key is a string key with the expected name`() {
+        assertEquals("openapi.info.title", OpenApiRuleKeys.OPENAPI_INFO_TITLE.name)
+        assertTrue(OpenApiRuleKeys.OPENAPI_INFO_TITLE is RuleKey.StringKey)
+    }
+
+    @Test
+    fun `openapi info version key is a string key with the expected name`() {
+        assertEquals("openapi.info.version", OpenApiRuleKeys.OPENAPI_INFO_VERSION.name)
+        assertTrue(OpenApiRuleKeys.OPENAPI_INFO_VERSION is RuleKey.StringKey)
+    }
+
+    @Test
+    fun `openapi info description key is a string key with the expected name`() {
+        assertEquals("openapi.info.description", OpenApiRuleKeys.OPENAPI_INFO_DESCRIPTION.name)
+        assertTrue(OpenApiRuleKeys.OPENAPI_INFO_DESCRIPTION is RuleKey.StringKey)
+    }
+
+    @Test
+    fun `all six openapi rule keys are present in collectFrom`() {
+        val names = RuleKey.collectFrom(OpenApiRuleKeys).map { it.name }.toSet()
+        assertTrue("openapi.host missing in $names", "openapi.host" in names)
+        assertTrue("openapi.server.url missing in $names", "openapi.server.url" in names)
+        assertTrue("openapi.info.title missing in $names", "openapi.info.title" in names)
+        assertTrue("openapi.info.version missing in $names", "openapi.info.version" in names)
+        assertTrue("openapi.info.description missing in $names", "openapi.info.description" in names)
+        assertTrue("openapi.format.after missing in $names", "openapi.format.after" in names)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSchemaConverterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSchemaConverterTest.kt
@@ -1,0 +1,493 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.psi.model.FieldModel
+import com.itangcent.easyapi.core.psi.model.FieldOption
+import com.itangcent.easyapi.core.psi.model.ObjectModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [OpenApiSchemaConverter] — the cycle-safe `ObjectModel → OAS
+ * Schema Object` converter.
+ *
+ * Constructs `ObjectModel` instances directly (no PSI) — the model is POJO.
+ */
+class OpenApiSchemaConverterTest {
+
+    // ─── primitive type table ──────────────────────────────────────
+
+    @Test
+    fun primitiveStringMapsToStringWithNullFormat() {
+        val schema = converter().convert(ObjectModel.single("string"))!!
+        assertEquals("string", schema.type)
+        assertNull(schema.format)
+    }
+
+    @Test
+    fun primitiveIntMapsToIntegerInt32() {
+        val schema = converter().convert(ObjectModel.single("int"))!!
+        assertEquals("integer", schema.type)
+        assertEquals("int32", schema.format)
+    }
+
+    @Test
+    fun primitiveIntegerMapsToIntegerInt32() {
+        val schema = converter().convert(ObjectModel.single("integer"))!!
+        assertEquals("integer", schema.type)
+        assertEquals("int32", schema.format)
+    }
+
+    @Test
+    fun primitiveLongMapsToIntegerInt64() {
+        val schema = converter().convert(ObjectModel.single("long"))!!
+        assertEquals("integer", schema.type)
+        assertEquals("int64", schema.format)
+    }
+
+    @Test
+    fun primitiveShortMapsToIntegerInt32() {
+        val schema = converter().convert(ObjectModel.single("short"))!!
+        assertEquals("integer", schema.type)
+        assertEquals("int32", schema.format)
+    }
+
+    @Test
+    fun primitiveByteMapsToIntegerInt32() {
+        val schema = converter().convert(ObjectModel.single("byte"))!!
+        assertEquals("integer", schema.type)
+        assertEquals("int32", schema.format)
+    }
+
+    @Test
+    fun primitiveFloatMapsToNumberFloat() {
+        val schema = converter().convert(ObjectModel.single("float"))!!
+        assertEquals("number", schema.type)
+        assertEquals("float", schema.format)
+    }
+
+    @Test
+    fun primitiveDoubleMapsToNumberDouble() {
+        val schema = converter().convert(ObjectModel.single("double"))!!
+        assertEquals("number", schema.type)
+        assertEquals("double", schema.format)
+    }
+
+    @Test
+    fun primitiveDecimalMapsToNumberDouble() {
+        val schema = converter().convert(ObjectModel.single("decimal"))!!
+        assertEquals("number", schema.type)
+        assertEquals("double", schema.format)
+    }
+
+    @Test
+    fun primitiveBigdecimalMapsToNumberDouble() {
+        val schema = converter().convert(ObjectModel.single("bigdecimal"))!!
+        assertEquals("number", schema.type)
+        assertEquals("double", schema.format)
+    }
+
+    @Test
+    fun primitiveNumberMapsToNumberDouble() {
+        val schema = converter().convert(ObjectModel.single("number"))!!
+        assertEquals("number", schema.type)
+        assertEquals("double", schema.format)
+    }
+
+    @Test
+    fun primitiveBooleanMapsToBooleanWithNullFormat() {
+        val schema = converter().convert(ObjectModel.single("boolean"))!!
+        assertEquals("boolean", schema.type)
+        assertNull(schema.format)
+    }
+
+    @Test
+    fun primitiveDateMapsToStringDate() {
+        val schema = converter().convert(ObjectModel.single("date"))!!
+        assertEquals("string", schema.type)
+        assertEquals("date", schema.format)
+    }
+
+    @Test
+    fun primitiveDatetimeMapsToStringDateTime() {
+        val schema = converter().convert(ObjectModel.single("datetime"))!!
+        assertEquals("string", schema.type)
+        assertEquals("date-time", schema.format)
+    }
+
+    @Test
+    fun primitiveDateTimeWithHyphenMapsToStringDateTime() {
+        val schema = converter().convert(ObjectModel.single("date-time"))!!
+        assertEquals("string", schema.type)
+        assertEquals("date-time", schema.format)
+    }
+
+    @Test
+    fun primitiveTimestampMapsToStringDateTime() {
+        val schema = converter().convert(ObjectModel.single("timestamp"))!!
+        assertEquals("string", schema.type)
+        assertEquals("date-time", schema.format)
+    }
+
+    @Test
+    fun primitiveInstantMapsToStringDateTime() {
+        val schema = converter().convert(ObjectModel.single("instant"))!!
+        assertEquals("string", schema.type)
+        assertEquals("date-time", schema.format)
+    }
+
+    @Test
+    fun primitiveZoneddatetimeMapsToStringDateTime() {
+        val schema = converter().convert(ObjectModel.single("zoneddatetime"))!!
+        assertEquals("string", schema.type)
+        assertEquals("date-time", schema.format)
+    }
+
+    @Test
+    fun primitiveUuidMapsToStringUuid() {
+        val schema = converter().convert(ObjectModel.single("uuid"))!!
+        assertEquals("string", schema.type)
+        assertEquals("uuid", schema.format)
+    }
+
+    @Test
+    fun primitiveByteArrayMapsToStringBinary() {
+        val schema = converter().convert(ObjectModel.single("byte[]"))!!
+        assertEquals("string", schema.type)
+        assertEquals("binary", schema.format)
+    }
+
+    @Test
+    fun primitiveBinaryMapsToStringBinary() {
+        val schema = converter().convert(ObjectModel.single("binary"))!!
+        assertEquals("string", schema.type)
+        assertEquals("binary", schema.format)
+    }
+
+    @Test
+    fun primitiveCharMapsToStringWithNullFormat() {
+        val schema = converter().convert(ObjectModel.single("char"))!!
+        assertEquals("string", schema.type)
+        assertNull(schema.format)
+    }
+
+    @Test
+    fun primitiveCharacterMapsToStringWithNullFormat() {
+        val schema = converter().convert(ObjectModel.single("character"))!!
+        assertEquals("string", schema.type)
+        assertNull(schema.format)
+    }
+
+    @Test
+    fun primitiveUnknownTypeDefaultsToStringWithNullFormat() {
+        val schema = converter().convert(ObjectModel.single("totallyUnknownThing"))!!
+        assertEquals("string", schema.type)
+        assertNull(schema.format)
+    }
+
+    @Test
+    fun primitiveTypeMatchIsCaseInsensitive() {
+        val schema = converter().convert(ObjectModel.single("INTEGER"))!!
+        assertEquals("integer", schema.type)
+        assertEquals("int32", schema.format)
+    }
+
+    // ─── Object with fields + required ────────────────────────────
+
+    @Test
+    fun objectMapsToObjectTypeWithPropertiesAndRequired() {
+        val model = ObjectModel.Object(
+            linkedMapOf(
+                "id" to FieldModel(model = ObjectModel.single("long"), required = true),
+                "name" to FieldModel(model = ObjectModel.single("string")),
+            )
+        )
+        val schema = converter().convert(model)!!
+        assertEquals("object", schema.type)
+        val properties = schema.properties
+        assertNotNull(properties)
+        assertTrue(properties!!.containsKey("id"))
+        assertTrue(properties.containsKey("name"))
+        assertEquals(listOf("id"), schema.required)
+        // Properties use LinkedHashMap to preserve insertion order
+        assertEquals(listOf("id", "name"), properties.keys.toList())
+    }
+
+    // ─── Array ──────────────────────────────────────────────────────
+
+    @Test
+    fun arrayMapsToArrayTypeWithItemsDerivedFromElementModel() {
+        val model = ObjectModel.Array(ObjectModel.single("int"))
+        val schema = converter().convert(model)!!
+        assertEquals("array", schema.type)
+        val items = schema.items
+        assertNotNull(items)
+        assertEquals("integer", items!!.type)
+        assertEquals("int32", items.format)
+    }
+
+    // ─── MapModel ──────────────────────────────────────────────────
+
+    @Test
+    fun mapModelMapsToObjectTypeWithAdditionalPropertiesFromValueType() {
+        val model = ObjectModel.MapModel(
+            keyType = ObjectModel.single("string"),
+            valueType = ObjectModel.single("int"),
+        )
+        val schema = converter().convert(model)!!
+        assertEquals("object", schema.type)
+        val additional = schema.additionalProperties
+        assertNotNull(additional)
+        assertEquals("integer", additional!!.type)
+        assertEquals("int32", additional.format)
+    }
+
+    // ─── field comment → description ───────────────────────────────
+
+    @Test
+    fun fieldCommentPopulatesSchemaDescription() {
+        val model = ObjectModel.Object(
+            linkedMapOf(
+                "name" to FieldModel(
+                    model = ObjectModel.single("string"),
+                    comment = "User's display name",
+                ),
+            )
+        )
+        val schema = converter().convert(model)!!
+        val fieldSchema = schema.properties!!["name"]!!
+        assertEquals("User's display name", fieldSchema.description)
+    }
+
+    // ─── field options → enum + x-enumDescriptions ─────────────────
+
+    @Test
+    fun fieldOptionsWithoutDescriptionsPopulateEnumValuesOnly() {
+        val model = ObjectModel.Object(
+            linkedMapOf(
+                "status" to FieldModel(
+                    model = ObjectModel.single("string"),
+                    options = listOf(
+                        FieldOption(value = "ACTIVE"),
+                        FieldOption(value = "INACTIVE"),
+                    ),
+                ),
+            )
+        )
+        val schema = converter().convert(model)!!
+        val fieldSchema = schema.properties!!["status"]!!
+        assertEquals(listOf("ACTIVE", "INACTIVE"), fieldSchema.enumValues)
+        assertNull(fieldSchema.xEnumDescriptions)
+    }
+
+    @Test
+    fun fieldOptionsWithDescriptionsPopulateEnumValuesAndXEnumDescriptions() {
+        val model = ObjectModel.Object(
+            linkedMapOf(
+                "status" to FieldModel(
+                    model = ObjectModel.single("string"),
+                    options = listOf(
+                        FieldOption(value = "ACTIVE", desc = "Active user"),
+                        FieldOption(value = "INACTIVE", desc = "Inactive user"),
+                    ),
+                ),
+            )
+        )
+        val schema = converter().convert(model)!!
+        val fieldSchema = schema.properties!!["status"]!!
+        assertEquals(listOf("ACTIVE", "INACTIVE"), fieldSchema.enumValues)
+        val enumDescs = fieldSchema.xEnumDescriptions
+        assertNotNull(enumDescs)
+        assertEquals("Active user", enumDescs!!["ACTIVE"])
+        assertEquals("Inactive user", enumDescs["INACTIVE"])
+    }
+
+    // ─── field demo → example ──────────────────────────────────────
+
+    @Test
+    fun fieldDemoPopulatesSchemaExample() {
+        val model = ObjectModel.Object(
+            linkedMapOf(
+                "name" to FieldModel(
+                    model = ObjectModel.single("string"),
+                    demo = "Alice",
+                ),
+            )
+        )
+        val schema = converter().convert(model)!!
+        val fieldSchema = schema.properties!!["name"]!!
+        assertEquals("Alice", fieldSchema.example)
+    }
+
+    // ─── cycle detection ───────────────────────────────
+
+    @Test
+    fun selfReferentialNodeReturnsDollarRefAndRegistersInComponents() {
+        val node = buildSelfReferentialNode()
+        val converter = converter()
+
+        val schema = converter.convert(node, nameHint = "Node")!!
+
+        // First use with nameHint returns a $ref (not an inline object).
+        assertEquals("#/components/schemas/Node", schema.`$ref`)
+
+        // components.schemas has Node registered.
+        val components = converter.buildComponents()
+        val schemas = components.schemas
+        assertNotNull(schemas)
+        assertTrue("Node" in schemas!!)
+        val nodeSchema = schemas["Node"]!!
+        assertEquals("object", nodeSchema.type)
+        // The `next` field of Node is a $ref back to Node (cycle broken).
+        val nextFieldSchema = nodeSchema.properties!!["next"]!!
+        assertEquals("#/components/schemas/Node", nextFieldSchema.`$ref`)
+    }
+
+    @Test
+    fun cycleDetectionTerminatesInFiniteTimeForDeepRecursion() {
+        // Construct Node → next → Node → next → ... (cycle of length 1).
+        // convert() must terminate, not StackOverflow.
+        val node = buildSelfReferentialNode()
+        val schema = converter().convert(node, nameHint = "Node")
+        assertNotNull(schema)
+    }
+
+    // ─── schema-name resolution ────────────────────
+
+    @Test
+    fun nameHintPresentFirstUseRegistersAndReturnsDollarRef() {
+        val model = ObjectModel.Object(
+            linkedMapOf("id" to FieldModel(model = ObjectModel.single("long")))
+        )
+        val converter = converter()
+
+        val schema = converter.convert(model, nameHint = "User")!!
+
+        assertEquals("#/components/schemas/User", schema.`$ref`)
+        val components = converter.buildComponents()
+        assertTrue(components.schemas!!.containsKey("User"))
+    }
+
+    @Test
+    fun nameHintPresentSecondUseSameShapeReturnsExistingDollarRefWithoutDuplicate() {
+        val model1 = ObjectModel.Object(
+            linkedMapOf("id" to FieldModel(model = ObjectModel.single("long")))
+        )
+        val model2 = ObjectModel.Object(
+            linkedMapOf("id" to FieldModel(model = ObjectModel.single("long")))
+        )
+        val converter = converter()
+
+        val first = converter.convert(model1, nameHint = "User")!!
+        val second = converter.convert(model2, nameHint = "User")!!
+
+        // Both calls return the same $ref — no _N suffix on second use.
+        assertEquals("#/components/schemas/User", first.`$ref`)
+        assertEquals("#/components/schemas/User", second.`$ref`)
+
+        // Only one entry registered.
+        val schemas = converter.buildComponents().schemas!!
+        assertEquals(1, schemas.size)
+        assertTrue(schemas.containsKey("User"))
+    }
+
+    @Test
+    fun nameHintPresentSecondUseDifferentShapeAppendsUnderscoreTwoSuffix() {
+        val model1 = ObjectModel.Object(
+            linkedMapOf("id" to FieldModel(model = ObjectModel.single("long")))
+        )
+        val model2 = ObjectModel.Object(
+            linkedMapOf("name" to FieldModel(model = ObjectModel.single("string")))
+        )
+        val converter = converter()
+
+        val first = converter.convert(model1, nameHint = "User")!!
+        val second = converter.convert(model2, nameHint = "User")!!
+
+        assertEquals("#/components/schemas/User", first.`$ref`)
+        // Different shape → _2 suffix (and a warn is logged).
+        assertEquals("#/components/schemas/User_2", second.`$ref`)
+
+        val schemas = converter.buildComponents().schemas!!
+        assertTrue(schemas.containsKey("User"))
+        assertTrue(schemas.containsKey("User_2"))
+    }
+
+    @Test
+    fun noNameHintCyclicAnonymousModelUsesGeneratedSchemaN() {
+        val anon1 = buildSelfReferentialNode()
+        val anon2 = buildSelfReferentialNode()
+        val converter = converter()
+
+        val first = converter.convert(anon1, nameHint = null)!!
+        val second = converter.convert(anon2, nameHint = null)!!
+
+        // Anonymous first-use returns an inline schema (type=object), not a $ref.
+        assertEquals("object", first.type)
+        assertNull(first.`$ref`)
+        // The `next` field is a $ref to GeneratedSchema1.
+        val firstNext = first.properties!!["next"]!!
+        assertEquals("#/components/schemas/GeneratedSchema1", firstNext.`$ref`)
+
+        // Second anonymous cyclic model → GeneratedSchema2.
+        assertEquals("object", second.type)
+        val secondNext = second.properties!!["next"]!!
+        assertEquals("#/components/schemas/GeneratedSchema2", secondNext.`$ref`)
+
+        val schemas = converter.buildComponents().schemas!!
+        assertTrue(schemas.containsKey("GeneratedSchema1"))
+        assertTrue(schemas.containsKey("GeneratedSchema2"))
+    }
+
+    @Test
+    fun nameHintStripsPackageAndGenerics() {
+        // `com.acme.Result<User>` → `Result`
+        val model = ObjectModel.Object(
+            linkedMapOf("data" to FieldModel(model = ObjectModel.single("string")))
+        )
+        val converter = converter()
+
+        val schema = converter.convert(model, nameHint = "com.acme.Result<User>")!!
+
+        assertEquals("#/components/schemas/Result", schema.`$ref`)
+        val schemas = converter.buildComponents().schemas!!
+        assertTrue(schemas.containsKey("Result"))
+        assertFalse(schemas.containsKey("com.acme.Result<User>"))
+    }
+
+    // ─── Misc: null model ───────────────────────────────────────────────────
+
+    @Test
+    fun convertNullModelReturnsNull() {
+        assertNull(converter().convert(null))
+    }
+
+    @Test
+    fun buildComponentsReturnsEmptyObjectWhenNothingRegistered() {
+        val components = converter().buildComponents()
+        // No schemas registered.
+        assertNull(components.schemas)
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private fun converter(): OpenApiSchemaConverter = OpenApiSchemaConverter()
+
+    /**
+     * Builds a self-referential `Node { next: Node }` model. The trick is to
+     * construct an `ObjectModel.Object` with an empty mutable `fields` map,
+     * then mutate the map to add the self-reference after construction. The
+     * `Object.id` is auto-assigned at construction and stays stable, so the
+     * cycle detection (which uses `Object.id`) sees the same id when we
+     * recurse into the `next` field.
+     */
+    private fun buildSelfReferentialNode(): ObjectModel.Object {
+        val fields = linkedMapOf<String, FieldModel>()
+        val node = ObjectModel.Object(fields = fields)
+        fields["next"] = FieldModel(model = node)
+        return node
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSerializerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSerializerTest.kt
@@ -1,0 +1,509 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.testFramework.ResourceLoader
+import com.itangcent.easyapi.testFramework.ResultLoader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Byte-parity golden-file tests for [OpenApiSerializer].
+ *
+ * Three fixtures exercise an increasing surface of the document model:
+ *  - `minimal` — one GET endpoint, void response (no components, no servers).
+ *  - `withSchema` — POST with request + response body referencing a `User`
+ *    schema in `components.schemas` (exercises `$ref` + `enum` + required
+ *    fields + nested `properties`).
+ *  - `allFeatures` — every feature exercised: query/path/header/cookie
+ *    params with enums and examples, request body (json + form + multipart),
+ *    200/204 responses, tags, server URL.
+ *
+ * JSON comparison uses [ResultLoader.load] (trailing-trimmed) — the
+ * golden files live at
+ * `result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.<name>.txt`.
+ *
+ * YAML comparison uses [ResourceLoader.readRaw] (byte-strict) because
+ * YAML's leading whitespace and trailing newline matter.
+ */
+class OpenApiSerializerTest {
+
+    // ─── minimal: one GET endpoint, void response ──────────────────────────
+
+    @Test
+    fun minimalJson() {
+        val json = OpenApiSerializer.toJson(minimalDoc())
+        assertEquals(ResultLoader.load("minimalJson"), json)
+    }
+
+    @Test
+    fun minimalYaml() {
+        val yaml = OpenApiSerializer.toYaml(minimalDoc())
+        assertEquals(
+            ResourceLoader.readRaw(resourcePath("minimalYaml")),
+            yaml,
+        )
+    }
+
+    // ─── withSchema: POST with request + response body referencing User ────
+
+    @Test
+    fun withSchemaJson() {
+        val json = OpenApiSerializer.toJson(withSchemaDoc())
+        assertEquals(ResultLoader.load("withSchemaJson"), json)
+    }
+
+    @Test
+    fun withSchemaYaml() {
+        val yaml = OpenApiSerializer.toYaml(withSchemaDoc())
+        assertEquals(
+            ResourceLoader.readRaw(resourcePath("withSchemaYaml")),
+            yaml,
+        )
+    }
+
+    // ─── allFeatures: every feature exercised ──────────────────────────────
+
+    @Test
+    fun allFeaturesJson() {
+        val json = OpenApiSerializer.toJson(allFeaturesDoc())
+        assertEquals(ResultLoader.load("allFeaturesJson"), json)
+    }
+
+    @Test
+    fun allFeaturesYaml() {
+        val yaml = OpenApiSerializer.toYaml(allFeaturesDoc())
+        assertEquals(
+            ResourceLoader.readRaw(resourcePath("allFeaturesYaml")),
+            yaml,
+        )
+    }
+
+    // ─── Critical structural assertions ───────────────
+
+    @Test
+    fun jsonRendersOpenApi303AsQuotedString() {
+        val json = OpenApiSerializer.toJson(minimalDoc())
+        // JSON output has `"openapi": "3.0.3"`.
+        assertTrue(
+            "Expected JSON to contain \"openapi\": \"3.0.3\" — got: $json",
+            json.contains("\"openapi\": \"3.0.3\""),
+        )
+        assertFalse(
+            "JSON must not contain \"openapi\": 3.0.3 (unquoted number) — got: $json",
+            json.contains("\"openapi\": 3.0.3"),
+        )
+    }
+
+    @Test
+    fun yamlRendersOpenApi303AsQuotedString() {
+        val yaml = OpenApiSerializer.toYaml(minimalDoc())
+        // YAML output has `openapi: "3.0.3"` quoted (not `openapi: 3.0.3`).
+        assertTrue(
+            "Expected YAML to contain openapi: \"3.0.3\" (quoted) — got: $yaml",
+            yaml.contains("openapi: \"3.0.3\""),
+        )
+        assertFalse(
+            "YAML must not contain openapi: 3.0.3 (unquoted) — got: $yaml",
+            yaml.contains("openapi: 3.0.3"),
+        )
+    }
+
+    @Test
+    fun yamlHasNoLeadingDocumentStartMarker() {
+        val yaml = OpenApiSerializer.toYaml(minimalDoc())
+        // WRITE_DOC_START_MARKER disabled — no leading `---`.
+        assertFalse(
+            "YAML must not start with '---' — got: ${yaml.take(20)}",
+            yaml.startsWith("---"),
+        )
+    }
+
+    @Test
+    fun jsonOmitsNullForAbsentOptionalFields() {
+        val json = OpenApiSerializer.toJson(minimalDoc())
+        // serializeNulls() OFF → no `"field": null` in the output.
+        assertFalse(
+            "JSON must not contain \": null\" for absent optional fields — got: $json",
+            json.contains(": null"),
+        )
+    }
+
+    @Test
+    fun yamlOmitsNullForAbsentOptionalFields() {
+        val yaml = OpenApiSerializer.toYaml(minimalDoc())
+        // NON_NULL inclusion → no `: null` in the output.
+        assertFalse(
+            "YAML must not contain \": null\" for absent optional fields — got: $yaml",
+            yaml.contains(": null"),
+        )
+    }
+
+    @Test
+    fun jsonSerializesRefEnumXEnumDescriptionsUnderWireNames() {
+        val json = OpenApiSerializer.toJson(withSchemaDoc())
+        // The Kotlin-safe identifiers (`$ref`, `enumValues`, `xEnumDescriptions`)
+        // must serialize under their OAS wire names: `$ref`, `enum`,
+        // `x-enumDescriptions`.
+        assertTrue(
+            "JSON should contain \"\$ref\": \"#/components/schemas/User\" — got: $json",
+            json.contains("\$ref"),
+        )
+        // `enumValues` field name MUST NOT leak through (Gson uses @SerializedName).
+        assertFalse(
+            "JSON must not contain 'enumValues' (wire name is 'enum') — got: $json",
+            json.contains("enumValues"),
+        )
+        // `xEnumDescriptions` field name MUST NOT leak through.
+        assertFalse(
+            "JSON must not contain 'xEnumDescriptions' (wire name is 'x-enumDescriptions') — got: $json",
+            json.contains("xEnumDescriptions"),
+        )
+    }
+
+    @Test
+    fun yamlSerializesRefEnumXEnumDescriptionsUnderWireNames() {
+        val yaml = OpenApiSerializer.toYaml(withSchemaDoc())
+        assertTrue(
+            "YAML should contain \$ref — got: $yaml",
+            yaml.contains("\$ref"),
+        )
+        assertFalse(
+            "YAML must not contain 'enumValues' (wire name is 'enum') — got: $yaml",
+            yaml.contains("enumValues"),
+        )
+        assertFalse(
+            "YAML must not contain 'xEnumDescriptions' (wire name is 'x-enumDescriptions') — got: $yaml",
+            yaml.contains("xEnumDescriptions"),
+        )
+    }
+
+    @Test
+    fun jsonPreservesInsertionOrderOfPathsSchemasTags() {
+        val json = OpenApiSerializer.toJson(allFeaturesDoc())
+        // Paths must appear in insertion order, not alphabetical.
+        val usersIdx = json.indexOf("\"/users\"")
+        val usersByIdx = json.indexOf("\"/users/{id}\"")
+        val formsIdx = json.indexOf("\"/forms/{id}\"")
+        val avatarIdx = json.indexOf("\"/users/{id}/avatar\"")
+        assertTrue("Expected /users before /users/{id} — got: $json", usersIdx < usersByIdx)
+        assertTrue("Expected /users/{id} before /forms/{id} — got: $json", usersByIdx < formsIdx)
+        assertTrue("Expected /forms/{id} before /users/{id}/avatar — got: $json", formsIdx < avatarIdx)
+
+        // Tags array must preserve insertion order: Users, Forms, Uploads.
+        val usersTagIdx = json.indexOf("\"name\": \"Users\"")
+        val formsTagIdx = json.indexOf("\"name\": \"Forms\"")
+        val uploadsTagIdx = json.indexOf("\"name\": \"Uploads\"")
+        assertTrue(
+            "Expected tag order Users < Forms < Uploads — got: $json",
+            usersTagIdx < formsTagIdx && formsTagIdx < uploadsTagIdx,
+        )
+    }
+
+    @Test
+    fun yamlPreservesInsertionOrderOfPathsSchemasTags() {
+        val yaml = OpenApiSerializer.toYaml(allFeaturesDoc())
+        // Paths in insertion order.
+        val usersIdx = yaml.indexOf("/users:")
+        val formsIdx = yaml.indexOf("/forms/{id}:")
+        val avatarIdx = yaml.indexOf("/users/{id}/avatar:")
+        assertTrue("Expected /users before /forms/{id} — got: $yaml", usersIdx < formsIdx)
+        assertTrue("Expected /forms/{id} before /users/{id}/avatar — got: $yaml", formsIdx < avatarIdx)
+    }
+
+    // ─── Determinism ────────────────────────────────────────────────
+
+    @Test
+    fun jsonOutputIsDeterministicAcrossMultipleRuns() {
+        val doc = allFeaturesDoc()
+        val first = OpenApiSerializer.toJson(doc)
+        val second = OpenApiSerializer.toJson(doc)
+        val third = OpenApiSerializer.toJson(doc)
+        assertEquals("JSON output must be byte-stable across runs (run 1 vs 2)", first, second)
+        assertEquals("JSON output must be byte-stable across runs (run 2 vs 3)", second, third)
+    }
+
+    @Test
+    fun yamlOutputIsDeterministicAcrossMultipleRuns() {
+        val doc = allFeaturesDoc()
+        val first = OpenApiSerializer.toYaml(doc)
+        val second = OpenApiSerializer.toYaml(doc)
+        val third = OpenApiSerializer.toYaml(doc)
+        assertEquals("YAML output must be byte-stable across runs (run 1 vs 2)", first, second)
+        assertEquals("YAML output must be byte-stable across runs (run 2 vs 3)", second, third)
+    }
+
+    // ─── Fixture builders ───────────────────────────────────────────────────
+
+    private fun resourcePath(name: String): String {
+        val className = "com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest"
+        return "result/$className.$name.txt"
+    }
+
+    private fun minimalDoc(): OpenApiDocument {
+        // One GET endpoint, void response (204), no components, no servers, no tags.
+        return OpenApiDocument(
+            info = InfoObject(title = "API", version = "1.0.0"),
+            paths = linkedMapOf(
+                "/users" to PathItemObject(
+                    get = OperationObject(
+                        operationId = "listUsers",
+                        responses = linkedMapOf(
+                            "204" to ResponseObject(description = "No content"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    private fun withSchemaDoc(): OpenApiDocument {
+        // POST with request + response body referencing a User schema in components.schemas.
+        val userSchema = SchemaObject(
+            type = "object",
+            properties = linkedMapOf(
+                "id" to SchemaObject(type = "integer", format = "int64"),
+                "name" to SchemaObject(type = "string", description = "User name"),
+                "status" to SchemaObject(
+                    type = "string",
+                    enumValues = listOf("ACTIVE", "INACTIVE"),
+                    xEnumDescriptions = mapOf(
+                        "ACTIVE" to "Active user",
+                        "INACTIVE" to "Inactive user",
+                    ),
+                ),
+            ),
+            required = listOf("id", "name"),
+        )
+        val userRef = SchemaObject(`$ref` = "#/components/schemas/User")
+        return OpenApiDocument(
+            info = InfoObject(title = "API", version = "1.0.0"),
+            paths = linkedMapOf(
+                "/users" to PathItemObject(
+                    post = OperationObject(
+                        operationId = "createUser",
+                        requestBody = RequestBodyObject(
+                            content = linkedMapOf(
+                                "application/json" to MediaTypeObject(schema = userRef),
+                            ),
+                        ),
+                        responses = linkedMapOf(
+                            "200" to ResponseObject(
+                                description = "OK",
+                                content = linkedMapOf(
+                                    "application/json" to MediaTypeObject(schema = userRef),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            components = ComponentsObject(
+                schemas = linkedMapOf("User" to userSchema),
+            ),
+        )
+    }
+
+    private fun allFeaturesDoc(): OpenApiDocument {
+        val userSchema = SchemaObject(
+            type = "object",
+            properties = linkedMapOf(
+                "id" to SchemaObject(type = "integer", format = "int64"),
+                "name" to SchemaObject(type = "string", description = "User name"),
+                "status" to SchemaObject(
+                    type = "string",
+                    enumValues = listOf("ACTIVE", "INACTIVE"),
+                    xEnumDescriptions = mapOf(
+                        "ACTIVE" to "Active user",
+                        "INACTIVE" to "Inactive user",
+                    ),
+                ),
+            ),
+            required = listOf("id", "name"),
+        )
+        val userRef = SchemaObject(`$ref` = "#/components/schemas/User")
+
+        return OpenApiDocument(
+            info = InfoObject(
+                title = "Demo API",
+                version = "2.0.0",
+                description = "A demo API for golden-file testing",
+            ),
+            servers = listOf(ServerObject(url = "https://api.example.com")),
+            tags = listOf(
+                TagObject(name = "Users"),
+                TagObject(name = "Forms"),
+                TagObject(name = "Uploads"),
+            ),
+            paths = linkedMapOf(
+                "/users" to PathItemObject(
+                    get = OperationObject(
+                        tags = listOf("Users"),
+                        summary = "List users",
+                        operationId = "listUsers",
+                        parameters = listOf(
+                            ParameterObject(
+                                name = "status",
+                                `in` = "query",
+                                description = "Filter by status",
+                                schema = SchemaObject(
+                                    type = "string",
+                                    enumValues = listOf("ACTIVE", "INACTIVE"),
+                                ),
+                                example = "ACTIVE",
+                            ),
+                            ParameterObject(
+                                name = "X-Request-Id",
+                                `in` = "header",
+                                description = "Request ID",
+                                schema = SchemaObject(type = "string"),
+                                example = "abc-123",
+                            ),
+                            ParameterObject(
+                                name = "session",
+                                `in` = "cookie",
+                                description = "Session cookie",
+                                schema = SchemaObject(type = "string"),
+                            ),
+                        ),
+                        responses = linkedMapOf(
+                            "200" to ResponseObject(
+                                description = "OK",
+                                content = linkedMapOf(
+                                    "application/json" to MediaTypeObject(schema = userRef),
+                                ),
+                            ),
+                        ),
+                    ),
+                    post = OperationObject(
+                        tags = listOf("Users"),
+                        summary = "Create user",
+                        operationId = "createUser",
+                        requestBody = RequestBodyObject(
+                            content = linkedMapOf(
+                                "application/json" to MediaTypeObject(schema = userRef),
+                            ),
+                        ),
+                        responses = linkedMapOf(
+                            "200" to ResponseObject(
+                                description = "OK",
+                                content = linkedMapOf(
+                                    "application/json" to MediaTypeObject(schema = userRef),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                "/users/{id}" to PathItemObject(
+                    get = OperationObject(
+                        tags = listOf("Users"),
+                        summary = "Get user by id",
+                        operationId = "getUser",
+                        parameters = listOf(
+                            ParameterObject(
+                                name = "id",
+                                `in` = "path",
+                                required = true,
+                                description = "User ID",
+                                schema = SchemaObject(type = "integer", format = "int64"),
+                                example = 42,
+                            ),
+                        ),
+                        responses = linkedMapOf(
+                            "200" to ResponseObject(
+                                description = "OK",
+                                content = linkedMapOf(
+                                    "application/json" to MediaTypeObject(schema = userRef),
+                                ),
+                            ),
+                        ),
+                    ),
+                    delete = OperationObject(
+                        tags = listOf("Users"),
+                        summary = "Delete user",
+                        operationId = "deleteUser",
+                        parameters = listOf(
+                            ParameterObject(
+                                name = "id",
+                                `in` = "path",
+                                required = true,
+                                schema = SchemaObject(type = "integer", format = "int64"),
+                            ),
+                        ),
+                        responses = linkedMapOf(
+                            "204" to ResponseObject(description = "No content"),
+                        ),
+                    ),
+                ),
+                "/forms/{id}" to PathItemObject(
+                    post = OperationObject(
+                        tags = listOf("Forms"),
+                        summary = "Submit form",
+                        operationId = "submitForm",
+                        parameters = listOf(
+                            ParameterObject(
+                                name = "id",
+                                `in` = "path",
+                                required = true,
+                                schema = SchemaObject(type = "string"),
+                            ),
+                        ),
+                        requestBody = RequestBodyObject(
+                            content = linkedMapOf(
+                                "application/x-www-form-urlencoded" to MediaTypeObject(
+                                    schema = SchemaObject(
+                                        type = "object",
+                                        properties = linkedMapOf(
+                                            "username" to SchemaObject(type = "string"),
+                                            "email" to SchemaObject(type = "string"),
+                                        ),
+                                        required = listOf("username"),
+                                    ),
+                                ),
+                            ),
+                            required = true,
+                        ),
+                        responses = linkedMapOf(
+                            "200" to ResponseObject(description = "OK"),
+                        ),
+                    ),
+                ),
+                "/users/{id}/avatar" to PathItemObject(
+                    post = OperationObject(
+                        tags = listOf("Uploads"),
+                        summary = "Upload avatar",
+                        operationId = "uploadAvatar",
+                        parameters = listOf(
+                            ParameterObject(
+                                name = "id",
+                                `in` = "path",
+                                required = true,
+                                schema = SchemaObject(type = "integer", format = "int64"),
+                            ),
+                        ),
+                        requestBody = RequestBodyObject(
+                            content = linkedMapOf(
+                                "multipart/form-data" to MediaTypeObject(
+                                    schema = SchemaObject(
+                                        type = "object",
+                                        properties = linkedMapOf(
+                                            "avatar" to SchemaObject(type = "string", format = "binary"),
+                                        ),
+                                        required = listOf("avatar"),
+                                    ),
+                                ),
+                            ),
+                            required = true,
+                        ),
+                        responses = linkedMapOf(
+                            "204" to ResponseObject(description = "No content"),
+                        ),
+                    ),
+                ),
+            ),
+            components = ComponentsObject(
+                schemas = linkedMapOf("User" to userSchema),
+            ),
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettingsPanelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettingsPanelTest.kt
@@ -1,0 +1,178 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.ui.SettingsPanel
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlin.reflect.full.memberProperties
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * Tests for [OpenApiSettingsPanel].
+ *
+ * The panel now exposes ONLY the
+ * default `outputFormat` combo with three options (`JSON` / `YAML` /
+ * `Always Ask`, default `Always Ask`). The v1 envelope fields
+ * (`infoTitle` / `infoVersion` / `infoDescription` / `serverUrl`) were
+ * removed from `OpenApiSettings` — those values vary per project and
+ * belong in rule scripts.
+ *
+ * Verifies the panel:
+ *  - extends `SettingsPanel<Settings>` (typed against the
+ *    `Settings` base so the configurable's `ChannelPanelEntry.panel` cast works
+ *    without a per-channel `Settings` subtype);
+ *  - reads from / writes to [SettingBinder] (never touches state components);
+ *  - round-trips the persisted `outputFormat` field;
+ *  - reports `isModified` correctly after a UI change.
+ *
+ * Uses [EasyApiLightCodeInsightFixtureTestCase] so the
+ * [com.itangcent.easyapi.core.settings.DefaultSettingBinder] is registered in
+ * `setUp` (the panel depends on it for reads/writes).
+ */
+class OpenApiSettingsPanelTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var panel: OpenApiSettingsPanel
+
+    override fun setUp() {
+        super.setUp()
+        panel = OpenApiSettingsPanel(project)
+    }
+
+    fun testComponentIsNotNull() {
+        assertNotNull(panel.component)
+    }
+
+    fun testExtendsSettingsPanelOfSettings() {
+        // Typed as SettingsPanel<Settings> (NOT SettingsPanel<OpenApiSettings>)
+        // so the configurable's ChannelPanelEntry.panel cast works.
+        assertTrue(
+            "OpenApiSettingsPanel should be assignable to SettingsPanel<Settings>",
+            panel is SettingsPanel<Settings>
+        )
+    }
+
+    fun testResetFromNullDoesNotThrow() {
+        panel.resetFrom(null)
+    }
+
+    fun testResetFromDefaultSettingsPopulatesUIWithDefaults() {
+        // outputFormat="ALWAYS_ASK" → "Always Ask" in UI.
+        panel.resetFrom(null)
+
+        // The raw stored value is "ALWAYS_ASK" (the OpenApiSettings default);
+        // the panel maps it to the UI display string "Always Ask".
+        val s = SettingBinder.getInstance(project).read(OpenApiSettings::class)
+        assertEquals("ALWAYS_ASK", s.outputFormat)
+        assertEquals("Always Ask", panel.outputFormatText())
+    }
+
+    fun testSettingsHasOnlyOutputFormatProperty() {
+        // The v1 envelope fields (infoTitle / infoVersion / infoDescription /
+        // serverUrl) were removed. Reflection-level guard so
+        // accidental re-introduction is caught by this test.
+        val propertyNames = OpenApiSettings::class.memberProperties.map { it.name }
+        assertEquals(
+            "OpenApiSettings should have only the outputFormat property, got: $propertyNames",
+            listOf("outputFormat"),
+            propertyNames,
+        )
+    }
+
+    fun testResetFromPopulatesUIFieldsFromSettings() {
+        val binder = SettingBinder.getInstance(project)
+        val settings = binder.read(OpenApiSettings::class).apply {
+            outputFormat = "YAML"
+        }
+        binder.save(settings)
+
+        panel.resetFrom(settings)
+        assertEquals("YAML", panel.outputFormatText())
+    }
+
+    fun testResetFromMapsAlwaysAskStoredValueToUiString() {
+        val binder = SettingBinder.getInstance(project)
+        val settings = binder.read(OpenApiSettings::class).apply {
+            outputFormat = "ALWAYS_ASK"
+        }
+        binder.save(settings)
+
+        panel.resetFrom(settings)
+        assertEquals("Always Ask", panel.outputFormatText())
+    }
+
+    fun testIsModifiedReturnsFalseAfterResetFrom() {
+        // After resetFrom, the UI fields match the persisted settings — isModified=false.
+        val s = SettingBinder.getInstance(project).read(OpenApiSettings::class)
+        panel.resetFrom(s)
+        assertFalse(panel.isModified(s))
+    }
+
+    fun testIsModifiedReturnsTrueWhenFormatChanged() {
+        val s = SettingBinder.getInstance(project).read(OpenApiSettings::class)
+        panel.resetFrom(s)
+
+        panel.setOutputFormat("YAML")
+        assertTrue(panel.isModified(s))
+    }
+
+    fun testIsModifiedReturnsTrueWhenAlwaysAskSelected() {
+        val s = SettingBinder.getInstance(project).read(OpenApiSettings::class).apply {
+            outputFormat = "JSON"
+        }
+        SettingBinder.getInstance(project).save(s)
+        panel.resetFrom(s)
+
+        panel.setOutputFormat("Always Ask")
+        assertTrue(panel.isModified(s))
+    }
+
+    fun testApplyToPersistsOutputFormat() {
+        panel.setOutputFormat("YAML")
+
+        panel.applyTo(OpenApiSettings())
+
+        val stored = SettingBinder.getInstance(project).read(OpenApiSettings::class)
+        assertEquals("YAML", stored.outputFormat)
+    }
+
+    fun testApplyToPersistsAlwaysAskFormat() {
+        panel.setOutputFormat("Always Ask")
+
+        panel.applyTo(OpenApiSettings())
+
+        val stored = SettingBinder.getInstance(project).read(OpenApiSettings::class)
+        assertEquals("ALWAYS_ASK", stored.outputFormat)
+    }
+
+    fun testRoundTripResetApplyIsModified() {
+        // Set UI → applyTo → read fresh → resetFrom → isModified=false.
+        panel.setOutputFormat("YAML")
+
+        panel.applyTo(OpenApiSettings())
+
+        val fresh = SettingBinder.getInstance(project).read(OpenApiSettings::class)
+        panel.resetFrom(fresh)
+        assertFalse("After apply+reset, panel should match persisted state", panel.isModified(fresh))
+    }
+
+    fun testRoundTripAllThreeFormats() {
+        // Round-trip each of the three format options through apply/reset.
+        for (stored in listOf("JSON", "YAML", "ALWAYS_ASK")) {
+            panel.setOutputFormat(when (stored) {
+                "JSON" -> "JSON"
+                "YAML" -> "YAML"
+                else -> "Always Ask"
+            })
+            panel.applyTo(OpenApiSettings())
+
+            val fresh = SettingBinder.getInstance(project).read(OpenApiSettings::class)
+            assertEquals("Round-trip failed for $stored", stored, fresh.outputFormat)
+
+            panel.resetFrom(fresh)
+            assertFalse("isModified should be false after reset for $stored", panel.isModified(fresh))
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettingsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiSettingsTest.kt
@@ -1,0 +1,127 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.settings.Scope
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.StorageScope
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Plain-JUnit tests for [OpenApiSettings].
+ *
+ * Pins the contract that `OpenApiSettings` carries **only**
+ * [OpenApiSettings.outputFormat] (default `"ALWAYS_ASK"`). The v1 `infoTitle`
+ * / `infoVersion` / `infoDescription` / `serverUrl` fields were removed —
+ * those values vary per project and belong in rule scripts.
+ *
+ * Pins the contract:
+ *  - Defaults: `outputFormat="ALWAYS_ASK"`.
+ *  - The only field carries `@StorageScope(Scope.APPLICATION)` — this is the
+ *    regression test for a misannotated field silently not persisting
+ *    (the SettingBinder only round-trips fields annotated with @StorageScope).
+ *  - The field is `var` (not `val`) — the SettingBinder mutates the instance
+ *    in place when loading from persistent state.
+ *  - The class implements [Settings] (marker interface for modular settings).
+ *
+ * `outputFormat` is stored as a String (not the [OpenApiOutputFormat] enum)
+ * because the unified settings state serializes to primitives; the channel
+ * layer parses the string back to the enum at use time.
+ */
+class OpenApiSettingsTest {
+
+    @Test
+    fun `default outputFormat is ALWAYS_ASK string`() {
+        // ALWAYS_ASK is the default. Stored as String — the
+        // enum conversion happens in the channel layer.
+        assertEquals("ALWAYS_ASK", OpenApiSettings().outputFormat)
+    }
+
+    @Test
+    fun `settings implements Settings marker interface`() {
+        // Compile-time + runtime check — SettingBinder.read<OpenApiSettings>
+        // requires the marker interface.
+        val s: Settings = OpenApiSettings()
+        assertNotNull(s)
+    }
+
+    @Test
+    fun `every field is annotated with StorageScope APPLICATION`() {
+        // Regression test: if a new field is added without @StorageScope, the
+        // SettingBinder silently skips it during round-trip persistence.
+        val fields = OpenApiSettings::class.memberProperties.toList()
+        // Sanity: confirm we're actually inspecting a non-trivial class with
+        // exactly one field now.
+        assertEquals(1, fields.size)
+
+        fields.forEach { prop ->
+            val annotation = prop.findAnnotation<StorageScope>()
+            assertNotNull(
+                "Property '${prop.name}' is missing @StorageScope — SettingBinder will not persist it",
+                annotation
+            )
+            assertEquals(
+                "Property '${prop.name}' should be APPLICATION-scoped",
+                Scope.APPLICATION,
+                annotation?.value
+            )
+        }
+    }
+
+    @Test
+    fun `every field is var not val`() {
+        // SettingBinder mutates the instance in place when loading from
+        // persistent state — val fields would throw at reflection time.
+        // Kotlin reflection surfaces `var` as `KMutableProperty1` (a subtype
+        // of `KProperty1`); `val` is `KProperty1` only.
+        val fields = OpenApiSettings::class.memberProperties.toList()
+        fields.forEach { prop ->
+            assertTrue(
+                "Property '${prop.name}' must be `var` (SettingBinder mutates it), got: ${prop::class.simpleName}",
+                prop is KMutableProperty1<*, *>
+            )
+        }
+    }
+
+    @Test
+    fun `constructed settings round-trips outputFormat`() {
+        val s = OpenApiSettings(outputFormat = "YAML")
+        assertEquals("YAML", s.outputFormat)
+    }
+
+    @Test
+    fun `fields are mutable`() {
+        // SettingBinder.load(instance) writes to the instance — verify a
+        // hand-written mutation actually changes the value, so we know the
+        // `var` declaration is real (not just an annotation artifact).
+        val s = OpenApiSettings()
+        s.outputFormat = "YAML"
+        assertEquals("YAML", s.outputFormat)
+        s.outputFormat = "ALWAYS_ASK"
+        assertEquals("ALWAYS_ASK", s.outputFormat)
+    }
+
+    @Test
+    fun `settings has only outputFormat property`() {
+        // Removed infoTitle / infoVersion / infoDescription /
+        // serverUrl. The data class should have exactly one declared
+        // property — outputFormat.
+        val propertyNames = OpenApiSettings::class.memberProperties.map { it.name }
+        assertEquals(listOf("outputFormat"), propertyNames)
+    }
+
+    @Test
+    fun `settings has no infoTitle infoVersion infoDescription serverUrl properties`() {
+        // Explicit assertion that the removed fields do NOT
+        // reappear — protects against an accidental re-add.
+        val propertyNames = OpenApiSettings::class.memberProperties.map { it.name }
+        assertTrue("infoTitle should be removed", "infoTitle" !in propertyNames)
+        assertTrue("infoVersion should be removed", "infoVersion" !in propertyNames)
+        assertTrue("infoDescription should be removed", "infoDescription" !in propertyNames)
+        assertTrue("serverUrl should be removed", "serverUrl" !in propertyNames)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiYamlDependencyTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OpenApiYamlDependencyTest.kt
@@ -1,0 +1,29 @@
+package com.itangcent.easyapi.channel.openapi
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Regression test for the `build.gradle.kts` YAML dependency addition.
+ *
+ * Asserts the two new dependencies — `jackson-dataformat-yaml:2.12.2`
+ * (used by [OpenApiSerializer.toYaml]) and `snakeyaml:1.33` (explicit
+ * override of the transitive 1.27 to silence CVE-2022-1471 scanners) —
+ * are on the test classpath. A thin-wrapper test per spec-driven
+ * best-practices "When to Skip" — `build.gradle.kts` is a configuration
+ * edit with no business logic.
+ */
+class OpenApiYamlDependencyTest {
+
+    @Test
+    fun jacksonYamlMapperIsOnClasspath() {
+        val clazz = Class.forName("com.fasterxml.jackson.dataformat.yaml.YAMLMapper")
+        assertNotNull(clazz)
+    }
+
+    @Test
+    fun snakeyamlIsOnClasspath() {
+        val clazz = Class.forName("org.yaml.snakeyaml.Yaml")
+        assertNotNull(clazz)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OperationIdResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/OperationIdResolverTest.kt
@@ -1,0 +1,196 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.HttpMetadata
+import com.intellij.psi.PsiMethod
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests for [OperationIdResolver].
+ *
+ * Covers operationId resolution order: `sourceMethod.name` →
+ * `{method}_{path_slug}` slug fallback, and numeric `-N` suffix on
+ * collision + `warn` log. The warn-log side effect is verified via a
+ * returned [ResolutionResult] data class (the simpler alternative to
+ * capturing an `IdeaLog` test fake).
+ */
+class OperationIdResolverTest {
+
+    // ─── sourceMethod.name takes precedence ────────────────────────
+
+    @Test
+    fun sourceMethodNameUsedWhenAvailableAndUnique() {
+        val meta = httpMetadata("/users/{id}", HttpMethod.GET)
+        val sourceMethod = mockMethod("getUser")
+        val used = mutableSetOf<String>()
+
+        val result = OperationIdResolver.resolve(meta, sourceMethod, used)
+
+        assertEquals("getUser", result.operationId)
+        assertFalse("first use must not flag a collision", result.collisionDetected)
+        assertTrue("resolved id must be registered in `used`", "getUser" in used)
+    }
+
+    // ─── slug fallback when sourceMethod is null ───────────────────
+
+    @Test
+    fun slugFallbackUsedWhenSourceMethodIsNull() {
+        val meta = httpMetadata("/users/{id}", HttpMethod.GET)
+        val used = mutableSetOf<String>()
+
+        val result = OperationIdResolver.resolve(meta, sourceMethod = null, used = used)
+
+        // path `/users/{id}` → slug `users_id` (after collapsing {/}/}/ to _,
+        // trimming, lowercasing). Final: `get_users_id`.
+        assertEquals("get_users_id", result.operationId)
+        assertFalse(result.collisionDetected)
+        assertTrue("get_users_id" in used)
+    }
+
+    @Test
+    fun slugFallbackForPostMethod() {
+        val meta = httpMetadata("/users", HttpMethod.POST)
+        val used = mutableSetOf<String>()
+
+        val result = OperationIdResolver.resolve(meta, sourceMethod = null, used = used)
+
+        assertEquals("post_users", result.operationId)
+        assertFalse(result.collisionDetected)
+    }
+
+    @Test
+    fun slugFallbackForRootPath() {
+        val meta = httpMetadata("/", HttpMethod.GET)
+        val used = mutableSetOf<String>()
+
+        val result = OperationIdResolver.resolve(meta, sourceMethod = null, used = used)
+
+        // Root path produces an empty path slug after trim; the method name
+        // alone is the operationId.
+        assertEquals("get", result.operationId)
+        assertFalse(result.collisionDetected)
+    }
+
+    @Test
+    fun slugFallbackCollapsesConsecutiveSeparators() {
+        // `/users/{id}/` → trailing slash collapses to nothing; the slug is
+        // still `users_id` (no trailing/double underscore).
+        val meta = httpMetadata("/users/{id}/", HttpMethod.GET)
+        val used = mutableSetOf<String>()
+
+        val result = OperationIdResolver.resolve(meta, sourceMethod = null, used = used)
+
+        assertEquals("get_users_id", result.operationId)
+    }
+
+    // ─── numeric -N suffix on collision ────────────────────────────
+
+    @Test
+    fun numericSuffixOnSecondAndThirdCollision() {
+        val meta = httpMetadata("/users/{id}", HttpMethod.GET)
+        val sourceMethod = mockMethod("getUser")
+        val used = mutableSetOf<String>()
+
+        val first = OperationIdResolver.resolve(meta, sourceMethod, used)
+        val second = OperationIdResolver.resolve(meta, sourceMethod, used)
+        val third = OperationIdResolver.resolve(meta, sourceMethod, used)
+
+        assertEquals("getUser", first.operationId)
+        assertFalse(first.collisionDetected)
+
+        assertEquals("getUser-2", second.operationId)
+        assertTrue("second use must flag a collision (warn-log side effect)", second.collisionDetected)
+
+        assertEquals("getUser-3", third.operationId)
+        assertTrue("third use must flag a collision", third.collisionDetected)
+
+        assertTrue("getUser" in used)
+        assertTrue("getUser-2" in used)
+        assertTrue("getUser-3" in used)
+    }
+
+    @Test
+    fun collisionAcrossSameSlugFromDifferentMethodPaths() {
+        // Two endpoints with no sourceMethod, both GET /users/{id} — same
+        // slug fallback → second gets -2 suffix.
+        val meta1 = httpMetadata("/users/{id}", HttpMethod.GET)
+        val meta2 = httpMetadata("/users/{id}", HttpMethod.GET)
+        val used = mutableSetOf<String>()
+
+        val first = OperationIdResolver.resolve(meta1, sourceMethod = null, used = used)
+        val second = OperationIdResolver.resolve(meta2, sourceMethod = null, used = used)
+
+        assertEquals("get_users_id", first.operationId)
+        assertFalse(first.collisionDetected)
+
+        assertEquals("get_users_id-2", second.operationId)
+        assertTrue(second.collisionDetected)
+    }
+
+    @Test
+    fun collisionWhenSourceMethodNameClashesAcrossPaths() {
+        // Same sourceMethod name on different paths — second gets -2 suffix.
+        val meta1 = httpMetadata("/users/{id}", HttpMethod.GET)
+        val meta2 = httpMetadata("/orders/{id}", HttpMethod.GET)
+        val sourceMethod = mockMethod("getItem")
+        val used = mutableSetOf<String>()
+
+        val first = OperationIdResolver.resolve(meta1, sourceMethod, used)
+        val second = OperationIdResolver.resolve(meta2, sourceMethod, used)
+
+        assertEquals("getItem", first.operationId)
+        assertFalse(first.collisionDetected)
+
+        assertEquals("getItem-2", second.operationId)
+        assertTrue(second.collisionDetected)
+    }
+
+    @Test
+    fun collisionSuffixDoesNotConflictWithPreExistingDashNEntry() {
+        // Pre-populate `used` with `getUser-2` so a fresh first call to
+        // `getUser` succeeds, but the second collision has to skip past
+        // `getUser-2` and pick `getUser-3`.
+        val meta = httpMetadata("/users/{id}", HttpMethod.GET)
+        val sourceMethod = mockMethod("getUser")
+        val used = mutableSetOf("getUser-2")
+
+        val first = OperationIdResolver.resolve(meta, sourceMethod, used)
+        val second = OperationIdResolver.resolve(meta, sourceMethod, used)
+
+        // `getUser` was not in `used` (only `getUser-2` was), so first wins.
+        assertEquals("getUser", first.operationId)
+        assertFalse(first.collisionDetected)
+
+        // Second call: `getUser` is now in `used`. The next free slot is
+        // `getUser-2`? No — `getUser-2` is also taken. Must skip to `-3`.
+        assertEquals("getUser-3", second.operationId)
+        assertTrue(second.collisionDetected)
+    }
+
+    @Test
+    fun slugFallbackCollisionWithPreExistingEntry() {
+        val meta = httpMetadata("/users/{id}", HttpMethod.GET)
+        val used = mutableSetOf("get_users_id")
+
+        val result = OperationIdResolver.resolve(meta, sourceMethod = null, used = used)
+
+        assertEquals("get_users_id-2", result.operationId)
+        assertTrue(result.collisionDetected)
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private fun httpMetadata(path: String, method: HttpMethod): HttpMetadata =
+        HttpMetadata(path = path, method = method)
+
+    private fun mockMethod(name: String): PsiMethod {
+        val method = mock<PsiMethod>()
+        whenever(method.name).thenReturn(name)
+        return method
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/PathNormalizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/PathNormalizerTest.kt
@@ -1,0 +1,105 @@
+package com.itangcent.easyapi.channel.openapi
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Tests for [PathNormalizer].
+ *
+ * Covers:
+ * - Spring colon form `/users/:id` → `/users/{id}`
+ * - Spring regex form `/users/{id:\\d+}` → `/users/{id}` (regex stripped)
+ * - Multi-char regex `/users/{id:[a-z]+}` → `/users/{id}`
+ * - Already-correct passthrough `/users/{id}`
+ * - No-params passthrough `/users`
+ * - Malformed input `/users/{unclosed` → `null` (triggers skip-with-warn upstream)
+ */
+class PathNormalizerTest {
+
+    @Test
+    fun normalizesSpringColonForm() {
+        assertEquals("/users/{id}", PathNormalizer.normalize("/users/:id"))
+    }
+
+    @Test
+    fun normalizesSpringColonFormAtStart() {
+        assertEquals("/{id}/details", PathNormalizer.normalize("/:id/details"))
+    }
+
+    @Test
+    fun normalizesMultipleColonForm() {
+        assertEquals("/users/{id}/posts/{postId}", PathNormalizer.normalize("/users/:id/posts/:postId"))
+    }
+
+    @Test
+    fun stripsDigitRegexFromBraceForm() {
+        assertEquals("/users/{id}", PathNormalizer.normalize("/users/{id:\\d+}"))
+    }
+
+    @Test
+    fun stripsMultiCharRegexFromBraceForm() {
+        assertEquals("/users/{id}", PathNormalizer.normalize("/users/{id:[a-z]+}"))
+    }
+
+    @Test
+    fun stripsComplexRegexFromBraceForm() {
+        assertEquals("/users/{id}", PathNormalizer.normalize("/users/{id:[0-9a-fA-F]{8,}}"))
+    }
+
+    @Test
+    fun preservesAlreadyCorrectPath() {
+        assertEquals("/users/{id}", PathNormalizer.normalize("/users/{id}"))
+    }
+
+    @Test
+    fun preservesAlreadyCorrectMultiParamPath() {
+        assertEquals(
+            "/users/{userId}/posts/{postId}",
+            PathNormalizer.normalize("/users/{userId}/posts/{postId}"),
+        )
+    }
+
+    @Test
+    fun preservesNoParamPath() {
+        assertEquals("/users", PathNormalizer.normalize("/users"))
+    }
+
+    @Test
+    fun preservesRootPath() {
+        assertEquals("/", PathNormalizer.normalize("/"))
+    }
+
+    @Test
+    fun returnsNullForUnclosedBrace() {
+        assertNull(PathNormalizer.normalize("/users/{unclosed"))
+    }
+
+    @Test
+    fun returnsNullForEmptyBrace() {
+        assertNull(PathNormalizer.normalize("/users/{}"))
+    }
+
+    @Test
+    fun returnsNullForUnmatchedClosingBrace() {
+        assertNull(PathNormalizer.normalize("/users/id}"))
+    }
+
+    @Test
+    fun returnsNullForSpacesInPath() {
+        assertNull(PathNormalizer.normalize("/users/{id }"))
+    }
+
+    @Test
+    fun normalizesColonThenAppliesGrammarCheck() {
+        // After :id → {id} normalization, the path must still be a valid
+        // OAS Path Template — no leftover invalid characters.
+        assertEquals("/users/{id}", PathNormalizer.normalize("/users/:id"))
+    }
+
+    @Test
+    fun doesNotTouchCurlyBracesInQuery() {
+        // OAS Path Templates carry no query string — if the user supplied one
+        // with braces, it's malformed for OAS purposes and we skip it.
+        assertNull(PathNormalizer.normalize("/users?filter={x}"))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/openapi/SwaggerConfigExtractionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/openapi/SwaggerConfigExtractionTest.kt
@@ -1,0 +1,506 @@
+package com.itangcent.easyapi.channel.openapi
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * Verifies that the dedicated OpenAPI-channel config files
+ * (`swagger3-openapi.config`, `swagger-openapi.config`, `springfox-openapi.config`)
+ * correctly map `@OpenAPIDefinition` (Swagger v3), `@SwaggerDefinition`
+ * (Swagger v2), and Springfox `@Bean Docket` to the OpenApi channel's rule
+ * keys (`openapi.info.title`, `openapi.info.version`,
+ * `openapi.info.description`, `openapi.server.url`).
+ *
+ * The extension configs use `helper.findClassesByAnnotation(...)` /
+ * `helper.findMethodsByAnnotation(...)` (global lookup) instead of
+ * `it.annMap(...)` (per-controller). This means:
+ *  - Each extension's rule keys search the WHOLE project for the annotated class,
+ *    not just the controller being exported.
+ *  - When multiple extensions define the same rule key (all 3 define
+ *    `openapi.info.title`), loading them together causes interference — the
+ *    first rule that returns a non-null value wins.
+ *
+ * To avoid interference, each extension is tested in its OWN inner class with
+ * its OWN `createConfigReader()` loading ONLY that extension's config file.
+ * Each inner class also loads ONLY the fixtures it needs — no cross-extension
+ * fixture leakage.
+ *
+ * Document-level annotations (`@OpenAPIDefinition`, `@SwaggerDefinition`) are
+ * placed on a SEPARATE `@Configuration` class, never on the exported
+ * `@RestController`. This mirrors the real-world convention and ensures the
+ * global lookup finds the annotation regardless of which controller is exported.
+ *
+ * ## Inner class layout
+ *
+ * - [Swagger3Test] — `swagger3-openapi.config` + `OpenApiConfig` (has
+ *   `@OpenAPIDefinition`) + `PingController` (plain, exported).
+ * - [Swagger3NoAnnotationTest] — `swagger3-openapi.config` +
+ *   `NoOpenApiDefinitionController` (no `@OpenAPIDefinition` anywhere →
+ *   verifies fall-through to defaults).
+ * - [Swagger2Test] — `swagger-openapi.config` + `SwaggerConfig` (has
+ *   `@SwaggerDefinition` with host) + `PingController` (plain, exported).
+ * - [Swagger2InfoOnlyTest] — `swagger-openapi.config` + `SwaggerInfoOnlyConfig`
+ *   (has `@SwaggerDefinition` without host → verifies `servers` is omitted but
+ *   `info` is still extracted) + `PingController` (plain, exported).
+ * - [SpringfoxTest] — `springfox-openapi.config` + `SpringfoxDocketConfig`
+ *   (has `@Bean Docket` method).
+ *
+ * JUnit 3-style `testXxx()` naming is required because
+ * [EasyApiLightCodeInsightFixtureTestCase] extends
+ * `LightJavaCodeInsightFixtureTestCase` (a JUnit 3 `TestCase` subclass).
+ */
+class SwaggerConfigExtractionTest {
+
+    /**
+     * Shared base class for the extension-specific inner test classes.
+     * Provides common setup (channel instance, JSON output format pin) and
+     * the `exportChannel` / `loadConfigFromResource` helpers.
+     */
+    abstract class Base : EasyApiLightCodeInsightFixtureTestCase() {
+
+        protected lateinit var channel: OpenApiChannel
+
+        override fun setUp() {
+            super.setUp()
+            channel = OpenApiChannel()
+            // Pin JSON output format so the ALWAYS_ASK prompt (which would
+            // block on EDT) is bypassed.
+            SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                outputFormat = "JSON"
+            }
+            // Load common Spring annotation stubs needed by all fixture
+            // controllers (@RestController, @RequestMapping, @GetMapping).
+            loadSpringStubs()
+        }
+
+        override fun tearDown() {
+            try {
+                SettingBinder.getInstance(project).update(OpenApiSettings::class) {
+                    outputFormat = "ALWAYS_ASK"
+                }
+            } finally {
+                super.tearDown()
+            }
+        }
+
+        /**
+         * Loads the common Spring annotation stubs needed by all fixture
+         * controllers (`@RestController`, `@RequestMapping`, `@GetMapping`).
+         */
+        protected fun loadSpringStubs() {
+            loadFile("spring/RestController.java")
+            loadFile("spring/RequestMapping.java")
+            loadFile("spring/GetMapping.java")
+        }
+
+        /**
+         * Exports an endpoint whose `sourceClass` is the given [psiClass],
+         * using an explicit JSON [OpenApiConfig] to bypass the ALWAYS_ASK
+         * prompt.
+         */
+        protected suspend fun exportChannel(psiClass: PsiClass): ExportResult {
+            val endpoint = endpointWithSourceClass(psiClass, methodName = "ping")
+            return channel.export(
+                ExportContext(
+                    project = project,
+                    endpoints = listOf(endpoint),
+                    channelId = "openapi",
+                    channelConfig = OpenApiConfig(outputFormat = OpenApiOutputFormat.JSON),
+                )
+            )
+        }
+
+        private fun endpointWithSourceClass(psiClass: PsiClass, methodName: String): ApiEndpoint {
+            val psiMethod = mock<PsiMethod> { on { this.name } doReturn methodName }
+            return ApiEndpoint(
+                name = methodName,
+                metadata = httpMetadata(path = "/api/ping", method = HttpMethod.GET),
+                sourceMethod = psiMethod,
+                sourceClass = psiClass,
+                className = psiClass.qualifiedName,
+            )
+        }
+
+        protected fun loadConfigFromResource(path: String): String {
+            return javaClass.classLoader.getResourceAsStream(path)
+                ?.bufferedReader(Charsets.UTF_8)
+                ?.use { it.readText() }
+                ?: error("Resource not found: $path")
+        }
+    }
+
+    // ─── swagger3-openapi.config — @OpenAPIDefinition on a config class ──
+
+    /**
+     * Verifies `swagger3-openapi.config` extracts `@OpenAPIDefinition` metadata
+     * from a separate `@Configuration` class. The annotation is located globally
+     * via `helper.findClassesByAnnotation("io.swagger.v3.oas.annotations.OpenAPIDefinition")`;
+     * the exported `PingController` carries no such annotation.
+     */
+    class Swagger3Test : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/swagger3-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // @Configuration stub (the doc-level annotation now lives on a config class)
+            loadFile("org/springframework/context/annotation/Configuration.java")
+            // Swagger v3 annotation stubs
+            loadFile("io/swagger/v3/oas/annotations/OpenAPIDefinition.java")
+            loadFile("io/swagger/v3/oas/annotations/info/Info.java")
+            loadFile("io/swagger/v3/oas/annotations/servers/Server.java")
+            // Config class carrying @OpenAPIDefinition (document-level metadata)
+            loadFile("api/swagger3/OpenApiConfig.java")
+            // Plain controller to export (no @OpenAPIDefinition)
+            loadFile("api/swagger3/PingController.java")
+        }
+
+        fun testOpenApiDefinitionExtractsInfoTitle() = runTest {
+            val psiClass = findClass("com.itangcent.swagger3.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue("Expected Success, got: $result", result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.title should be extracted from @OpenAPIDefinition.info.title",
+                "OpenAPIDefinition Title",
+                metadata.document.info.title,
+            )
+        }
+
+        fun testOpenApiDefinitionExtractsInfoVersion() = runTest {
+            val psiClass = findClass("com.itangcent.swagger3.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.version should be extracted from @OpenAPIDefinition.info.version",
+                "2.1.0",
+                metadata.document.info.version,
+            )
+        }
+
+        fun testOpenApiDefinitionExtractsInfoDescription() = runTest {
+            val psiClass = findClass("com.itangcent.swagger3.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.description should be extracted from @OpenAPIDefinition.info.description",
+                "OpenAPIDefinition Description",
+                metadata.document.info.description,
+            )
+        }
+
+        fun testOpenApiDefinitionExtractsServerUrl() = runTest {
+            val psiClass = findClass("com.itangcent.swagger3.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val servers = metadata.document.servers
+            assertNotNull("servers should be populated when @OpenAPIDefinition declares @Server", servers)
+            assertEquals("Expected exactly one server entry", 1, servers!!.size)
+            assertEquals(
+                "servers[0].url should be extracted from @OpenAPIDefinition.servers[0].url",
+                "https://test.example.com",
+                servers.first().url,
+            )
+        }
+    }
+
+    // ─── swagger3-openapi.config — fall-through to defaults ─────────────
+
+    /**
+     * Verifies that when NO class in the project has `@OpenAPIDefinition`,
+     * the channel falls through to built-in defaults (project name for title,
+     * "1.0.0" for version, null for description / servers).
+     *
+     * Document-level rule keys are evaluated ONCE per export (without an
+     * element context). When the global lookup finds no annotated class, the
+     * rules return null → channel falls through to defaults.
+     */
+    class Swagger3NoAnnotationTest : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/swagger3-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // Swagger v3 annotation stubs (needed so the @OpenAPIDefinition
+            // annotation class is resolvable, even though no class uses it)
+            loadFile("io/swagger/v3/oas/annotations/OpenAPIDefinition.java")
+            loadFile("io/swagger/v3/oas/annotations/info/Info.java")
+            loadFile("io/swagger/v3/oas/annotations/servers/Server.java")
+            // Plain controller WITHOUT @OpenAPIDefinition
+            loadFile("api/swagger3/NoOpenApiDefinitionController.java")
+            // NOTE: OpenApiConfig is intentionally NOT loaded — otherwise the
+            // global lookup would find its @OpenAPIDefinition and the
+            // fall-through test would fail.
+        }
+
+        fun testNoOpenApiDefinitionFallsThroughToDefaults() = runTest {
+            val psiClass = findClass("com.itangcent.swagger3.openapi.NoOpenApiDefinitionController")
+            assertNotNull("Should find NoOpenApiDefinitionController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            // info.title falls through to project name (or "API"); version to "1.0.0".
+            assertNotNull("info.title should have a default even without @OpenAPIDefinition", metadata.document.info.title)
+            assertEquals(
+                "info.version should fall through to default '1.0.0'",
+                "1.0.0",
+                metadata.document.info.version,
+            )
+            // No @Server → servers is null (no serverUrl resolved).
+            assertNull(
+                "servers should be null when no @OpenAPIDefinition provides @Server",
+                metadata.document.servers,
+            )
+        }
+    }
+
+    // ─── swagger-openapi.config — @SwaggerDefinition with host ───────────
+
+    /**
+     * Verifies `swagger-openapi.config` extracts `@SwaggerDefinition` metadata
+     * (with host) from a separate `@Configuration` class. The exported
+     * `PingController` carries no such annotation.
+     */
+    class Swagger2Test : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/swagger-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // @Configuration stub (the doc-level annotation now lives on a config class)
+            loadFile("org/springframework/context/annotation/Configuration.java")
+            // Swagger v2 annotation stubs
+            loadFile("io/swagger/annotations/SwaggerDefinition.java")
+            loadFile("io/swagger/annotations/Info.java")
+            // Config class carrying @SwaggerDefinition (with host)
+            loadFile("api/swagger2/SwaggerConfig.java")
+            // Plain controller to export (no @SwaggerDefinition)
+            loadFile("api/swagger2/PingController.java")
+        }
+
+        fun testSwaggerDefinitionExtractsInfoTitle() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue("Expected Success, got: $result", result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.title should be extracted from @SwaggerDefinition.info.title",
+                "V2 API",
+                metadata.document.info.title,
+            )
+        }
+
+        fun testSwaggerDefinitionExtractsInfoVersion() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.version should be extracted from @SwaggerDefinition.info.version",
+                "1.0",
+                metadata.document.info.version,
+            )
+        }
+
+        fun testSwaggerDefinitionExtractsInfoDescription() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.description should be extracted from @SwaggerDefinition.info.description",
+                "V2 desc",
+                metadata.document.info.description,
+            )
+        }
+
+        fun testSwaggerDefinitionCombinesHostBasePathAndSchemeIntoServerUrl() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val servers = metadata.document.servers
+            assertNotNull("servers should be populated when @SwaggerDefinition declares host", servers)
+            assertEquals("Expected exactly one server entry", 1, servers!!.size)
+            assertEquals(
+                "servers[0].url should be assembled from scheme + host + basePath",
+                "https://api.example.com/v2",
+                servers.first().url,
+            )
+        }
+    }
+
+    // ─── swagger-openapi.config — @SwaggerDefinition info-only ──────────
+
+    /**
+     * Verifies `swagger-openapi.config` when `@SwaggerDefinition` declares
+     * only `info` (no `host`) — `servers` should be omitted, but `info` fields
+     * should still be extracted.
+     *
+     * Isolated from [Swagger2Test] because both config classes have
+     * `@SwaggerDefinition` — loading them together would cause the global
+     * lookup to return whichever class is `cls[0]`, making the test flaky.
+     */
+    class Swagger2InfoOnlyTest : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/swagger-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // @Configuration stub (the doc-level annotation now lives on a config class)
+            loadFile("org/springframework/context/annotation/Configuration.java")
+            // Swagger v2 annotation stubs
+            loadFile("io/swagger/annotations/SwaggerDefinition.java")
+            loadFile("io/swagger/annotations/Info.java")
+            // Config class carrying @SwaggerDefinition (info only, no host)
+            loadFile("api/swagger2/SwaggerInfoOnlyConfig.java")
+            // Plain controller to export (no @SwaggerDefinition)
+            loadFile("api/swagger2/PingController.java")
+        }
+
+        fun testSwaggerDefinitionWithoutHostOmitsServersButKeepsInfo() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.PingController")
+            assertNotNull("Should find PingController", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            // info.title is still extracted from @SwaggerDefinition.info.title.
+            assertEquals(
+                "info.title should still be extracted when host is absent",
+                "Info Only API",
+                metadata.document.info.title,
+            )
+            // No host → serverUrl is null → servers is omitted.
+            assertNull(
+                "servers should be null when @SwaggerDefinition has no host (groovy script returns null)",
+                metadata.document.servers,
+            )
+        }
+    }
+
+    // ─── springfox-openapi.config — @Bean Docket ────────────────────────
+
+    /**
+     * Verifies `springfox-openapi.config` extracts Springfox `Docket` metadata
+     * from a `@Bean` method on the controller being exported.
+     *
+     * Each rule key's groovy script is self-contained (no `${...}`
+     * cross-references) and uses the correct script-context method names
+     * (`m.sourceCode()` not `m.text()`, `ret.name()` not `ret.qualifiedName()`).
+     */
+    class SpringfoxTest : Base() {
+
+        override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+            project,
+            loadConfigFromResource("extensions/springfox-openapi.config"),
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // Spring @Bean / @Configuration
+            loadFile("org/springframework/context/annotation/Bean.java")
+            loadFile("org/springframework/context/annotation/Configuration.java")
+            // Springfox stubs
+            loadFile("springfox/documentation/spring/web/plugins/Docket.java")
+            loadFile("springfox/documentation/service/ApiInfo.java")
+            // Springfox fixture controller (has @Bean Docket method)
+            loadFile("api/springfox/SpringfoxDocketConfig.java")
+        }
+
+        fun testSpringfoxDocketExtractsInfoTitle() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.SpringfoxDocketConfig")
+            assertNotNull("Should find SpringfoxDocketConfig", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue("Expected Success, got: $result", result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.title should be parsed from `new ApiInfo(\"Springfox Title\", ...)` in the @Bean Docket body",
+                "Springfox Title",
+                metadata.document.info.title,
+            )
+        }
+
+        fun testSpringfoxDocketExtractsInfoVersion() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.SpringfoxDocketConfig")
+            assertNotNull("Should find SpringfoxDocketConfig", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.version should be the third positional arg of the ApiInfo constructor",
+                "2.3.0",
+                metadata.document.info.version,
+            )
+        }
+
+        fun testSpringfoxDocketExtractsInfoDescription() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.SpringfoxDocketConfig")
+            assertNotNull("Should find SpringfoxDocketConfig", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            assertEquals(
+                "info.description should be the second positional arg of the ApiInfo constructor",
+                "Springfox Desc",
+                metadata.document.info.description,
+            )
+        }
+
+        fun testSpringfoxDocketCombinesHostAndPathMappingIntoServerUrl() = runTest {
+            val psiClass = findClass("com.itangcent.swagger2.openapi.SpringfoxDocketConfig")
+            assertNotNull("Should find SpringfoxDocketConfig", psiClass)
+            val result = exportChannel(psiClass!!)
+            assertTrue(result is ExportResult.Success)
+            val metadata = (result as ExportResult.Success).metadata as OpenApiExportMetadata
+            val servers = metadata.document.servers
+            assertNotNull(
+                "servers should be populated when the @Bean Docket declares .host(...) and .pathMapping(...)",
+                servers,
+            )
+            assertEquals("Expected exactly one server entry", 1, servers!!.size)
+            assertEquals(
+                "servers[0].url should be assembled from scheme + host + pathMapping",
+                "https://api.example.com/v3",
+                servers.first().url,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/channel/postman/PostmanChannelWarnPathTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/postman/PostmanChannelWarnPathTest.kt
@@ -33,7 +33,7 @@ import org.mockito.kotlin.mock
  * `ExportResult.Error`.
  *
  * Moved here from `core/export/ExportOrchestratorTest.kt` to keep
- * `core.export.*` free of `channel.<id>.*` imports (Decision CO3 DAG rule).
+ * `core.export.*` free of `channel.<id>.*` imports (DAG rule).
  */
 class PostmanChannelWarnPathTest : EasyApiLightCodeInsightFixtureTestCase() {
 

--- a/src/test/kotlin/com/itangcent/easyapi/channel/postman/PostmanHeaderVarConversionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/postman/PostmanHeaderVarConversionTest.kt
@@ -18,11 +18,11 @@ import org.junit.Test
  * unresolved placeholders, while leaving resolved placeholders and regex-capture
  * references untouched.
  *
- * Backs Req 5.1, 5.3, 5.4 and the NFR-3 byte-parity guarantee for placeholder-free
+ * Backs the byte-parity guarantee for placeholder-free
  * single-app exports.
  *
  * The test project's rule config defines `baseUrl` so `${baseUrl}` is treated as
- * resolvable by the config layer (Decision 2 — `ConfigReader.getFirst` is the
+ * resolvable by the config layer (`ConfigReader.getFirst` is the
  * resolvability oracle). Namespaced vars like `${order-service-token}` and the
  * regex-capture `${1}` are exercised against the same config.
  */
@@ -54,7 +54,7 @@ class PostmanHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() 
         val item = formatter().toItem(endpoint)
         val header = item.request?.header?.firstOrNull { it.key == "X-Base" }
         assertNotNull(header)
-        // baseUrl is resolvable via the config layer — left as ${baseUrl} (Req 5.3).
+        // baseUrl is resolvable via the config layer — left as ${baseUrl}.
         assertEquals("\${baseUrl}", header?.value)
     }
 
@@ -67,7 +67,7 @@ class PostmanHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() 
         val item = formatter().toItem(endpoint)
         val header = item.request?.header?.firstOrNull { it.key == "X-Capture" }
         assertNotNull(header)
-        // ${1} is a regex-capture reference — left untouched (Req 5.4).
+        // ${1} is a regex-capture reference — left untouched.
         assertEquals("Basic \${1}", header?.value)
     }
 
@@ -80,7 +80,7 @@ class PostmanHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() 
         )
         val item = formatter().toItem(endpoint)
         val actual = PostmanGson.pretty.toJson(item)
-        // NFR-3: a placeholder-free single-app endpoint exports byte-identically
+        // A placeholder-free single-app endpoint exports byte-identically
         // to the pre-feature golden. The converter fast-path returns the value
         // unchanged when no `${` is present, so the output is unaffected.
         // Explicit caller class avoids the coroutine-continuation name that

--- a/src/test/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistryIsEnabledTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistryIsEnabledTest.kt
@@ -16,7 +16,7 @@ import org.junit.Assert.*
  *
  * Coverage targets (from Codecov PR #736):
  * - The `try { ... } catch { LOG.warn(...); return enabledByDefault }` fallback
- *   path when [SettingBinder.read] throws (Req 2.6).
+ *   path when [SettingBinder.read] throws.
  * - The happy path: reading stored preferences and delegating to
  *   [ChannelRegistry.resolveEnabled].
  */
@@ -80,7 +80,7 @@ class ChannelRegistryIsEnabledTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertTrue(registry.isEnabled(defaultOff))
     }
 
-    // --- Fallback path: SettingBinder.read throws → enabledByDefault (Req 2.6) ---
+    // --- Fallback path: SettingBinder.read throws → enabledByDefault ---
 
     fun testIsEnabled_fallbackReturnsEnabledByDefault_whenSettingsReadThrows_defaultOn() {
         project.registerServiceInstance(

--- a/src/test/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/spi/ChannelRegistryTest.kt
@@ -121,7 +121,7 @@ class ChannelRegistryTest {
         assertEquals("First", found?.displayName)
     }
 
-    // --- Task 1.1: Channel.enabledByDefault ---
+    // --- Channel.enabledByDefault ---
 
     @Test
     fun testEnabledByDefaultDefaultsToTrue() {
@@ -137,7 +137,7 @@ class ChannelRegistryTest {
         assertFalse(channel.enabledByDefault)
     }
 
-    // --- Task 1.3: ChannelRegistry.resolveEnabled (pure resolution rule) ---
+    // --- ChannelRegistry.resolveEnabled (pure resolution rule) ---
     // Exercises the full truth table of the resolution rule without a Project.
     // Integrated filtering (getActionChannels/getAvailableChannels/channelsForSettings
     // via isEnabled) is covered by ExportOrchestratorTest's IDE-fixture tests.
@@ -187,13 +187,13 @@ class ChannelRegistryTest {
 
     @Test
     fun testResolveEnabled_fallsBackToEnabledByDefaultWhenPreferenceAbsent() {
-        // Req 2.6: absent preference (empty arrays) falls back to enabledByDefault.
+        // Absent preference (empty arrays) falls back to enabledByDefault.
         // This mirrors the fallback path taken when settings storage is unreadable.
         assertTrue(ChannelRegistry.resolveEnabled(defaultOn, empty, empty))
         assertFalse(ChannelRegistry.resolveEnabled(defaultOff, empty, empty))
     }
 
-    // --- Task 1.3: filtered query logic ---
+    // --- Filtered query logic ---
     // The registry query methods need a Project (covered by ExportOrchestratorTest).
     // Here we replicate the exact filtering they apply (&& resolveEnabled) to verify
     // the rule excludes disabled channels from each enumeration shape.
@@ -250,7 +250,7 @@ class ChannelRegistryTest {
 
     @Test
     fun testFilteredQueryLogic_allChannelsAndGetChannelRemainUnfiltered() {
-        // Req 4.5: allChannels()/getChannel(id) are pure registry primitives — they
+        // allChannels()/getChannel(id) are pure registry primitives — they
         // do NOT consult enablement. Here we assert the lookup-by-id logic itself
         // ignores enabledByDefault (a disabled channel is still found by id).
         val channels = listOf(

--- a/src/test/kotlin/com/itangcent/easyapi/channel/spi/ChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/spi/ChannelTest.kt
@@ -229,23 +229,23 @@ class ChannelTest {
         assertNull(channel.actionText)
     }
 
-    // --- Task 2.1: default-on shipping channels inherit enabledByDefault = true ---
+    // --- Default-on shipping channels inherit enabledByDefault = true ---
 
     @Test
     fun testMarkdownChannelIsDefaultOn() {
-        // Req 1.5: MarkdownChannel inherits the default (enabledByDefault = true).
+        // MarkdownChannel inherits the default (enabledByDefault = true).
         assertTrue(MarkdownChannel().enabledByDefault)
     }
 
     @Test
     fun testPostmanChannelIsDefaultOn() {
-        // Req 1.5: PostmanChannel inherits the default (enabledByDefault = true).
+        // PostmanChannel inherits the default (enabledByDefault = true).
         assertTrue(PostmanChannel().enabledByDefault)
     }
 
     @Test
     fun testCurlChannelIsDefaultOn() {
-        // Req 1.5: CurlChannel inherits the default (enabledByDefault = true).
+        // CurlChannel inherits the default (enabledByDefault = true).
         assertTrue(CurlChannel().enabledByDefault)
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/LangChain4jAIServiceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/LangChain4jAIServiceTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.mock
 /**
  * Regression tests for [LangChain4jAIService] timeout handling.
  *
- * Verifies design Decision 4: a chat timeout (the underlying
+ * Verifies that a chat timeout (the underlying
  * [ChatModel.chat] blocking longer than
  * [AiRuntimeConfig.requestTimeoutSec]) is surfaced as a
  * [ChatTimeoutException] — a normal transient exception the retry policy

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/AmbientPerceptionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/AmbientPerceptionTest.kt
@@ -190,7 +190,7 @@ class AmbientPerceptionTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testFeignHintGatedWhenFeignDisabled() {
-        // Req 9.3: with feignEnable=false (the default), the FeignClient
+        // With feignEnable=false (the default), the FeignClient
         // annotation FQN is excluded from allTargetAnnotations, so even with a
         // @FeignClient class present in the fixture, "Feign" must NOT appear
         // in frameworkHints — settings gates are respected automatically.
@@ -225,7 +225,7 @@ class AmbientPerceptionTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testFrameworkHintsCarryNoEnvVarKeysOrValues() {
-        // NFR-5 / Req 9.5: frameworkHints carries only short framework labels
+        // frameworkHints carries only short framework labels
         // — never env-var keys or values from the Environments panel. Even with
         // a controller present (so capture ran the recognizer scan) and an
         // env-var key/value in the process environment, neither may appear in

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/ChatRetryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/ChatRetryTest.kt
@@ -26,7 +26,7 @@ import java.io.IOException
 class ChatRetryTest {
 
     // ==================================================================
-    // Task 16: Transient classifier isTransient
+    // Transient classifier isTransient
     // ==================================================================
 
     // --- Transient by type ---
@@ -157,7 +157,7 @@ class ChatRetryTest {
     }
 
     // ==================================================================
-    // Task 17: chatWithRetry suspend helper
+    // chatWithRetry suspend helper
     // ==================================================================
 
     /** Fast config: zero backoff so tests run instantly (jitter 0–249 ms only). */

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuardTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuardTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 class LoopGuardTest {
 
     // ==================================================================
-    // Task 9: Normalization & fingerprinting helpers
+    // Normalization & fingerprinting helpers
     // ==================================================================
 
     @Test
@@ -105,7 +105,7 @@ class LoopGuardTest {
     }
 
     // ==================================================================
-    // Task 10: Consecutive duplicate detection
+    // Consecutive duplicate detection
     // ==================================================================
 
     @Test
@@ -171,7 +171,7 @@ class LoopGuardTest {
     }
 
     // ==================================================================
-    // Task 11: Call-sequence cycle detection
+    // Call-sequence cycle detection
     // ==================================================================
 
     @Test
@@ -281,7 +281,7 @@ class LoopGuardTest {
     }
 
     // ==================================================================
-    // Task 12: Output stagnation detection
+    // Output stagnation detection
     // ==================================================================
 
     @Test
@@ -355,7 +355,7 @@ class LoopGuardTest {
     }
 
     // ==================================================================
-    // Task 13: Reasoning repetition detection
+    // Reasoning repetition detection
     // ==================================================================
 
     @Test
@@ -430,7 +430,7 @@ class LoopGuardTest {
     }
 
     // ==================================================================
-    // Task 14: Debounce hook
+    // Debounce hook
     // ==================================================================
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgentTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgentTest.kt
@@ -504,7 +504,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
         )
     }
 
-    // --- Loop-detection integration tests (Phase 5, Task 25) ---
+    // --- Loop-detection integration tests ---
 
     /**
      * 3 identical `list_rule_keys` calls → `TurnOutcome.LoopDetected` via
@@ -652,7 +652,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     /**
      * On `LoopDetected`, the event sequence must NOT contain `TurnComplete`
-     * or `ProposalReady` (abnormal exit — REQ-2 AC-2).
+     * or `ProposalReady` (abnormal exit).
      */
     fun testLoopDetectedEmitsNoTurnComplete() = runBlocking {
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
@@ -677,7 +677,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
     /**
      * Two sequential `runTurn` calls: turn 1 loops (LoopDetected), turn 2
      * starts with a fresh `LoopGuard` (counter reset) and can call the same
-     * tool once without immediate termination (REQ-1 AC-4).
+     * tool once without immediate termination.
      */
     fun testPerTurnFreshness() = runBlocking {
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
@@ -700,7 +700,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
         events.cancelAndCollect()
     }
 
-    // --- Retry integration tests (Phase 5, Task 26) ---
+    // --- Retry integration tests ---
 
     /**
      * Transient `IOException` on the first attempt, then a plain-text answer.
@@ -731,7 +731,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
     /**
      * Non-transient `IllegalArgumentException("401 unauthorized")` → fail
      * fast. Asserts `TurnOutcome.Answered`, `Failed` with "attempt(s)", NO
-     * `Retrying` (REQ-4 AC-3, NFR-2).
+     * `Retrying`.
      */
     fun testNoRetryOnAuth() = runBlocking {
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
@@ -755,7 +755,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
     /**
      * `ChatTimeoutException` on the first attempt, then a plain-text answer.
      * Asserts the timeout is classified as transient and retried (end-to-end
-     * test for the Phase 4 fix — REQ-4 Decision 4, NFR-2).
+     * test for the timeout-classification fix).
      */
     fun testTimeoutRetriedAsTransient() = runBlocking {
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
@@ -778,7 +778,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
     /**
      * `1 + chatMaxRetries` transient failures → retries exhausted. Asserts
      * `TurnOutcome.Answered`, `Failed` with attempt count, `Retrying` per
-     * attempt (REQ-4 AC-4, AC-8).
+     * attempt.
      */
     fun testRetriesExhaustedTerminal() = runBlocking {
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
@@ -802,8 +802,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     /**
      * Assert `Retrying(attempt, maxRetries)` is emitted on each transient
-     * failure that is retried, and NOT on success or non-transient failures
-     * (REQ-4 AC-8).
+     * failure that is retried, and NOT on success or non-transient failures.
      */
     fun testRetryingEventEmitted() = runBlocking {
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
@@ -831,7 +830,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     /**
      * Assert `Failed.reason` contains "after N attempt(s)" on terminal
-     * exhaustion (REQ-4 AC-4).
+     * exhaustion.
      */
     fun testTerminalFailedHasAttemptCount() = runBlocking {
         val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
@@ -854,7 +853,7 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
     /**
      * Cancel the turn job mid-retry backoff → `CancellationException` must
      * propagate (not swallowed by the retry policy). Asserts the job is
-     * cancelled and no `Failed` event was emitted (REQ-4 AC-5).
+     * cancelled and no `Failed` event was emitted.
      *
      * NOTE: tested with `runBlocking` + a long backoff. The agent job is
      * launched UNDISPATCHED so it runs synchronously until it suspends in

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilderTest.kt
@@ -101,7 +101,7 @@ class SystemPromptBuilderTest {
         // resolve a namespace key and namespace every env var in a workflow
         // bundle by that key. The full recipe lives in rule-guide.md; the
         // preamble carries only the condensed detection + on-demand-fetch
-        // pointer (Decision 5).
+        // pointer.
         val msg = SystemPromptBuilder.build()
         val text = msg.content
         Assert.assertTrue(
@@ -296,21 +296,21 @@ class SystemPromptBuilderTest {
         )
     }
 
-    // ── Token-budget tripwire (review Issue #8) ──
+    // ── Token-budget tripwire ──
 
     @Test
     fun `preamble content stays under token-budget ceiling`() {
         // The preamble is the fixed system prompt appended once at conversation start.
-        // NFR-3 targets a ~600-token preamble budget. T5.1 added a condensed
-        // "## Workflow-pattern detection" section (~2.8k chars). This tripwire catches
+        // Targets a ~600-token preamble budget. A condensed
+        // "## Workflow-pattern detection" section (~2.8k chars) was added. This tripwire catches
         // unexpected growth beyond the current actual length + a small headroom.
         //
         // Ceiling raised from 16_500 → 17_800 for the condensed "### Multi-app
         // namespacing" subsection added under "## Workflow-pattern detection"
-        // (per Decision 5: ~600-800-char target subsection + on-demand fetch via
+        // (~600-800-char target subsection + on-demand fetch via
         // `get_plugin_doc name="rule-guide"` for the full recipe; ceiling is the new
         // actual ~16.8k + ~1k headroom).
-        // Ceiling raised 17_800 → 19_200 for the agent-psi-resolution spec (Task 14):
+        // Ceiling raised 17_800 → 19_200 for the agent-psi-resolution preamble update:
         // preamble now documents `find_classes_by_name` as the primary simple-name
         // resolver, `typeFqn` chaining, and `detail="full"` opt-in. Actual ~18.2k
         // + ~1k headroom.
@@ -319,7 +319,7 @@ class SystemPromptBuilderTest {
         val ceiling = 19_200 // raised for agent-psi-resolution preamble update: actual ~18.2k + ~1k headroom
         Assert.assertTrue(
             "Preamble content length (${content.length} chars) must stay under $ceiling chars " +
-                "to stay within NFR-3's token budget. If a future section is added, raise the " +
+                "to stay within the token budget. If a future section is added, raise the " +
                 "ceiling to the new actual length + headroom.",
             content.length < ceiling
         )

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationToolTest.kt
@@ -253,7 +253,7 @@ class FindClassesByAnnotationToolTest : EasyApiLightCodeInsightFixtureTestCase()
     }
 
     // ------------------------------------------------------------------
-    // Task 11 — tolerance + context parameter
+    // tolerance + context parameter
     // ------------------------------------------------------------------
 
     fun testAcceptsSimpleNameForAnnotationFqn() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeToolTest.kt
@@ -200,7 +200,7 @@ class FindClassesBySupertypeToolTest : EasyApiLightCodeInsightFixtureTestCase() 
     }
 
     // ------------------------------------------------------------------
-    // Task 12 — tolerance + context parameter
+    // tolerance + context parameter
     // ------------------------------------------------------------------
 
     fun testAcceptsSimpleNameForSupertypeFqn() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetModuleDependencyGraphToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetModuleDependencyGraphToolTest.kt
@@ -208,7 +208,7 @@ class GetModuleDependencyGraphToolTest : EasyApiLightCodeInsightFixtureTestCase(
         )
     }
 
-    // --- Privacy (NFR-5 / Req 8.5) ---
+    // --- Privacy ---
 
     fun testRenderedOutputCarriesNoEnvVarMaterial() {
         // The renderer is structural: only module names + edges. A typical
@@ -225,7 +225,7 @@ class GetModuleDependencyGraphToolTest : EasyApiLightCodeInsightFixtureTestCase(
         Assert.assertFalse("must not leak an env-var value syntax", rendered.contains("sk-"))
     }
 
-    // --- Tool-kind (NFR-6) ---
+    // --- Tool-kind ---
 
     fun testToolKindIsPerception() {
         val tool = GetModuleDependencyGraphTool()

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoToolTest.kt
@@ -105,7 +105,7 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     // ------------------------------------------------------------------
-    // Task 6 — type enrichment (typeFqn / returnTypeFqn — inline type args)
+    // type enrichment (typeFqn / returnTypeFqn — inline type args)
     // ------------------------------------------------------------------
 
     fun testFieldIncludesTypeFqnForClassType() {
@@ -223,7 +223,7 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     // ------------------------------------------------------------------
-    // Task 7 — tolerance + context parameter
+    // tolerance + context parameter
     // ------------------------------------------------------------------
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoToolTest.kt
@@ -266,7 +266,7 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     // ------------------------------------------------------------------
-    // Task 8 — type enrichment (returnType/returnTypeFqn/per-param typeFqn)
+    // type enrichment (returnType/returnTypeFqn/per-param typeFqn)
     // ------------------------------------------------------------------
 
     /**
@@ -363,7 +363,7 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     // ------------------------------------------------------------------
-    // Task 9 — detail / maxBodyChars / body (REQ-3 core)
+    // detail / maxBodyChars / body
     // ------------------------------------------------------------------
 
     /**
@@ -609,7 +609,7 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     // ------------------------------------------------------------------
-    // Task 10 — tolerance + context parameter
+    // tolerance + context parameter
     // ------------------------------------------------------------------
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/core/export/ExportContextTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/export/ExportContextTest.kt
@@ -92,7 +92,7 @@ class ExportContextTest {
 
         // Use ChannelConfig.FileConfig (the SPI base class) instead of a concrete
         // channel-specific subclass — the core/export package must not import
-        // channel.<id>.* per the DAG rule (Decision CO3).
+        // channel.<id>.* per the DAG rule.
         val modified = context.withChannel("postman", ChannelConfig.FileConfig(outputDir = "Test"))
         assertEquals("postman", modified.channelId)
         assertTrue(modified.channelConfig is ChannelConfig.FileConfig)

--- a/src/test/kotlin/com/itangcent/easyapi/core/export/ExportOrchestratorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/export/ExportOrchestratorTest.kt
@@ -218,8 +218,8 @@ class ExportOrchestratorTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertTrue("Should be Error for unknown channel", result is ExportResult.Error)
     }
 
-    // --- Task 3.1: ExportOrchestrator refuses a disabled channel (Req 4.4) ---
-    // http-client is default-off (Task 2.1), so with no stored preference it is
+    // --- ExportOrchestrator refuses a disabled channel ---
+    // http-client is default-off, so with no stored preference it is
     // disabled and the export boundary must refuse it before scanning/exporting.
 
     fun testOrchestrateExportWithDefaultOffChannelReturnsError() = runTest {
@@ -273,7 +273,7 @@ class ExportOrchestratorTest : EasyApiLightCodeInsightFixtureTestCase() {
         }
     }
 
-    // --- Task 3.2: exportViaChannel LOG.warn path when channel.export returns Error ---
+    // --- exportViaChannel LOG.warn path when channel.export returns Error ---
     // Moved to channel/postman/PostmanChannelWarnPathTest.kt — co-located with the
     // Postman channel it tests (the test mocks PostmanSettings + HttpClientProvider
     // to force the upload-failure path, which is Postman-specific). The warn-path

--- a/src/test/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizerEnabledByDefaultTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizerEnabledByDefaultTest.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Test-first test for [ApiClassRecognizer.enabledByDefault] SPI addition (PR6).
+ * Test-first test for [ApiClassRecognizer.enabledByDefault] SPI addition.
  *
  * This test is written BEFORE the SPI property is added to the interface.
  * It MUST fail to compile against current code (the `enabledByDefault` property
@@ -20,9 +20,6 @@ import org.junit.Test
  * pass, and (c) passes for the default-on recognizers (SpringMVC, JAX-RS, gRPC).
  * Assertion (c) for the default-off recognizers (Feign, Actuator) only passes
  * after tasks 24/25 add the `false` overrides.
- *
- * Requirements: Framework Enablement 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7;
- * Decision: PR6
  */
 class ApiClassRecognizerEnabledByDefaultTest {
 
@@ -65,15 +62,15 @@ class ApiClassRecognizerEnabledByDefaultTest {
     /**
      * (c) Verifies the 5 in-tree recognizers' `enabledByDefault` values match
      * the pre-patch defaults:
-     * - SpringControllerRecognizer → true (inherits default — Req 1.2)
-     * - JaxRsResourceRecognizer → true (explicit — Req 1.3, preserves jaxrsEnable=true)
-     * - GrpcServiceRecognizer → true (explicit — Req 1.4, preserves grpcEnable=true)
-     * - FeignClientRecognizer → false (Req 1.5, preserves feignEnable=false)
-     * - ActuatorEndpointRecognizer → false (Req 1.6, preserves actuatorEnable=false)
+     * - SpringControllerRecognizer → true (inherits default)
+     * - JaxRsResourceRecognizer → true (explicit, preserves jaxrsEnable=true)
+     * - GrpcServiceRecognizer → true (explicit, preserves grpcEnable=true)
+     * - FeignClientRecognizer → false (preserves feignEnable=false)
+     * - ActuatorEndpointRecognizer → false (preserves actuatorEnable=false)
      *
-     * This test fails to compile before task 17 adds the SPI property, and
-     * fails on the Feign/Actuator assertions until tasks 24/25 add the
-     * `false` overrides.
+     * This test fails to compile before the SPI property is added, and
+     * fails on the Feign/Actuator assertions until the
+     * `false` overrides are added.
      */
     @Test
     fun testInTreeRecognizersMatchPrePatchDefaults() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizerMatchesClassTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizerMatchesClassTest.kt
@@ -7,7 +7,7 @@ import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCas
 import com.itangcent.easyapi.testFramework.TestConfigReader
 
 /**
- * Test-first test for [ApiClassRecognizer.matchesClass] SPI addition (PR1).
+ * Test-first test for [ApiClassRecognizer.matchesClass] SPI addition.
  *
  * This test is written BEFORE the SPI member is added to the interface.
  * It MUST fail to compile against current code (the `matchesClass` method
@@ -18,8 +18,6 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
  * and default-behavior assertions (a) and (b) pass. Assertion (c) — that
  * `GrpcServiceRecognizer.matchesClass` returns `true` on a class extending
  * `BindableService` — only passes after task 8 adds the gRPC override.
- *
- * Requirements: Recognizer Relocation 2.6, 4.6; Decision: PR1
  */
 class ApiClassRecognizerMatchesClassTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -71,7 +69,7 @@ class ApiClassRecognizerMatchesClassTest : EasyApiLightCodeInsightFixtureTestCas
      * FeignClientRecognizer, ActuatorEndpointRecognizer).
      *
      * These recognizers inherit the default `false` implementation and do NOT
-     * override `matchesClass` (PR1: only gRPC overrides).
+     * override `matchesClass` (only gRPC overrides).
      */
     fun testDefaultImplReturnsFalseForNonGrpcRecognizers() = runTest {
         val fixtureClass = findClass("com.itangcent.grpc.model.UserInfo")!!

--- a/src/test/kotlin/com/itangcent/easyapi/core/export/recognizer/CompositeApiClassRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/export/recognizer/CompositeApiClassRecognizerTest.kt
@@ -81,7 +81,7 @@ class CompositeApiClassRecognizerTest : EasyApiLightCodeInsightFixtureTestCase()
     }
 
     /**
-     * Decision CO5: `CompositeApiClassRecognizer.recognizers()` exposes the cached
+     * `CompositeApiClassRecognizer.recognizers()` exposes the cached
      * recognizer list (populated by `buildRecognizers()` based on project settings)
      * so callers can iterate the EP-respecting seam instead of hard-coding concrete
      * framework recognizer imports.

--- a/src/test/kotlin/com/itangcent/easyapi/core/extension/ExtensionConfigRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/extension/ExtensionConfigRegistryTest.kt
@@ -695,7 +695,9 @@ class ExtensionConfigRegistryTest {
             "mybatis-plus",
             "spring", "spring-configuration", "spring-properties",
             "spring-validations", "spring-webflux",
-            "swagger", "swagger3"
+            "springfox-openapi",
+            "swagger", "swagger-openapi",
+            "swagger3", "swagger3-openapi"
         )
         val actualCodes = ExtensionConfigRegistry.codes().toList()
         for (code in expectedCodes) {

--- a/src/test/kotlin/com/itangcent/easyapi/core/http/HttpClientScriptInterceptorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/http/HttpClientScriptInterceptorTest.kt
@@ -115,7 +115,7 @@ class HttpClientScriptInterceptorTest {
         assertEquals(200, response.code)
     }
 
-    // ---- T2.2: mutation + recursion guard (Spec: ai-workflow-patterns, D2/D3) ----
+    // ---- mutation + recursion guard ----
 
     /**
      * Minimal [RuleContext] double that records `setExt` calls into a map and

--- a/src/test/kotlin/com/itangcent/easyapi/core/http/HttpWrappersTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/http/HttpWrappersTest.kt
@@ -104,7 +104,7 @@ class HttpRequestWrapperTest {
         assertEquals("application/json", wrapper.contentType())
     }
 
-    // ---- T2.2: mutable header support (Spec: ai-workflow-patterns, D2) ----
+    // ---- mutable header support ----
 
     @Test
     fun testSetHeaderAddsNewHeader() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/http/ScriptHttpClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/http/ScriptHttpClientTest.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Tests for [ScriptHttpClient] (Spec: ai-workflow-patterns, T2.1 / D1).
+ * Tests for [ScriptHttpClient].
  *
  * Verifies the sync adapter:
  *  - returns the delegate's [HttpResponse]

--- a/src/test/kotlin/com/itangcent/easyapi/core/ide/action/ChannelQuickActionGroupRefreshTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ide/action/ChannelQuickActionGroupRefreshTest.kt
@@ -13,7 +13,7 @@ import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCas
 
 /**
  * IDE-fixture tests for [ChannelQuickActionGroup.refreshActions] and
- * [ChannelExportAction.update] (Task 4.3, Req 5.1, 5.2, Decision 4).
+ * [ChannelExportAction.update].
  *
  * Verifies that:
  * - disabling a channel hides its action (per-context presentation visible=false)
@@ -136,7 +136,7 @@ class ChannelQuickActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCas
         return event.presentation.isVisible
     }
 
-    // --- Req 5.2: disabling a channel hides its action ---
+    // --- disabling a channel hides its action ---
 
     fun testRefreshActions_hidesDisabledChannelAction() {
         // Start with hoppscotch enabled so its action gets registered.
@@ -163,7 +163,7 @@ class ChannelQuickActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCas
         )
     }
 
-    // --- Req 5.1: re-enabling a channel shows its action ---
+    // --- re-enabling a channel shows its action ---
 
     fun testRefreshActions_showsReEnabledChannelAction() {
         // Register the action while enabled, then disable+refresh to hide it.
@@ -188,7 +188,7 @@ class ChannelQuickActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCas
         )
     }
 
-    // --- Decision 4 / Resolved Q#2: refreshActions does NOT unregister actions ---
+    // --- refreshActions does NOT unregister actions ---
 
     fun testRefreshActions_doesNotUnregisterAction() {
         enableChannel("hoppscotch")
@@ -276,7 +276,7 @@ class ChannelQuickActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCas
     fun testUpdate_unregisteredChannel_setsVisibleTrue() {
         // A ChannelExportAction with a channelId that is not registered in the
         // EP: getChannel returns null, so the `?: true` branch makes the action
-        // visible (Decision 4 — hide not unregister; unregistered-id actions
+        // visible (hide not unregister; unregistered-id actions
         // default to visible so they can still be discovered in Keymap).
         val action = ChannelExportAction("nonexistent-channel", "Nonexistent")
         val event = createActionEvent()

--- a/src/test/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProviderCharacterizationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProviderCharacterizationTest.kt
@@ -13,12 +13,12 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
  * Characterization test for [ApiMethodLineMarkerProvider] behavior.
  *
  * Captures the line-marker's `getLineMarkerInfo` decisions (null vs non-null)
- * for a representative fixture set BEFORE the Item 1 refactor (recognizer
- * relocation + EP-seam refactor). The test MUST pass against current
+ * for a representative fixture set BEFORE the recognizer
+ * relocation + EP-seam refactor. The test MUST pass against current
  * (pre-patch) code AND against post-patch code &mdash; byte-identical
- * behavior per Migration Req 5.1.
+ * behavior.
  *
- * Fixture set per `requirements-recognizer-relocation.md` Req 4.7:
+ * Fixture set:
  *  (a) Spring MVC controller method (`@RequestMapping`)
  *  (b) JAX-RS resource method (`@GET` + `@Path`)
  *  (c) gRPC unary method (`(Req, StreamObserver<Resp>) -> void` on a
@@ -27,10 +27,7 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
  *  (e) non-API method (plain class, no annotations)
  *  (f) class with `class.is.grpc = true` rule-engine override but NO
  *      `BindableService` supertype and NO `@GrpcService` annotation &mdash;
- *      MUST NOT be marked (PR1's "MUST NOT consult rule engine" contract)
- *
- * Requirements: Recognizer Relocation 4.7; Decision: PR1 (rule-engine
- * exclusion contract)
+ *      MUST NOT be marked (rule-engine exclusion contract)
  */
 class ApiMethodLineMarkerProviderCharacterizationTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -197,7 +194,7 @@ class ApiMethodLineMarkerProviderCharacterizationTest : EasyApiLightCodeInsightF
 
     // ------------------------------------------------------------------
     // Case (f): rule-engine gRPC override but no BindableService / @GrpcService
-    //           &mdash; MUST NOT be marked (PR1's "MUST NOT consult rule engine" contract)
+    //           &mdash; MUST NOT be marked (the "MUST NOT consult rule engine" contract)
     // ------------------------------------------------------------------
 
     fun testCaseFRuleEngineOverrideNotMarked() = runTest {
@@ -207,7 +204,7 @@ class ApiMethodLineMarkerProviderCharacterizationTest : EasyApiLightCodeInsightF
         // Even with `class.is.grpc = true` rule override (see createConfigReader),
         // the line marker MUST NOT mark this method &mdash; because the line marker's
         // gRPC detection is structural (BindableService/@GrpcService only), not
-        // rule-driven. This is PR1's load-bearing contract.
+        // rule-driven. This is the load-bearing contract.
         val echoMethod = findMethod(fakeService, "echo")!!
         val echoMarker = lineMarkerProvider.getLineMarkerInfo(echoMethod.nameIdentifier!!)
         assertNull(

--- a/src/test/kotlin/com/itangcent/easyapi/core/logging/AntiPatternGateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/logging/AntiPatternGateTest.kt
@@ -136,6 +136,57 @@ class AntiPatternGateTest {
         )
     }
 
+    /**
+     * OpenApi channel — focused anti-pattern gate.
+     *
+     * Asserts every `*.kt` under `channel/openapi/` adheres to the AGENTS.md
+     * logging rule: `LOG.info` and `LOG.warn` only — no `LOG.error` (triggers
+     * an intrusive IDE popup), no `LOG.debug`/`LOG.trace` (filtered out of
+     * `idea.log` by default, invisible when debugging). Also bans
+     * `println`/`printStackTrace` and direct `Notifications.Bus.notify` /
+     * `NotificationGroupManager` calls.
+     *
+     * The broader [noLogErrorInProductionCode] / [noDebugTraceOnLogChannel] /
+     * [noPrintlnInProductionCode] / [noPrintStackTraceInProductionCode] /
+     * [noDirectNotificationsOutsideNotificationUtils] tests already cover
+     * `src/main/kotlin` as a whole; this test is a focused, named guard so an
+     * OpenApi-specific regression is immediately identifiable in test output.
+     */
+    @Test
+    fun openApiChannelAdheresToLoggingAntiPatternRules() {
+        val openApiRoot = File("src/main/kotlin/com/itangcent/easyapi/channel/openapi")
+        assertTrue(
+            "OpenApi channel source root should exist at $openApiRoot",
+            openApiRoot.exists()
+        )
+
+        val offenders = mutableListOf<String>()
+        openApiRoot.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { file ->
+            val stripped = stripComments(file.readText())
+            val patterns = listOf(
+                Regex("""\bLOG\.error\s*\(""") to "LOG.error",
+                Regex("""\bLOG\.debug\s*\(""") to "LOG.debug",
+                Regex("""\bLOG\.trace\s*\(""") to "LOG.trace",
+                Regex("""\bprintln\s*\(""") to "println",
+                Regex("""\.printStackTrace\s*\(""") to ".printStackTrace()",
+                Regex("""Notifications\.Bus\.notify""") to "Notifications.Bus.notify",
+                Regex("""NotificationGroupManager""") to "NotificationGroupManager",
+            )
+            patterns.forEach { (regex, label) ->
+                if (regex.containsMatchIn(stripped)) {
+                    offenders.add("${file.path}: $label")
+                }
+            }
+        }
+
+        assertTrue(
+            "OpenApi channel files must follow AGENTS.md logging rules (LOG.info/warn only, " +
+                "no println/printStackTrace, no direct Notifications.Bus.notify). " +
+                "Violations:\n${offenders.joinToString("\n")}",
+            offenders.isEmpty()
+        )
+    }
+
     // --- helpers ---
 
     private fun scanFiles(matcher: (content: String, file: File) -> List<String>): List<String> {

--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/helper/AnnotatedElementsHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/helper/AnnotatedElementsHelperTest.kt
@@ -1,0 +1,283 @@
+package com.itangcent.easyapi.core.psi.helper
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * Direct PSI tests for [AnnotatedElementsHelper].
+ *
+ * Unlike [com.itangcent.easyapi.core.rule.parser.ScriptHelperFindAnnotatedTest],
+ * these tests do NOT go through `ScriptHelper` / the JSR-223 binding. They
+ * exercise the project-scoped `@Service` directly, asserting on raw
+ * [PsiClass] / [PsiMethod] return types. This is the whole point of the
+ * refactor: the lookup logic must be reachable from non-script code
+ * and independently testable.
+ *
+ * Mirrors the fixture style of
+ * [com.itangcent.easyapi.core.ai.tools.FindClassesByAnnotationToolTest] and
+ * `ScriptHelperFindAnnotatedTest`:
+ * [com.intellij.psi.search.searches.AnnotatedElementsSearch.searchPsiClasses]
+ * / `searchPsiMethods` need source files (annotation + annotated classes) in
+ * the fixture's VFS, so each test loads them via `myFixture.addFileToProject`
+ * inside a write action.
+ *
+ * JUnit 3-style `testXxx()` naming is required because
+ * [EasyApiLightCodeInsightFixtureTestCase] extends
+ * `LightJavaCodeInsightFixtureTestCase` (a JUnit 3 `TestCase` subclass).
+ */
+class AnnotatedElementsHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var helper: AnnotatedElementsHelper
+
+    override fun setUp() {
+        super.setUp()
+        helper = AnnotatedElementsHelper.getInstance(project)
+    }
+
+    private fun addClasses() {
+        ApplicationManager.getApplication().runWriteAction {
+            // A project-defined annotation that targets both TYPE and METHOD.
+            myFixture.addFileToProject(
+                "com/example/Marker.java",
+                """
+                package com.example;
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE, ElementType.METHOD})
+                public @interface Marker {}
+                """.trimIndent()
+            )
+            // Project classes annotated with @Marker.
+            myFixture.addFileToProject(
+                "com/example/MarkedOne.java",
+                """
+                package com.example;
+                @Marker
+                public class MarkedOne {}
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/MarkedTwo.java",
+                """
+                package com.example;
+                @Marker
+                public class MarkedTwo {}
+                """.trimIndent()
+            )
+            // A class with @Marker-annotated methods (and one unannotated method).
+            myFixture.addFileToProject(
+                "com/example/ServiceBean.java",
+                """
+                package com.example;
+                public class ServiceBean {
+                    @Marker
+                    public void doSomething() {}
+
+                    @Marker
+                    public String computeValue() { return ""; }
+
+                    public void unannotated() {}
+                }
+                """.trimIndent()
+            )
+            // Unannotated class — must not be returned.
+            myFixture.addFileToProject(
+                "com/example/PlainService.java",
+                """
+                package com.example;
+                public class PlainService {}
+                """.trimIndent()
+            )
+        }
+    }
+
+    // ─── getInstance ─────────────────────────────────────────────────────
+
+    fun testGetInstanceReturnsSameInstance() {
+        val instance1 = AnnotatedElementsHelper.getInstance(project)
+        val instance2 = AnnotatedElementsHelper.getInstance(project)
+        assertSame(
+            "getInstance should return the same project-scoped service instance",
+            instance1,
+            instance2,
+        )
+    }
+
+    // ─── findClassByAnnotation (singular) ────────────────────────────────
+
+    fun testFindClassByAnnotationReturnsFirstAnnotatedClass() {
+        addClasses()
+        val hit = helper.findClassByAnnotation("com.example.Marker")
+        assertNotNull("expected a non-null result for @Marker, got null", hit)
+        val fqn = hit!!.qualifiedName
+        assertTrue(
+            "expected one of MarkedOne/MarkedTwo, got $fqn",
+            fqn == "com.example.MarkedOne" || fqn == "com.example.MarkedTwo",
+        )
+    }
+
+    fun testFindClassByAnnotationReturnsRawPsiClassInstance() {
+        addClasses()
+        val hit = helper.findClassByAnnotation("com.example.Marker")
+        assertNotNull("expected a non-null result for @Marker, got null", hit)
+        assertTrue(
+            "result must be a raw PsiClass (not a script context wrapper): $hit",
+            hit is PsiClass,
+        )
+    }
+
+    fun testFindClassByAnnotationReturnsNullWhenAnnotationNotResolvable() {
+        addClasses()
+        val hit = helper.findClassByAnnotation("does.not.Exist")
+        assertNull("expected null for unresolvable annotation, got $hit", hit)
+    }
+
+    fun testFindClassByAnnotationReturnsNullWhenFqnIsNotAnAnnotationType() {
+        addClasses()
+        // PlainService is a regular class, not an annotation — the helper
+        // must refuse to search and return null (mirrors
+        // FindClassesByAnnotationTool behavior).
+        val hit = helper.findClassByAnnotation("com.example.PlainService")
+        assertNull("expected null when FQN is not an annotation, got $hit", hit)
+    }
+
+    fun testFindClassByAnnotationReturnsNullWhenNoClassIsAnnotated() {
+        // No project source annotated with @Nonexistent — the annotation
+        // itself resolves, but nothing carries it.
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "com/example/Unused.java",
+                """
+                package com.example;
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE})
+                public @interface Unused {}
+                """.trimIndent()
+            )
+        }
+        val hit = helper.findClassByAnnotation("com.example.Unused")
+        assertNull("expected null when no class carries the annotation, got $hit", hit)
+    }
+
+    fun testFindClassByAnnotationReturnsNullForBlankFqn() {
+        val hit = helper.findClassByAnnotation("   ")
+        assertNull("expected null for blank annotation FQN, got $hit", hit)
+    }
+
+    // ─── findClassesByAnnotation ─────────────────────────────────────────
+
+    fun testFindClassesByAnnotationReturnsAnnotatedClasses() {
+        addClasses()
+        val hits = helper.findClassesByAnnotation("com.example.Marker")
+        val fqns = hits.mapNotNull { it.qualifiedName }
+        assertTrue(
+            "expected MarkedOne and MarkedTwo in $fqns",
+            fqns.contains("com.example.MarkedOne") && fqns.contains("com.example.MarkedTwo"),
+        )
+        // PlainService is unannotated — must not be returned.
+        assertTrue(
+            "unannotated class must not be returned: $fqns",
+            !fqns.contains("com.example.PlainService"),
+        )
+        // ServiceBean has annotated methods but the class itself is NOT @Marker.
+        assertTrue(
+            "class with annotated methods (but not annotated itself) must not appear: $fqns",
+            !fqns.contains("com.example.ServiceBean"),
+        )
+    }
+
+    fun testFindClassesByAnnotationReturnsRawPsiClassInstances() {
+        addClasses()
+        // The whole point of the refactor: results are raw PsiClass instances, NOT
+        // ScriptPsiClassContext wrappers. Non-script callers can use them directly.
+        val hits = helper.findClassesByAnnotation("com.example.Marker")
+        assertTrue(
+            "every result must be a raw PsiClass (not a script context wrapper)",
+            hits.all { it is PsiClass },
+        )
+    }
+
+    fun testFindClassesByAnnotationReturnsEmptyWhenAnnotationNotResolvable() {
+        addClasses()
+        val hits = helper.findClassesByAnnotation("does.not.Exist")
+        assertTrue("expected empty list for unresolvable annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindClassesByAnnotationReturnsEmptyWhenFqnIsNotAnAnnotationType() {
+        addClasses()
+        // PlainService is a regular class, not an annotation — the helper
+        // must refuse to search and return an empty list (mirrors
+        // FindClassesByAnnotationTool behavior).
+        val hits = helper.findClassesByAnnotation("com.example.PlainService")
+        assertTrue("expected empty list when FQN is not an annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindClassesByAnnotationReturnsEmptyForBlankFqn() {
+        val hits = helper.findClassesByAnnotation("   ")
+        assertTrue("expected empty list for blank annotation FQN, got: $hits", hits.isEmpty())
+    }
+
+    // ─── findMethodsByAnnotation ──────────────────────────────────────────
+
+    fun testFindMethodsByAnnotationReturnsAnnotatedMethods() {
+        addClasses()
+        val hits = helper.findMethodsByAnnotation("com.example.Marker")
+        // Only ServiceBean has @Marker-annotated methods — doSomething and computeValue.
+        assertEquals(
+            "expected exactly 2 @Marker-annotated methods, got: ${hits.size}",
+            2,
+            hits.size,
+        )
+        val methodNames = hits.map { it.name }
+        assertTrue(
+            "expected doSomething and computeValue in $methodNames",
+            methodNames.contains("doSomething") && methodNames.contains("computeValue"),
+        )
+        // The unannotated method must not appear.
+        assertTrue(
+            "unannotated method must not be returned: $methodNames",
+            !methodNames.contains("unannotated"),
+        )
+    }
+
+    fun testFindMethodsByAnnotationReturnsRawPsiMethodInstances() {
+        addClasses()
+        // The whole point of the refactor: results are raw PsiMethod instances, NOT
+        // ScriptPsiMethodContext wrappers.
+        val hits = helper.findMethodsByAnnotation("com.example.Marker")
+        assertTrue(
+            "every result must be a raw PsiMethod (not a script context wrapper)",
+            hits.all { it is PsiMethod },
+        )
+    }
+
+    fun testFindMethodsByAnnotationReturnsEmptyWhenAnnotationNotResolvable() {
+        addClasses()
+        val hits = helper.findMethodsByAnnotation("does.not.Exist")
+        assertTrue("expected empty list for unresolvable annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindMethodsByAnnotationReturnsEmptyWhenFqnIsNotAnAnnotationType() {
+        addClasses()
+        val hits = helper.findMethodsByAnnotation("com.example.PlainService")
+        assertTrue("expected empty list when FQN is not an annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindMethodsByAnnotationReturnsEmptyForBlankFqn() {
+        val hits = helper.findMethodsByAnnotation("")
+        assertTrue("expected empty list for blank annotation FQN, got: $hits", hits.isEmpty())
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223CryptoInteropTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223CryptoInteropTest.kt
@@ -9,10 +9,10 @@ import javax.crypto.spec.SecretKeySpec
 import javax.script.ScriptEngineManager
 
 /**
- * Spike test (Spec: ai-workflow-patterns, T1.1 / review Issue #6).
+ * Spike test.
  *
- * Resolves Requirements Open Question #1: is `javax.crypto.Mac` reachable from
- * a `groovy:` rule value? Req 5.2's HMAC signing recipe depends on this.
+ * Resolves the open question: is `javax.crypto.Mac` reachable from
+ * a `groovy:` rule value? The HMAC signing recipe depends on this.
  *
  * `GroovyScriptParser.parse()` (see [Jsr223ScriptParser.parse]) evaluates `groovy:`
  * expressions via `enginePool.withEngine { engine -> engine.eval(script, bindings) }`
@@ -22,9 +22,9 @@ import javax.script.ScriptEngineManager
  * heavyweight `RuleContext` mocking, giving the cleanest possible signal for the
  * crypto-interop question.
  *
- * - If this test PASSES → Req 5.2 stays first-class; proceed.
- * - If this test FAILS → demote Req 5.2 to a scaffold in the catalog (T4.1) and record
- *   the failure in `review-design.md`.
+ * - If this test PASSES → the HMAC recipe stays first-class; proceed.
+ * - If this test FAILS → demote the HMAC recipe to a scaffold in the catalog and record
+ *   the failure.
  *
  * The Groovy engine comes from the optional `org.intellij.groovy` bundled plugin
  * (declared `optional` in `plugin.xml`); when absent, *all* `groovy:`/`pm.*` scripts
@@ -57,7 +57,7 @@ class Jsr223CryptoInteropTest {
         val expectedHex = expectedHmacSha256Hex(message, secret)
 
         // Groovy script that mirrors the JDK computation via Java interop — exactly the
-        // kind of code the Req 5.2 HMAC recipe generates inside a `postman.prerequest`
+        // kind of code the HMAC recipe generates inside a `postman.prerequest`
         // (or `groovy:`) rule value.
         val groovyScript = """
             import javax.crypto.Mac

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptParserBindingTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptParserBindingTest.kt
@@ -15,7 +15,7 @@ import javax.script.ScriptEngineManager
 import kotlinx.coroutines.runBlocking
 
 /**
- * Binding lock-in test for [Jsr223ScriptParser] (Spec: ai-workflow-patterns, T2.3 / review Issue #2, #7).
+ * Binding lock-in test for [Jsr223ScriptParser].
  *
  * Verifies that the `httpClient` binding in a `groovy:` evaluation context is a
  * [ScriptHttpClient] (the sync adapter that bridges the suspend-only [HttpClient]

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/ScriptHelperFindAnnotatedTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/ScriptHelperFindAnnotatedTest.kt
@@ -1,0 +1,227 @@
+package com.itangcent.easyapi.core.rule.parser
+
+import com.intellij.openapi.application.ApplicationManager
+import com.itangcent.easyapi.core.rule.context.RuleContext
+import com.itangcent.easyapi.core.rule.context.ScriptPsiClassContext
+import com.itangcent.easyapi.core.rule.context.ScriptPsiMethodContext
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * Tests for the `findClassesByAnnotation` / `findMethodsByAnnotation`
+ * helpers on [ScriptHelper].
+ *
+ * These helpers back the `springfox-openapi.config` Springfox `Docket`
+ * extractor and are generally useful for any `groovy:` rule script that
+ * needs to locate annotated code (`helper.findClassesByAnnotation(...)`
+ * / `H.findMethodsByAnnotation(...)`).
+ *
+ * Mirrors the fixture style of
+ * [com.itangcent.easyapi.core.ai.tools.FindClassesByAnnotationToolTest]:
+ * `AnnotatedElementsSearch` needs source files (annotation + annotated
+ * classes) in the fixture's VFS, so each test loads them via
+ * `myFixture.addFileToProject` inside a write action.
+ *
+ * JUnit 3-style `testXxx()` naming is required because
+ * [EasyApiLightCodeInsightFixtureTestCase] extends
+ * `LightJavaCodeInsightFixtureTestCase` (a JUnit 3 `TestCase` subclass).
+ */
+class ScriptHelperFindAnnotatedTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun addClasses() {
+        ApplicationManager.getApplication().runWriteAction {
+            // A project-defined annotation that targets both TYPE and METHOD.
+            myFixture.addFileToProject(
+                "com/example/Marker.java",
+                """
+                package com.example;
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE, ElementType.METHOD})
+                public @interface Marker {}
+                """.trimIndent()
+            )
+            // Project classes annotated with @Marker.
+            myFixture.addFileToProject(
+                "com/example/MarkedOne.java",
+                """
+                package com.example;
+                @Marker
+                public class MarkedOne {}
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/MarkedTwo.java",
+                """
+                package com.example;
+                @Marker
+                public class MarkedTwo {}
+                """.trimIndent()
+            )
+            // A class with @Marker-annotated methods (and one unannotated method).
+            myFixture.addFileToProject(
+                "com/example/ServiceBean.java",
+                """
+                package com.example;
+                public class ServiceBean {
+                    @Marker
+                    public void doSomething() {}
+
+                    @Marker
+                    public String computeValue() { return ""; }
+
+                    public void unannotated() {}
+                }
+                """.trimIndent()
+            )
+            // Unannotated class — must not be returned.
+            myFixture.addFileToProject(
+                "com/example/PlainService.java",
+                """
+                package com.example;
+                public class PlainService {}
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun newHelper(): ScriptHelper {
+        // `findClassesByAnnotation` / `findMethodsByAnnotation` don't use the
+        // context's element; they resolve the annotation via
+        // `JavaPsiFacade.findClass(...)` and search the project scope. A
+        // without-element context is sufficient.
+        val context = RuleContext.withoutElement(project)
+        return ScriptHelper(context)
+    }
+
+    // ─── findClassByAnnotation (singular) ────────────────────────────────
+
+    fun testFindClassByAnnotationReturnsFirstAnnotatedClass() {
+        addClasses()
+        val hit = newHelper().findClassByAnnotation("com.example.Marker")
+        assertNotNull("expected a non-null result for @Marker, got null", hit)
+        val fqn = (hit as? ScriptPsiClassContext)?.qualifiedName()
+        assertTrue(
+            "expected one of MarkedOne/MarkedTwo, got $fqn",
+            fqn == "com.example.MarkedOne" || fqn == "com.example.MarkedTwo",
+        )
+    }
+
+    fun testFindClassByAnnotationReturnsScriptPsiClassContext() {
+        addClasses()
+        val hit = newHelper().findClassByAnnotation("com.example.Marker")
+        assertNotNull("expected a non-null result for @Marker, got null", hit)
+        assertTrue(
+            "result must be a ScriptPsiClassContext for the script binding: $hit",
+            hit is ScriptPsiClassContext,
+        )
+    }
+
+    fun testFindClassByAnnotationReturnsNullWhenAnnotationNotResolvable() {
+        addClasses()
+        val hit = newHelper().findClassByAnnotation("does.not.Exist")
+        assertNull("expected null for unresolvable annotation, got $hit", hit)
+    }
+
+    fun testFindClassByAnnotationReturnsNullWhenFqnIsNotAnAnnotationType() {
+        addClasses()
+        // PlainService is a regular class, not an annotation — the helper
+        // must refuse to search and return null (mirrors
+        // FindClassesByAnnotationTool behavior).
+        val hit = newHelper().findClassByAnnotation("com.example.PlainService")
+        assertNull("expected null when FQN is not an annotation, got $hit", hit)
+    }
+
+    fun testFindClassByAnnotationReturnsNullForBlankFqn() {
+        val hit = newHelper().findClassByAnnotation("   ")
+        assertNull("expected null for blank annotation FQN, got $hit", hit)
+    }
+
+    // ─── findClassesByAnnotation ─────────────────────────────────────────
+
+    fun testFindClassesByAnnotationReturnsAnnotatedClasses() {
+        addClasses()
+        val hits = newHelper().findClassesByAnnotation("com.example.Marker")
+        val fqns = hits.mapNotNull { (it as? ScriptPsiClassContext)?.qualifiedName() }
+        assertTrue(
+            "expected MarkedOne and MarkedTwo in $fqns",
+            fqns.contains("com.example.MarkedOne") && fqns.contains("com.example.MarkedTwo"),
+        )
+        // PlainService is unannotated — must not appear.
+        assertTrue(
+            "unannotated class must not be returned: $fqns",
+            !fqns.contains("com.example.PlainService"),
+        )
+        // ServiceBean has annotated methods but the class itself is NOT @Marker.
+        assertTrue(
+            "class with annotated methods (but not annotated itself) must not appear: $fqns",
+            !fqns.contains("com.example.ServiceBean"),
+        )
+    }
+
+    fun testFindClassesByAnnotationReturnsEmptyWhenAnnotationNotResolvable() {
+        addClasses()
+        val hits = newHelper().findClassesByAnnotation("does.not.Exist")
+        assertTrue("expected empty list for unresolvable annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindClassesByAnnotationReturnsEmptyWhenFqnIsNotAnAnnotationType() {
+        addClasses()
+        // PlainService is a regular class, not an annotation — the helper
+        // must refuse to search and return an empty list (mirrors
+        // FindClassesByAnnotationTool behavior).
+        val hits = newHelper().findClassesByAnnotation("com.example.PlainService")
+        assertTrue("expected empty list when FQN is not an annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindClassesByAnnotationReturnsEmptyForBlankFqn() {
+        val hits = newHelper().findClassesByAnnotation("   ")
+        assertTrue("expected empty list for blank annotation FQN, got: $hits", hits.isEmpty())
+    }
+
+    // ─── findMethodsByAnnotation ──────────────────────────────────────────
+
+    fun testFindMethodsByAnnotationReturnsAnnotatedMethods() {
+        addClasses()
+        val hits = newHelper().findMethodsByAnnotation("com.example.Marker")
+        // Only ServiceBean has @Marker-annotated methods — doSomething and computeValue.
+        assertEquals(
+            "expected exactly 2 @Marker-annotated methods, got: ${hits.size}",
+            2,
+            hits.size,
+        )
+        val methodNames = hits.mapNotNull { (it as? ScriptPsiMethodContext)?.name() }
+        assertTrue(
+            "expected doSomething and computeValue in $methodNames",
+            methodNames.contains("doSomething") && methodNames.contains("computeValue"),
+        )
+        // The unannotated method must not appear.
+        assertTrue(
+            "unannotated method must not be returned: $methodNames",
+            !methodNames.contains("unannotated"),
+        )
+    }
+
+    fun testFindMethodsByAnnotationReturnsEmptyWhenAnnotationNotResolvable() {
+        addClasses()
+        val hits = newHelper().findMethodsByAnnotation("does.not.Exist")
+        assertTrue("expected empty list for unresolvable annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindMethodsByAnnotationReturnsEmptyWhenFqnIsNotAnAnnotationType() {
+        addClasses()
+        val hits = newHelper().findMethodsByAnnotation("com.example.PlainService")
+        assertTrue("expected empty list when FQN is not an annotation, got: $hits", hits.isEmpty())
+    }
+
+    fun testFindMethodsByAnnotationReturnsEmptyForBlankFqn() {
+        val hits = newHelper().findMethodsByAnnotation("")
+        assertTrue("expected empty list for blank annotation FQN, got: $hits", hits.isEmpty())
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/script/pm/PmScriptExecutorBindingTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/script/pm/PmScriptExecutorBindingTest.kt
@@ -8,7 +8,7 @@ import java.io.File
 import javax.script.ScriptEngineManager
 
 /**
- * Binding lock-in test for [PmScriptExecutor] (Spec: ai-workflow-patterns, T2.3 / review Issue #2).
+ * Binding lock-in test for [PmScriptExecutor].
  *
  * Verifies that `httpClient` is **NOT** bound in the `pm.*` script execution context
  * (`postman.test` / `postman.prerequest`). This is a deliberate security-surface

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/migration/SettingsMigrationActivityV4Test.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/migration/SettingsMigrationActivityV4Test.kt
@@ -17,7 +17,7 @@ import org.junit.Assert.assertTrue
  * `actuatorEnable`, `grpcEnable`) on `ApplicationSettingsState.State` to the
  * unified `enabledFrameworks`/`disabledFrameworks` arrays on `GeneralSettings`.
  *
- * Coverage per PR7 (design-framework-enablement.md):
+ * Coverage:
  * - (a) `feignEnable == true` → `enabledFrameworks += "Feign"`
  * - (b) `jaxrsEnable == false` → `disabledFrameworks += "JAX-RS"`
  * - (c) `actuatorEnable == true` → `enabledFrameworks += "SpringActuator"`

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/BackupSettingsPanelChannelEnablementTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/BackupSettingsPanelChannelEnablementTest.kt
@@ -7,7 +7,7 @@ import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCas
 
 /**
  * IDE-fixture tests for [BackupSettingsPanel] channel-enablement round-trip
- * (Task 5.1, "Additional Considerations — Settings backup/restore").
+ * ("Additional Considerations — Settings backup/restore").
  *
  * Verifies that `enabledChannels` / `disabledChannels` are included in the
  * exported JSON, restored on import, and that a legacy JSON without those
@@ -149,7 +149,7 @@ class BackupSettingsPanelChannelEnablementTest : EasyApiLightCodeInsightFixtureT
         )
     }
 
-    // --- Task A.7: field-format channel arrays backup/restore ---
+    // --- field-format channel arrays backup/restore ---
 
     fun testExportSettings_includesEnabledAndDisabledFieldFormatChannels() {
         // Persist known field-format arrays, then export and assert they round-trip

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/EasyApiSettingsConfigurableTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/EasyApiSettingsConfigurableTest.kt
@@ -132,7 +132,7 @@ class EasyApiSettingsConfigurableTest : EasyApiLightCodeInsightFixtureTestCase()
         assertTrue("General tab must precede Features; got: $tabs", generalIdx >= 0 && featuresIdx == generalIdx + 1)
     }
 
-    // --- Task 4.2: channel enablement wiring (Req 3.5, 5.1, 5.3) ---
+    // --- channel enablement wiring ---
 
     /**
      * Helper: restore GeneralSettings to a clean default state in [tearDown]
@@ -206,7 +206,7 @@ class EasyApiSettingsConfigurableTest : EasyApiLightCodeInsightFixtureTestCase()
     }
 
     /**
-     * Req 4.3 regression: a disabled channel does NOT get a Settings tab.
+     * Regression: a disabled channel does NOT get a Settings tab.
      * Hoppscotch is default-off AND contributes a settings panel, so by default
      * (no explicit enable) it must not appear as a tab.
      */
@@ -246,7 +246,7 @@ class EasyApiSettingsConfigurableTest : EasyApiLightCodeInsightFixtureTestCase()
         }
     }
 
-    // --- Task A.5: field-format enablement wiring (Req A3.5, A4) ---
+    // --- field-format enablement wiring ---
 
     fun testIsModified_includesFieldFormatEnablement() {
         try {
@@ -312,7 +312,7 @@ class EasyApiSettingsConfigurableTest : EasyApiLightCodeInsightFixtureTestCase()
     }
 
     fun testFieldFormatEnablementIndependentFromExportChannelEnablement() {
-        // Decision A4: toggling a field-format checkbox must not affect export-channel
+        // Toggling a field-format checkbox must not affect export-channel
         // isModified state, and vice versa.
         try {
             configurable.createComponent()

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/EnhancedSettingsPanelsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/EnhancedSettingsPanelsTest.kt
@@ -16,7 +16,7 @@ class EnhancedSettingsPanelsTest {
 
         // EnhancedGeneralSettingsPanel.resetFrom() is a no-op (self-contained panel),
         // so any Settings subtype is acceptable as the fixture. HttpSettings avoids a
-        // concrete channel.<id>.* import from core.* (DAG rule per Decision CO3).
+        // concrete channel.<id>.* import from core.* (DAG rule).
         val settings = HttpSettings()
 
         panel.resetFrom(settings)

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/FeaturesSettingsPanelChannelEnablementTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/FeaturesSettingsPanelChannelEnablementTest.kt
@@ -6,8 +6,7 @@ import com.itangcent.easyapi.core.settings.module.GeneralSettings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 /**
- * IDE-fixture tests for the "Export Channels" section of [FeaturesSettingsPanel]
- * (Task 4.1, Req 3.1–3.7).
+ * IDE-fixture tests for the "Export Channels" section of [FeaturesSettingsPanel].
  *
  * The test fixture loads `plugin.xml`, so [ChannelRegistry.allChannels] returns
  * the five production channels (markdown, postman, curl, http-client, hoppscotch).
@@ -20,7 +19,7 @@ class FeaturesSettingsPanelChannelEnablementTest : EasyApiLightCodeInsightFixtur
     override fun setUp() {
         super.setUp()
         // Constructing the panel builds the "Export Channels" section from
-        // ChannelRegistry.allChannels() (unfiltered — Req 3.4).
+        // ChannelRegistry.allChannels() (unfiltered).
         panel = FeaturesSettingsPanel(project)
     }
 
@@ -29,7 +28,7 @@ class FeaturesSettingsPanelChannelEnablementTest : EasyApiLightCodeInsightFixtur
     private fun defaultOn(): Channel = channels().first { it.id == "markdown" }
     private fun defaultOff(): Channel = channels().first { it.id == "http-client" }
 
-    // --- Req 3.3: checkbox reflects effective enabled state on reset ---
+    // --- checkbox reflects effective enabled state on reset ---
 
     fun testResetChannelEnablement_defaultOnNoPreference_checked() {
         val settings = GeneralSettings() // no preference
@@ -174,7 +173,7 @@ class FeaturesSettingsPanelChannelEnablementTest : EasyApiLightCodeInsightFixtur
         )
     }
 
-    // --- Req 3.7: graceful skip when no channels ---
+    // --- graceful skip when no channels ---
 
     fun testPanelBuildsWithoutErrorWhenChannelsRegistered() {
         // The fixture registers channels, so allChannels() is non-empty.

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/FeaturesSettingsPanelFieldFormatEnablementTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/FeaturesSettingsPanelFieldFormatEnablementTest.kt
@@ -6,12 +6,11 @@ import com.itangcent.easyapi.core.settings.module.GeneralSettings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 /**
- * IDE-fixture tests for the "Field Format Channels" section of [FeaturesSettingsPanel]
- * (Task A.4, Req A3.1–A3.7).
+ * IDE-fixture tests for the "Field Format Channels" section of [FeaturesSettingsPanel].
  *
  * Mirrors [FeaturesSettingsPanelChannelEnablementTest]. The test fixture loads
  * `plugin.xml`, so [FieldFormatChannelRegistry.allChannels] returns the four
- * production formats (json, json5, properties, yaml), all default-on (Decision A2).
+ * production formats (json, json5, properties, yaml), all default-on.
  */
 class FeaturesSettingsPanelFieldFormatEnablementTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -20,14 +19,14 @@ class FeaturesSettingsPanelFieldFormatEnablementTest : EasyApiLightCodeInsightFi
     override fun setUp() {
         super.setUp()
         // Constructing the panel builds the "Field Format Channels" section from
-        // FieldFormatChannelRegistry.allChannels() (unfiltered — Req A3.4).
+        // FieldFormatChannelRegistry.allChannels() (unfiltered).
         panel = FeaturesSettingsPanel(project)
     }
 
     private fun channels(): List<FieldFormatChannel> =
         FieldFormatChannelRegistry.getInstance(project).allChannels()
 
-    // --- Req A3.3: checkbox reflects effective enabled state on reset ---
+    // --- checkbox reflects effective enabled state on reset ---
 
     fun testResetFieldFormatEnablement_defaultOnNoPreference_checked() {
         val settings = GeneralSettings() // no preference
@@ -40,12 +39,12 @@ class FeaturesSettingsPanelFieldFormatEnablementTest : EasyApiLightCodeInsightFi
     }
 
     fun testResetFieldFormatEnablement_allFourFormatsCheckedByDefault() {
-        // Decision A2: all four shipping formats are default-on.
+        // All four shipping formats are default-on.
         val settings = GeneralSettings()
         panel.resetFieldFormatEnablementFrom(channels(), settings)
         listOf("json", "json5", "yaml", "properties").forEach { id ->
             assertEquals(
-                "Format '$id' should be checked by default (Decision A2)",
+                "Format '$id' should be checked by default",
                 true,
                 panel.fieldFormatCheckboxState(id)
             )
@@ -155,7 +154,7 @@ class FeaturesSettingsPanelFieldFormatEnablementTest : EasyApiLightCodeInsightFi
         )
     }
 
-    // --- Req A3.7: graceful skip when no channels ---
+    // --- graceful skip when no channels ---
 
     fun testPanelBuildsWithoutErrorWhenFieldFormatsRegistered() {
         // The fixture registers formats, so allChannels() is non-empty.
@@ -166,7 +165,7 @@ class FeaturesSettingsPanelFieldFormatEnablementTest : EasyApiLightCodeInsightFi
     }
 
     fun testFieldFormatEnablementIndependentFromExportChannelEnablement() {
-        // Decision A4: the two enablement sections use independent id spaces.
+        // The two enablement sections use independent id spaces.
         // Setting export-channel preferences must not affect field-format checkboxes.
         val settings = GeneralSettings(
             enabledChannels = arrayOf("markdown"),

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/FeaturesSettingsPanelPlatformTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/FeaturesSettingsPanelPlatformTest.kt
@@ -11,7 +11,7 @@ import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCas
  * [FeaturesSettingsPanelChannelEnablementTest] and
  * [FeaturesSettingsPanelFieldFormatEnablementTest].
  *
- * After the framework-enablement unification (Item 2), the panel's
+ * After the framework-enablement unification, the panel's
  * `resetFrom`/`applyTo`/`isModified` are no-ops for framework toggles —
  * the dynamic UI is driven by `resetFrameworkEnablementFrom` /
  * `applyFrameworkEnablementTo` / `isFrameworkEnablementModified`, which

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/GeneralSettingsPanelLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/GeneralSettingsPanelLogicTest.kt
@@ -186,7 +186,7 @@ class GeneralSettingsPanelLogicTest {
         assertNotEquals(s1, s2)
     }
 
-    // --- Task 1.2: GeneralSettings enabledChannels / disabledChannels ---
+    // --- GeneralSettings enabledChannels / disabledChannels ---
 
     @Test
     fun testEnabledChannelsDefaultEmpty() {
@@ -237,7 +237,7 @@ class GeneralSettingsPanelLogicTest {
         assertEquals(1, s1.disabledChannels.size)
     }
 
-    // --- Task A.2: GeneralSettings enabledFieldFormatChannels / disabledFieldFormatChannels ---
+    // --- GeneralSettings enabledFieldFormatChannels / disabledFieldFormatChannels ---
 
     @Test
     fun testEnabledFieldFormatChannelsDefaultEmpty() {
@@ -299,7 +299,7 @@ class GeneralSettingsPanelLogicTest {
 
     @Test
     fun testFieldFormatChannelsIndependentFromExportChannels() {
-        // The two EPs use independent id spaces (Decision A4). Setting one pair
+        // The two EPs use independent id spaces. Setting one pair
         // must not affect the other.
         val settings = GeneralSettings(
             enabledChannels = arrayOf("markdown"),

--- a/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideContentTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideContentTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 /**
  * Content-assertion test for the `rule-guide.md` "Multi-Application Namespace"
- * section (Req 6.1, 6.5).
+ * section.
  *
  * The existing `RuleGuideWorkflowCatalogTest.kt` is an empty stub (a single
  * `package com.itangcent` line) and cannot be extended; this dedicated test is
@@ -34,7 +34,7 @@ class RuleGuideContentTest {
 
     @Test
     fun `section documents the namespace-key resolution order`() {
-        // The three branches of the resolution order (Req 1.1/1.4/1.5).
+        // The three branches of the resolution order.
         assertTrue(
             "section must reference module name as the first resolution branch",
             ruleGuide.contains("Module name", ignoreCase = true)
@@ -51,7 +51,7 @@ class RuleGuideContentTest {
 
     @Test
     fun `section documents the per-app env-var naming convention`() {
-        // The full naming convention surface (Req 1.1, 3.1, 3.2): host, bearer
+        // The full naming convention surface: host, bearer
         // token, and login params, all namespaced by <key>.
         assertTrue(
             "section must document the host placeholder {{<key>}}",
@@ -73,7 +73,7 @@ class RuleGuideContentTest {
 
     @Test
     fun `section documents the multi-app bundle-split rule`() {
-        // Req 4.2: one propose_rule_content per app; bundle integrity still
+        // One propose_rule_content per app; bundle integrity still
         // required per app.
         assertTrue(
             "section must reference the propose_rule_content tool",
@@ -105,11 +105,11 @@ class RuleGuideContentTest {
 
     @Test
     fun `section records the body-level namespacing limitation`() {
-        // Req 5.5 (deferred per Decision 3): the v1 enabler converts header
+        // The v1 enabler converts header
         // values only; param/body conversion is deferred. The agent must not
         // promise body-level namespacing.
         assertTrue(
-            "section must document the body-level namespacing limitation (Req 5.5)",
+            "section must document the body-level namespacing limitation",
             ruleGuide.contains("body", ignoreCase = true) &&
                 (ruleGuide.contains("deferred", ignoreCase = true) ||
                     ruleGuide.contains("limitation", ignoreCase = true))
@@ -118,7 +118,7 @@ class RuleGuideContentTest {
 
     @Test
     fun `section records the resolution branch used in the proposal summary`() {
-        // Req 1.5: the proposal summary must state which branch was used and
+        // The proposal summary must state which branch was used and
         // the resulting key so the user can correct a wrong guess.
         assertTrue(
             "section must instruct the agent to record the resolution branch in the proposal summary",
@@ -128,7 +128,7 @@ class RuleGuideContentTest {
 
     @Test
     fun `section documents the dependency-graph clustering step`() {
-        // Req 4.1, 8.4: the rule-guide must name get_module_dependency_graph
+        // The rule-guide must name get_module_dependency_graph
         // as the tool to call when N > 1 to cluster modules into app groups.
         assertTrue(
             "section must reference the get_module_dependency_graph tool",
@@ -138,10 +138,10 @@ class RuleGuideContentTest {
 
     @Test
     fun `section documents the namespace-key normalization convention and examples`() {
-        // Req 2.1: the normalization convention lives as prose in the rule-guide
+        // The normalization convention lives as prose in the rule-guide
         // (it governs the LLM agent's behavior, which performs the transform in
         // its own reasoning and bakes the literal — no Kotlin code calls a
-        // normalizer). The load-bearing examples from Req 2.1 MUST be present so
+        // normalizer). The load-bearing examples MUST be present so
         // the agent (and humans) can predict the result.
         assertTrue(
             "section must state the camelCase splitting rule",
@@ -151,7 +151,7 @@ class RuleGuideContentTest {
             "section must state the allowed character class [a-z0-9-]",
             ruleGuide.contains("[a-z0-9-]")
         )
-        // The three canonical Req 2.1 examples.
+        // The three canonical examples.
         assertTrue(
             "section must show the OrderService -> order-service example",
             ruleGuide.contains("OrderService") && ruleGuide.contains("order-service")

--- a/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideWorkflowCatalogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideWorkflowCatalogTest.kt
@@ -1,1 +1,222 @@
-package com.itangcent
+package com.itangcent.easyapi.docs
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Drift tripwire for the Workflow-Pattern Catalog in `rule-guide.md`.
+ *
+ * Asserts that the canonical knowledge-base `rule-guide.md` contains the
+ * anchor strings for each workflow recipe. This is a cheap structural check
+ * — it does NOT validate the full markdown, only that the key recipe
+ * fragments survive future edits. If a refactor renames a section or drops a
+ * recipe line, this test fails before release.
+ *
+ * Additionally, enforces **script-context isolation invariants** (review
+ * Issue: recipe context-mixing). `postman.test`/`postman.prerequest` rule
+ * values must NOT carry a `groovy:` prefix (that routes them to
+ * `Jsr223ScriptParser` at export time, where `pm` is unbound — the script
+ * throws and the failure is silently swallowed). Conversely, `http.call.after`
+ * recipes must NOT reference `pm.*` (that binding lives only in
+ * `PmScriptExecutor`). These tests prevent regressions that re-introduce the
+ * silent-failure trap.
+ *
+ * The canonical source is `src/main/resources/docs/knowledge-base/rule-guide.md`.
+ * The external skill's mirror (`skills/easy-api-assistant/docs/rule-guide.md`)
+ * is kept in sync by the `syncKnowledgeBase` Gradle task (verified by
+ * `EasyApiAssistantSkillTest`).
+ *
+ * Run with: `./gradlew test --tests "*.RuleGuideWorkflowCatalogTest*"`
+ */
+class RuleGuideWorkflowCatalogTest {
+
+    private val ruleGuide: File =
+        File("src/main/resources/docs/knowledge-base/rule-guide.md")
+
+    private val content: String by lazy {
+        assertTrue(
+            "rule-guide.md must exist at ${ruleGuide.path} " +
+                "(test must run from project root)",
+            ruleGuide.exists()
+        )
+        ruleGuide.readText()
+    }
+
+    @Test
+    fun `Workflow Patterns section exists`() {
+        assertTrue(
+            "rule-guide.md must contain a '## Workflow Patterns' section",
+            content.contains("## Workflow Patterns")
+        )
+    }
+
+    @Test
+    fun `auth-chaining recipe uses postman test not prerequest for token extraction`() {
+        // The #1 mistake is using postman.prerequest for token extraction.
+        // The auth-chaining producer recipe MUST use postman.test (post-response).
+        assertTrue(
+            "auth-chaining producer recipe must use postman.test (post-response) " +
+                "for token extraction, NOT postman.prerequest",
+            content.contains("postman.test")
+        )
+        assertTrue(
+            "auth-chaining recipe must reference pm.environment.set (token storage)",
+            content.contains("pm.environment.set")
+        )
+    }
+
+    @Test
+    fun `auth-chaining recipe value is a literal script not groovy-prefixed`() {
+        // Script-context isolation: postman.test values must NOT start with groovy:.
+        // A groovy: prefix routes the value to Jsr223ScriptParser at export time,
+        // where pm is NOT bound — the script throws MissingPropertyException and
+        // the failure is silently swallowed (no test script lands in the collection).
+        assertTrue(
+            "auth-chaining recipe value must be a literal script (no groovy: prefix): " +
+                "postman.test[...]=def token = pm.response.json()...",
+            content.contains("postman.test[groovy: it.containingClass().name() == \"com.example.AuthController\"]=def token = pm.response.json().token")
+        )
+        assertFalse(
+            "auth-chaining recipe value must NOT be groovy-prefixed " +
+                "(would execute in Jsr223ScriptParser where pm is unbound, silently failing)",
+            content.contains("postman.test[\$class:com.example.AuthController]=groovy: def token")
+        )
+    }
+
+    @Test
+    fun `auth-chaining filter uses containingClass not dollar-class`() {
+        // $class: on a PsiMethod matches the RETURN TYPE, not the containing class.
+        // The auth-chaining recipe must use a groovy filter with containingClass().
+        assertFalse(
+            "auth-chaining recipe must NOT use \$class: filter " +
+                "(\$class: on a PsiMethod matches return type, not containing class)",
+            content.contains("postman.test[\$class:com.example.AuthController]")
+        )
+        assertTrue(
+            "auth-chaining recipe must use a groovy filter with containingClass()",
+            content.contains("postman.test[groovy: it.containingClass().name() == \"com.example.AuthController\"]")
+        )
+    }
+
+    @Test
+    fun `static-auth and consumer recipes use method additional header`() {
+        assertTrue(
+            "static-auth recipe must use method.additional.header",
+            content.contains("method.additional.header")
+        )
+        assertTrue(
+            "consumer recipe must reference Bearer \${Authorization} (shared-env-var rule)",
+            content.contains("Bearer \${Authorization}")
+        )
+    }
+
+    @Test
+    fun `per-request-injection and HMAC recipes use postman prerequest`() {
+        assertTrue(
+            "per-request-injection recipe must use postman.prerequest (pre-request)",
+            content.contains("postman.prerequest")
+        )
+    }
+
+    @Test
+    fun `hmac recipe value is a literal script not groovy-prefixed`() {
+        // Script-context isolation: postman.prerequest values must NOT start with groovy:.
+        // Same reasoning as the auth-chaining test — groovy: prefix routes to
+        // Jsr223ScriptParser where pm is unbound.
+        assertTrue(
+            "HMAC recipe value must be a literal script (no groovy: prefix): " +
+                "postman.prerequest[...]=def mac = javax.crypto.Mac...",
+            content.contains("postman.prerequest[groovy: it.containingClass().name().startsWith(\"com.example.api.\")]=def mac = javax.crypto.Mac")
+        )
+        assertFalse(
+            "HMAC recipe value must NOT be groovy-prefixed " +
+                "(would execute in Jsr223ScriptParser where pm is unbound, silently failing)",
+            content.contains("]=groovy: def mac = javax.crypto.Mac.getInstance")
+        )
+    }
+
+    @Test
+    fun `401-refresh recipe uses http call after`() {
+        assertTrue(
+            "401-refresh recipe must use http.call.after (post-call rule)",
+            content.contains("http.call.after")
+        )
+        assertTrue(
+            "401-refresh recipe must reference httpClient.executeSync (sub-request)",
+            content.contains("httpClient.executeSync")
+        )
+    }
+
+    @Test
+    fun `401-refresh recipe does not reference pm binding`() {
+        // Script-context isolation: http.call.after runs in Jsr223ScriptParser,
+        // where pm is NOT bound. The recipe must not reference pm.* at all.
+        // The 401-refresh recipe line is a single long line; extract it and
+        // assert no pm. reference appears in the script body.
+        val recipeLine = content.lines().firstOrNull { it.contains("http.call.after=groovy:") }
+        assertTrue(
+            "401-refresh recipe line must exist (http.call.after=groovy:...)",
+            recipeLine != null
+        )
+        assertFalse(
+            "401-refresh recipe must NOT reference pm. (pm is not bound in " +
+                "Jsr223ScriptParser / http.call.after context — use session.set() " +
+                "or localStorage.set() for storage instead). Recipe line:\n$recipeLine",
+            recipeLine!!.contains("pm.environment.set") || recipeLine.contains("pm.response") ||
+                recipeLine.contains("pm.request") || recipeLine.contains("pm.sendRequest")
+        )
+    }
+
+    @Test
+    fun `never-emit-secrets rule is present`() {
+        assertTrue(
+            "catalog must state the never-emit-secrets rule " +
+                "(every credential is an env-var reference, never a literal value)",
+            content.contains("never emit secrets") || content.contains("Never emit secrets") ||
+                content.contains("no-hardcoded-secret") || content.contains("No hardcoded secret")
+        )
+    }
+
+    @Test
+    fun `never-strip-legitimate-auth-fields rule is present`() {
+        assertTrue(
+            "catalog must state the never-strip-legitimate-auth-fields rule " +
+                "(do NOT generate field.ignore for password/secret/clientSecret/refreshToken)",
+            content.contains("never strip legitimate auth") ||
+                content.contains("Never strip legitimate auth") ||
+                content.contains("legitimately")
+        )
+    }
+
+    @Test
+    fun `script-context isolation correctness rule is present`() {
+        // The #6 correctness rule documents the silent-failure trap: postman.*
+        // values must not be groovy-prefixed; http.call.* values must not use pm.
+        assertTrue(
+            "catalog must carry the script-context-isolation correctness rule " +
+                "(postman.* values: no groovy: prefix; http.call.* values: no pm)",
+            content.contains("Script-context isolation") || content.contains("script-context isolation") ||
+                content.contains("silently swallowed")
+        )
+    }
+
+    @Test
+    fun `scope note correctly attributes postman and http call rules`() {
+        // The scope note must distinguish: postman.* rules affect Postman export;
+        // http.call.* rules affect the plugin HTTP client. Neither affects Markdown/cURL.
+        assertTrue(
+            "scope note must mention Postman",
+            content.contains("Postman")
+        )
+        assertTrue(
+            "scope note must mention the plugin HTTP client (interceptor hooks)",
+            content.contains("HTTP client") || content.contains("interceptor")
+        )
+        assertTrue(
+            "scope note must state neither affects Markdown/cURL export",
+            content.contains("Markdown") && content.contains("cURL")
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/format/json/ObjectModelValueConverterTypesTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/format/json/ObjectModelValueConverterTypesTest.kt
@@ -13,7 +13,7 @@ import junit.framework.TestCase
  * [ObjectModelValueConverter] — every test case calls
  * `ObjectModelValueConverter.toSimpleValue(...)` on a model built from a
  * [JsonType]. Co-locating the test with the converter avoids a concrete-impl
- * upward import from `core.psi` to `format.json` (DAG rule per Decision CO3).
+ * upward import from `core.psi` to `format.json` (DAG rule).
  */
 class ObjectModelValueConverterTypesTest : TestCase() {
 

--- a/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatActionGroupRefreshTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatActionGroupRefreshTest.kt
@@ -13,7 +13,7 @@ import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCas
 
 /**
  * IDE-fixture tests for [FieldFormatActionGroup.refreshActions] and
- * [FieldFormatAction.update] (Task A.6, Req A4.1–A4.3, Decision A5).
+ * [FieldFormatAction.update].
  *
  * Mirrors [com.itangcent.easyapi.core.ide.action.ChannelQuickActionGroupRefreshTest].
  * Verifies that:
@@ -90,7 +90,7 @@ class FieldFormatActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCase
     /**
      * Re-enables all formats by clearing the field-format preferences (so every
      * format falls back to its `enabledByDefault`, which is `true` for all four
-     * shipping formats — Decision A2).
+     * shipping formats).
      */
     private fun enableAllFormats() {
         SettingBinder.getInstance(project).save(GeneralSettings())
@@ -138,7 +138,7 @@ class FieldFormatActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCase
         return event.presentation.isVisible
     }
 
-    // --- Req A4.1: disabling a format hides its action ---
+    // --- disabling a format hides its action ---
 
     fun testRefreshActions_hidesDisabledFormatAction() {
         // Start with json enabled (default-on, no preference) so its action gets registered.
@@ -165,7 +165,7 @@ class FieldFormatActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCase
         )
     }
 
-    // --- Req A4.3: re-enabling a format shows its action ---
+    // --- re-enabling a format shows its action ---
 
     fun testRefreshActions_showsReEnabledFormatAction() {
         // Register the action while enabled, then disable+refresh to hide it.
@@ -190,7 +190,7 @@ class FieldFormatActionGroupRefreshTest : EasyApiLightCodeInsightFixtureTestCase
         )
     }
 
-    // --- Decision A5: refreshActions does NOT unregister actions ---
+    // --- refreshActions does NOT unregister actions ---
 
     fun testRefreshActions_doesNotUnregisterAction() {
         enableAllFormats()

--- a/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistryIsEnabledTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistryIsEnabledTest.kt
@@ -18,7 +18,7 @@ import org.junit.Assert.*
  *
  * Coverage targets (from Codecov PR #736):
  * - The `try { ... } catch { LOG.warn(...); return enabledByDefault }` fallback
- *   path when [SettingBinder.read] throws (Req A2.6).
+ *   path when [SettingBinder.read] throws.
  * - The happy path: reading stored preferences and delegating to
  *   [FieldFormatChannelRegistry.resolveEnabled].
  */
@@ -82,7 +82,7 @@ class FieldFormatChannelRegistryIsEnabledTest : EasyApiLightCodeInsightFixtureTe
         assertTrue(registry.isEnabled(defaultOff))
     }
 
-    // --- Fallback path: SettingBinder.read throws → enabledByDefault (Req A2.6) ---
+    // --- Fallback path: SettingBinder.read throws → enabledByDefault ---
 
     fun testIsEnabled_fallbackReturnsEnabledByDefault_whenSettingsReadThrows_defaultOn() {
         project.registerServiceInstance(

--- a/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelRegistryTest.kt
@@ -28,7 +28,7 @@ class FieldFormatChannelRegistryTest {
         override suspend fun format(project: Project, psiClass: PsiClass): String = ""
     }
 
-    // --- Task A.1: FieldFormatChannel.enabledByDefault ---
+    // --- FieldFormatChannel.enabledByDefault ---
 
     @Test
     fun testEnabledByDefaultDefaultsToTrue() {
@@ -44,7 +44,7 @@ class FieldFormatChannelRegistryTest {
         assertFalse(channel.enabledByDefault)
     }
 
-    // --- Task A.3: FieldFormatChannelRegistry.resolveEnabled (pure resolution rule) ---
+    // --- FieldFormatChannelRegistry.resolveEnabled (pure resolution rule) ---
     // Exercises the full truth table of the resolution rule without a Project.
 
     private val defaultOn = StubFieldFormatChannel("default-on", "Default On", enabledByDefault = true)
@@ -92,13 +92,13 @@ class FieldFormatChannelRegistryTest {
 
     @Test
     fun testResolveEnabled_fallsBackToEnabledByDefaultWhenPreferenceAbsent() {
-        // Req A2.6: absent preference (empty arrays) falls back to enabledByDefault.
+        // Absent preference (empty arrays) falls back to enabledByDefault.
         // This mirrors the fallback path taken when settings storage is unreadable.
         assertTrue(FieldFormatChannelRegistry.resolveEnabled(defaultOn, empty, empty))
         assertFalse(FieldFormatChannelRegistry.resolveEnabled(defaultOff, empty, empty))
     }
 
-    // --- Task A.3: filtered query logic ---
+    // --- filtered query logic ---
     // The registry query method (getEnabledChannels) needs a Project (covered by
     // FieldFormatActionGroupRefreshTest). Here we replicate the exact filtering it
     // applies (filter resolveEnabled) to verify the rule excludes disabled formats.
@@ -124,7 +124,7 @@ class FieldFormatChannelRegistryTest {
 
     @Test
     fun testFilteredQueryLogic_allChannelsRemainUnfiltered() {
-        // Req A3.4: allChannels() is a pure registry primitive — it does NOT
+        // allChannels() is a pure registry primitive — it does NOT
         // consult enablement. Here we assert the lookup-by-id logic itself
         // ignores enabledByDefault (a disabled format is still listed).
         val channels = listOf(

--- a/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannelTest.kt
@@ -156,7 +156,7 @@ class FieldFormatChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
         }
     }
 
-    // ---------- Task A.1: FieldFormatChannel.enabledByDefault ----------
+    // ---------- FieldFormatChannel.enabledByDefault ----------
 
     /**
      * A stub [FieldFormatChannel] that does NOT override [FieldFormatChannel.enabledByDefault],
@@ -187,7 +187,7 @@ class FieldFormatChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
             "FieldFormatChannel.enabledByDefault should default to true when not overridden",
             channel.enabledByDefault
         )
-        // All four production channels also keep the default (Decision A2).
+        // All four production channels also keep the default.
         assertTrue(JsonFieldFormatChannel().enabledByDefault)
         assertTrue(Json5FieldFormatChannel().enabledByDefault)
         assertTrue(YamlFieldFormatChannel().enabledByDefault)

--- a/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatExtensionsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/format/spi/FieldFormatExtensionsTest.kt
@@ -23,10 +23,10 @@ import com.itangcent.easyapi.testFramework.TestConfigReader
  * - [toYaml] → [YamlFormatter.format]
  *
  * The `testToJson*ParityWithDirectConverterCall` / `testToJson5*ParityWithDirectConverterCall`
- * methods are the **Decision CO6 characterization tests**: they verify that the
+ * methods are the **characterization tests**: they verify that the
  * pre-migration direct call (`ObjectModelJsonConverter.toJson(model)`, as used
  * by `ScriptPsiContexts.toJson()` today) and the post-migration extension
- * (`model.toJson()`, which `ScriptPsiContexts.toJson()` will use after the CO6
+ * (`model.toJson()`, which `ScriptPsiContexts.toJson()` will use after the
  * migration) produce byte-identical output. Both must equal the golden file
  * captured from pre-refactor behavior. If either parity check fails after the
  * migration, the migration broke the output.
@@ -58,7 +58,7 @@ class FieldFormatExtensionsTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     /**
-     * **Decision CO6 characterization test (JSON).**
+     * **Characterization test (JSON).**
      *
      * Builds the same `ObjectModel` that `ScriptPsiContexts.toJson()` builds
      * (same `PsiClass`, same `JsonOption.READ_GETTER_OR_SETTER`) and asserts:
@@ -66,9 +66,9 @@ class FieldFormatExtensionsTest : EasyApiLightCodeInsightFixtureTestCase() {
      *    equals the golden output (captured from pre-refactor behavior).
      * 2. The post-migration extension `model.toJson()` equals the same golden
      *    output.
-     * 3. Therefore the two are byte-identical — the CO6 migration preserves
-     *    output. This test MUST pass both BEFORE the migration (Task 20) and
-     *    AFTER the migration (Task 21).
+     * 3. Therefore the two are byte-identical — the migration preserves
+     *    output. This test MUST pass both BEFORE the migration and
+     *    AFTER the migration.
      */
     fun testToJsonParityWithDirectConverterCall() = runTest {
         loadFile("model/UserInfo.java")
@@ -82,11 +82,11 @@ class FieldFormatExtensionsTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         assertEquals("direct call must match golden", expected, directCallOutput)
         assertEquals("extension must match golden", expected, extensionOutput)
-        assertEquals("direct call must match extension (CO6 parity)", directCallOutput, extensionOutput)
+        assertEquals("direct call must match extension (parity)", directCallOutput, extensionOutput)
     }
 
     /**
-     * **Decision CO6 characterization test (JSON5).**
+     * **Characterization test (JSON5).**
      *
      * Builds the same `ObjectModel` that `ScriptPsiContexts.toJson5()` builds
      * (same `PsiClass`, same `JsonOption.ALL`) and asserts:
@@ -94,9 +94,9 @@ class FieldFormatExtensionsTest : EasyApiLightCodeInsightFixtureTestCase() {
      *    equals the golden output (captured from pre-refactor behavior).
      * 2. The post-migration extension `model.toJson5()` equals the same golden
      *    output.
-     * 3. Therefore the two are byte-identical — the CO6 migration preserves
-     *    output. This test MUST pass both BEFORE the migration (Task 20) and
-     *    AFTER the migration (Task 21).
+     * 3. Therefore the two are byte-identical — the migration preserves
+     *    output. This test MUST pass both BEFORE the migration and
+     *    AFTER the migration.
      */
     fun testToJson5ParityWithDirectConverterCall() = runTest {
         loadFile("model/UserInfo.java")
@@ -110,7 +110,7 @@ class FieldFormatExtensionsTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         assertEquals("direct call must match golden", expected, directCallOutput)
         assertEquals("extension must match golden", expected, extensionOutput)
-        assertEquals("direct call must match extension (CO6 parity)", directCallOutput, extensionOutput)
+        assertEquals("direct call must match extension (parity)", directCallOutput, extensionOutput)
     }
 
     fun testToProperties() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/framework/spi/FrameworkRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/spi/FrameworkRegistryTest.kt
@@ -12,23 +12,21 @@ import org.junit.Test
  * [com.itangcent.easyapi.channel.spi.ChannelRegistry.resolveEnabled]
  * (test: `ChannelRegistryTest`).
  *
- * Cases per `requirements-framework-enablement.md` Req 7.6 (a)-(e):
+ * Cases (a)-(e):
  *  (a) default-on framework, absent from both arrays → `true`;
  *  (b) default-on framework, in `disabledFrameworks` → `false`;
  *  (c) default-off framework, absent from both arrays → `false`;
  *  (d) default-off framework, in `enabledFrameworks` → `true`;
  *  (e) framework id in BOTH arrays (explicit-on wins) → `true`.
  *
- * Decision PR5: the framework id is `recognizer.frameworkName`.
+ * The framework id is `recognizer.frameworkName`.
  *
- * This is a **test-first** test (written BEFORE task 19 implements
- * [FrameworkRegistry]). It MUST fail to compile against current code
+ * This is a **test-first** test (written BEFORE [FrameworkRegistry] is
+ * implemented). It MUST fail to compile against current code
  * because [FrameworkRegistry] does not exist yet.
  *
  * No `Project` is needed — [FrameworkRegistry.resolveEnabled] is the pure
  * `internal` companion rule extracted for testability.
- *
- * Requirements: Framework Enablement 3.1, 7.6; Decision: PR4, PR5
  */
 class FrameworkRegistryTest {
 

--- a/src/test/resources/api/extension/springfox/DocketConfig.java
+++ b/src/test/resources/api/extension/springfox/DocketConfig.java
@@ -1,0 +1,32 @@
+package com.itangcent.extension.springfox;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.service.ApiInfo;
+
+/**
+ * Realistic fixture: Springfox `Docket` is configured via a `@Bean` method on
+ * a SEPARATE `@Configuration` class, NOT on the controller.
+ *
+ * Used by `ExtensionParsingTest.SpringfoxExtensionTest` to verify that
+ * `springfox-openapi.config` uses `helper.findMethodsByAnnotation(...)` to
+ * locate the `@Bean Docket` method globally and extract the document-level
+ * metadata from its body.
+ */
+@Configuration
+public class DocketConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket()
+            .apiInfo(new ApiInfo(
+                "Cross-Class Springfox Title",
+                "Cross-class Springfox description",
+                "5.0",
+                "", "", "", ""
+            ))
+            .host("cross-class.example.com")
+            .pathMapping("/v5");
+    }
+}

--- a/src/test/resources/api/extension/springfox/PingController.java
+++ b/src/test/resources/api/extension/springfox/PingController.java
@@ -1,0 +1,22 @@
+package com.itangcent.extension.springfox;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Plain controller WITHOUT any `@Bean Docket` method.
+ *
+ * Used by `ExtensionParsingTest.SpringfoxExtensionTest` to verify that
+ * exporting THIS controller still picks up the `Docket` bean from the
+ * separate `DocketConfig` class via `helper.findMethodsByAnnotation(...)`.
+ */
+@RestController
+@RequestMapping("/ping")
+public class PingController {
+
+    @GetMapping
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/test/resources/api/extension/swagger2/PingController.java
+++ b/src/test/resources/api/extension/swagger2/PingController.java
@@ -1,0 +1,22 @@
+package com.itangcent.extension.swagger2;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Plain controller WITHOUT `@SwaggerDefinition`.
+ *
+ * Used by `ExtensionParsingTest.Swagger2ExtensionTest` to verify that
+ * exporting THIS controller still picks up `@SwaggerDefinition` from the
+ * separate `SwaggerConfig` class via `helper.findClassesByAnnotation(...)`.
+ */
+@RestController
+@RequestMapping("/ping")
+public class PingController {
+
+    @GetMapping
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/test/resources/api/extension/swagger2/SwaggerConfig.java
+++ b/src/test/resources/api/extension/swagger2/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.itangcent.extension.swagger2;
+
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Realistic fixture: `@SwaggerDefinition` lives on a SEPARATE
+ * `@Configuration` class, NOT on the controller.
+ *
+ * Used by `ExtensionParsingTest.Swagger2ExtensionTest` to verify that
+ * `swagger-openapi.config` uses `helper.findClassesByAnnotation(...)` to
+ * locate this class globally and extract the document-level metadata.
+ */
+@Configuration
+@SwaggerDefinition(
+    host = "cross-class.example.com",
+    basePath = "/v2",
+    schemes = {SwaggerDefinition.Scheme.HTTPS},
+    info = @Info(title = "Cross-Class Swagger2 Title", version = "2.9", description = "Cross-class SwaggerDefinition description")
+)
+public class SwaggerConfig {
+}

--- a/src/test/resources/api/extension/swagger3/OpenApiConfig.java
+++ b/src/test/resources/api/extension/swagger3/OpenApiConfig.java
@@ -1,0 +1,27 @@
+package com.itangcent.extension.swagger3;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Realistic fixture: `@OpenAPIDefinition` lives on a SEPARATE `@Configuration`
+ * class, NOT on the controller. This mirrors how real projects declare
+ * OpenAPI metadata — on a dedicated config class, not on every controller.
+ *
+ * Used by `ExtensionParsingTest.Swagger3ExtensionTest` to verify that
+ * `swagger3-openapi.config` uses `helper.findClassesByAnnotation(...)` to
+ * locate this class globally and extract the document-level metadata.
+ */
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Cross-Class Swagger3 Title",
+        version = "9.1.0",
+        description = "Cross-class OpenAPIDefinition description"
+    ),
+    servers = {@Server(url = "https://cross-class.example.com")}
+)
+public class OpenApiConfig {
+}

--- a/src/test/resources/api/extension/swagger3/PingController.java
+++ b/src/test/resources/api/extension/swagger3/PingController.java
@@ -1,0 +1,22 @@
+package com.itangcent.extension.swagger3;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Plain controller WITHOUT `@OpenAPIDefinition`.
+ *
+ * Used by `ExtensionParsingTest.Swagger3ExtensionTest` to verify that
+ * exporting THIS controller still picks up `@OpenAPIDefinition` from the
+ * separate `OpenApiConfig` class via `helper.findClassesByAnnotation(...)`.
+ */
+@RestController
+@RequestMapping("/ping")
+public class PingController {
+
+    @GetMapping
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/test/resources/api/springfox/SpringfoxDocketConfig.java
+++ b/src/test/resources/api/springfox/SpringfoxDocketConfig.java
@@ -1,0 +1,38 @@
+package com.itangcent.swagger2.openapi;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.service.ApiInfo;
+
+/**
+ * Springfox Docket configuration fixture for the springfox-openapi.config
+ * extractor test (see SwaggerConfigExtractionTest#testSpringfox*).
+ *
+ * The @Bean method {@link #api()} returns {@link Docket} and walks both the
+ * constructor form of {@code ApiInfo(...)} (covers title/version/description)
+ * and the {@code .host(...)} / {@code .pathMapping(...)} calls (covers
+ * server.url).
+ */
+@Configuration
+@RestController
+@RequestMapping("/api")
+public class SpringfoxDocketConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket()
+            .apiInfo(new ApiInfo("Springfox Title", "Springfox Desc", "2.3.0",
+                "", "", "", ""))
+            .host("api.example.com")
+            .pathMapping("/v3");
+    }
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/test/resources/api/swagger2/PingController.java
+++ b/src/test/resources/api/swagger2/PingController.java
@@ -1,0 +1,22 @@
+package com.itangcent.swagger2.openapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Plain controller WITHOUT `@SwaggerDefinition`.
+ *
+ * Used by `SwaggerConfigExtractionTest.Swagger2Test` and `Swagger2InfoOnlyTest`
+ * to verify that exporting THIS controller still picks up `@SwaggerDefinition`
+ * from the separate config class via `helper.findClassesByAnnotation(...)`.
+ */
+@RestController
+@RequestMapping("/api")
+public class PingController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/test/resources/api/swagger2/SwaggerConfig.java
+++ b/src/test/resources/api/swagger2/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.itangcent.swagger2.openapi;
+
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Document-level Swagger v2 metadata lives on a SEPARATE `@Configuration`
+ * class, NOT on the controller. This mirrors how real Spring Boot projects
+ * declare Swagger metadata — on a dedicated config class, not on every
+ * controller.
+ *
+ * Used by `SwaggerConfigExtractionTest.Swagger2Test` to verify that
+ * `swagger-openapi.config` uses `helper.findClassesByAnnotation(...)` to
+ * locate this class globally and extract the document-level metadata.
+ */
+@Configuration
+@SwaggerDefinition(
+    host = "api.example.com",
+    basePath = "/v2",
+    schemes = {SwaggerDefinition.Scheme.HTTPS},
+    info = @Info(title = "V2 API", version = "1.0", description = "V2 desc")
+)
+public class SwaggerConfig {
+}

--- a/src/test/resources/api/swagger2/SwaggerInfoOnlyConfig.java
+++ b/src/test/resources/api/swagger2/SwaggerInfoOnlyConfig.java
@@ -1,0 +1,20 @@
+package com.itangcent.swagger2.openapi;
+
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Document-level Swagger v2 metadata (info only, no host) lives on a SEPARATE
+ * `@Configuration` class, NOT on the controller.
+ *
+ * Used by `SwaggerConfigExtractionTest.Swagger2InfoOnlyTest` to verify that
+ * `servers` is omitted when `host` is absent, but `info` fields are still
+ * extracted via `helper.findClassesByAnnotation(...)`.
+ */
+@Configuration
+@SwaggerDefinition(
+    info = @Info(title = "Info Only API", version = "2.0", description = "Info only desc")
+)
+public class SwaggerInfoOnlyConfig {
+}

--- a/src/test/resources/api/swagger3/NoOpenApiDefinitionController.java
+++ b/src/test/resources/api/swagger3/NoOpenApiDefinitionController.java
@@ -1,0 +1,19 @@
+package com.itangcent.swagger3.openapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller without @OpenAPIDefinition — used to verify the channel falls
+ * through to settings/defaults cleanly when the annotation is absent.
+ */
+@RestController
+@RequestMapping("/api")
+public class NoOpenApiDefinitionController {
+
+    @GetMapping("/status")
+    public String status() {
+        return "ok";
+    }
+}

--- a/src/test/resources/api/swagger3/OpenApiConfig.java
+++ b/src/test/resources/api/swagger3/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.itangcent.swagger3.openapi;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Document-level OpenAPI metadata lives on a SEPARATE `@Configuration` class,
+ * NOT on the controller. This mirrors how real Spring Boot projects declare
+ * OpenAPI metadata — on a dedicated config class, not on every controller.
+ *
+ * Used by `SwaggerConfigExtractionTest.Swagger3Test` to verify that
+ * `swagger3-openapi.config` uses `helper.findClassesByAnnotation(...)` to
+ * locate this class globally and extract the document-level metadata.
+ */
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "OpenAPIDefinition Title", version = "2.1.0", description = "OpenAPIDefinition Description"),
+    servers = {@Server(url = "https://test.example.com", description = "Test server")}
+)
+public class OpenApiConfig {
+}

--- a/src/test/resources/api/swagger3/PingController.java
+++ b/src/test/resources/api/swagger3/PingController.java
@@ -1,0 +1,22 @@
+package com.itangcent.swagger3.openapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Plain controller WITHOUT `@OpenAPIDefinition`.
+ *
+ * Used by `SwaggerConfigExtractionTest.Swagger3Test` to verify that exporting
+ * THIS controller still picks up `@OpenAPIDefinition` from the separate
+ * `OpenApiConfig` class via `helper.findClassesByAnnotation(...)`.
+ */
+@RestController
+@RequestMapping("/api")
+public class PingController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/test/resources/io/swagger/annotations/Info.java
+++ b/src/test/resources/io/swagger/annotations/Info.java
@@ -1,0 +1,20 @@
+package io.swagger.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Swagger 2.x nested @Info annotation used inside @SwaggerDefinition.
+ *
+ * Note: This is the v2 {@code io.swagger.annotations.Info}, distinct from the
+ * v3 {@code io.swagger.v3.oas.annotations.info.Info}.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Info {
+    String title() default "";
+    String version() default "";
+    String description() default "";
+}

--- a/src/test/resources/io/swagger/annotations/SwaggerDefinition.java
+++ b/src/test/resources/io/swagger/annotations/SwaggerDefinition.java
@@ -1,0 +1,25 @@
+package io.swagger.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwaggerDefinition {
+    String host() default "";
+    String basePath() default "";
+    Scheme[] schemes() default {};
+    Info info() default @Info;
+
+    /**
+     * Enumeration of supported Swagger 2.x transport schemes.
+     */
+    enum Scheme {
+        HTTP,
+        HTTPS,
+        WS,
+        WSS
+    }
+}

--- a/src/test/resources/io/swagger/v3/oas/annotations/OpenAPIDefinition.java
+++ b/src/test/resources/io/swagger/v3/oas/annotations/OpenAPIDefinition.java
@@ -1,0 +1,16 @@
+package io.swagger.v3.oas.annotations;
+
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OpenAPIDefinition {
+    Info info() default @Info;
+    Server[] servers() default {};
+}

--- a/src/test/resources/io/swagger/v3/oas/annotations/info/Info.java
+++ b/src/test/resources/io/swagger/v3/oas/annotations/info/Info.java
@@ -1,0 +1,14 @@
+package io.swagger.v3.oas.annotations.info;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Info {
+    String title() default "";
+    String version() default "";
+    String description() default "";
+}

--- a/src/test/resources/io/swagger/v3/oas/annotations/servers/Server.java
+++ b/src/test/resources/io/swagger/v3/oas/annotations/servers/Server.java
@@ -1,0 +1,13 @@
+package io.swagger.v3.oas.annotations.servers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Server {
+    String url() default "";
+    String description() default "";
+}

--- a/src/test/resources/org/springframework/context/annotation/Bean.java
+++ b/src/test/resources/org/springframework/context/annotation/Bean.java
@@ -1,0 +1,13 @@
+package org.springframework.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Bean {
+    String value() default "";
+    String name() default "";
+}

--- a/src/test/resources/org/springframework/context/annotation/Configuration.java
+++ b/src/test/resources/org/springframework/context/annotation/Configuration.java
@@ -1,0 +1,12 @@
+package org.springframework.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Configuration {
+    String value() default "";
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.grpcSkipped.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.grpcSkipped.txt
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "summary": "Get user",
+        "operationId": "getUser",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.operationIdCollision.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.operationIdCollision.txt
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "summary": "Get user",
+        "operationId": "getUser",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    },
+    "/admin/users/{id}": {
+      "get": {
+        "summary": "Get user (admin)",
+        "operationId": "getUser-2",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.parameters.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.parameters.txt
@@ -1,0 +1,73 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "summary": "Search users",
+        "operationId": "searchUsers",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "42"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ACTIVE",
+                "INACTIVE"
+              ]
+            }
+          },
+          {
+            "name": "X-Custom-Header",
+            "in": "header",
+            "description": "Custom header from ApiParameter",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "description": "Session cookie",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "Request ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "abc-123"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.pathCollapse.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.pathCollapse.txt
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "List users",
+        "operationId": "listUsers",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create user",
+        "operationId": "createUser",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.pathNormalization.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.pathNormalization.txt
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "summary": "Get user by id",
+        "operationId": "getUser",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.postWithJsonBody.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.postWithJsonBody.txt
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "post": {
+        "summary": "Create user",
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.requestBodyFormUrlencoded.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.requestBodyFormUrlencoded.txt
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/forms/{id}": {
+      "post": {
+        "summary": "Submit form",
+        "operationId": "submitForm",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.requestBodyMultipart.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.requestBodyMultipart.txt
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}/avatar": {
+      "post": {
+        "summary": "Upload avatar",
+        "operationId": "uploadAvatar",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "avatar": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "gallery": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "avatar"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.requestBodySuppressedForGet.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.requestBodySuppressedForGet.txt
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/search": {
+      "get": {
+        "summary": "Search",
+        "operationId": "search",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.responseTypeOnly.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.responseTypeOnly.txt
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/config": {
+      "get": {
+        "summary": "Get config",
+        "operationId": "getConfig",
+        "responses": {
+          "200": {
+            "description": "Response type: com.example.Config"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.simpleGet.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.simpleGet.txt
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "List users",
+        "operationId": "listUsers",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.tagsResolution.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.tagsResolution.txt
@@ -1,0 +1,59 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "Users"
+    },
+    {
+      "name": "AdminController"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "List users",
+        "operationId": "listUsers",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    },
+    "/admins": {
+      "get": {
+        "tags": [
+          "AdminController"
+        ],
+        "summary": "List admins",
+        "operationId": "listAdmins",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get user",
+        "operationId": "getUser",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.voidResponse.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiFormatterTest.voidResponse.txt
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}": {
+      "delete": {
+        "summary": "Delete user",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.allFeaturesJson.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.allFeaturesJson.txt
@@ -1,0 +1,289 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Demo API",
+    "version": "2.0.0",
+    "description": "A demo API for golden-file testing"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Forms"
+    },
+    {
+      "name": "Uploads"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "List users",
+        "operationId": "listUsers",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ACTIVE",
+                "INACTIVE"
+              ]
+            },
+            "example": "ACTIVE"
+          },
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "Request ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "abc-123"
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "description": "Session cookie",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Create user",
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get user by id",
+        "operationId": "getUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "example": 42
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Delete user",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    },
+    "/forms/{id}": {
+      "post": {
+        "tags": [
+          "Forms"
+        ],
+        "summary": "Submit form",
+        "operationId": "submitForm",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/users/{id}/avatar": {
+      "post": {
+        "tags": [
+          "Uploads"
+        ],
+        "summary": "Upload avatar",
+        "operationId": "uploadAvatar",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "avatar": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "avatar"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "description": "User name"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ],
+            "x-enumDescriptions": {
+              "ACTIVE": "Active user",
+              "INACTIVE": "Inactive user"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.allFeaturesYaml.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.allFeaturesYaml.txt
@@ -1,0 +1,182 @@
+openapi: "3.0.3"
+info:
+  title: "Demo API"
+  version: "2.0.0"
+  description: "A demo API for golden-file testing"
+servers:
+- url: "https://api.example.com"
+tags:
+- name: "Users"
+- name: "Forms"
+- name: "Uploads"
+paths:
+  /users:
+    get:
+      tags:
+      - "Users"
+      summary: "List users"
+      operationId: "listUsers"
+      parameters:
+      - in: "query"
+        name: "status"
+        description: "Filter by status"
+        required: false
+        schema:
+          type: "string"
+          enum:
+          - "ACTIVE"
+          - "INACTIVE"
+        example: "ACTIVE"
+      - in: "header"
+        name: "X-Request-Id"
+        description: "Request ID"
+        required: false
+        schema:
+          type: "string"
+        example: "abc-123"
+      - in: "cookie"
+        name: "session"
+        description: "Session cookie"
+        required: false
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+    post:
+      tags:
+      - "Users"
+      summary: "Create user"
+      operationId: "createUser"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        required: false
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+  /users/{id}:
+    get:
+      tags:
+      - "Users"
+      summary: "Get user by id"
+      operationId: "getUser"
+      parameters:
+      - in: "path"
+        name: "id"
+        description: "User ID"
+        required: true
+        schema:
+          type: "integer"
+          format: "int64"
+        example: 42
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+    delete:
+      tags:
+      - "Users"
+      summary: "Delete user"
+      operationId: "deleteUser"
+      parameters:
+      - in: "path"
+        name: "id"
+        required: true
+        schema:
+          type: "integer"
+          format: "int64"
+      responses:
+        "204":
+          description: "No content"
+  /forms/{id}:
+    post:
+      tags:
+      - "Forms"
+      summary: "Submit form"
+      operationId: "submitForm"
+      parameters:
+      - in: "path"
+        name: "id"
+        required: true
+        schema:
+          type: "string"
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: "object"
+              properties:
+                username:
+                  type: "string"
+                email:
+                  type: "string"
+              required:
+              - "username"
+        required: true
+      responses:
+        "200":
+          description: "OK"
+  /users/{id}/avatar:
+    post:
+      tags:
+      - "Uploads"
+      summary: "Upload avatar"
+      operationId: "uploadAvatar"
+      parameters:
+      - in: "path"
+        name: "id"
+        required: true
+        schema:
+          type: "integer"
+          format: "int64"
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: "object"
+              properties:
+                avatar:
+                  type: "string"
+                  format: "binary"
+              required:
+              - "avatar"
+        required: true
+      responses:
+        "204":
+          description: "No content"
+components:
+  schemas:
+    User:
+      type: "object"
+      properties:
+        id:
+          type: "integer"
+          format: "int64"
+        name:
+          type: "string"
+          description: "User name"
+        status:
+          type: "string"
+          enum:
+          - "ACTIVE"
+          - "INACTIVE"
+          x-enumDescriptions:
+            ACTIVE: "Active user"
+            INACTIVE: "Inactive user"
+      required:
+      - "id"
+      - "name"

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.minimalJson.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.minimalJson.txt
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.minimalYaml.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.minimalYaml.txt
@@ -1,0 +1,11 @@
+openapi: "3.0.3"
+info:
+  title: "API"
+  version: "1.0.0"
+paths:
+  /users:
+    get:
+      operationId: "listUsers"
+      responses:
+        "204":
+          description: "No content"

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.withSchemaJson.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.withSchemaJson.txt
@@ -1,0 +1,68 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "post": {
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "description": "User name"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ],
+            "x-enumDescriptions": {
+              "ACTIVE": "Active user",
+              "INACTIVE": "Inactive user"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.withSchemaYaml.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.channel.openapi.OpenApiSerializerTest.withSchemaYaml.txt
@@ -1,0 +1,43 @@
+openapi: "3.0.3"
+info:
+  title: "API"
+  version: "1.0.0"
+paths:
+  /users:
+    post:
+      operationId: "createUser"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        required: false
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: "object"
+      properties:
+        id:
+          type: "integer"
+          format: "int64"
+        name:
+          type: "string"
+          description: "User name"
+        status:
+          type: "string"
+          enum:
+          - "ACTIVE"
+          - "INACTIVE"
+          x-enumDescriptions:
+            ACTIVE: "Active user"
+            INACTIVE: "Inactive user"
+      required:
+      - "id"
+      - "name"

--- a/src/test/resources/springfox/documentation/service/ApiInfo.java
+++ b/src/test/resources/springfox/documentation/service/ApiInfo.java
@@ -1,0 +1,12 @@
+package springfox.documentation.service;
+
+/**
+ * Minimal stub of Springfox's {@code ApiInfo} class for config-extraction
+ * tests. The groovy extractor parses the constructor-arg literal from the
+ * source text of the @Bean method (e.g. {@code new ApiInfo("title", "desc",
+ * "version", ...)}) — the real ApiInfo class is never loaded.
+ */
+public class ApiInfo {
+    public ApiInfo(String title, String description, String version,
+                   String terms, String contact, String license, String licenseUrl) {}
+}

--- a/src/test/resources/springfox/documentation/spring/web/plugins/Docket.java
+++ b/src/test/resources/springfox/documentation/spring/web/plugins/Docket.java
@@ -1,0 +1,11 @@
+package springfox.documentation.spring.web.plugins;
+
+/**
+ * Minimal stub of Springfox's {@code Docket} class for config-extraction
+ * tests. The groovy extractor only inspects the {@code @Bean} method's
+ * declared return type name (must end with "Docket") and the method body
+ * text — neither requires the real Springfox implementation.
+ */
+public class Docket {
+    public Docket() {}
+}


### PR DESCRIPTION
## Summary

Adds a built-in export channel (`openapi`) that converts HTTP `ApiEndpoint`s produced by the existing pipeline into an [OpenAPI Specification (OAS) 3.0.3](https://spec.openapis.org/oas/v3.0.3) document, serializable as either JSON (via Gson) or YAML (via Jackson `YAMLMapper` + SnakeYAML 1.33).

This is a new channel implementation that reuses the neutral `core.export` pipeline (`ApiEndpoint`, `HttpMetadata`, `ObjectModel`) and the existing `Channel` SPI — no changes to the pipeline or to sibling channels.

**Disabled by default** — the user opts in via Settings → General → "Export Channels".

## What changes

### Production code (`src/main/kotlin/com/itangcent/easyapi/channel/openapi/`)
- **`OpenApiDocument.kt`** — OAS 3.0.3 data-class tree (`Info`, `Server`, `Tag`, `PathItem`, `Operation`, `Parameter`, `RequestBody`, `MediaType`, `Response`, `Components`, `Schema`) with `@SerializedName` / `@get:JsonProperty` aliases for reserved Kotlin identifiers (`$ref`, `enum`, `x-enumDescriptions`).
- **`PathNormalizer.kt`** — pure `object` converting Spring-style paths to OAS Path Templates (`{var}` form, deduplicated leading slash, empty path → `/`).
- **`OperationIdResolver.kt`** — pure `object` producing document-unique operationIds with `_N` suffix on collision.
- **`OpenApiSchemaConverter.kt`** — cycle-safe `ObjectModel` → `SchemaObject` converter using immutable pass-by-copy `seenIds: LinkedHashSet<Int>`, `_N` suffix on schema-name collisions.
- **`OpenApiFormatter.kt`** — thin orchestrator: `List<ApiEndpoint> + OpenApiConfig → OpenApiDocument`. Handles path collapse, tag resolution, parameter mapping, request body (multipart / form-urlencoded / JSON), responses, gRPC skip.
- **`OpenApiSerializer.kt`** — `object` with `toJson(doc)` (Gson pretty, NON_NULL, `serializeNulls=false`) and `toYaml(doc)` (Jackson `YAMLMapper` with `NON_NULL`, no `---` marker).
- **`OpenApiConfig.kt`** — `data class` extending `ChannelConfig`; embeds `OpenApiOutputFormat` enum (JSON / YAML).
- **`OpenApiSettings.kt`** — `data class` with `@StorageScope(Scope.APPLICATION)` on every field; all fields `var` for settings round-trip. Includes `outputFormat` persistent setting.
- **`OpenApiRuleKeys.kt`** — `object` mirroring `HoppscotchRuleKeys`: `OPENAPI_HOST`, `OPENAPI_FORMAT_AFTER`.
- **`OpenApiExportMetadata.kt`** — implements `ExportMetadata.formatDisplay()` returning `"Format: JSON"` / `"Format: YAML"`.
- **`OpenApiChannel.kt`** — `Channel` impl with `IdeaLog`; `enabledByDefault = false`; gRPC filter → `OpenApiFormatter.format` → `OpenApiSerializer.to{Json,Yaml}` → file save via `IdeDispatchers.background` → success dialog via `IdeDispatchers.swing`. Config is built inside `export()` (matching the convention used by all other channels) with the fallback chain: options panel > persistent settings > built-in defaults. The `outputFormat` setting is respected on the quick-export path (when no options panel is shown).
- **`OpenApiOptionsPanel.kt`** — `ChannelOptionsPanel` with JSON/YAML radio + title/version/server fields.
- **`OpenApiSettingsPanel.kt`** — `SettingsPanel<Settings>`.

### Infrastructure
- **`build.gradle.kts`** — adds `jackson-dataformat-yaml:2.12.2` and `snakeyaml:1.33` (SnakeYAML override pins to a non-vulnerable release; serialization-only usage is unaffected by CVE-2022-1471).
- **`src/main/resources/META-INF/plugin.xml`** — single new line under `<extensions defaultExtensionNs="com.itangcent.idea.plugin.easy-api">`:
  ```xml
  <channel implementation="com.itangcent.easyapi.channel.openapi.OpenApiChannel"/>
  ```

### Docs
- **`README.md`** — added OpenAPI *(Beta)* to the API Export table, "How to Export APIs" instructions, built-in channels list, and package structure tree.
- **`docs/developer/channels.md`** — added OpenApiChannel to the "6 built-in channels" table.
- **`AGENTS.md`** — added `openapi/` to the channel package tree.

### Tests (`src/test/kotlin/com/itangcent/easyapi/channel/openapi/`)
15 new test files (≈ 2500 lines) covering each unit:
- `OpenApiDocumentTest`, `PathNormalizerTest`, `OperationIdResolverTest`, `OpenApiSchemaConverterTest` (incl. self-referential `Node` cycle), `OpenApiFormatterTest` (13 golden-file cases + 6 structural), `OpenApiSerializerTest` (byte-parity for JSON + YAML), `OpenApiConfigTest`, `OpenApiSettingsTest` (with `@StorageScope` + `var` reflection check), `OpenApiRuleKeysTest` (disjoint from `core.rule.RuleKeys`), `OpenApiExportMetadataTest`, `OpenApiChannelTest` (17 tests incl. 3 new settings-outputFormat fallback tests), `OpenApiOptionsPanelTest`, `OpenApiSettingsPanelTest`, `OpenApiChannelRegistrationTest` (integration smoke via `ChannelRegistry`), `OpenApiYamlDependencyTest`.

### Logging-discipline gate
- **`src/test/kotlin/com/itangcent/easyapi/core/logging/AntiPatternGateTest.kt`** — new `openApiChannelAdheresToLoggingAntiPatternRules` test scans `channel/openapi/*.kt` for forbidden patterns (`LOG.error`, `LOG.debug`, `LOG.trace`, `println`, `printStackTrace`, `runCatching{}.getOrNull()` without log).

### Golden fixtures (`src/test/resources/result/`)
19 new `.txt` fixtures loaded via `ResultLoader.load()` (CRLF→LF collapsed) and `ResourceLoader.readRaw()` (byte-strict) per the AGENTS.md cross-platform golden-file rule.

## Scope

- **DAG compliant** — `channel/openapi/` imports only from `channel.spi.*`, `format.spi.*`, `core.*`, and standard/third-party libraries. No imports from `framework.*` or sibling `channel.<id>.*` packages.
- **Logging discipline** — `IdeaLog` interface; `LOG.info` / `LOG.warn` only (never `LOG.error`/`debug`/`trace` per AGENTS.md §"Anti-patterns"). CI gate enforced by `AntiPatternGateTest`.
- **No changes to the neutral pipeline** — `core.export.*` is consumed unchanged; `ApiEndpoint`, `HttpMetadata`, `ObjectModel` are read-only from the channel's perspective.
- **No changes to existing channels** — Postman, Markdown, cURL, Hoppscotch, HTTP Client untouched.

## How to test

1. **Unit tests**
   ```bash
   ./gradlew test --tests "com.itangcent.easyapi.channel.openapi.*"
   ```
   Expected: 150 OpenAPI-channel tests pass.

2. **Anti-pattern gate**
   ```bash
   ./gradlew test --tests "com.itangcent.easyapi.core.logging.AntiPatternGateTest"
   ```
   Expected: `openApiChannelAdheresToLoggingAntiPatternRules` passes.

3. **Build the plugin**
   ```bash
   ./gradlew build buildPlugin
   ```

4. **Manual smoke test** (optional)
   - `./gradlew runIde`
   - Enable the OpenAPI channel in Settings → General → "Export Channels"
   - Open a Spring MVC project with `@RestController` classes
   - Run the "Export APIs" action and select "OpenAPI"
   - Choose JSON or YAML, set title/version/server, save to `.json`/`.yaml`
   - Verify the output validates against the [OpenAPI 3.0.3 schema](https://validator.swagger.io/).