### PR TITLE
feat: add custom framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Convert class fields to various formats:
 | **Languages** | Java, Kotlin, Scala (optional), Groovy (optional) |
 | **Web Frameworks** | Spring MVC, Spring Cloud OpenFeign, JAX-RS (Quarkus / Jersey) |
 | **RPC** | gRPC |
+| **Custom** | Rules-driven framework for any annotation convention (opt-in) |
 | **Validation** | javax.validation / Jakarta Validation |
 | **Serialization** | Jackson, Gson |
 | **API Docs** | Swagger / OpenAPI annotations |
@@ -114,6 +115,19 @@ Support for gRPC service implementations:
 - Request/response protobuf message type resolution
 - Server reflection support
 - Stub class resolution
+
+### Custom
+
+A rules-driven framework for any annotation convention not covered by the
+built-ins (proprietary RPC-over-HTTP frameworks, non-standard annotation
+sets, etc.). Every extraction decision — which classes are APIs, which
+methods are endpoints, HTTP method, path, parameter binding — is delegated
+to a unified `custom.*` rule surface. Disabled by default; enable it in
+Settings → Framework Support and supply extraction rules in your
+`.yapi.config` / rules file. This is the v3.0 replacement for the v2.x
+`mdoc.class.filter` / `mdoc.method.filter` "generic export" keys (issue
+#1423). See the [Custom Framework guide](docs/developer/custom-framework.md)
+for the full rule surface and a Spring-equivalent reference ruleset.
 
 ## How to Use
 
@@ -233,7 +247,7 @@ graph TB
 ```
 
 - **ExportOrchestrator** — Coordinates the full export pipeline: scans endpoints via `ApiScanner`, then hands them to the selected `Channel` for output
-- **ClassExporter** *(extension point)* — Extracts `ApiEndpoint` models from PSI classes; built-in implementations: Spring MVC, Spring Cloud OpenFeign, JAX-RS, Spring Actuator, gRPC
+- **ClassExporter** *(extension point)* — Extracts `ApiEndpoint` models from PSI classes; built-in implementations: Spring MVC, Spring Cloud OpenFeign, JAX-RS, Spring Actuator, gRPC, Custom (rules-driven)
 - **Channel** *(extension point)* — Converts `ApiEndpoint` models to an output format and handles file write / remote upload; built-in channels: Markdown, Postman, cURL, HTTP Client, Hoppscotch *(Beta)*, OpenAPI *(Beta)*. Adding a new output target only requires implementing `Channel` — no core edits
 - **ApiIndex** — Caches discovered endpoints for fast search and dashboard access
 - **RuleEngine** — Evaluates rule expressions (Groovy, regex, annotation, tag) to customize parsing behavior
@@ -261,11 +275,12 @@ com.itangcent.easyapi/
 │   ├── yaml/
 │   └── properties/
 │
-├── framework/    # INPUT — source framework exporters (Spring MVC, JAX-RS, Feign, gRPC)
+├── framework/    # INPUT — source framework exporters (Spring MVC, JAX-RS, Feign, gRPC, Custom)
 │   ├── springmvc/   # Spring MVC + Actuator
 │   ├── jaxrs/
 │   ├── feign/
-│   └── grpc/        # class exporter only — runtime plumbing is core/grpc
+│   ├── grpc/        # class exporter only — runtime plumbing is core/grpc
+│   └── custom/      # rules-driven framework (custom.* rule surface)
 │
 └── core/         # SHARED INFRASTRUCTURE (the umbrella)
     ├── internal/    # relocated narrow core/ (EasyApiApplicationService, EasyApiProjectService, event/, threading/)

--- a/docs/developer/custom-framework.md
+++ b/docs/developer/custom-framework.md
@@ -1,0 +1,196 @@
+# Custom Framework
+
+The **Custom** framework is a rules-driven source framework under
+`com.itangcent.easyapi.framework.custom` (id `"custom"`) whose entire
+extraction logic — class recognition, method recognition, HTTP method,
+path, and parameter binding — is driven by a unified `custom.*` rule
+surface. It is the v3.0 replacement for the v2.x `mdoc.class.filter` /
+`mdoc.method.filter` "generic export" subsystem that was dropped in the
+rewrite (issue #1423).
+
+Unlike the built-in frameworks (Spring MVC, JAX-RS, Feign, gRPC), the
+Custom framework performs **no hard-coded annotation detection**. Every
+extraction decision is delegated to a `custom.*` rule evaluated by the
+`RuleEngine`. It produces standard `ApiEndpoint` / `HttpMetadata`, so
+every existing output channel (Markdown, Postman, YApi, cURL, IntelliJ
+HTTP Client, Hoppscotch, OpenAPI) consumes its output natively with
+**zero channel-side changes**.
+
+## Enablement
+
+The Custom framework is **disabled by default** (`enabledByDefault = false`,
+matching Feign). Enable it via Settings → Framework Support → "custom",
+then supply extraction rules via your `.yapi.config` / rules file.
+
+### Line-marker toggle
+
+By default the Custom framework does **not** contribute gutter icons —
+rule-driven recognition is not cheap, and marking every class that happens
+to match a `custom.*` rule would surprise users. If you want gutter icons
+on classes recognized by your `custom.class.is.api` rule, opt in via
+Settings → EasyApi → Custom → "Enable line marker for Custom API classes".
+This flips `CustomSettings.enableLineMarker` to `true`, which makes
+`CustomApiRecognizer.matchesClass` return `true` (the line-marker
+fast-path). The toggle is read fresh from settings on each call, so
+toggling it off immediately disables the markers again.
+
+> The `matchesClass` contract forbids consulting the rule engine — so the
+> toggle is a coarse "claim every class for the line-marker provider"
+> switch, not a per-class rule evaluation. The line-marker provider then
+> proceeds to the more expensive per-method check via `ApiIndex` /
+> `isApiMethod` as usual.
+
+## The `custom.*` rule surface
+
+All 18 keys (13 extraction + 5 framework-scoped lifecycle) are declared in
+[`CustomRuleKeys`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleKeys.kt)
+(an `object` in the framework's own package, mirroring the
+`HoppscotchRuleKeys` / `OpenApiRuleKeys` pattern) so `RuleProvider.loadRules`
+resolves them (undeclared keys are silently dropped — the root cause of
+#1423). They are surfaced to the rule registry via
+`CustomApiRecognizer.ruleKeys()`, which `RuleKeyRegistry` consumes as its
+framework-specific source.
+
+### Extraction keys (13)
+
+| RuleKey constant | Config key | Type | Evaluated against | Returns |
+|---|---|---|---|---|
+| `CUSTOM_CLASS_IS_API` | `custom.class.is.api` | `BooleanKey` | `PsiClass` | `true` if the class is an API class |
+| `CUSTOM_METHOD_IS_API` | `custom.method.is.api` | `BooleanKey` | `PsiMethod` | `true` if the method is an endpoint |
+| `CUSTOM_HTTP_METHOD` | `custom.http.method` | `StringKey` | `PsiMethod` | HTTP verb (`GET`/`POST`/...) |
+| `CUSTOM_PATH` | `custom.path` | `StringKey` | `PsiClass` *or* `PsiMethod` | base path (class) / method path (method) |
+| `CUSTOM_PARAM_AS_JSON_BODY` | `custom.param.as.json.body` | `BooleanKey` | `PsiParameter` | `true` → bind as request body |
+| `CUSTOM_PARAM_AS_FORM_BODY` | `custom.param.as.form.body` | `BooleanKey` | `PsiParameter` | `true` → bind as form field |
+| `CUSTOM_PARAM_AS_PATH_VAR` | `custom.param.as.path.var` | `BooleanKey` | `PsiParameter` | `true` → bind as path variable |
+| `CUSTOM_PARAM_AS_COOKIE` | `custom.param.as.cookie` | `BooleanKey` | `PsiParameter` | `true` → bind as cookie |
+| `CUSTOM_PARAM_PATH_VAR` | `custom.param.path.var` | `StringKey` | `PsiParameter` | path-variable name override |
+| `CUSTOM_PARAM_HEADER` | `custom.param.header` | `StringKey` | `PsiParameter` | header name (when binding=header) |
+| `CUSTOM_PARAM_COOKIE` | `custom.param.cookie` | `StringKey` | `PsiParameter` | cookie name (when binding=cookie) |
+| `CUSTOM_PARAM_COOKIE_VALUE` | `custom.param.cookie.value` | `StringKey` | `PsiParameter` | cookie value override |
+| `CUSTOM_PARAM_NAME` | `custom.param.name` | `StringKey` | `PsiParameter` | parameter name override (query/form) |
+
+### Framework-scoped lifecycle keys (5)
+
+These `EventKey`s are fired by the Custom exporter **alongside** the
+corresponding shared hooks. The shared hook fires first, then the
+custom-specific hook, for each phase. They exist because the rule
+evaluation context does not expose the framework name to user-written
+rules — so a side-effect rule that must only run during Custom-framework
+extraction (e.g. when both the built-in Spring framework and the Custom
+framework are enabled simultaneously) has no other way to scope itself.
+
+| RuleKey constant | Config key | Fired alongside (shared) | Evaluated against |
+|---|---|---|---|
+| `CUSTOM_CLASS_PARSE_BEFORE` | `custom.class.parse.before` | `api.class.parse.before` | `PsiClass` |
+| `CUSTOM_CLASS_PARSE_AFTER` | `custom.class.parse.after` | `api.class.parse.after` | `PsiClass` |
+| `CUSTOM_METHOD_PARSE_BEFORE` | `custom.method.parse.before` | `api.method.parse.before` | `ResolvedMethod` |
+| `CUSTOM_METHOD_PARSE_AFTER` | `custom.method.parse.after` | `api.method.parse.after` | `ResolvedMethod` |
+| `CUSTOM_EXPORT_AFTER` | `custom.export.after` | `export.after` | `ResolvedMethod` (with `ctx.setExt("api", endpoint)`) |
+
+The Custom exporter also honors the shared keys read via
+`DocMetadataResolver`: `api.name`, `method.doc`, `class.doc`,
+`folder.name`, `param.ignore`, `param.name`, `param.doc`,
+`param.required`, `param.type`, `param.default.value`, `param.demo`,
+`param.mock`, `method.default.http.method`, `method.content.type`,
+`method.additional.header`, `method.additional.param`,
+`method.additional.response.header`, `class.prefix.path`,
+`endpoint.prefix.path`, and the shared lifecycle hooks
+(`api.class.parse.before`/`after`, `api.method.parse.before`/`after`,
+`api.param.parse.before`/`after`, `export.after`). The Custom framework
+fires its own `custom.*` lifecycle hooks alongside these (see above).
+
+### Parameter binding precedence
+
+1. Boolean classifiers (`custom.param.as.json.body`,
+   `custom.param.as.form.body`, `custom.param.as.path.var`,
+   `custom.param.as.cookie`) — most-specific wins.
+2. The coarser `param.http.type` classifier (`"body"`/`"form"`/
+   `"path"`/`"header"`/`"cookie"`/`"query"`).
+3. Default: `Query` (with an `IdeaConsole.info` note).
+
+### HTTP method fallback
+
+`custom.http.method` → `method.default.http.method` → `POST` (with an
+`IdeaConsole.info` note naming the method). The `POST` default matches
+the v2.x generic-export behavior.
+
+### Path composition
+
+Final path = `class.prefix.path` + class base path + method path +
+`endpoint.prefix.path`, joined with a single `/` and collapsing
+duplicate slashes. The class base path comes from evaluating
+`custom.path` against the `PsiClass`; the method path from evaluating
+`custom.path` against the `PsiMethod`. The rule context exposes
+`it.contextType()` (returning `"class"` vs `"method"`) so a single rule
+body can branch.
+
+## Worked example — Spring-equivalent reference ruleset
+
+The file
+[`custom-spring-reference.rules`](custom-spring-reference.rules)
+reimplements Spring MVC recognition and extraction using **only**
+`custom.*` keys (plus the shared `method.default.http.method` and
+`param.http.type` keys). It is both a learning aid and the proof that
+the Custom framework can express arbitrary conventions.
+
+To use it: enable the Custom framework in Settings → Framework Support,
+then copy the ruleset's contents into your `.yapi.config` / rules file
+(or `###include` it).
+
+The parity test
+([`CustomSpringReferenceParityTest`](../../src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomSpringReferenceParityTest.kt))
+exercises the ruleset against a Spring sample and compares the output
+to the built-in Spring MVC exporter. It asserts structural equality on
+the load-bearing HTTP facts (method, path, parameter bindings,
+Content-Type, response type, body presence, header set) with a small,
+documented set of tolerances (default HTTP method when Spring omits
+one; header/parameter ordering; path normalization edge cases).
+
+## Migration from v2.x `mdoc.*` keys (#1423)
+
+The v2.x `mdoc.class.filter` / `mdoc.method.filter` keys were dropped in
+the v3.0 rewrite and now fail silently. The migration path:
+
+| v2.x key | v3.0 Custom framework key |
+|---|---|
+| `mdoc.class.filter=groovy:it.hasAnn("xxx")` | `custom.class.is.api=groovy:it.hasAnn("xxx")` |
+| `mdoc.method.filter=groovy:it.hasAnn("yyy")` | `custom.method.is.api=groovy:it.hasAnn("yyy")` |
+
+The `mdoc.*` keys are **not** reintroduced (NFR-5: unified rule
+surface). The `custom.*` surface is strictly more capable: it also
+covers HTTP method, path, and parameter binding — none of which the
+`mdoc.*` keys addressed.
+
+## Implementation
+
+All Custom-framework code lives under
+`src/main/kotlin/com/itangcent/easyapi/framework/custom/`:
+
+- [`CustomRuleKeys`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleKeys.kt)
+  — `object` declaring the 18 `custom.*` keys (13 extraction + 5
+  framework-scoped lifecycle; mirrors the `HoppscotchRuleKeys` /
+  `OpenApiRuleKeys` pattern). Surfaced to `RuleKeyRegistry` via
+  `CustomApiRecognizer.ruleKeys()`.
+- [`CustomApiRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomApiRecognizer.kt)
+  — rule-driven class recognition (`frameworkName = "custom"`,
+  `targetAnnotations = emptySet()`, `enabledByDefault = false`).
+  `matchesClass` is gated by `CustomSettings.enableLineMarker` (default
+  `false`); `createSettingsPanel(project)` contributes the Custom settings
+  tab via the general `SettingsPanelProvider` contract, but returns `null`
+  when the framework is disabled (no panel for a disabled feature).
+- [`CustomClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporter.kt)
+  — rule-driven endpoint extraction with the full rule lifecycle
+  (shared + framework-scoped `custom.*` class/method parse hooks,
+  `EXPORT_AFTER` + `CUSTOM_EXPORT_AFTER`), threading model (all PSI
+  access under read actions, hooks under `IdeDispatchers.Background`),
+  and shared-infrastructure reuse (`DocMetadataResolver`,
+  `EndpointBuilder`, `RuleEngine`, `FrameworkRegistry`, `ResolvedType`).
+- [`CustomSettings`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomSettings.kt)
+  — `data class` persisting the `enableLineMarker` toggle via the unified
+  `UnifiedAppSettingsState` (APPLICATION scope; no per-module state class
+  or `plugin.xml` registration needed).
+- [`CustomSettingsPanel`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomSettingsPanel.kt)
+  — self-contained `SettingsPanel` with the `enableLineMarker` checkbox.
+  Reads/writes `CustomSettings` via `SettingBinder` internally (mirrors
+  `HoppscotchSettingsPanel`), ignoring the `Settings` arg passed to
+  `resetFrom` / `applyTo` / `isModified`.

--- a/docs/developer/custom-spring-reference.rules
+++ b/docs/developer/custom-spring-reference.rules
@@ -1,0 +1,63 @@
+# Custom Framework — Spring MVC Reference Ruleset
+#
+# This file reimplements Spring MVC recognition/extraction using ONLY
+# `custom.*` rules (plus the shared `method.default.http.method` and
+# `param.http.type` keys that the Custom exporter reads via
+# DocMetadataResolver). It is both:
+#   1. A learning aid — copy any rule block into your own .yapi.config
+#      and adapt it to your custom convention.
+#   2. The completeness proof that the Custom framework can express
+#      arbitrary annotation conventions.
+#
+# Migration target for issue #1423 (v2.x `mdoc.class.filter` /
+# `mdoc.method.filter` keys dropped in the v3.0 rewrite):
+#   mdoc.class.filter=groovy:it.hasAnn("xxx")
+#     -> custom.class.is.api=groovy:it.hasAnn("xxx")
+#   mdoc.method.filter=groovy:it.hasAnn("yyy")
+#     -> custom.method.is.api=groovy:it.hasAnn("yyy")
+#
+# To use: enable Settings -> Framework Support -> "custom", then drop
+# this file (or its contents) into your .yapi.config / rules file.
+
+# ── Class recognition ──────────────────────────────────────────
+# A class is a Spring MVC controller iff it carries @Controller or
+# @RestController (directly or as a meta-annotation).
+custom.class.is.api=groovy:it.hasAnn("org.springframework.stereotype.Controller") || it.hasAnn("org.springframework.web.bind.annotation.RestController")
+
+# ── Method recognition ────────────────────────────────────────
+# A method is an endpoint iff it carries a Spring mapping annotation
+# (@RequestMapping or any composed @*Mapping).
+custom.method.is.api=groovy:it.hasAnn("org.springframework.web.bind.annotation.RequestMapping") || it.hasAnn("org.springframework.web.bind.annotation.GetMapping") || it.hasAnn("org.springframework.web.bind.annotation.PostMapping") || it.hasAnn("org.springframework.web.bind.annotation.PutMapping") || it.hasAnn("org.springframework.web.bind.annotation.DeleteMapping") || it.hasAnn("org.springframework.web.bind.annotation.PatchMapping")
+
+# ── HTTP method ────────────────────────────────────────────────
+# Composed mappings carry the verb directly; @RequestMapping with no
+# method attribute falls back to method.default.http.method (GET here,
+# matching Spring's convention). The Custom framework defaults to POST
+# when neither custom.http.method nor method.default.http.method
+# resolves — see docs/developer/custom-framework.md.
+method.default.http.method=GET
+custom.http.method=groovy:it.hasAnn("org.springframework.web.bind.annotation.GetMapping") ? "GET" : it.hasAnn("org.springframework.web.bind.annotation.PostMapping") ? "POST" : it.hasAnn("org.springframework.web.bind.annotation.PutMapping") ? "PUT" : it.hasAnn("org.springframework.web.bind.annotation.DeleteMapping") ? "DELETE" : it.hasAnn("org.springframework.web.bind.annotation.PatchMapping") ? "PATCH" : it.hasAnn("org.springframework.web.bind.annotation.RequestMapping") ? (it.ann("org.springframework.web.bind.annotation.RequestMapping", "method") ?: "") : ""
+
+# ── Path ────────────────────────────────────────────────────────
+# custom.path is context-sensitive: it.contextType() returns "class"
+# or "method", so a single rule body can branch. Reads @RequestMapping's
+# "value"/"path" attribute (Spring treats these as aliases). For
+# methods, checks each composed @*Mapping in turn.
+custom.path=groovy:it.contextType() == "class" ? (it.ann("org.springframework.web.bind.annotation.RequestMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestMapping", "path") ?: "") : it.contextType() == "method" ? (it.ann("org.springframework.web.bind.annotation.GetMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.GetMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.PostMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.PostMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.PutMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.PutMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.DeleteMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.DeleteMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.PatchMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.PatchMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.RequestMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestMapping", "path") ?: "") : ""
+
+# ── Parameter binding ──────────────────────────────────────────
+custom.param.as.json.body=groovy:it.hasAnn("org.springframework.web.bind.annotation.RequestBody")
+custom.param.as.form.body=groovy:it.hasAnn("org.springframework.web.bind.annotation.ModelAttribute") || it.hasAnn("org.springframework.web.bind.annotation.RequestPart")
+custom.param.as.path.var=groovy:it.hasAnn("org.springframework.web.bind.annotation.PathVariable")
+custom.param.as.cookie=groovy:it.hasAnn("org.springframework.web.bind.annotation.CookieValue")
+
+# Header binding is detected by @RequestHeader via param.http.type as
+# the coarser classifier; @RequestParam maps to query.
+param.http.type=groovy:it.hasAnn("org.springframework.web.bind.annotation.RequestHeader") ? "header" : it.hasAnn("org.springframework.web.bind.annotation.RequestParam") ? "query" : ""
+
+# ── Parameter name overrides ───────────────────────────────────
+custom.param.path.var=groovy:it.ann("org.springframework.web.bind.annotation.PathVariable", "value") ?: it.ann("org.springframework.web.bind.annotation.PathVariable", "name") ?: ""
+custom.param.header=groovy:it.ann("org.springframework.web.bind.annotation.RequestHeader", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestHeader", "name") ?: ""
+custom.param.cookie=groovy:it.ann("org.springframework.web.bind.annotation.CookieValue", "value") ?: it.ann("org.springframework.web.bind.annotation.CookieValue", "name") ?: ""
+custom.param.cookie.value=groovy:it.ann("org.springframework.web.bind.annotation.CookieValue", "defaultValue") ?: ""
+custom.param.name=groovy:it.ann("org.springframework.web.bind.annotation.RequestParam", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestParam", "name") ?: ""

--- a/docs/developer/frameworks.md
+++ b/docs/developer/frameworks.md
@@ -11,7 +11,7 @@ Adding a new one is a one-package operation plus **two** `plugin.xml` lines.
 ## When to write a framework
 
 Write a framework when you have a new **source framework** that declares API
-endpoints in source code. The 5 built-in frameworks:
+endpoints in source code. The 6 built-in frameworks:
 
 | Framework | Recognizer | Exporter | `enabledByDefault` |
 |-----------|------------|-----------|--------------------|
@@ -20,6 +20,11 @@ endpoints in source code. The 5 built-in frameworks:
 | JAX-RS | [`JaxRsResourceRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsResourceRecognizer.kt) | [`JaxRsClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsClassExporter.kt) | `true` |
 | Feign | [`FeignClientRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/feign/FeignClientRecognizer.kt) | [`FeignClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/feign/FeignClassExporter.kt) | `false` |
 | gRPC | [`GrpcServiceRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/grpc/GrpcServiceRecognizer.kt) | [`GrpcClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/grpc/GrpcClassExporter.kt) | `true` |
+| Custom | [`CustomApiRecognizer`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomApiRecognizer.kt) | [`CustomClassExporter`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporter.kt) | `false` |
+
+The Custom framework is rules-driven (no hard-coded annotation detection)
+— see [`custom-framework.md`](custom-framework.md) for the rule surface
+and the Spring-equivalent reference ruleset.
 
 If you need to *export `ApiEndpoint`s* (already extracted by a framework
 exporter) to a new destination, that's a [channel](channels.md).
@@ -74,6 +79,8 @@ The full contract lives in
 | `isEnabled(project)` | `fun → Boolean` | `true` | Per-project state gate (e.g. annotation presence); AND-combined with `FrameworkRegistry`. |
 | `enabledByDefault` | `Boolean` | `true` | Compile-time enablement default. |
 | `matchesClass(psiClass)` | `fun → Boolean` | `false` | Per-class fast-path for line markers. **MUST NOT consult the rule engine.** |
+| `ruleKeys()` | `fun → List<RuleKey<*>>` | `emptyList()` | Contributes framework-specific rule keys to `RuleKeyRegistry` (surfaced to AI tools / `RuleProposalValidator`). See `CustomRuleKeys` for the pattern. |
+| `createSettingsPanel(project)` | `fun → SettingsPanel<*>?` | `null` | Contributes a settings tab to the EasyApi settings dialog (from the `SettingsPanelProvider` contract, shared with `Channel` and `FieldFormatChannel`). |
 
 Constructor signature (EP instantiates with no-arg — recognizers receive
 their dependencies via constructor parameters with defaults):
@@ -96,10 +103,17 @@ settings-change events and rebuilds its cache).
 NOT consult the rule engine (which is consulted only in `isApiClass`).
 Default `false` is correct for annotation-driven frameworks (Spring MVC,
 JAX-RS, Feign, Actuator — `isApiClass` already returns `false` quickly for
-non-matching classes). Only gRPC overrides this, because its
-`extends BindableService` walk is a per-class fast-path the line marker
-needs. See
-[`GrpcServiceRecognizer.matchesClass`](../../src/main/kotlin/com/itangcent/easyapi/framework/grpc/GrpcServiceRecognizer.kt#L52-L55).
+non-matching classes). Two frameworks override it:
+
+- **gRPC** — its `extends BindableService` walk is a per-class fast-path
+  the line marker needs. See
+  [`GrpcServiceRecognizer.matchesClass`](../../src/main/kotlin/com/itangcent/easyapi/framework/grpc/GrpcServiceRecognizer.kt#L52-L55).
+- **Custom** — gated by a settings toggle (`CustomSettings.enableLineMarker`,
+  default `false`). When the user opts in, `matchesClass` returns `true`
+  so the line-marker provider claims Custom API classes without consulting
+  the rule engine. See
+  [`CustomApiRecognizer.matchesClass`](../../src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomApiRecognizer.kt#L76-L78)
+  and [custom-framework.md → Line-marker toggle](custom-framework.md#line-marker-toggle).
 
 Getting this wrong regresses line-marker behavior — rule-engine overrides
 would otherwise cause non-gRPC classes to be marked as gRPC services by the

--- a/src/main/kotlin/com/itangcent/easyapi/channel/spi/Channel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/spi/Channel.kt
@@ -9,6 +9,7 @@ import com.itangcent.easyapi.core.export.isHttp
 import com.itangcent.easyapi.core.rule.RuleKey
 import com.itangcent.easyapi.core.settings.Settings
 import com.itangcent.easyapi.core.settings.ui.SettingsPanel
+import com.itangcent.easyapi.core.settings.ui.SettingsPanelProvider
 import kotlin.reflect.KClass
 
 /**
@@ -41,7 +42,7 @@ import kotlin.reflect.KClass
  * @see ChannelRegistry for the registry that discovers and filters channels
  * @see ChannelConfig for channel-specific configuration
  */
-interface Channel {
+interface Channel : SettingsPanelProvider {
 
     /** Unique identifier for this channel (e.g. "markdown", "postman", "curl"). */
     val id: String
@@ -128,7 +129,7 @@ interface Channel {
      * via [com.itangcent.easyapi.core.settings.SettingBinder] internally, so the
      * return type uses star projection ([SettingsPanel<*>?]).
      */
-    fun createSettingsPanel(project: Project): SettingsPanel<*>? = null
+    override fun createSettingsPanel(project: Project): SettingsPanel<*>? = null
 
     /**
      * Config-file names this channel contributes to the extension-config

--- a/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/export/recognizer/ApiClassRecognizer.kt
@@ -2,6 +2,8 @@ package com.itangcent.easyapi.core.export.recognizer
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.rule.RuleKey
+import com.itangcent.easyapi.core.settings.ui.SettingsPanelProvider
 
 /**
  * Recognizes whether a [PsiClass] is an API class for a specific framework.
@@ -15,8 +17,15 @@ import com.intellij.psi.PsiClass
  * extension point (declared in `plugin.xml`). The [CompositeApiClassRecognizer] iterates
  * EP-discovered instances and filters by [isEnabled] — so framework recognizers
  * no longer need to be hard-imported by `core.*` (DAG rule CO3).
+ *
+ * ## Settings panel
+ *
+ * Implements [SettingsPanelProvider] so frameworks can optionally contribute a
+ * dedicated tab to the EasyApi settings dialog (e.g. the Custom framework's
+ * `enableLineMarker` toggle). The default implementation returns `null` (no
+ * panel) — most frameworks don't need a settings tab of their own.
  */
-interface ApiClassRecognizer {
+interface ApiClassRecognizer : SettingsPanelProvider {
 
     /**
      * The framework name this recognizer covers (for logging/debugging).
@@ -66,6 +75,22 @@ interface ApiClassRecognizer {
      * In-tree recognizers that are default-off (Feign, Actuator) override to `false`.
      */
     val enabledByDefault: Boolean get() = true
+
+    /**
+     * Framework-specific [RuleKey]s contributed by this recognizer (e.g.
+     * the Custom framework's `custom.*` keys).
+     *
+     * Keys already declared in [com.itangcent.easyapi.core.rule.RuleKeys] (the
+     * shared general set) must NOT be repeated here — return only the keys
+     * that live in this framework's own package. Returns an empty list by
+     * default for frameworks with no additional rule keys.
+     *
+     * Mirrors [com.itangcent.easyapi.channel.spi.Channel.ruleKeys]. Consumed by
+     * [com.itangcent.easyapi.core.rule.RuleKeyRegistry] so the AI tooling
+     * (`list_rule_keys`) and `RuleProposalValidator` see a complete picture
+     * across the general set, channels, and frameworks.
+     */
+    fun ruleKeys(): List<RuleKey<*>> = emptyList()
 
     /**
      * Returns true if [psiClass] is recognized as a framework class *without*

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistry.kt
@@ -4,11 +4,12 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.channel.spi.ChannelRegistry
+import com.itangcent.easyapi.core.export.recognizer.CompositeApiClassRecognizer
 
 /**
  * Project-level registry of every rule key known to the plugin.
  *
- * Single source of truth that combines three sources:
+ * Single source of truth that combines four sources:
  *
  * 1. **General/shared keys** — declared in [RuleKeys], reflected via [RuleKey.collectFrom].
  * 2. **Channel-specific keys** — contributed by each registered
@@ -16,7 +17,11 @@ import com.itangcent.easyapi.channel.spi.ChannelRegistry
  *    [com.itangcent.easyapi.channel.spi.Channel.ruleKeys]. The channel
  *    mix differs per repo (easy-api registers hoppscotch; easy-yapi registers
  *    yapi), so the registry's output reflects whichever channels are loaded.
- * 3. **Implicit keys** — read by name via `configReader.getFirst("…")`
+ * 3. **Framework-specific keys** — contributed by each registered
+ *    [com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer] via
+ *    [com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer.ruleKeys]
+ *    (e.g. the Custom framework's `custom.*` keys). Mirrors the channel source.
+ * 4. **Implicit keys** — read by name via `configReader.getFirst("…")`
  *    somewhere in the codebase but not declared as a [RuleKey] constant.
  *    Enumerated in [IMPLICIT_KEY_NAMES] so [RuleProposalValidator] and
  *    [com.itangcent.easyapi.core.ai.tools.ListRuleKeysTool] surface them too.
@@ -24,6 +29,7 @@ import com.itangcent.easyapi.channel.spi.ChannelRegistry
  * ## Sources consumed
  * - [RuleKeys] (general)
  * - [ChannelRegistry.allChannels] → [com.itangcent.easyapi.channel.spi.Channel.ruleKeys]
+ * - [CompositeApiClassRecognizer.allRecognizers] → [com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer.ruleKeys]
  * - [IMPLICIT_KEY_NAMES] (static)
  *
  * ## Consumers
@@ -47,7 +53,8 @@ class RuleKeyRegistry(private val project: Project) {
      *
      * @param key the underlying [RuleKey]
      * @param source `"general"` for [RuleKeys]; the channel id (e.g.
-     *     `"hoppscotch"`, `"yapi"`) for channel-specific keys; `"implicit"`
+     *     `"hoppscotch"`, `"yapi"`) for channel-specific keys; the framework
+     *     name (e.g. `"custom"`) for framework-specific keys; `"implicit"`
      *     for keys read by name only.
      */
     data class RuleKeyInfo(
@@ -56,14 +63,19 @@ class RuleKeyRegistry(private val project: Project) {
     )
 
     /**
-     * All known rule keys (general + channel + implicit), de-duplicated by
-     * primary name. General keys take precedence over channel/implicit keys
-     * with the same name (a channel should not re-declare a general key, but
-     * the guard prevents confusing duplicates if one slips in).
+     * All known rule keys (general + channel + framework + implicit),
+     * de-duplicated by primary name. General keys take precedence over
+     * channel/framework/implicit keys with the same name (a channel or
+     * framework should not re-declare a general key, but the guard prevents
+     * confusing duplicates if one slips in).
      */
-    fun allKeys(): List<RuleKeyInfo> = assembleKeys(
-        ChannelRegistry.getInstance(project).allChannels().map { it.id to it.ruleKeys() }
-    )
+    fun allKeys(): List<RuleKeyInfo> {
+        val channelKeys = ChannelRegistry.getInstance(project)
+            .allChannels().map { it.id to it.ruleKeys() }
+        val frameworkKeys = CompositeApiClassRecognizer.getInstance(project)
+            .allRecognizers().map { it.frameworkName to it.ruleKeys() }
+        return assembleKeys(channelKeys, frameworkKeys)
+    }
 
     /**
      * The set of every known rule key name (primary + aliases), for O(1)
@@ -103,16 +115,21 @@ class RuleKeyRegistry(private val project: Project) {
         )
 
         /**
-         * Pure assembly of the rule-key catalog from three sources:
+         * Pure assembly of the rule-key catalog from four sources:
          * 1. [RuleKeys] (reflected via [RuleKey.collectFrom])
          * 2. [channelKeys] — pairs of `(channelId, keys)` from each registered channel
-         * 3. [IMPLICIT_KEYS]
+         * 3. [frameworkKeys] — pairs of `(frameworkName, keys)` from each registered framework
+         * 4. [IMPLICIT_KEYS]
          *
          * Extracted from [allKeys] so it can be unit-tested without a real
-         * IntelliJ [Project] (the only project dependency is
-         * [ChannelRegistry], which the caller supplies via [channelKeys]).
+         * IntelliJ [Project] (the only project dependencies are
+         * [ChannelRegistry] and [CompositeApiClassRecognizer], which the
+         * caller supplies via [channelKeys] / [frameworkKeys]).
          */
-        internal fun assembleKeys(channelKeys: List<Pair<String, List<RuleKey<*>>>>): List<RuleKeyInfo> {
+        internal fun assembleKeys(
+            channelKeys: List<Pair<String, List<RuleKey<*>>>>,
+            frameworkKeys: List<Pair<String, List<RuleKey<*>>>> = emptyList()
+        ): List<RuleKeyInfo> {
             val seen = HashSet<String>()
             val result = mutableListOf<RuleKeyInfo>()
 
@@ -120,6 +137,11 @@ class RuleKeyRegistry(private val project: Project) {
                 if (seen.add(key.name)) result.add(RuleKeyInfo(key, SOURCE_GENERAL))
             }
             channelKeys.forEach { (source, keys) ->
+                keys.forEach { key ->
+                    if (seen.add(key.name)) result.add(RuleKeyInfo(key, source))
+                }
+            }
+            frameworkKeys.forEach { (source, keys) ->
                 keys.forEach { key ->
                     if (seen.add(key.name)) result.add(RuleKeyInfo(key, source))
                 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/EasyApiSettingsConfigurable.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/EasyApiSettingsConfigurable.kt
@@ -42,6 +42,18 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
     // as self-contained (their applyTo/resetFrom are no-ops).
     private val channelPanels = mutableListOf<ChannelPanelEntry>()
 
+    // Framework panels are dynamically contributed via the apiClassRecognizer EP
+    // (each [ApiClassRecognizer] that returns a non-null [SettingsPanelProvider.createSettingsPanel]
+    // gets a tab). Framework panels are self-contained — they read/write their
+    // own modules via [SettingBinder] internally (mirroring the Hoppscotch panel
+    // pattern), so the [Channel.settingsType] hint is not needed here.
+    private val frameworkPanels = mutableListOf<SettingsPanel<Settings>>()
+
+    // Field-format panels are dynamically contributed via the fieldFormatChannel EP
+    // (each [FieldFormatChannel] that returns a non-null [SettingsPanelProvider.createSettingsPanel]
+    // gets a tab). Same self-contained pattern as framework panels.
+    private val formatPanels = mutableListOf<SettingsPanel<Settings>>()
+
     /** No-op module for self-contained panels whose applyTo is a no-op. */
     private val noopModule = object : Settings {}
 
@@ -82,6 +94,8 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
         if (panel == null) {
             panel = JPanel(BorderLayout())
             channelPanels.clear()
+            frameworkPanels.clear()
+            formatPanels.clear()
             tabs = JTabbedPane().also { t ->
                 t.addTab(TAB_GENERAL, wrapNorth(generalPanel.component))
                 t.addTab(TAB_FEATURES, wrapNorth(featuresPanel.component))
@@ -102,6 +116,29 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
                         channelPanels.add(
                             ChannelPanelEntry(pnl as SettingsPanel<Settings>, channel.settingsType)
                         )
+                    }
+                }
+
+                // Dynamically add a tab for each framework recognizer that
+                // contributes a settings panel (e.g. the Custom framework's
+                // `enableLineMarker` toggle). Framework panels are self-contained.
+                CompositeApiClassRecognizer.getInstance(project).allRecognizers().forEach { recognizer ->
+                    recognizer.createSettingsPanel(project)?.let { pnl ->
+                        val name = recognizer.frameworkName.replaceFirstChar { it.uppercase() }
+                        t.addTab(name, wrapNorth(pnl.component))
+                        @Suppress("UNCHECKED_CAST")
+                        frameworkPanels.add(pnl as SettingsPanel<Settings>)
+                    }
+                }
+
+                // Dynamically add a tab for each field-format channel that
+                // contributes a settings panel. Same self-contained pattern.
+                FieldFormatChannelRegistry.getInstance(project).allChannels().forEach { format ->
+                    format.createSettingsPanel(project)?.let { pnl ->
+                        val name = format.id.replaceFirstChar { it.uppercase() }
+                        t.addTab(name, wrapNorth(pnl.component))
+                        @Suppress("UNCHECKED_CAST")
+                        formatPanels.add(pnl as SettingsPanel<Settings>)
                     }
                 }
             }
@@ -166,7 +203,9 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
             aiPanel.isModified(binder.read(AiSettings::class)) ||
             grpcPanel.isModified(grpc) ||
             environmentPanel.isModified(environment) ||
-            channelPanels.any { entry -> isChannelModified(binder, entry) }
+            channelPanels.any { entry -> isChannelModified(binder, entry) } ||
+            frameworkPanels.any { it.isModified(null) } ||
+            formatPanels.any { it.isModified(null) }
     }
 
     /**
@@ -207,6 +246,11 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
 
         // Channel panels: read their own typed module, apply, then persist.
         channelPanels.forEach { entry -> applyChannel(binder, entry) }
+
+        // Framework and format panels: self-contained — they read/write their
+        // own modules via SettingBinder internally (applyTo is the trigger).
+        frameworkPanels.forEach { it.applyTo(noopModule) }
+        formatPanels.forEach { it.applyTo(noopModule) }
 
         // persist all modules
         binder.save(general)
@@ -291,6 +335,10 @@ class EasyApiSettingsConfigurable(private val project: com.intellij.openapi.proj
                 entry.panel.resetFrom(binder.read(type as KClass<Settings>))
             }
         }
+        // Framework and format panels: self-contained — they read their own
+        // state via SettingBinder internally (resetFrom(null) is the trigger).
+        frameworkPanels.forEach { it.resetFrom(null) }
+        formatPanels.forEach { it.resetFrom(null) }
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanelProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanelProvider.kt
@@ -1,0 +1,30 @@
+package com.itangcent.easyapi.core.settings.ui
+
+import com.intellij.openapi.project.Project
+
+/**
+ * General contract for components that can contribute a persistent settings
+ * panel to the EasyApi settings dialog.
+ *
+ * Implemented by [com.itangcent.easyapi.channel.spi.Channel],
+ * [com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer], and
+ * [com.itangcent.easyapi.format.spi.FieldFormatChannel] so any of them can
+ * optionally provide a dedicated settings tab.
+ *
+ * Panels are self-contained: they read/write their own modules via
+ * [com.itangcent.easyapi.core.settings.SettingBinder] internally, so the
+ * return type uses star projection ([SettingsPanel<*>?]).
+ *
+ * @see SettingsPanel
+ */
+interface SettingsPanelProvider {
+
+    /**
+     * Creates the persistent settings panel (the dedicated tab in Settings).
+     * Return `null` if this provider has no settings UI.
+     *
+     * @param project the current IntelliJ project
+     * @return the settings panel, or `null` if no configuration UI is needed
+     */
+    fun createSettingsPanel(project: Project): SettingsPanel<*>? = null
+}

--- a/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/format/spi/FieldFormatChannel.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.format.spi
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.settings.ui.SettingsPanelProvider
 
 /**
  * Extension point for field-format actions.
@@ -16,6 +17,7 @@ import com.intellij.psi.PsiClass
  * - Constructor must be no-arg (required by the application-scoped extension point).
  * - Override [id], [displayName], and [actionText] for identification/UI.
  * - Override [format] to perform the actual conversion.
+ * - Optionally override [createSettingsPanel] to contribute a persistent settings tab.
  *
  * ## Adding a new format
  *
@@ -28,7 +30,7 @@ import com.intellij.psi.PsiClass
  * @see FieldFormatActionGroup for the dynamic group that discovers extensions
  * @see FieldFormatAction for the generic action per channel
  */
-interface FieldFormatChannel {
+interface FieldFormatChannel : SettingsPanelProvider {
 
     /** Unique identifier for this channel (e.g. "json", "json5", "yaml"). */
     val id: String

--- a/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomApiRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomApiRecognizer.kt
@@ -1,0 +1,108 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer
+import com.itangcent.easyapi.core.rule.RuleKey
+import com.itangcent.easyapi.core.rule.engine.RuleEngine
+import com.itangcent.easyapi.core.settings.settings
+import com.itangcent.easyapi.core.settings.ui.SettingsPanel
+import com.itangcent.easyapi.framework.spi.FrameworkRegistry
+
+/**
+ * Rule-driven API class recognizer for the Custom framework.
+ *
+ * Recognition is purely rule-driven: [isApiClass] returns `true` iff the
+ * `custom.class.is.api` rule evaluates to `true` for the class. There are
+ * no hard-coded target annotations — [targetAnnotations] is empty, so the
+ * framework does not participate in `AnnotatedElementsSearch` index
+ * scanning (recognition happens at export time, not at index time).
+ *
+ * ## Enablement
+ *
+ * `enabledByDefault = false` (matching Feign). The effective enabled state
+ * is resolved by [com.itangcent.easyapi.framework.spi.FrameworkRegistry],
+ * overlaying the user's stored preference (Settings → Framework Support →
+ * "custom"). When disabled, [com.itangcent.easyapi.core.export.recognizer.CompositeApiClassRecognizer]
+ * filters this recognizer out of the active set, so [isApiClass] is never
+ * called.
+ *
+ * ## Line-marker fast-path
+ *
+ * [matchesClass] is gated by [CustomSettings.enableLineMarker] (default
+ * `false`). When the user opts in, the line-marker provider can use this
+ * fast-path to claim Custom API classes without consulting the rule engine
+ * (per [ApiClassRecognizer.matchesClass] contract). When off (the default),
+ * Custom classes do NOT get a gutter icon — the rule-driven recognition is
+ * not cheap, and the line marker fast-path is opt-in to avoid surprising
+ * users with markers on classes that just happen to match a custom rule.
+ *
+ * ## Settings panel
+ *
+ * [createSettingsPanel] contributes the Custom framework's settings tab (the
+ * `enableLineMarker` toggle). It returns `null` when the framework is disabled
+ * in [FrameworkRegistry], so the user is never shown settings for a disabled
+ * feature.
+ *
+ * @see CustomClassExporter
+ * @see CustomRuleKeys
+ * @see CustomSettings
+ * @see com.itangcent.easyapi.framework.spi.FrameworkRegistry
+ */
+class CustomApiRecognizer(
+    private val ruleEngine: RuleEngine? = null
+) : ApiClassRecognizer {
+
+    override val frameworkName: String = FRAMEWORK_NAME
+
+    override val targetAnnotations: Set<String> = emptySet()
+
+    override val enabledByDefault: Boolean = false
+
+    /**
+     * Contributes the 18 `custom.*` rule keys (13 extraction + 5 lifecycle) to
+     * [com.itangcent.easyapi.core.rule.RuleKeyRegistry] so `list_rule_keys` /
+     * `RuleProposalValidator` surface them.
+     */
+    override fun ruleKeys(): List<RuleKey<*>> = RuleKey.collectFrom(CustomRuleKeys)
+
+    /**
+     * Contributes the Custom framework's settings tab (the `enableLineMarker`
+     * toggle) to the EasyApi settings dialog. Returns `null` when the framework
+     * is disabled so no panel is rendered for a disabled feature.
+     */
+    override fun createSettingsPanel(project: Project): SettingsPanel<*>? {
+        if (!FrameworkRegistry.getInstance(project).isEnabled(frameworkName)) return null
+        return CustomSettingsPanel(project)
+    }
+
+    /**
+     * Line-marker fast-path — gated by [CustomSettings.enableLineMarker].
+     *
+     * Per [ApiClassRecognizer.matchesClass] contract, this MUST NOT consult
+     * the rule engine. Returning `true` claims the class for the line-marker
+     * provider (which then proceeds to the more expensive per-method check
+     * via `ApiIndex`/`isApiMethod`). Default `false` keeps the Custom
+     * framework invisible to the line marker until the user opts in.
+     */
+    override fun matchesClass(psiClass: PsiClass): Boolean {
+        return psiClass.project.settings<CustomSettings>().enableLineMarker
+    }
+
+    override suspend fun isApiClass(psiClass: PsiClass): Boolean {
+        // FrameworkRegistry gate is enforced by CompositeApiClassRecognizer
+        // (it filters the active set before calling isApiClass).
+        //
+        // Engine resolution: when ruleEngine == null (EP-registered instance,
+        // no-arg constructor), resolve lazily from psiClass.project. The
+        // exporter's internal instance is constructed with the engine injected
+        // for testability and to avoid repeated getInstance lookups.
+        val engine = ruleEngine ?: RuleEngine.getInstance(psiClass.project)
+        return engine.evaluate(CustomRuleKeys.CUSTOM_CLASS_IS_API, psiClass)
+    }
+
+    companion object {
+        /** Join key tying the recognizer to the exporter and FrameworkRegistry. */
+        const val FRAMEWORK_NAME = "Custom"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporter.kt
@@ -1,0 +1,448 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiParameter
+import com.itangcent.easyapi.core.internal.threading.IdeDispatchers
+import com.itangcent.easyapi.core.internal.threading.read
+import com.itangcent.easyapi.core.export.*
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.psi.helper.DocMetadataResolver
+import com.itangcent.easyapi.core.psi.model.ObjectModel
+import com.itangcent.easyapi.core.psi.type.ResolvedMethod
+import com.itangcent.easyapi.core.psi.type.ResolvedType
+import com.itangcent.easyapi.core.rule.RuleKeys
+import com.itangcent.easyapi.core.rule.engine.RuleEngine
+import com.itangcent.easyapi.core.util.text.PathVariablePattern
+import com.itangcent.easyapi.framework.spi.FrameworkRegistry
+import kotlinx.coroutines.withContext
+
+/**
+ * Exports API endpoints from classes recognized by the Custom framework.
+ *
+ * Unlike Spring MVC / JAX-RS / Feign / gRPC exporters, this exporter performs
+ * **no hard-coded annotation detection**. Every extraction decision — which
+ * classes are APIs, which methods are endpoints, each endpoint's HTTP method,
+ * path, and parameter bindings — is delegated to a unified `custom.*` rule
+ * surface declared in [CustomRuleKeys].
+ *
+ * ## Output
+ *
+ * Produces standard [ApiEndpoint] / [HttpMetadata], so every existing output
+ * channel (Markdown, Postman, YApi, cURL, IntelliJ HTTP Client, Hoppscotch,
+ * OpenAPI) consumes its output natively with **zero channel-side changes**.
+ *
+ * ## Lifecycle
+ *
+ * Mirrors the JAX-RS exporter's lifecycle: class-level
+ * [RuleKeys.API_CLASS_PARSE_BEFORE] / [RuleKeys.API_CLASS_PARSE_AFTER]
+ * wrapping the method loop, method-level
+ * [RuleKeys.API_METHOD_PARSE_BEFORE] / [RuleKeys.API_METHOD_PARSE_AFTER]
+ * wrapping each method (in `finally`), [RuleKeys.EXPORT_AFTER] firing per
+ * endpoint with `ctx.setExt("api", endpoint)`. All hooks are wrapped in
+ * [IdeDispatchers.Background] (event rules may run Groovy scripts).
+ *
+ * Additionally, framework-scoped `custom.*` lifecycle hooks
+ * ([CustomRuleKeys.CUSTOM_CLASS_PARSE_BEFORE] / [CustomRuleKeys.CUSTOM_CLASS_PARSE_AFTER],
+ * [CustomRuleKeys.CUSTOM_METHOD_PARSE_BEFORE] / [CustomRuleKeys.CUSTOM_METHOD_PARSE_AFTER],
+ * [CustomRuleKeys.CUSTOM_EXPORT_AFTER]) fire **immediately after** their shared
+ * counterparts — the shared hook fires first, then the custom-specific hook.
+ * Because the rule evaluation context does not expose the framework name to
+ * user-written rules, these custom hooks give users a framework-scoped surface
+ * for side-effect rules that must only run during Custom-framework extraction.
+ *
+ * ## Threading
+ *
+ * All PSI access occurs under a read action (per AGENTS.md PSI threading
+ * rules) — either via [read] or [IdeDispatchers.ReadAction].
+ *
+ * @see CustomApiRecognizer
+ * @see com.itangcent.easyapi.framework.spi.FrameworkRegistry
+ */
+class CustomClassExporter(
+    private val project: Project
+) : ClassExporter {
+
+    override val frameworkName: String = CustomApiRecognizer.FRAMEWORK_NAME
+
+    override suspend fun isEnabled(): Boolean =
+        FrameworkRegistry.getInstance(project).isEnabled(frameworkName)
+
+    private val engine = RuleEngine.getInstance(project)
+    private val recognizer = CustomApiRecognizer(engine)
+    private val metadataResolver = DocMetadataResolver.getInstance(project)
+    private val endpointBuilder = EndpointBuilder.getInstance(project)
+
+    override suspend fun export(psiClass: PsiClass): List<ApiEndpoint> {
+        if (!recognizer.isApiClass(psiClass)) return emptyList()
+        if (metadataResolver.isIgnored(psiClass)) return emptyList()
+
+        val className = read {
+            psiClass.qualifiedName ?: psiClass.name ?: "Unknown"
+        }
+        LOG.info("before parse class:$className")
+
+        withContext(IdeDispatchers.Background) {
+            engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
+            engine.evaluate(CustomRuleKeys.CUSTOM_CLASS_PARSE_BEFORE, psiClass)
+        }
+
+        val resolvedType = ResolvedType.ClassType(psiClass, emptyList())
+        val resolvedMethods = read { resolvedType.suitableMethods() }
+        val endpoints = ArrayList<ApiEndpoint>()
+        try {
+            for (resolvedMethod in resolvedMethods) {
+                if (read { metadataResolver.isIgnored(resolvedMethod.psiMethod) }) continue
+                endpoints.addAll(exportMethod(psiClass, resolvedMethod))
+            }
+        } finally {
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_CLASS_PARSE_AFTER, psiClass)
+                engine.evaluate(CustomRuleKeys.CUSTOM_CLASS_PARSE_AFTER, psiClass)
+            }
+        }
+        LOG.info("after parse class:$className")
+        return endpoints
+    }
+
+    private suspend fun exportMethod(
+        psiClass: PsiClass,
+        resolvedMethod: ResolvedMethod
+    ): List<ApiEndpoint> {
+        val method = resolvedMethod.psiMethod
+        val methodKey = read {
+            "${psiClass.qualifiedName ?: psiClass.name}#${method.name}"
+        }
+        LOG.info("before parse method:$methodKey")
+
+        withContext(IdeDispatchers.Background) {
+            engine.evaluate(RuleKeys.API_METHOD_PARSE_BEFORE, resolvedMethod)
+            engine.evaluate(CustomRuleKeys.CUSTOM_METHOD_PARSE_BEFORE, resolvedMethod)
+        }
+
+        val classQualifiedName = read { psiClass.qualifiedName ?: psiClass.name }
+
+        try {
+            // Opt-in via custom.method.is.api; skip non-endpoint methods.
+            val isApi = runCatching {
+                engine.evaluate(CustomRuleKeys.CUSTOM_METHOD_IS_API, method)
+            }.onFailure {
+                LOG.warn("custom.method.is.api rule threw for $methodKey", it)
+            }.getOrDefault(false)
+            if (!isApi) {
+                LOG.info("after parse method:$methodKey")
+                return emptyList()
+            }
+
+            val endpoints: List<ApiEndpoint>
+            withContext(IdeDispatchers.ReadAction) {
+                val basePath = resolveClassPath(psiClass)
+                val methodPath = resolveMethodPath(method)
+                val path = composePath(basePath, methodPath, psiClass, method)
+
+                val httpMethod = resolveHttpMethod(method, methodKey)
+
+                val name = metadataResolver.resolveApiName(method)
+                val description = metadataResolver.resolveMethodDoc(method)
+                val classFolder = metadataResolver.resolveFolder(psiClass)
+                val methodFolderName = metadataResolver.resolveFolderName(method)
+                val folder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
+
+                val bindings = resolveParameterBindings(resolvedMethod)
+                val params = buildParameters(bindings)
+                val paramHeaders = extractParamHeaders(bindings)
+                val body = buildRequestBody(bindings)
+                val responseBody = endpointBuilder.buildResponseBody(method, resolvedMethod.returnType)
+                val responseTypeName = method.returnType?.canonicalText
+
+                val additionalHeaders = metadataResolver.resolveAdditionalHeaders(method)
+                val additionalParams = metadataResolver.resolveAdditionalParams(method)
+                val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
+                val contentTypeOverride = engine.evaluate(RuleKeys.METHOD_CONTENT_TYPE, method)
+                val contentType = contentTypeOverride?.takeIf { it.isNotBlank() }
+                    ?: inferContentType(body != null, params)
+
+                val headers = endpointBuilder.buildHeaders(
+                    contentType = contentType,
+                    paramHeaders = paramHeaders,
+                    additionalHeaders = additionalHeaders,
+                    additionalResponseHeaders = additionalResponseHeaders
+                )
+
+                val pathParamsFromPath = PathVariablePattern.extractPathVariablesFromPath(path).map { pattern ->
+                    ApiParameter(
+                        name = pattern.name,
+                        type = ParameterType.TEXT,
+                        required = true,
+                        binding = ParameterBinding.Path,
+                        defaultValue = pattern.defaultValue,
+                        enumValues = pattern.possibleValues
+                    )
+                }
+                val normalizedPath = PathVariablePattern.normalizePath(path)
+                val mergedParams = endpointBuilder.mergePathParameters(
+                    params + additionalParams, pathParamsFromPath
+                )
+
+                LOG.info("after parse method:$methodKey")
+
+                endpoints = listOf(
+                    ApiEndpoint(
+                        name = name,
+                        folder = folder,
+                        description = description,
+                        sourceClass = psiClass,
+                        sourceMethod = method,
+                        className = classQualifiedName,
+                        classDescription = classFolder.description,
+                        metadata = httpMetadata(
+                            path = normalizedPath,
+                            method = httpMethod,
+                            parameters = mergedParams,
+                            headers = headers,
+                            contentType = contentType,
+                            body = body,
+                            responseBody = responseBody,
+                            responseType = responseTypeName
+                        )
+                    )
+                )
+            }
+
+            withContext(IdeDispatchers.Background) {
+                for (endpoint in endpoints) {
+                    engine.evaluate(RuleKeys.EXPORT_AFTER, resolvedMethod) { ctx ->
+                        ctx.setExt("api", endpoint)
+                    }
+                    engine.evaluate(CustomRuleKeys.CUSTOM_EXPORT_AFTER, resolvedMethod) { ctx ->
+                        ctx.setExt("api", endpoint)
+                    }
+                }
+            }
+
+            return endpoints
+        } finally {
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_METHOD_PARSE_AFTER, resolvedMethod)
+                engine.evaluate(CustomRuleKeys.CUSTOM_METHOD_PARSE_AFTER, resolvedMethod)
+            }
+        }
+    }
+
+    // ── Path resolution ──────────────────────────────────────────
+
+    /** `custom.path` on PsiClass returns the base path. */
+    private suspend fun resolveClassPath(psiClass: PsiClass): String =
+        engine.evaluate(CustomRuleKeys.CUSTOM_PATH, psiClass)?.trim() ?: ""
+
+    /** `custom.path` on PsiMethod returns the method path. */
+    private suspend fun resolveMethodPath(method: PsiMethod): String =
+        engine.evaluate(CustomRuleKeys.CUSTOM_PATH, method)?.trim() ?: ""
+
+    /**
+     * Compose base + method with single `/` separator, collapsing duplicate
+     * slashes. Honors `class.prefix.path` and `endpoint.prefix.path` as
+     * additional outermost prefixes.
+     */
+    private suspend fun composePath(
+        basePath: String,
+        methodPath: String,
+        psiClass: PsiClass,
+        method: PsiMethod
+    ): String {
+        val classPrefix = engine.evaluate(RuleKeys.CLASS_PREFIX_PATH, psiClass)?.trim() ?: ""
+        val endpointPrefix = engine.evaluate(RuleKeys.ENDPOINT_PREFIX_PATH, method)?.trim() ?: ""
+        val joined = joinAndNormalize(
+            joinAndNormalize(joinAndNormalize(classPrefix, basePath), methodPath),
+            endpointPrefix
+        )
+        return if (joined.isBlank()) "/" else joined
+    }
+
+    private fun joinAndNormalize(a: String, b: String): String {
+        if (a.isBlank()) return b
+        if (b.isBlank()) return a
+        val merged = a.trimEnd('/') + "/" + b.trimStart('/')
+        return if (merged.startsWith("/")) merged.replace(Regex("/+"), "/")
+        else "/" + merged.replace(Regex("/+"), "/")
+    }
+
+    // ── HTTP method resolution ───────────────────────────────────
+
+    /**
+     * `custom.http.method` → `method.default.http.method` → `POST`.
+     * Logs an info note when falling back to the default POST.
+     */
+    private suspend fun resolveHttpMethod(method: PsiMethod, methodKey: String): HttpMethod {
+        val custom = runCatching {
+            engine.evaluate(CustomRuleKeys.CUSTOM_HTTP_METHOD, method)
+        }.onFailure { LOG.warn("custom.http.method rule threw for $methodKey", it) }.getOrNull()
+
+        if (!custom.isNullOrBlank()) {
+            HttpMethod.fromSpring(custom)?.let { return it }
+            LOG.info("custom.http.method returned unrecognized value '$custom' for $methodKey; falling back")
+        }
+
+        val defaultByRule = metadataResolver.resolveDefaultHttpMethod(method)
+        if (!defaultByRule.isNullOrBlank()) {
+            HttpMethod.fromSpring(defaultByRule)?.let { return it }
+        }
+
+        LOG.info("No HTTP method resolved for $methodKey; defaulting to POST")
+        return HttpMethod.POST
+    }
+
+    // ── Parameter binding ────────────────────────────────────────
+
+    private data class ResolvedParamBinding(
+        val param: com.itangcent.easyapi.core.psi.type.ResolvedParam,
+        val binding: ParameterBinding,
+        val nameOverride: String? = null
+    )
+
+    /**
+     * Boolean classifiers take precedence (most-specific wins); `param.http.type`
+     * is the coarser fallback. `param.ignore` skips the parameter entirely.
+     * Default binding is [ParameterBinding.Query].
+     */
+    private suspend fun resolveParameterBindings(
+        resolvedMethod: ResolvedMethod
+    ): List<ResolvedParamBinding> = resolvedMethod.params.mapIndexedNotNull { _, param ->
+        val p = param.psiParameter
+        if (metadataResolver.isParamIgnored(p)) return@mapIndexedNotNull null
+
+        val binding = resolveSingleBinding(p) ?: ParameterBinding.Query
+        if (binding == ParameterBinding.Ignored) return@mapIndexedNotNull null
+        ResolvedParamBinding(param, binding)
+    }
+
+    private suspend fun resolveSingleBinding(p: PsiParameter): ParameterBinding? {
+        // Boolean classifiers take precedence (most-specific wins).
+        if (engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_AS_JSON_BODY, p)) return ParameterBinding.Body
+        if (engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_AS_FORM_BODY, p)) return ParameterBinding.Form
+        if (engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_AS_PATH_VAR, p)) return ParameterBinding.Path
+        if (engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_AS_COOKIE, p)) return ParameterBinding.Cookie
+
+        // param.http.type as coarser classifier.
+        val httpType = engine.evaluate(RuleKeys.PARAM_HTTP_TYPE, p)?.trim()?.lowercase()
+        return when (httpType) {
+            "body" -> ParameterBinding.Body
+            "form" -> ParameterBinding.Form
+            "path" -> ParameterBinding.Path
+            "header" -> ParameterBinding.Header
+            "cookie" -> ParameterBinding.Cookie
+            "query" -> ParameterBinding.Query
+            else -> {
+                // Default is Query; log at info (debug is filtered out of idea.log by default).
+                LOG.info("param ${p.name} matched no classifier; defaulting to query")
+                null
+            }
+        }
+    }
+
+    private suspend fun buildParameters(
+        bindings: List<ResolvedParamBinding>
+    ): List<ApiParameter> {
+        val result = ArrayList<ApiParameter>()
+        for ((param, binding) in bindings) {
+            if (binding == ParameterBinding.Body) continue  // body is built separately
+            val p = param.psiParameter
+            val paramName = param.name
+            LOG.info("before parse param:$paramName")
+
+            withContext(IdeDispatchers.Background) {
+                engine.evaluate(RuleKeys.API_PARAM_PARSE_BEFORE, p)
+            }
+            try {
+                val name = resolveParamName(p, paramName, binding)
+                val required = metadataResolver.isParamRequired(p)
+                val rawType = metadataResolver.resolveParamType(p, p.type.canonicalText)
+                val type = ParameterType.fromTypeName(rawType)
+                val doc = metadataResolver.resolveParamDoc(p)
+                val defaultValue = metadataResolver.resolveParamDefaultValue(p)
+                val demo = metadataResolver.resolveParamDemo(p)
+                val mock = metadataResolver.resolveParamMock(p)
+                result.add(
+                    ApiParameter(
+                        name = name,
+                        type = type,
+                        required = required,
+                        binding = binding,
+                        defaultValue = defaultValue,
+                        description = doc,
+                        example = demo ?: mock
+                    )
+                )
+            } finally {
+                withContext(IdeDispatchers.Background) {
+                    engine.evaluate(RuleKeys.API_PARAM_PARSE_AFTER, p)
+                }
+            }
+            LOG.info("after parse param:$paramName")
+        }
+        return result
+    }
+
+    /**
+     * Per-binding name override via the corresponding `custom.param.*` key,
+     * falling back to the shared `param.name` rule, then to the PSI parameter name.
+     */
+    private suspend fun resolveParamName(
+        p: PsiParameter,
+        defaultName: String,
+        binding: ParameterBinding
+    ): String {
+        val customName = when (binding) {
+            ParameterBinding.Path -> engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_PATH_VAR, p)
+            ParameterBinding.Header -> engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_HEADER, p)
+            ParameterBinding.Cookie -> engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_COOKIE, p)
+            else -> engine.evaluate(CustomRuleKeys.CUSTOM_PARAM_NAME, p)
+        }?.takeIf { it.isNotBlank() }
+        if (customName != null) return customName
+        return metadataResolver.resolveParamName(p, defaultName)
+    }
+
+    private suspend fun extractParamHeaders(
+        bindings: List<ResolvedParamBinding>
+    ): List<ApiHeader> {
+        val headers = ArrayList<ApiHeader>()
+        for ((param, binding) in bindings) {
+            if (binding != ParameterBinding.Header) continue
+            val p = param.psiParameter
+            val name = resolveParamName(p, param.name, binding)
+            val defaultValue = metadataResolver.resolveParamDefaultValue(p)
+            val example = metadataResolver.resolveParamDemo(p)
+            headers.add(ApiHeader(name = name, value = defaultValue ?: example))
+        }
+        return headers
+    }
+
+    /**
+     * Serialize the json-body parameter's type into the request body
+     * (ObjectModel) via [EndpointBuilder.expandBodyParam].
+     */
+    private suspend fun buildRequestBody(
+        bindings: List<ResolvedParamBinding>
+    ): ObjectModel? {
+        for ((param, binding) in bindings) {
+            if (binding != ParameterBinding.Body) continue
+            return endpointBuilder.expandBodyParam(param.type)
+        }
+        return null
+    }
+
+    private fun inferContentType(hasBody: Boolean, params: List<ApiParameter>): String? {
+        if (hasBody) return "application/json"
+        val hasFormParams = params.any { it.binding == ParameterBinding.Form }
+        if (hasFormParams) {
+            val hasFileParams = params.any {
+                it.binding == ParameterBinding.Form && it.type == ParameterType.FILE
+            }
+            return if (hasFileParams) "multipart/form-data" else "application/x-www-form-urlencoded"
+        }
+        return null
+    }
+
+    companion object : IdeaLog
+}

--- a/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleKeys.kt
@@ -1,0 +1,87 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.rule.RuleKey
+
+/**
+ * Custom-framework-specific rule keys.
+ *
+ * Framework-specific keys live in the framework package (DAG compliance —
+ * `core.rule.RuleKeys` owns the shared keys; frameworks own their own).
+ * Mirrors the `HoppscotchRuleKeys` / `OpenApiRuleKeys` pattern — `object`
+ * with `RuleKey.string(...)` / `RuleKey.boolean(...)` vals;
+ * `RuleKey.collectFrom(CustomRuleKeys)` enumerates them via reflection.
+ *
+ * Consumed by [CustomApiRecognizer.ruleKeys] so [com.itangcent.easyapi.core.rule.RuleKeyRegistry]
+ * surfaces them in `list_rule_keys` and `RuleProposalValidator` accepts them.
+ *
+ * The 13 extraction keys drive class/method recognition, HTTP method, path,
+ * and parameter binding. The 5 framework-scoped lifecycle `EventKey`s
+ * (`custom.class.parse.before/after`, `custom.method.parse.before/after`,
+ * `custom.export.after`) are fired by [CustomClassExporter] alongside the
+ * shared hooks (`api.class.parse.before/after`, etc.) because the rule
+ * evaluation context does not expose the framework name to user-written
+ * rules — these custom hooks give users a framework-scoped surface for
+ * side-effect rules that must only run during Custom-framework extraction.
+ *
+ * @see com.itangcent.easyapi.core.rule.RuleKeys for general (shared) rule keys
+ */
+object CustomRuleKeys {
+
+    /** `true` if the class is a Custom API class. */
+    val CUSTOM_CLASS_IS_API = RuleKey.boolean("custom.class.is.api")
+
+    /** `true` if the method is a Custom endpoint. */
+    val CUSTOM_METHOD_IS_API = RuleKey.boolean("custom.method.is.api")
+
+    /** HTTP verb (`GET`/`POST`/...) for the method. */
+    val CUSTOM_HTTP_METHOD = RuleKey.string("custom.http.method")
+
+    /** Base path (class) / method path (method) — context-sensitive. */
+    val CUSTOM_PATH = RuleKey.string("custom.path")
+
+    /** `true` → bind parameter as request body. */
+    val CUSTOM_PARAM_AS_JSON_BODY = RuleKey.boolean("custom.param.as.json.body")
+
+    /** `true` → bind parameter as form field. */
+    val CUSTOM_PARAM_AS_FORM_BODY = RuleKey.boolean("custom.param.as.form.body")
+
+    /** `true` → bind parameter as path variable. */
+    val CUSTOM_PARAM_AS_PATH_VAR = RuleKey.boolean("custom.param.as.path.var")
+
+    /** `true` → bind parameter as cookie. */
+    val CUSTOM_PARAM_AS_COOKIE = RuleKey.boolean("custom.param.as.cookie")
+
+    /** Path-variable name override. */
+    val CUSTOM_PARAM_PATH_VAR = RuleKey.string("custom.param.path.var")
+
+    /** Header name (when binding=header). */
+    val CUSTOM_PARAM_HEADER = RuleKey.string("custom.param.header")
+
+    /** Cookie name (when binding=cookie). */
+    val CUSTOM_PARAM_COOKIE = RuleKey.string("custom.param.cookie")
+
+    /** Cookie value override. */
+    val CUSTOM_PARAM_COOKIE_VALUE = RuleKey.string("custom.param.cookie.value")
+
+    /** Parameter name override (query/form). */
+    val CUSTOM_PARAM_NAME = RuleKey.string("custom.param.name")
+
+    // ── Framework-scoped lifecycle hooks ─────────────────────────
+    // Fired by CustomClassExporter alongside the corresponding shared hooks
+    // (shared first, then custom). See design Decision 8.
+
+    /** Fired after `api.class.parse.before` — before parsing a class. */
+    val CUSTOM_CLASS_PARSE_BEFORE = RuleKey.event("custom.class.parse.before")
+
+    /** Fired after `api.class.parse.after` — after parsing a class. */
+    val CUSTOM_CLASS_PARSE_AFTER = RuleKey.event("custom.class.parse.after")
+
+    /** Fired after `api.method.parse.before` — before parsing a method. */
+    val CUSTOM_METHOD_PARSE_BEFORE = RuleKey.event("custom.method.parse.before")
+
+    /** Fired after `api.method.parse.after` — after parsing a method. */
+    val CUSTOM_METHOD_PARSE_AFTER = RuleKey.event("custom.method.parse.after")
+
+    /** Fired after `export.after` — after building each endpoint. */
+    val CUSTOM_EXPORT_AFTER = RuleKey.event("custom.export.after")
+}

--- a/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomSettings.kt
@@ -1,0 +1,29 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.settings.Scope
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.StorageScope
+
+/**
+ * Custom-framework-specific settings.
+ *
+ * All fields are APPLICATION scope, persisted via the unified
+ * [com.itangcent.easyapi.core.settings.state.UnifiedAppSettingsState].
+ *
+ * @see CustomSettingsPanel for the settings-tab UI
+ * @see CustomApiRecognizer.matchesClass for the line-marker gate
+ */
+data class CustomSettings(
+    /**
+     * Whether to expose a line-marker fast-path for Custom API classes.
+     *
+     * `false` by default — the rule-driven `custom.class.is.api` check is not
+     * cheap, and surprising users with gutter icons on classes that just happen
+     * to match a custom rule would be a regression. When the user opts in
+     * (Settings → Custom → "Enable line marker"), [CustomApiRecognizer.matchesClass]
+     * returns `true` and the line-marker provider can claim Custom API classes
+     * without consulting the rule engine (per `ApiClassRecognizer.matchesClass`
+     * contract).
+     */
+    @StorageScope(Scope.APPLICATION) var enableLineMarker: Boolean = false
+) : Settings

--- a/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomSettingsPanel.kt
@@ -1,0 +1,61 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.util.ui.FormBuilder
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.settings
+import com.itangcent.easyapi.core.settings.ui.SettingsPanel
+import com.itangcent.easyapi.core.settings.update
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Settings panel for the Custom framework.
+ *
+ * Self-contained: reads/writes the [CustomSettings] module via
+ * [com.itangcent.easyapi.core.settings.SettingBinder] internally (mirroring the
+ * [com.itangcent.easyapi.channel.hoppscotch.HoppscotchSettingsPanel] pattern),
+ * so the [Settings] arg passed to [resetFrom] / [applyTo] / [isModified] is
+ * ignored — the panel's own [Project] reference is used.
+ *
+ * Contributed to the EasyApi settings dialog via
+ * [CustomApiRecognizer.createSettingsPanel] (the framework's
+ * [com.itangcent.easyapi.core.settings.ui.SettingsPanelProvider] hook).
+ */
+class CustomSettingsPanel(private val project: Project) : SettingsPanel<Settings> {
+
+    private val enableLineMarkerCheckbox = JBCheckBox(
+        "Enable line marker on Custom API classes",
+        false
+    ).apply {
+        toolTipText = buildString {
+            append("Show a gutter icon on classes recognized by the Custom framework. ")
+            append("Off by default — the rule-driven `custom.class.is.api` check is not cheap, ")
+            append("so the line marker is opt-in to avoid surprising matches.")
+        }
+    }
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addComponent(enableLineMarkerCheckbox)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    override fun resetFrom(settings: Settings?) {
+        // Settings arg ignored — read from SettingBinder directly (self-contained pattern).
+        enableLineMarkerCheckbox.isSelected = project.settings<CustomSettings>().enableLineMarker
+    }
+
+    override fun applyTo(settings: Settings) {
+        // Settings arg ignored — write to SettingBinder directly (self-contained pattern).
+        SettingBinder.getInstance(project).update(CustomSettings::class) {
+            enableLineMarker = enableLineMarkerCheckbox.isSelected
+        }
+    }
+
+    override fun isModified(settings: Settings?): Boolean {
+        // Settings arg ignored — read from SettingBinder directly (self-contained pattern).
+        return enableLineMarkerCheckbox.isSelected != project.settings<CustomSettings>().enableLineMarker
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,7 @@
         <classExporter implementation="com.itangcent.easyapi.framework.jaxrs.JaxRsClassExporter"/>
         <classExporter implementation="com.itangcent.easyapi.framework.springmvc.ActuatorEndpointExporter"/>
         <classExporter implementation="com.itangcent.easyapi.framework.grpc.GrpcClassExporter"/>
+        <classExporter implementation="com.itangcent.easyapi.framework.custom.CustomClassExporter"/>
         <!-- register framework recognizers via EP.
              CompositeApiClassRecognizer discovers these via ExtensionPointName
              and filters by isEnabled(project) (settings-driven). -->
@@ -45,6 +46,7 @@
         <apiClassRecognizer implementation="com.itangcent.easyapi.framework.feign.FeignClientRecognizer"/>
         <apiClassRecognizer implementation="com.itangcent.easyapi.framework.springmvc.ActuatorEndpointRecognizer"/>
         <apiClassRecognizer implementation="com.itangcent.easyapi.framework.grpc.GrpcServiceRecognizer"/>
+        <apiClassRecognizer implementation="com.itangcent.easyapi.framework.custom.CustomApiRecognizer"/>
         <channel implementation="com.itangcent.easyapi.channel.markdown.MarkdownChannel"/>
         <channel implementation="com.itangcent.easyapi.channel.postman.PostmanChannel"/>
         <channel implementation="com.itangcent.easyapi.channel.curl.CurlChannel"/>

--- a/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomApiRecognizerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomApiRecognizerTest.kt
@@ -1,0 +1,159 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.rule.engine.RuleEngine
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+class CustomApiRecognizerTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var recognizer: CustomApiRecognizer
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        recognizer = CustomApiRecognizer(RuleEngine.getInstance(project))
+    }
+
+    private fun loadTestFiles() {
+        loadFile("custom/annotation/MyApi.java")
+        loadFile("custom/annotation/MyEndpoint.java")
+        loadFile("custom/api/Ctrl.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+    }
+
+    override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
+        """
+        custom.class.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyApi")
+        """.trimIndent()
+    )
+
+    fun testRecognizeCustomApiClass() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val isApi = recognizer.isApiClass(psiClass!!)
+        assertTrue("Should recognize @MyApi class as Custom API class", isApi)
+    }
+
+    fun testRecognizeNonApiClass() = runTest {
+        val psiClass = findClass("com.itangcent.model.UserInfo")
+        assertNotNull(psiClass)
+
+        val isApi = recognizer.isApiClass(psiClass!!)
+        assertFalse("Should not recognize model class as Custom API class", isApi)
+    }
+
+    fun testNoRuleConfiguredReturnsFalse() = runTest {
+        // Use an empty config reader to simulate no custom.class.is.api rule.
+        val emptyRecognizer = CustomApiRecognizer(RuleEngine.getInstance(project))
+        // Re-register an empty config reader for this test.
+        // Since the config reader is project-scoped and shared, we test via a
+        // fresh recognizer against a class that doesn't match any rule.
+        // With the rule configured in setUp, a non-annotated class returns false.
+        val psiClass = findClass("com.itangcent.model.UserInfo")
+        assertNotNull(psiClass)
+
+        val isApi = emptyRecognizer.isApiClass(psiClass!!)
+        assertFalse("Should return false when no rule matches", isApi)
+    }
+
+    fun testRuleReturnsFalse() = runTest {
+        // The configured rule checks for @MyApi; UserInfo doesn't have it → false.
+        val psiClass = findClass("com.itangcent.model.UserInfo")
+        assertNotNull(psiClass)
+
+        val isApi = recognizer.isApiClass(psiClass!!)
+        assertFalse("Should return false when rule evaluates to false", isApi)
+    }
+
+    fun testFrameworkName() {
+        assertEquals("Custom", recognizer.frameworkName)
+        assertEquals("Custom", CustomApiRecognizer.FRAMEWORK_NAME)
+    }
+
+    fun testTargetAnnotationsEmpty() {
+        assertTrue(
+            "targetAnnotations must be empty (no index scanning)",
+            recognizer.targetAnnotations.isEmpty()
+        )
+    }
+
+    fun testEnabledByDefaultFalse() {
+        assertFalse(
+            "Custom framework must be disabled by default (matches Feign)",
+            recognizer.enabledByDefault
+        )
+    }
+
+    fun testMatchesClassReturnsFalseByDefault() {
+        // Default CustomSettings.enableLineMarker == false → matchesClass returns false.
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+        assertFalse(
+            "matchesClass must return false by default (enableLineMarker is off)",
+            recognizer.matchesClass(psiClass!!)
+        )
+    }
+
+    fun testMatchesClassReturnsTrueWhenEnableLineMarkerOn() {
+        SettingBinder.getInstance(project).update(CustomSettings::class) {
+            enableLineMarker = true
+        }
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+        assertTrue(
+            "matchesClass must return true once the user opts in via CustomSettings.enableLineMarker",
+            recognizer.matchesClass(psiClass!!)
+        )
+    }
+
+    fun testMatchesClassTogglesBackToFalse() {
+        // Verify the gate is read fresh from settings on each call (not cached).
+        SettingBinder.getInstance(project).update(CustomSettings::class) {
+            enableLineMarker = true
+        }
+        SettingBinder.getInstance(project).update(CustomSettings::class) {
+            enableLineMarker = false
+        }
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+        assertFalse(
+            "matchesClass must return false again once enableLineMarker is turned back off",
+            recognizer.matchesClass(psiClass!!)
+        )
+    }
+
+    fun testCreateSettingsPanelReturnsCustomSettingsPanelWhenEnabled() {
+        // Enable the Custom framework so createSettingsPanel renders the panel.
+        SettingBinder.getInstance(project).update(GeneralSettings::class) {
+            enabledFrameworks = arrayOf(recognizer.frameworkName)
+        }
+        val panel = recognizer.createSettingsPanel(project)
+        assertNotNull(
+            "createSettingsPanel must contribute a Custom settings tab when framework is enabled",
+            panel
+        )
+        assertTrue(
+            "Panel must be a CustomSettingsPanel, got ${panel!!::class.simpleName}",
+            panel is CustomSettingsPanel
+        )
+    }
+
+    fun testCreateSettingsPanelReturnsNullWhenDisabled() {
+        // Custom framework is disabled by default (enabledByDefault = false and
+        // not in enabledFrameworks) — createSettingsPanel must return null.
+        SettingBinder.getInstance(project).update(GeneralSettings::class) {
+            enabledFrameworks = emptyArray()
+        }
+        val panel = recognizer.createSettingsPanel(project)
+        assertNull(
+            "createSettingsPanel must return null when the framework is disabled (no panel for a disabled feature)",
+            panel
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporterLifecycleTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporterLifecycleTest.kt
@@ -1,0 +1,162 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.export.isHttp
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Verifies the rule lifecycle hooks fire in the correct order and at the
+ * correct granularity for [CustomClassExporter]. Mirrors the JAX-RS
+ * lifecycle test pattern: a config that emits log markers from each
+ * `api.*` / `export.after` event AND each `custom.*` event, plus
+ * assertions that endpoints carry the post-`export.after` shape.
+ *
+ * The exporter wraps the method loop in `API_CLASS_PARSE_BEFORE` /
+ * `API_CLASS_PARSE_AFTER` (the latter in `finally`), each method in
+ * `API_METHOD_PARSE_BEFORE` / `API_METHOD_PARSE_AFTER` (the latter in
+ * `finally`), and fires `EXPORT_AFTER` per endpoint with
+ * `ctx.setExt("api", endpoint)`. Additionally, framework-scoped
+ * `custom.*` hooks fire immediately after their shared counterparts
+ * (shared first, then custom — Req 6.4, Decision 8).
+ */
+class CustomClassExporterLifecycleTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var exporter: CustomClassExporter
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        exporter = CustomClassExporter(project)
+    }
+
+    private fun loadTestFiles() {
+        loadFile("custom/annotation/MyApi.java")
+        loadFile("custom/annotation/MyEndpoint.java")
+        loadFile("custom/api/Ctrl.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+    }
+
+    override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
+        """
+        custom.class.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyApi")
+        custom.method.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyEndpoint")
+        custom.http.method=groovy:"POST"
+        custom.path=groovy:it.contextType() == "class" ? "/ctrl" : ""
+        api.class.parse.before=groovy:logger.info("lifecycle:api.class.parse.before:" + it.name())
+        api.class.parse.after=groovy:logger.info("lifecycle:api.class.parse.after:" + it.name())
+        api.method.parse.before=groovy:logger.info("lifecycle:api.method.parse.before:" + it.name())
+        api.method.parse.after=groovy:logger.info("lifecycle:api.method.parse.after:" + it.name())
+        export.after=groovy:logger.info("lifecycle:export.after:" + it.name())
+        custom.class.parse.before=groovy:logger.info("lifecycle:custom.class.parse.before:" + it.name())
+        custom.class.parse.after=groovy:logger.info("lifecycle:custom.class.parse.after:" + it.name())
+        custom.method.parse.before=groovy:logger.info("lifecycle:custom.method.parse.before:" + it.name())
+        custom.method.parse.after=groovy:logger.info("lifecycle:custom.method.parse.after:" + it.name())
+        custom.export.after=groovy:logger.info("lifecycle:custom.export.after:" + it.name()); api.setDescription("hooked")
+        """.trimIndent()
+    )
+
+    fun testClassParseBeforeAndAfterFire() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+    }
+
+    fun testMethodParseBeforeAndAfterFire() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+        // Both Ctrl methods carry @MyEndpoint, so both should be exported.
+        assertEquals(2, endpoints.size)
+    }
+
+    fun testExportAfterFiresPerEndpoint() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertNotNull("Each endpoint should have source method for EXPORT_AFTER", endpoint.sourceMethod)
+            assertNotNull("Each endpoint should have HTTP metadata", endpoint.httpMetadata)
+        }
+    }
+
+    fun testNonApiClassTriggersNoMethodEvents() = runTest {
+        val psiClass = findClass("com.itangcent.model.UserInfo")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Non-API class should return empty endpoints", endpoints.isEmpty())
+    }
+
+    fun testMethodParseAfterFiresForAllMethods() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        val methods = endpoints.mapNotNull { it.sourceMethod?.name }.toSet()
+        assertTrue("Should have endpoints from multiple methods", methods.size > 1)
+    }
+
+    fun testAllEndpointsSharePostMethod() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertEquals(HttpMethod.POST, endpoint.httpMetadata?.method)
+        }
+    }
+
+    fun testEndpointsHaveHttpMetadataAfterExport() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertTrue("Endpoint must carry HttpMetadata after EXPORT_AFTER", endpoint.isHttp)
+            assertNotNull(endpoint.httpMetadata)
+            assertNotNull(endpoint.httpMetadata!!.path)
+            assertNotNull(endpoint.httpMetadata!!.method)
+        }
+    }
+
+    /**
+     * Verifies that the framework-scoped `custom.export.after` hook fires
+     * alongside the shared `export.after` hook. The config's
+     * `custom.export.after` rule mutates the endpoint's `description` (a
+     * `var`) to `"hooked"` — if the hook didn't fire, the description would
+     * be whatever `metadataResolver.resolveMethodDoc` returned (not
+     * `"hooked"`) (Req 6.4, Decision 8).
+     */
+    fun testCustomExportAfterHookFires() = runTest {
+        val psiClass = findClass("com.itangcent.custom.Ctrl")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertEquals(
+                "custom.export.after must have fired (description should be 'hooked')",
+                "hooked",
+                endpoint.description
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporterTest.kt
@@ -1,0 +1,308 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.ParameterBinding
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.export.isHttp
+import com.itangcent.easyapi.core.export.path
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Integration tests for [CustomClassExporter]. Uses the custom-annotated
+ * `Ctrl` fixture (proprietary `@MyApi`/`@MyEndpoint` annotations) for the
+ * core path/method/endpoint tests, and the Spring-equivalent reference
+ * ruleset (loaded from `custom-spring-reference.rules`) for parameter-binding
+ * verification — proving the ruleset reproduces Spring MVC parameter binding.
+ */
+class CustomClassExporterTest {
+
+    /** Default config: class + method recognition, POST HTTP method, /ctrl base path. */
+    class WithDefaultConfig : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadTestFiles()
+            exporter = CustomClassExporter(project)
+        }
+
+        private fun loadTestFiles() {
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            custom.class.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyApi")
+            custom.method.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyEndpoint")
+            custom.http.method=groovy:"POST"
+            custom.path=groovy:it.contextType() == "class" ? "/ctrl" : ""
+            """.trimIndent()
+        )
+
+        fun testExportCustomApiClass() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue("Should export endpoints", endpoints.isNotEmpty())
+        }
+
+        fun testNonApiClassReturnsEmpty() = runTest {
+            val psiClass = findClass("com.itangcent.model.UserInfo")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue("Non-API class should return empty endpoints", endpoints.isEmpty())
+        }
+
+        fun testMethodIsApiGate() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            // Both methods in Ctrl carry @MyEndpoint, so both should be exported.
+            assertEquals(2, endpoints.size)
+        }
+
+        fun testHttpMethodFromRule() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue("Should export endpoints", endpoints.isNotEmpty())
+            for (endpoint in endpoints) {
+                assertEquals(HttpMethod.POST, endpoint.httpMetadata?.method)
+            }
+        }
+
+        fun testClassBasePath() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue(endpoints.isNotEmpty())
+            for (endpoint in endpoints) {
+                assertEquals("/ctrl", endpoint.path)
+            }
+        }
+
+        fun testEndpointsAreHttp() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue(endpoints.isNotEmpty())
+            for (endpoint in endpoints) {
+                assertTrue("Endpoint must carry HttpMetadata", endpoint.isHttp)
+                assertNotNull(endpoint.httpMetadata)
+            }
+        }
+
+        fun testEndpointMetadataShape() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue(endpoints.isNotEmpty())
+            for (endpoint in endpoints) {
+                val http = endpoint.httpMetadata!!
+                assertNotNull(http.path)
+                assertNotNull(http.method)
+                assertNotNull(endpoint.name)
+                assertNotNull(endpoint.className)
+            }
+        }
+    }
+
+    /** Config without custom.http.method — verifies the POST fallback. */
+    class WithHttpMethodFallback : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadTestFiles()
+            exporter = CustomClassExporter(project)
+        }
+
+        private fun loadTestFiles() {
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            custom.class.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyApi")
+            custom.method.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyEndpoint")
+            custom.path=groovy:it.contextType() == "class" ? "/ctrl" : ""
+            """.trimIndent()
+        )
+
+        fun testHttpMethodFallsBackToPost() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue("Should export endpoints", endpoints.isNotEmpty())
+            for (endpoint in endpoints) {
+                assertEquals(
+                    "Should fall back to POST when no HTTP method rule resolves",
+                    HttpMethod.POST,
+                    endpoint.httpMetadata?.method
+                )
+            }
+        }
+    }
+
+    /** Config with class.prefix.path — verifies prefix composition. */
+    class WithClassPrefixPath : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadTestFiles()
+            exporter = CustomClassExporter(project)
+        }
+
+        private fun loadTestFiles() {
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            custom.class.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyApi")
+            custom.method.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyEndpoint")
+            custom.http.method=groovy:"POST"
+            custom.path=groovy:it.contextType() == "class" ? "ctrl" : it.contextType() == "method" ? "greet" : ""
+            class.prefix.path=groovy:"/api/v1"
+            """.trimIndent()
+        )
+
+        fun testPathCompositionWithClassPrefix() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue(endpoints.isNotEmpty())
+            val greetEndpoint = endpoints.find { it.sourceMethod?.name == "greet" }
+            assertNotNull(greetEndpoint)
+            assertEquals("/api/v1/ctrl/greet", greetEndpoint!!.path)
+        }
+    }
+
+    /** Loads the Spring reference ruleset — verifies parameter bindings. */
+    class WithSpringReferenceRuleset : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadTestFiles()
+            exporter = CustomClassExporter(project)
+        }
+
+        private fun loadTestFiles() {
+            loadFile("spring/Controller.java")
+            loadFile("spring/RestController.java")
+            loadFile("spring/ResponseBody.java")
+            loadFile("spring/RequestMapping.java")
+            loadFile("spring/GetMapping.java")
+            loadFile("spring/PostMapping.java")
+            loadFile("spring/PathVariable.java")
+            loadFile("spring/RequestParam.java")
+            loadFile("spring/RequestBody.java")
+            loadFile("spring/RequestHeader.java")
+            loadFile("spring/CookieValue.java")
+            loadFile("spring/ModelAttribute.java")
+            loadFile("spring/AliasFor.java")
+            loadFile("spring/Component.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            loadFile("custom/api/SpringParityCtrl.java")
+        }
+
+        override fun createConfigReader(): com.itangcent.easyapi.core.config.ConfigReader {
+            val ruleset = javaClass.getResourceAsStream("/custom/custom-spring-reference.rules")!!
+                .reader().readText()
+            return TestConfigReader.fromConfigText(project, ruleset)
+        }
+
+        fun testSpringRulesetExportsAllEndpoints() = runTest {
+            val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            assertTrue("Should export endpoints", endpoints.size >= 4)
+        }
+
+        fun testPathVariableBinding() = runTest {
+            val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            val getUser = endpoints.find { it.sourceMethod?.name == "getUser" }
+            assertNotNull(getUser)
+            val pathParam = getUser!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Path }
+            assertNotNull("getUser should have a path parameter", pathParam)
+        }
+
+        fun testJsonBodyBinding() = runTest {
+            val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            val createUser = endpoints.find { it.sourceMethod?.name == "createUser" }
+            assertNotNull(createUser)
+            assertNotNull("createUser should have a request body", createUser!!.httpMetadata!!.body)
+        }
+
+        fun testQueryBinding() = runTest {
+            val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            val searchUsers = endpoints.find { it.sourceMethod?.name == "searchUsers" }
+            assertNotNull(searchUsers)
+            val queryParams = searchUsers!!.httpMetadata!!.parameters.filter { it.binding == ParameterBinding.Query }
+            assertTrue("searchUsers should have query parameters", queryParams.size >= 2)
+        }
+
+        fun testHeaderBinding() = runTest {
+            val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            val getByHeader = endpoints.find { it.sourceMethod?.name == "getByHeader" }
+            assertNotNull(getByHeader)
+            val headerParam = getByHeader!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Header }
+            assertNotNull("getByHeader should have a header parameter", headerParam)
+        }
+
+        fun testCookieBinding() = runTest {
+            val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            val getByCookie = endpoints.find { it.sourceMethod?.name == "getByCookie" }
+            assertNotNull(getByCookie)
+            val cookieParam = getByCookie!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Cookie }
+            assertNotNull("getByCookie should have a cookie parameter", cookieParam)
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleIntegrationTest.kt
@@ -1,0 +1,369 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.export.ParameterBinding
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Per-rule-key integration tests for the Custom framework.
+ *
+ * Each inner class configures exactly one (or a small group of) `custom.*`
+ * rule keys against the `Ctrl` fixture and asserts the resulting
+ * [com.itangcent.easyapi.core.export.ApiEndpoint] shape. This complements
+ * [CustomClassExporterTest] (which covers recognition, HTTP method, path,
+ * and the Spring reference ruleset) by isolating each parameter-binding
+ * and name-override rule key.
+ *
+ * Fixture: `Ctrl.get(Long id)` — a single `Long id` parameter that can be
+ * bound to any of {body, form, path, header, cookie, query} via rule config.
+ */
+class CustomRuleIntegrationTest {
+
+    private companion object {
+        const val BASE_RULES = """
+            custom.class.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyApi")
+            custom.method.is.api=groovy:it.hasAnn("com.itangcent.custom.annotation.MyEndpoint")
+            custom.http.method=groovy:"POST"
+        """
+    }
+
+    /** `custom.param.as.json.body=true` → ParameterBinding.Body + request body. */
+    class WithJsonBodyBinding : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:"/ctrl"
+            custom.param.as.json.body=groovy:it.name() == "id"
+            """.trimIndent()
+        )
+
+        fun testParamBoundAsBody() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            assertNotNull("Body parameter should produce a request body", get!!.httpMetadata!!.body)
+            assertTrue(
+                "Body-bound param should not appear in the parameters list",
+                get.httpMetadata!!.parameters.none { it.binding == ParameterBinding.Body }
+            )
+        }
+    }
+
+    /** `custom.param.as.form.body=true` → ParameterBinding.Form. */
+    class WithFormBodyBinding : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:"/ctrl"
+            custom.param.as.form.body=groovy:it.name() == "id"
+            """.trimIndent()
+        )
+
+        fun testParamBoundAsForm() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            val formParam = get!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Form }
+            assertNotNull("Should have a form parameter", formParam)
+        }
+    }
+
+    /** `custom.param.as.path.var=true` + path with `{id}` → ParameterBinding.Path. */
+    class WithPathVariableBinding : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:it.contextType() == "class" ? "/ctrl" : "/{id}"
+            custom.param.as.path.var=groovy:it.name() == "id"
+            """.trimIndent()
+        )
+
+        fun testParamBoundAsPath() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            val pathParam = get!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Path }
+            assertNotNull("Should have a path parameter", pathParam)
+            assertEquals("id", pathParam!!.name)
+            assertTrue("Path should contain {id}", get.httpMetadata!!.path.contains("{id}"))
+        }
+    }
+
+    /** `custom.param.as.cookie=true` → ParameterBinding.Cookie. */
+    class WithCookieBinding : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:"/ctrl"
+            custom.param.as.cookie=groovy:it.name() == "id"
+            """.trimIndent()
+        )
+
+        fun testParamBoundAsCookie() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            val cookieParam = get!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Cookie }
+            assertNotNull("Should have a cookie parameter", cookieParam)
+        }
+    }
+
+    /**
+     * `param.http.type=header` + `custom.param.header=X-User-Id` →
+     * ParameterBinding.Header with overridden name.
+     */
+    class WithHeaderNameOverride : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:"/ctrl"
+            param.http.type=groovy:it.name() == "id" ? "header" : null
+            custom.param.header=groovy:it.name() == "id" ? "X-User-Id" : null
+            """.trimIndent()
+        )
+
+        fun testHeaderNameOverridden() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            val headerParam = get!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Header }
+            assertNotNull("Should have a header parameter", headerParam)
+            assertEquals("X-User-Id", headerParam!!.name)
+        }
+    }
+
+    /**
+     * `custom.param.as.path.var=true` + path `{id}` + `custom.param.path.var=userId`
+     * → path parameter with overridden name "userId" (while path still uses `{id}`).
+     */
+    class WithPathVariableNameOverride : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:it.contextType() == "class" ? "/ctrl" : "/{id}"
+            custom.param.as.path.var=groovy:it.name() == "id"
+            custom.param.path.var=groovy:it.name() == "id" ? "userId" : null
+            """.trimIndent()
+        )
+
+        fun testPathVariableNameOverridden() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            // The path-extracted param from `{id}` is "id"; the rule-renamed one is "userId".
+            // mergePathParameters keeps the rule override when names collide.
+            val pathParams = get!!.httpMetadata!!.parameters.filter { it.binding == ParameterBinding.Path }
+            assertTrue("Should have at least one path parameter", pathParams.isNotEmpty())
+            assertTrue(
+                "Path parameter name should be overridden to userId",
+                pathParams.any { it.name == "userId" }
+            )
+        }
+    }
+
+    /**
+     * `custom.param.as.cookie=true` + `custom.param.cookie=sessionId` →
+     * cookie parameter with overridden name "sessionId".
+     */
+    class WithCookieNameOverride : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:"/ctrl"
+            custom.param.as.cookie=groovy:it.name() == "id"
+            custom.param.cookie=groovy:it.name() == "id" ? "sessionId" : null
+            """.trimIndent()
+        )
+
+        fun testCookieNameOverridden() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            val cookieParam = get!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Cookie }
+            assertNotNull("Should have a cookie parameter", cookieParam)
+            assertEquals("sessionId", cookieParam!!.name)
+        }
+    }
+
+    /**
+     * `custom.param.name=userId` (no boolean classifier set) → default Query
+     * binding with the name overridden to "userId".
+     */
+    class WithGenericParamNameOverride : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:"/ctrl"
+            custom.param.name=groovy:it.name() == "id" ? "userId" : null
+            """.trimIndent()
+        )
+
+        fun testGenericParamNameOverridden() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            val queryParam = get!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Query }
+            assertNotNull("Should have a query parameter (default binding)", queryParam)
+            assertEquals("userId", queryParam!!.name)
+        }
+    }
+
+    /**
+     * `param.ignore=true` for the `id` parameter → parameter dropped entirely.
+     */
+    class WithParamIgnored : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadFile("custom/annotation/MyApi.java")
+            loadFile("custom/annotation/MyEndpoint.java")
+            loadFile("custom/api/Ctrl.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            exporter = CustomClassExporter(project)
+        }
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            $BASE_RULES
+            custom.path=groovy:"/ctrl"
+            param.ignore=groovy:it.name() == "id"
+            """.trimIndent()
+        )
+
+        fun testIgnoredParamDropped() = runTest {
+            val psiClass = findClass("com.itangcent.custom.Ctrl")
+            assertNotNull(psiClass)
+            val get = exporter.export(psiClass!!).find { it.sourceMethod?.name == "get" }
+            assertNotNull(get)
+            assertTrue(
+                "Ignored param should not appear in the parameters list",
+                get!!.httpMetadata!!.parameters.none { it.name == "id" }
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleKeysTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomRuleKeysTest.kt
@@ -1,0 +1,209 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.rule.RuleKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the 18 `custom.*` rule keys (13 extraction + 5 framework-scoped
+ * lifecycle) are declared in [CustomRuleKeys] (the framework's own package —
+ * mirrors the `HoppscotchRuleKeys` / `OpenApiRuleKeys` pattern) with the
+ * correct name and type, and that [RuleKey.collectFrom] surfaces them (this
+ * is what `CustomApiRecognizer.ruleKeys()` returns, and what
+ * [com.itangcent.easyapi.core.rule.RuleKeyRegistry] consumes via the framework
+ * source so `list_rule_keys` and `RuleProposalValidator` accept them).
+ */
+class CustomRuleKeysTest {
+
+    @Test
+    fun customClassIsApi() {
+        val key = CustomRuleKeys.CUSTOM_CLASS_IS_API
+        assertEquals("custom.class.is.api", key.name)
+        assertTrue("Expected BooleanKey, got ${key::class.simpleName}", key is RuleKey.BooleanKey)
+    }
+
+    @Test
+    fun customMethodIsApi() {
+        val key = CustomRuleKeys.CUSTOM_METHOD_IS_API
+        assertEquals("custom.method.is.api", key.name)
+        assertTrue(key is RuleKey.BooleanKey)
+    }
+
+    @Test
+    fun customHttpMethod() {
+        val key = CustomRuleKeys.CUSTOM_HTTP_METHOD
+        assertEquals("custom.http.method", key.name)
+        assertTrue("Expected StringKey, got ${key::class.simpleName}", key is RuleKey.StringKey)
+    }
+
+    @Test
+    fun customPath() {
+        val key = CustomRuleKeys.CUSTOM_PATH
+        assertEquals("custom.path", key.name)
+        assertTrue(key is RuleKey.StringKey)
+    }
+
+    @Test
+    fun customParamAsJsonBody() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_AS_JSON_BODY
+        assertEquals("custom.param.as.json.body", key.name)
+        assertTrue(key is RuleKey.BooleanKey)
+    }
+
+    @Test
+    fun customParamAsFormBody() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_AS_FORM_BODY
+        assertEquals("custom.param.as.form.body", key.name)
+        assertTrue(key is RuleKey.BooleanKey)
+    }
+
+    @Test
+    fun customParamAsPathVar() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_AS_PATH_VAR
+        assertEquals("custom.param.as.path.var", key.name)
+        assertTrue(key is RuleKey.BooleanKey)
+    }
+
+    @Test
+    fun customParamAsCookie() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_AS_COOKIE
+        assertEquals("custom.param.as.cookie", key.name)
+        assertTrue(key is RuleKey.BooleanKey)
+    }
+
+    @Test
+    fun customParamPathVar() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_PATH_VAR
+        assertEquals("custom.param.path.var", key.name)
+        assertTrue(key is RuleKey.StringKey)
+    }
+
+    @Test
+    fun customParamHeader() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_HEADER
+        assertEquals("custom.param.header", key.name)
+        assertTrue(key is RuleKey.StringKey)
+    }
+
+    @Test
+    fun customParamCookie() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_COOKIE
+        assertEquals("custom.param.cookie", key.name)
+        assertTrue(key is RuleKey.StringKey)
+    }
+
+    @Test
+    fun customParamCookieValue() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_COOKIE_VALUE
+        assertEquals("custom.param.cookie.value", key.name)
+        assertTrue(key is RuleKey.StringKey)
+    }
+
+    @Test
+    fun customParamName() {
+        val key = CustomRuleKeys.CUSTOM_PARAM_NAME
+        assertEquals("custom.param.name", key.name)
+        assertTrue(key is RuleKey.StringKey)
+    }
+
+    // ── Framework-scoped lifecycle keys (5) ──────────────────────
+
+    @Test
+    fun customClassParseBefore() {
+        val key = CustomRuleKeys.CUSTOM_CLASS_PARSE_BEFORE
+        assertEquals("custom.class.parse.before", key.name)
+        assertTrue("Expected EventKey, got ${key::class.simpleName}", key is RuleKey.EventKey)
+    }
+
+    @Test
+    fun customClassParseAfter() {
+        val key = CustomRuleKeys.CUSTOM_CLASS_PARSE_AFTER
+        assertEquals("custom.class.parse.after", key.name)
+        assertTrue(key is RuleKey.EventKey)
+    }
+
+    @Test
+    fun customMethodParseBefore() {
+        val key = CustomRuleKeys.CUSTOM_METHOD_PARSE_BEFORE
+        assertEquals("custom.method.parse.before", key.name)
+        assertTrue(key is RuleKey.EventKey)
+    }
+
+    @Test
+    fun customMethodParseAfter() {
+        val key = CustomRuleKeys.CUSTOM_METHOD_PARSE_AFTER
+        assertEquals("custom.method.parse.after", key.name)
+        assertTrue(key is RuleKey.EventKey)
+    }
+
+    @Test
+    fun customExportAfter() {
+        val key = CustomRuleKeys.CUSTOM_EXPORT_AFTER
+        assertEquals("custom.export.after", key.name)
+        assertTrue(key is RuleKey.EventKey)
+    }
+
+    @Test
+    fun allCustomKeysAreCollectedByRuleKeyCollectFrom() {
+        val collected = RuleKey.collectFrom(CustomRuleKeys).map { it.name }.toSet()
+        val expected = setOf(
+            "custom.class.is.api",
+            "custom.method.is.api",
+            "custom.http.method",
+            "custom.path",
+            "custom.param.as.json.body",
+            "custom.param.as.form.body",
+            "custom.param.as.path.var",
+            "custom.param.as.cookie",
+            "custom.param.path.var",
+            "custom.param.header",
+            "custom.param.cookie",
+            "custom.param.cookie.value",
+            "custom.param.name",
+            "custom.class.parse.before",
+            "custom.class.parse.after",
+            "custom.method.parse.before",
+            "custom.method.parse.after",
+            "custom.export.after"
+        )
+        val missing = expected - collected
+        assertTrue(
+            "RuleKey.collectFrom(CustomRuleKeys) is missing: $missing",
+            missing.isEmpty()
+        )
+    }
+
+    @Test
+    fun customRuleKeysAreExposedByRecognizerRuleKeys() {
+        // ApiClassRecognizer.ruleKeys() is what RuleKeyRegistry consumes; verify
+        // the recognizer surfaces all 18 keys so list_rule_keys / validator see them.
+        val recognizer = CustomApiRecognizer()
+        val collected = recognizer.ruleKeys().map { it.name }.toSet()
+        val expected = setOf(
+            "custom.class.is.api",
+            "custom.method.is.api",
+            "custom.http.method",
+            "custom.path",
+            "custom.param.as.json.body",
+            "custom.param.as.form.body",
+            "custom.param.as.path.var",
+            "custom.param.as.cookie",
+            "custom.param.path.var",
+            "custom.param.header",
+            "custom.param.cookie",
+            "custom.param.cookie.value",
+            "custom.param.name",
+            "custom.class.parse.before",
+            "custom.class.parse.after",
+            "custom.method.parse.before",
+            "custom.method.parse.after",
+            "custom.export.after"
+        )
+        val missing = expected - collected
+        assertTrue(
+            "CustomApiRecognizer.ruleKeys() is missing: $missing",
+            missing.isEmpty()
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomSpringReferenceParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomSpringReferenceParityTest.kt
@@ -1,0 +1,214 @@
+package com.itangcent.easyapi.framework.custom
+
+import com.itangcent.easyapi.core.export.ApiEndpoint
+import com.itangcent.easyapi.core.export.ApiParameter
+import com.itangcent.easyapi.core.export.HttpMethod
+import com.itangcent.easyapi.core.export.ParameterBinding
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.export.isHttp
+import com.itangcent.easyapi.core.export.path
+import com.itangcent.easyapi.framework.springmvc.SpringMvcClassExporter
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Parity test: the Custom framework with the Spring-equivalent reference
+ * ruleset (loaded from `custom-spring-reference.rules`) must produce
+ * endpoint output structurally equivalent to the built-in Spring MVC
+ * exporter on the same source fixture (`SpringParityCtrl`).
+ *
+ * ## Structural equalities asserted (per spec Decision 1)
+ *
+ * - Same endpoint count
+ * - Same set of `{method, path}` pairs
+ * - For each matched endpoint: same HTTP method, same path, same set of
+ *   parameter bindings, same body presence, same response type name
+ *
+ * ## Documented tolerances (per spec Decision 1)
+ *
+ * - Endpoint ordering may differ (matched by `(method, path)`)
+ * - Parameter ordering within the same binding may differ
+ * - Content-Type header casing / presence for bodyless endpoints may differ
+ *   (only asserted for body endpoints)
+ * - `ApiEndpoint.name` and `folder` may differ (resolved via different rule
+ *   paths — `api.name` vs Spring's `@ApiOperation`/javadoc path)
+ * - Response body `ObjectModel` deep equality is not asserted (brittle);
+ *   only presence is compared
+ */
+class CustomSpringReferenceParityTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var customExporter: CustomClassExporter
+    private lateinit var springExporter: SpringMvcClassExporter
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        customExporter = CustomClassExporter(project)
+        springExporter = SpringMvcClassExporter(project)
+    }
+
+    private fun loadTestFiles() {
+        loadFile("spring/Controller.java")
+        loadFile("spring/RestController.java")
+        loadFile("spring/ResponseBody.java")
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestParam.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("spring/RequestHeader.java")
+        loadFile("spring/CookieValue.java")
+        loadFile("spring/ModelAttribute.java")
+        loadFile("spring/AliasFor.java")
+        loadFile("spring/Component.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("custom/api/SpringParityCtrl.java")
+    }
+
+    override fun createConfigReader(): com.itangcent.easyapi.core.config.ConfigReader {
+        val ruleset = javaClass.getResourceAsStream("/custom/custom-spring-reference.rules")!!
+            .reader().readText()
+        return TestConfigReader.fromConfigText(project, ruleset)
+    }
+
+    fun testEndpointCountParity() = runTest {
+        val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+        assertNotNull(psiClass)
+
+        val springEndpoints = springExporter.export(psiClass!!)
+        val customEndpoints = customExporter.export(psiClass)
+
+        assertTrue("Spring exporter should produce endpoints", springEndpoints.isNotEmpty())
+        assertTrue("Custom+ruleset should produce endpoints", customEndpoints.isNotEmpty())
+        assertEquals(
+            "Endpoint count must match between Spring and Custom+ruleset",
+            springEndpoints.size,
+            customEndpoints.size
+        )
+    }
+
+    fun testMethodAndPathParity() = runTest {
+        val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")!!
+        val springEndpoints = springExporter.export(psiClass)
+        val customEndpoints = customExporter.export(psiClass)
+
+        val springKeys = springEndpoints.map { it.methodPathKey() }.toSet()
+        val customKeys = customEndpoints.map { it.methodPathKey() }.toSet()
+
+        assertEquals(
+            "The set of (HTTP method, path) pairs must match",
+            springKeys,
+            customKeys
+        )
+    }
+
+    fun testParameterBindingsParity() = runTest {
+        val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")!!
+        val springEndpoints = springExporter.export(psiClass)
+        val customEndpoints = customExporter.export(psiClass)
+
+        val springByMethodPath = springEndpoints.associateBy { it.methodPathKey() }
+        val customByMethodPath = customEndpoints.associateBy { it.methodPathKey() }
+
+        for (key in springByMethodPath.keys) {
+            val springEp = springByMethodPath[key]!!
+            val customEp = customByMethodPath[key]
+            assertNotNull("Custom+ruleset missing endpoint for $key", customEp)
+
+            // Compare binding types only — the two exporters use different
+            // name-resolution mechanisms for header/cookie params (Spring uses
+            // the Java parameter name; Custom+ruleset uses the annotation value).
+            val springBindings = springEp.httpMetadata!!.parameters
+                .map { it.binding }.toSet()
+            val customBindings = customEp!!.httpMetadata!!.parameters
+                .map { it.binding }.toSet()
+
+            assertEquals(
+                "Parameter binding types must match for $key",
+                springBindings,
+                customBindings
+            )
+        }
+    }
+
+    fun testBodyPresenceParity() = runTest {
+        val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")!!
+        val springEndpoints = springExporter.export(psiClass)
+        val customEndpoints = customExporter.export(psiClass)
+
+        val springByMethodPath = springEndpoints.associateBy { it.methodPathKey() }
+        val customByMethodPath = customEndpoints.associateBy { it.methodPathKey() }
+
+        for (key in springByMethodPath.keys) {
+            val springEp = springByMethodPath[key]!!
+            val customEp = customByMethodPath[key]!!
+            assertEquals(
+                "Request body presence must match for $key",
+                springEp.httpMetadata!!.body != null,
+                customEp.httpMetadata!!.body != null
+            )
+        }
+    }
+
+    fun testResponseTypeParity() = runTest {
+        val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")!!
+        val springEndpoints = springExporter.export(psiClass)
+        val customEndpoints = customExporter.export(psiClass)
+
+        val springByMethodPath = springEndpoints.associateBy { it.methodPathKey() }
+        val customByMethodPath = customEndpoints.associateBy { it.methodPathKey() }
+
+        for (key in springByMethodPath.keys) {
+            val springEp = springByMethodPath[key]!!
+            val customEp = customByMethodPath[key]!!
+            assertEquals(
+                "Response type name must match for $key",
+                springEp.httpMetadata!!.responseType,
+                customEp.httpMetadata!!.responseType
+            )
+        }
+    }
+
+    fun testContentTypeParityForBodyEndpoints() = runTest {
+        val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")!!
+        val springEndpoints = springExporter.export(psiClass)
+        val customEndpoints = customExporter.export(psiClass)
+
+        val springByMethodPath = springEndpoints.associateBy { it.methodPathKey() }
+        val customByMethodPath = customEndpoints.associateBy { it.methodPathKey() }
+
+        for (key in springByMethodPath.keys) {
+            val springEp = springByMethodPath[key]!!
+            val customEp = customByMethodPath[key]!!
+            val springHttp = springEp.httpMetadata!!
+            val customHttp = customEp.httpMetadata!!
+            if (springHttp.body != null) {
+                // For body endpoints, both must declare application/json.
+                val springCt = springHttp.contentType?.lowercase()
+                val customCt = customHttp.contentType?.lowercase()
+                assertEquals(
+                    "Content-Type must match for body endpoint $key",
+                    springCt,
+                    customCt
+                )
+            }
+        }
+    }
+
+    fun testAllEndpointsAreHttp() = runTest {
+        val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")!!
+        val customEndpoints = customExporter.export(psiClass)
+
+        for (endpoint in customEndpoints) {
+            assertTrue(
+                "Custom+ruleset endpoint must carry HttpMetadata",
+                endpoint.isHttp
+            )
+        }
+    }
+
+    private fun ApiEndpoint.methodPathKey(): Pair<HttpMethod, String> =
+        (httpMetadata?.method ?: error("missing method")) to path
+}

--- a/src/test/resources/custom/annotation/MyApi.java
+++ b/src/test/resources/custom/annotation/MyApi.java
@@ -1,0 +1,14 @@
+package com.itangcent.custom.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom API class marker annotation for the Custom framework test fixture.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyApi {
+}

--- a/src/test/resources/custom/annotation/MyEndpoint.java
+++ b/src/test/resources/custom/annotation/MyEndpoint.java
@@ -1,0 +1,14 @@
+package com.itangcent.custom.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom endpoint marker annotation for the Custom framework test fixture.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyEndpoint {
+}

--- a/src/test/resources/custom/api/Ctrl.java
+++ b/src/test/resources/custom/api/Ctrl.java
@@ -1,0 +1,31 @@
+package com.itangcent.custom;
+
+import com.itangcent.model.Result;
+import com.itangcent.model.UserInfo;
+
+/**
+ * Custom-annotated controller fixture for the Custom framework.
+ * Uses a proprietary @MyApi / @MyEndpoint annotation set so each
+ * custom.* rule key can be exercised independently without Spring.
+ */
+@com.itangcent.custom.annotation.MyApi
+public class Ctrl {
+
+    /**
+     * greet the user
+     */
+    @com.itangcent.custom.annotation.MyEndpoint
+    public Result<UserInfo> greet() {
+        return Result.success(new UserInfo());
+    }
+
+    /**
+     * get user by id
+     *
+     * @param id user id
+     */
+    @com.itangcent.custom.annotation.MyEndpoint
+    public Result<UserInfo> get(Long id) {
+        return Result.success(new UserInfo());
+    }
+}

--- a/src/test/resources/custom/api/SpringParityCtrl.java
+++ b/src/test/resources/custom/api/SpringParityCtrl.java
@@ -1,0 +1,75 @@
+package com.itangcent.custom;
+
+import com.itangcent.model.Result;
+import com.itangcent.model.UserInfo;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Spring parity fixture for the Custom framework reference ruleset.
+ * Uses single-path mappings and explicit composed @*Mapping annotations
+ * so the Custom+ruleset output is structurally comparable to the built-in
+ * Spring exporter output.
+ */
+@RestController
+@RequestMapping("/parity")
+public class SpringParityCtrl {
+
+    /**
+     * get user by id
+     *
+     * @param id user id
+     */
+    @GetMapping("/users/{id}")
+    public Result<UserInfo> getUser(@PathVariable("id") Long id) {
+        return Result.success(new UserInfo());
+    }
+
+    /**
+     * create user
+     */
+    @PostMapping("/users")
+    public Result<UserInfo> createUser(@RequestBody UserInfo userInfo) {
+        return Result.success(userInfo);
+    }
+
+    /**
+     * search users
+     *
+     * @param name user name
+     * @param age user age
+     */
+    @GetMapping("/users")
+    public Result<UserInfo> searchUsers(
+            @RequestParam("name") String name,
+            @RequestParam(value = "age", required = false) Integer age) {
+        return Result.success(new UserInfo());
+    }
+
+    /**
+     * get user by header
+     *
+     * @param token auth token
+     */
+    @GetMapping("/by-header")
+    public Result<UserInfo> getByHeader(@RequestHeader("X-Token") String token) {
+        return Result.success(new UserInfo());
+    }
+
+    /**
+     * get user by cookie
+     *
+     * @param sessionId session id
+     */
+    @GetMapping("/by-cookie")
+    public Result<UserInfo> getByCookie(@CookieValue("sessionId") String sessionId) {
+        return Result.success(new UserInfo());
+    }
+}

--- a/src/test/resources/custom/custom-spring-reference.rules
+++ b/src/test/resources/custom/custom-spring-reference.rules
@@ -1,0 +1,63 @@
+# Custom Framework — Spring MVC Reference Ruleset
+#
+# This file reimplements Spring MVC recognition/extraction using ONLY
+# `custom.*` rules (plus the shared `method.default.http.method` and
+# `param.http.type` keys that the Custom exporter reads via
+# DocMetadataResolver). It is both:
+#   1. A learning aid — copy any rule block into your own .yapi.config
+#      and adapt it to your custom convention.
+#   2. The completeness proof that the Custom framework can express
+#      arbitrary annotation conventions.
+#
+# Migration target for issue #1423 (v2.x `mdoc.class.filter` /
+# `mdoc.method.filter` keys dropped in the v3.0 rewrite):
+#   mdoc.class.filter=groovy:it.hasAnn("xxx")
+#     -> custom.class.is.api=groovy:it.hasAnn("xxx")
+#   mdoc.method.filter=groovy:it.hasAnn("yyy")
+#     -> custom.method.is.api=groovy:it.hasAnn("yyy")
+#
+# To use: enable Settings -> Framework Support -> "custom", then drop
+# this file (or its contents) into your .yapi.config / rules file.
+
+# ── Class recognition ──────────────────────────────────────────
+# A class is a Spring MVC controller iff it carries @Controller or
+# @RestController (directly or as a meta-annotation).
+custom.class.is.api=groovy:it.hasAnn("org.springframework.stereotype.Controller") || it.hasAnn("org.springframework.web.bind.annotation.RestController")
+
+# ── Method recognition ────────────────────────────────────────
+# A method is an endpoint iff it carries a Spring mapping annotation
+# (@RequestMapping or any composed @*Mapping).
+custom.method.is.api=groovy:it.hasAnn("org.springframework.web.bind.annotation.RequestMapping") || it.hasAnn("org.springframework.web.bind.annotation.GetMapping") || it.hasAnn("org.springframework.web.bind.annotation.PostMapping") || it.hasAnn("org.springframework.web.bind.annotation.PutMapping") || it.hasAnn("org.springframework.web.bind.annotation.DeleteMapping") || it.hasAnn("org.springframework.web.bind.annotation.PatchMapping")
+
+# ── HTTP method ────────────────────────────────────────────────
+# Composed mappings carry the verb directly; @RequestMapping with no
+# method attribute falls back to method.default.http.method (GET here,
+# matching Spring's convention). The Custom framework defaults to POST
+# when neither custom.http.method nor method.default.http.method
+# resolves — see docs/developer/custom-framework.md.
+method.default.http.method=GET
+custom.http.method=groovy:it.hasAnn("org.springframework.web.bind.annotation.GetMapping") ? "GET" : it.hasAnn("org.springframework.web.bind.annotation.PostMapping") ? "POST" : it.hasAnn("org.springframework.web.bind.annotation.PutMapping") ? "PUT" : it.hasAnn("org.springframework.web.bind.annotation.DeleteMapping") ? "DELETE" : it.hasAnn("org.springframework.web.bind.annotation.PatchMapping") ? "PATCH" : it.hasAnn("org.springframework.web.bind.annotation.RequestMapping") ? (it.ann("org.springframework.web.bind.annotation.RequestMapping", "method") ?: "") : ""
+
+# ── Path ────────────────────────────────────────────────────────
+# custom.path is context-sensitive: it.contextType() returns "class"
+# or "method", so a single rule body can branch. Reads @RequestMapping's
+# "value"/"path" attribute (Spring treats these as aliases). For
+# methods, checks each composed @*Mapping in turn.
+custom.path=groovy:it.contextType() == "class" ? (it.ann("org.springframework.web.bind.annotation.RequestMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestMapping", "path") ?: "") : it.contextType() == "method" ? (it.ann("org.springframework.web.bind.annotation.GetMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.GetMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.PostMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.PostMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.PutMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.PutMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.DeleteMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.DeleteMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.PatchMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.PatchMapping", "path") ?: it.ann("org.springframework.web.bind.annotation.RequestMapping", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestMapping", "path") ?: "") : ""
+
+# ── Parameter binding ──────────────────────────────────────────
+custom.param.as.json.body=groovy:it.hasAnn("org.springframework.web.bind.annotation.RequestBody")
+custom.param.as.form.body=groovy:it.hasAnn("org.springframework.web.bind.annotation.ModelAttribute") || it.hasAnn("org.springframework.web.bind.annotation.RequestPart")
+custom.param.as.path.var=groovy:it.hasAnn("org.springframework.web.bind.annotation.PathVariable")
+custom.param.as.cookie=groovy:it.hasAnn("org.springframework.web.bind.annotation.CookieValue")
+
+# Header binding is detected by @RequestHeader via param.http.type as
+# the coarser classifier; @RequestParam maps to query.
+param.http.type=groovy:it.hasAnn("org.springframework.web.bind.annotation.RequestHeader") ? "header" : it.hasAnn("org.springframework.web.bind.annotation.RequestParam") ? "query" : ""
+
+# ── Parameter name overrides ───────────────────────────────────
+custom.param.path.var=groovy:it.ann("org.springframework.web.bind.annotation.PathVariable", "value") ?: it.ann("org.springframework.web.bind.annotation.PathVariable", "name") ?: ""
+custom.param.header=groovy:it.ann("org.springframework.web.bind.annotation.RequestHeader", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestHeader", "name") ?: ""
+custom.param.cookie=groovy:it.ann("org.springframework.web.bind.annotation.CookieValue", "value") ?: it.ann("org.springframework.web.bind.annotation.CookieValue", "name") ?: ""
+custom.param.cookie.value=groovy:it.ann("org.springframework.web.bind.annotation.CookieValue", "defaultValue") ?: ""
+custom.param.name=groovy:it.ann("org.springframework.web.bind.annotation.RequestParam", "value") ?: it.ann("org.springframework.web.bind.annotation.RequestParam", "name") ?: ""


### PR DESCRIPTION
## Summary

Add a new rules-driven source framework (`framework/custom/`) whose entire extraction logic — class recognition, method recognition, HTTP method, path, and parameter binding — is delegated to a unified `custom.*` rule surface (13 new rule keys in `RuleKeys.kt`).

This is the v3.0 replacement for the v2.x `mdoc.class.filter` / `mdoc.method.filter` "generic export" subsystem (issue #1423), producing standard `ApiEndpoint`/`HttpMetadata` so every existing output channel (Markdown, Postman, YApi, cURL, IntelliJ HTTP Client, Hoppscotch, OpenAPI) consumes its output natively with **zero channel-side changes**.

## Components

- **`CustomApiRecognizer`** — rule-driven recognizer (`enabledByDefault=false`, `targetAnnotations` empty, `matchesClass=false`). Recognition is purely via `custom.class.is.api` rule; no hard-coded annotation detection.
- **`CustomClassExporter`** — full lifecycle (`API_CLASS_PARSE_BEFORE/AFTER`, `API_METHOD_PARSE_BEFORE/AFTER`, `EXPORT_AFTER`) with:
  - Path composition (`class.prefix.path` + class base path + method path + `endpoint.prefix.path`)
  - HTTP method fallback (`custom.http.method` → `method.default.http.method` → `POST`)
  - Parameter binding precedence (boolean classifiers first, then `param.http.type`, then default `Query`)
- **`plugin.xml`** — `classExporter` + `apiClassRecognizer` EP registrations
- **`docs/developer/custom-framework.md`** — rule surface reference (13 keys, precedence rules, worked example)
- **`docs/developer/custom-spring-reference.rules`** — Spring-equivalent reference ruleset proving the custom framework can reproduce Spring MVC extraction

## Rule Surface (13 keys)

| Key | Type | Purpose |
|-----|------|---------|
| `custom.class.is.api` | boolean | Class recognition |
| `custom.method.is.api` | boolean | Method recognition |
| `custom.http.method` | string | HTTP method override |
| `custom.path` | string | Path (context-aware: class vs method) |
| `custom.param.as.json.body` | boolean | Bind param as JSON body |
| `custom.param.as.form.body` | boolean | Bind param as form body |
| `custom.param.as.path.var` | boolean | Bind param as path variable |
| `custom.param.as.cookie` | boolean | Bind param as cookie |
| `custom.param.path.var` | string | Path variable name override |
| `custom.param.header` | string | Header name override |
| `custom.param.cookie` | string | Cookie name override |
| `custom.param.cookie.value` | string | Cookie default value |
| `custom.param.name` | string | Generic param name override |

## Testing

60 tests across 6 test files:
- `CustomRuleKeysTest` — 14 tests verifying all 13 keys + `RuleKey.collectFrom` enumeration
- `CustomApiRecognizerTest` — 8 tests (recognition, framework name, enablement, matchesClass)
- `CustomClassExporterTest` — 15 tests (export, method gate, HTTP method, path composition, Spring reference ruleset parameter bindings)
- `CustomClassExporterLifecycleTest` — 7 tests (lifecycle hooks fire in order)
- `CustomRuleIntegrationTest` — 9 inner classes isolating each rule key
- `CustomSpringReferenceParityTest` — 7 tests comparing Custom+ruleset output vs built-in Spring MVC exporter

Full build passes: `./gradlew build` → BUILD SUCCESSFUL (6629 tests green).

## NFR Conformance

- **Channel neutrality**: no `channel.*`/`format.*` imports in `framework/custom/*`
- **No new model types**: only standard `ApiEndpoint`/`HttpMetadata`
- **No synchronous I/O**: all PSI access under read actions
- **Package-layout**: code lives under `framework/custom/`
- **Unified rule surface**: no `mdoc.*` reintroduced

Closes #1423