### PR TITLE
feat(ai): hybrid agent architecture with per-task sub-agent isolation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -254,7 +254,50 @@ fun copyFileIfDifferent(source: File, target: File) {
     source.copyTo(target, overwrite = true)
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Agent catalog sync (R3-C3)
+//
+// `src/main/resources/ai/{detection,rules}/*.md` are the canonical prompt
+// catalog the in-plugin agent loads at runtime via `PromptCatalog`. The
+// external `easy-api-assistant` skill ships a verbatim copy under
+// `skills/easy-api-assistant/ai/` so the external assistant has the same
+// per-detection / per-key recipe surface (mirrored by the
+// `get_detection_prompt.sh` / `get_rule_detail.sh` CLI scripts).
+//
+// This task is the catalog counterpart of `syncKnowledgeBase` — same
+// content-equality-checked / idempotent contract. It does NOT sync
+// `agent-base.md` or `catalog-manifest.txt`: those are in-plugin prompt
+// infrastructure, not part of the external skill's surface (the external
+// assistant reads the catalog via scripts, not via `agent-base.md`).
+// ─────────────────────────────────────────────────────────────────────────────
+val agentCatalogSourceDir = file("src/main/resources/ai")
+val agentCatalogSkillDir = file("skills/easy-api-assistant/ai")
+
+val syncAgentCatalog by tasks.registering {
+    group = "documentation"
+    description = "Sync src/main/resources/ai/{detection,rules}/*.md into the easy-api-assistant skill folder."
+
+    val sourceFiles = fileTree(agentCatalogSourceDir) {
+        include("detection/*.md")
+        include("rules/*.md")
+    }
+    inputs.files(sourceFiles)
+    outputs.files(fileTree(agentCatalogSkillDir) { include("**/*.md") })
+    outputs.upToDateWhen { true }
+
+    doLast {
+        val sources = sourceFiles.files.sortedBy { it.path }
+        logger.lifecycle("Syncing ${sources.size} agent-catalog file(s) into the easy-api-assistant skill folder:")
+        sources.forEach { source ->
+            val rel = source.relativeTo(agentCatalogSourceDir).path   // detection/<id>.md / rules/<key>.md
+            copyFileIfDifferent(source, File(agentCatalogSkillDir, rel))
+            logger.lifecycle("  - $rel")
+        }
+    }
+}
+
 // Ensure the JAR always ships docs synced from the canonical source.
 tasks.named("processResources") {
     dependsOn("syncKnowledgeBase")
+    dependsOn("syncAgentCatalog")
 }

--- a/skills/easy-api-assistant/SKILL.md
+++ b/skills/easy-api-assistant/SKILL.md
@@ -29,11 +29,19 @@ Invoke this skill when:
 
 ## Bundled Knowledge Base (read these first — they ARE the built-in agent's docs)
 
-This skill ships the **same knowledge-base pages** the plugin bundles for its
-built-in agent's `get_plugin_doc` tool, copied verbatim into the bundled
-`docs/` folder next to `SKILL.md`. They are kept in sync by the
-`syncKnowledgeBase` Gradle task in the easy-api repo, so the rule content the
-built-in and external agents produce is identical. Always read the relevant
+This skill ships **two** verbatim mirrors of the in-plugin agent's
+authoritative sources, kept in sync by Gradle tasks in the easy-api repo:
+
+1. **`docs/`** — the long-form knowledge-base pages the plugin bundles for its
+   built-in agent's `get_plugin_doc` tool. Kept in sync by the
+   `syncKnowledgeBase` Gradle task.
+2. **`ai/detection/` + `ai/rules/`** — the per-detection / per-key recipe
+   catalog the in-plugin agent loads via `PromptCatalog` (the same files
+   `get_detection_prompt` and `get_rule_detail` read at runtime). Kept in sync
+   by the `syncAgentCatalog` Gradle task.
+
+Both mirrors are content-equality-checked and idempotent, so the rule content
+the built-in and external agents produce is identical. Always read the relevant
 page first — do **not** rely on memory or guess syntax.
 
 | Bundled file | Built-in `get_plugin_doc` name | What it covers |
@@ -84,6 +92,49 @@ scripts/read_rule_file.sh project:custom.rules
 scripts/get_existing_rules_for_key.sh field.name
 scripts/get_existing_rules_for_key.sh method.doc method.additional.header
 ```
+
+### Catalog recipe tools (mirrors of in-plugin `get_detection_prompt` / `get_rule_detail`)
+
+The built-in agent's decomposed prompt catalog (Phase A of the in-plugin
+agent) lives under `src/main/resources/ai/{detection,rules}/` in the easy-api
+repo. This skill ships a verbatim copy under `ai/{detection,rules}/` next to
+`SKILL.md`, kept in sync by the `syncAgentCatalog` Gradle task. Four CLI
+scripts mirror the in-plugin perception tools that read that catalog — same
+id space, same body content, same error shape — so your workflow tracks the
+in-plugin agent's exactly.
+
+| Built-in tool | Your equivalent | What it does |
+|---------------|-----------------|--------------|
+| `get_detection_prompt` | `scripts/get_detection_prompt.sh <id>` | Fetches the full detection recipe for one detection family by id (e.g. `spring-filters-interceptors`, `static-auth`). Strips the YAML front-matter; prints the markdown body. Unknown id → `error: unknown detection id: <id>` on stderr, exit 1. |
+| `get_rule_detail` (by-key path) | `scripts/get_rule_detail.sh <key>` | Fetches the full per-key rule recipe by rule key (e.g. `postman.test`, `method.additional.header`). Strips the YAML front-matter; prints the body. Unknown key → `error: unknown rule key: <key>` on stderr, exit 1. |
+| `SystemPromptBuilder.indexMessage("detection")` | `scripts/list_detections.sh` | Lists every detection family: `id — title: cue` per file (lexicographic by filename). |
+| `SystemPromptBuilder.indexMessage("rules")` | `scripts/list_rule_details.sh` | Lists every per-key rule recipe: `key — title: cue` per file. Complements (does NOT replace) `docs/rule-keys.md`, which lists every supported rule key including those without a per-key recipe file. |
+
+**Usage examples:**
+```bash
+# Discover which detection families exist before proposing rules
+scripts/list_detections.sh
+
+# Fetch the recipe for one detection family
+scripts/get_detection_prompt.sh spring-filters-interceptors
+scripts/get_detection_prompt.sh static-auth
+
+# Discover which per-key rule recipes exist
+scripts/list_rule_details.sh
+
+# Fetch the recipe for one rule key (before drafting a rule for that key)
+scripts/get_rule_detail.sh postman.test
+scripts/get_rule_detail.sh method.additional.header
+```
+
+**Catalog recipe access priority** (mirrors the in-plugin agent's
+`agent-base.md`): for a detection-family question, the **preferred first
+stop** is `scripts/get_detection_prompt.sh <id>`; for a per-key recipe
+question, the **preferred first stop** is `scripts/get_rule_detail.sh <key>`.
+The long-form `docs/rule-guide.md` stays the reference for cross-cutting
+context (Workflow Patterns, Multi-Application Namespace, the full
+filter-prefix table). Memory is **never** a substitute for the catalog —
+always read the recipe before drafting.
 
 ### General codebase-perception tools (your file/grep capabilities)
 
@@ -143,19 +194,44 @@ three keys at once. Prefer the combined form.
 
 Work in a **perceive → reason → act** loop, mirroring the built-in agent.
 
-### Step 1: Perceive — read the authoritative guide
+### Step 1: Perceive — fetch the per-recipe catalog entry, then the long-form guide
 
-Read the bundled `docs/rule-guide.md` first. It is the source of truth for
-the rule file format, the full rule-key catalog, filter syntax, expression
-prefixes, recipes, and the Custom-Pattern Catalog. If the topic is
-settings/usage/scripting rather than rules, read the corresponding bundled
-page instead.
+The in-plugin agent's decomposed prompt catalog is the **preferred first
+stop** for any detection-family or per-key recipe question. This skill
+mirrors that catalog and exposes it via CLI scripts — use them before
+opening the long-form guide.
+
+- For a **detection family** (filters, interceptors, response wrappers,
+  argument resolvers, custom frameworks, auth chaining, HMAC signing, …):
+  ```bash
+  scripts/list_detections.sh                       # discover the families
+  scripts/get_detection_prompt.sh spring-filters-interceptors   # fetch one recipe
+  ```
+- For a **per-key rule recipe** (a specific rule key like `postman.test` or
+  `method.additional.header`):
+  ```bash
+  scripts/list_rule_details.sh                     # discover the keys with recipes
+  scripts/get_rule_detail.sh postman.test          # fetch one recipe
+  ```
+
+The long-form `docs/rule-guide.md` is the **reference for cross-cutting
+context**: the full rule file format, the full rule-key catalog, the complete
+filter-prefix table, the Workflow-Pattern Catalog (cross-endpoint
+auth/signing/refresh recipes), and the Multi-Application Namespace section.
+Read it after the per-recipe entry when you need that broader context —
+not instead of it.
+
+If the topic is settings/usage/scripting rather than rules, read the
+corresponding bundled `docs/` page instead (no per-recipe catalog exists
+for those topics).
 
 ### Step 2: Perceive — find the right rule key
 
-If the rule key isn't obvious from the guide, scan the bundled `docs/rule-keys.md`
-catalog. **Never invent keys not in that catalog** — unknown keys are silently
-ignored by the plugin's config loader.
+If the rule key isn't obvious from the catalog or guide, scan the bundled
+`docs/rule-keys.md` catalog (the snapshot of `RuleKeys.kt`). Cross-check
+against `scripts/list_rule_details.sh` to see whether a per-key recipe file
+exists for it. **Never invent keys not in the `docs/rule-keys.md`
+catalog** — unknown keys are silently ignored by the plugin's config loader.
 
 ### Step 3: Perceive — inspect existing rules
 
@@ -178,15 +254,26 @@ global folder, which overrides the built-in rules.
 
 **Most projects do not need custom rules.** EasyApi understands standard HTTP
 frameworks (Spring MVC, WebFlux, JAX-RS, Feign) out of the box. Before
-proposing a rule, scan the project for the **Custom-Pattern Catalog** signals
-documented in the bundled `docs/rule-guide.md` (section "Custom-Pattern Catalog").
+proposing a rule, scan the project for the **detection catalog** signals —
+each detection family in `scripts/list_detections.sh` has a full recipe in
+`ai/detection/<id>.md` (read via `scripts/get_detection_prompt.sh <id>`)
+that lists the exact signals to look for.
+
+```bash
+# Discover every detection family the in-plugin agent knows
+scripts/list_detections.sh
+
+# Fetch the recipe for one family before scanning the codebase
+scripts/get_detection_prompt.sh spring-filters-interceptors
+scripts/get_detection_prompt.sh custom-framework
+```
 
 Use the discovery patterns under "General codebase-perception tools" above —
 `find_classes_by_supertype` (your `extends`/`implements` scan) is the most
 common blind spot, since annotation-only scans miss inheritance-declared
 components. For each candidate, ask: *does it change the request/response
-contract invisibly?* If yes, apply the catalog recipe. If no, no rule is
-needed.
+contract invisibly?* If yes, fetch the matching detection recipe and apply
+its rule(s). If no, no rule is needed.
 
 ### Step 5: Reason — is a rule actually needed?
 
@@ -385,10 +472,12 @@ AI assistant, briefly explain:
   gives the assistant the same workflow, mapping each built-in PSI tool to a
   CLI equivalent. Best for users already invested in an external AI workflow.
 
-Both approaches share the same knowledge base (the built-in agent reads it
-from the plugin JAR via `get_plugin_doc`; this skill ships a verbatim copy,
-kept in sync by the `syncKnowledgeBase` Gradle task), so the rule content
-they produce is consistent.
+Both approaches share the same knowledge base and recipe catalog: the
+built-in agent reads them from the plugin JAR (`get_plugin_doc` for the
+long-form pages, `get_detection_prompt` / `get_rule_detail` for the
+per-recipe catalog); this skill ships verbatim copies of both, kept in sync
+by the `syncKnowledgeBase` and `syncAgentCatalog` Gradle tasks. So the rule
+content they produce is consistent.
 
 ## What This Skill Does NOT Do
 
@@ -412,8 +501,14 @@ they produce is consistent.
 - `docs/rule-keys.md` — complete rule-key catalog (snapshot of `RuleKeys.kt`).
 - `docs/index.md`, `docs/README.md`, `docs/settings-guide.md`, `docs/usage-guide.md`,
   `docs/easyapi-script-reference.md` — the rest of the knowledge base.
+- `ai/detection/*.md` — per-detection-family recipe catalog (verbatim mirror of
+  the in-plugin agent's `src/main/resources/ai/detection/`). Read via
+  `scripts/get_detection_prompt.sh <id>`; listed by `scripts/list_detections.sh`.
+- `ai/rules/*.md` — per-key rule recipe catalog (verbatim mirror of the in-plugin
+  agent's `src/main/resources/ai/rules/`). Read via `scripts/get_rule_detail.sh <key>`;
+  listed by `scripts/list_rule_details.sh`.
 - `scripts/` — CLI tools mirroring the built-in AI perception tools (see
-  "EasyApi-domain tools" above).
+  "EasyApi-domain tools" and "Catalog recipe tools" above).
 
 Plugin home: https://github.com/tangcent/easy-api
 
@@ -423,19 +518,24 @@ User asks: "Add a rule that renames the `createTime` field to `created_at`
 in all exported APIs."
 
 Workflow:
-1. Read the bundled `docs/rule-guide.md` — find the field-rename section / the
+1. Check whether a per-key recipe exists for `field.name`:
+   ```bash
+   scripts/get_rule_detail.sh field.name        # → "error: unknown rule key" (no recipe file)
+   ```
+   No per-key recipe — fall back to the long-form guide.
+2. Read the bundled `docs/rule-guide.md` — find the field-rename section / the
    `field.name` key.
-2. Check the bundled `docs/rule-keys.md` — confirm the key is `field.name` (alias
+3. Check the bundled `docs/rule-keys.md` — confirm the key is `field.name` (alias
    `json.rule.field.name`), mode `replace`.
-3. **Run `scripts/get_existing_rules_for_key.sh field.name`** — confirm no
+4. **Run `scripts/get_existing_rules_for_key.sh field.name`** — confirm no
    `field.name` rule already covers this.
-4. Open (or create) `<project>/.easyapi/field.rules`.
-5. Draft (using the correct `key[filter]=value` format; a field rename map
+5. Open (or create) `<project>/.easyapi/field.rules`.
+6. Draft (using the correct `key[filter]=value` format; a field rename map
    is a JSON object value with no filter):
    ```
    field.name={"createTime":"created_at"}
    ```
-6. Show the user the diff and apply on confirmation.
+7. Show the user the diff and apply on confirmation.
 
 ## Forbidden Patterns
 

--- a/skills/easy-api-assistant/ai/detection/auth-token-chaining.md
+++ b/skills/easy-api-assistant/ai/detection/auth-token-chaining.md
@@ -1,0 +1,101 @@
+---
+id: auth-token-chaining
+title: Auth token chaining (login producer + secured consumer)
+cue: a login/token endpoint whose response carries a token, plus secured controllers needing a Bearer header
+---
+
+A login/token endpoint whose response carries a token, plus secured
+controllers needing a `Bearer` (or custom) header. The producer/consumer
+split is the key insight — a script attached to the login endpoint stores
+the token, and a header attached to the secured endpoints reads it. This
+is the most common auth workflow pattern; it spans both the request side
+(header injection on secured endpoints) and the response side (token
+extraction from the login response).
+
+## Detection signals
+
+- A **producer endpoint**: a login/token/refresh endpoint whose response
+  body carries a token field. Look for method names like `login`,
+  `authenticate`, `token`, `refresh`, `oauth`, `accessToken`; or paths
+  like `/login`, `/auth`, `/oauth/token`, `/api/token`.
+- A **consumer scope**: secured controllers distinguished by:
+  - A security annotation (`@PreAuthorize`, `@Secured`, `@RolesAllowed`,
+    custom `@RequiresAuth`), OR
+  - A security filter/interceptor reading `Authorization` headers, OR
+  - A Spring Security configuration (`@EnableWebSecurity`,
+    `@EnableResourceServer`, `SecurityFilterChain` bean) that protects
+    URL patterns.
+- The consumer side needs a `Bearer ${token}` (or custom) header; the
+  producer side needs a script that extracts the token from the response
+  and stores it for subsequent requests.
+
+## Discovery
+
+- `list_project_endpoints` to find login/token/refresh endpoints; filter
+  by path/name patterns.
+- `find_classes_by_annotation` for security annotations
+  (`@PreAuthorize`, `@Secured`, `@RolesAllowed`, `@RequiresApiToken`,
+  custom auth annotations).
+- `find_classes_by_supertype` for auth filters/interceptors (see the
+  `spring-filters-interceptors` / `jaxrs-filters` detections for the
+  supertype lists).
+- `get_psi_method_info` on the producer to confirm the token field name
+  in the response body.
+
+## Perceive → reason → act
+
+- **Perceive.** Run the discovery tools above. For the producer,
+  `get_psi_method_info` with `detail="full"` to read the response shape
+  and identify the token field name (commonly `token`, `accessToken`,
+  `access_token`, `idToken`). For the consumer scope, identify the
+  annotation or filter that marks secured endpoints.
+  `get_existing_rules_for_key` for `method.additional.header`,
+  `postman.test`, `postman.prerequest`, `http.call.after` to avoid
+  duplicates.
+- **Reason.** Confirm the producer/consumer split. If the token field is
+  ambiguous (multiple `*token*` keys) or the consumer scope is unclear,
+  call `ask_clarification` with concrete options — do not guess. Reuse
+  an existing env-var name when one is already referenced in the
+  project's rules — resolve it from the rule files (e.g. grep `${...}`
+  out of the existing `method.additional.header` values returned by
+  `get_existing_rules_for_key`), not from the Environments panel.
+  Default to `Authorization` when no existing rule references a token
+  env var.
+- **Act.** Propose the full bundle in one `propose_rule_content` call
+  (filename like `auth-chaining.properties`):
+  - **Producer side** (when Postman is enabled): a `postman.test` rule
+    scoped to the login endpoint that extracts the token from the
+    response and stores it via `pm.environment.set("token",
+    pm.response.json().accessToken)`.
+  - **Consumer side**: a `method.additional.header` rule scoped to the
+    secured endpoints that injects `Authorization: Bearer ${token}`.
+  Never propose half a bundle.
+
+## Bundle integrity (CRITICAL)
+
+Workflow rules that form a chain (login-script + consumer-header) MUST be
+proposed together in a single `propose_rule_content` call. Proposing half
+a chain is forbidden — a consumer header that references a token no
+script stores is a silent bug.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${Authorization}`, `${appSecret}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Script-context isolation (CRITICAL)
+
+`postman.prerequest` and `postman.test` rule values MUST be **literal
+scripts** (NO `groovy:` prefix). A `groovy:` prefix routes the value to
+`Jsr223ScriptParser` at export time, where `pm` is NOT bound — the script
+throws and the failure is silently swallowed, so no script lands in the
+Postman collection.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Auth token chaining"
+section). Do NOT reproduce the table from memory — the canonical doc
+carries detection signals, complete `key[filter]=value` lines, and
+env-var-reuse notes.

--- a/skills/easy-api-assistant/ai/detection/correlation-idempotency.md
+++ b/skills/easy-api-assistant/ai/detection/correlation-idempotency.md
@@ -1,0 +1,59 @@
+---
+id: correlation-idempotency
+title: Correlation & idempotency headers
+cue: X-Request-Id, X-Correlation-Id, Idempotency-Key headers injected per request
+---
+
+Per-request injection of correlation / idempotency headers —
+`X-Request-Id`, `X-Correlation-Id`, `Idempotency-Key`. A filter or
+interceptor generates the value (UUID, counter) and adds it to the
+outgoing request; the export must surface the header so the consumer
+knows the contract.
+
+## Detection signals
+
+- A filter / interceptor / web filter that sets `X-Request-Id`,
+  `X-Correlation-Id`, `Idempotency-Key`, `X-Trace-Id`, or similar
+  correlation/tracing headers on the request or response.
+- A custom annotation (`@Correlated`, `@Idempotent`) marking endpoints
+  that require the header.
+- Constants/fields named `REQUEST_ID_HEADER`, `CORRELATION_ID_HEADER`,
+  `IDEMPOTENCY_KEY_HEADER` — strong signal of a per-request injection.
+
+## Discovery
+
+- `find_classes_by_supertype` for filters / interceptors extending
+  `OncePerRequestFilter` / implementing `HandlerInterceptor` (Spring) or
+  `ContainerRequestFilter` / `ContainerResponseFilter` (JAX-RS). See the
+  `spring-filters-interceptors` / `jaxrs-filters` detections for the full
+  supertype lists.
+- `find_classes_by_annotation` for `@WebFilter` and any custom correlation
+  / idempotency annotations.
+- `get_psi_method_info` with `detail="full"` on the filter to read the
+  header name being set and the value source (UUID? counter? request
+  attribute?).
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools. For each hit, `get_psi_method_info`
+  with `detail="full"` on the filtering method to read the header name(s)
+  and value source. `get_existing_rules_for_key` for
+  `method.additional.header` and `method.additional.response.header` to
+  avoid duplicates.
+- **Reason.** Confirm the header name(s). If multiple correlation headers
+  are present (e.g. both `X-Request-Id` and `X-Correlation-Id`), bundle
+  them in one proposal. Reuse an existing env-var name when one is already
+  referenced in the project's rules; otherwise the value is typically a
+  literal or a script reference (`groovy: UUID.randomUUID().toString()`).
+  For idempotency headers, the consumer typically generates the value
+  client-side, so the rule's `value` is a script reference, not a literal.
+- **Act.** Propose the `method.additional.header` rule(s) in one
+  `propose_rule_content` call (filename like `correlation.rules`). If the
+  filter also injects the header into the response (echo-back for tracing),
+  bundle a `method.additional.response.header` rule in the same call.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Per-request injection"
+section). Do NOT reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/detection/custom-framework.md
+++ b/skills/easy-api-assistant/ai/detection/custom-framework.md
@@ -1,0 +1,81 @@
+---
+id: custom-framework
+title: Custom framework (proprietary API annotations)
+cue: project uses its own annotations (not Spring/JAX-RS/Feign/gRPC) to mark API classes and methods
+---
+
+EasyApi understands standard HTTP frameworks (Spring MVC, WebFlux, JAX-RS,
+Feign, gRPC) out of the box — those need no rules. When a project uses
+**proprietary annotations** to mark API classes/methods (e.g. `@MyApi`,
+`@MyEndpoint`, `@RpcService`), the standard recognizers will not find them
+and no endpoints will be exported. The Custom framework + a `custom.*` rule
+set is the escape hatch.
+
+## Detection signals
+
+- Endpoints exist in the project (the user has controllers/services) but
+  `list_project_endpoints` returns empty or far fewer than expected.
+- Classes annotated with project-specific annotations whose names suggest
+  API exposure (`@Api`, `@Endpoint`, `@Rpc`, `@RestApi`, `@Controller`-like
+  but not the Spring/JAX-RS FQNs).
+- Methods annotated with project-specific HTTP-verb-like annotations
+  (`@Get`, `@Post`, `@RequestMapping`-like but not the standard FQN).
+
+## Discovery
+
+`find_classes_by_annotation` is the primary tool. Probe candidate annotation
+FQNs mentioned by the user; if none, scan for short annotation names that
+look API-related (`Api`, `Endpoint`, `Rpc`, `Rest`) and confirm with
+`get_psi_class_info`. The Custom framework recognizer
+(`frameworkName = "Custom"`) is **disabled by default** — it only fires
+after the user enables it in settings AND a `custom.class.is.api` rule
+recognizes the class.
+
+## Perceive → reason → act
+
+- **Perceive.** `find_classes_by_annotation` for the proprietary annotation
+  FQN(s); `get_psi_class_info` on a sample class to read its methods and
+  method-level annotations; `get_psi_method_info` with `detail="full"` on
+  a sample method to read parameters and return type; `get_existing_rules_for_key`
+  for `custom.class.is.api`, `custom.method.is.api`, `custom.http.method`,
+  `custom.path` to avoid duplicates.
+- **Reason.** Identify the class-level annotation that marks an API class
+  and the method-level annotation that marks an API method. For methods,
+  determine the HTTP verb (from the annotation name or attribute) and the
+  path (from an attribute or convention). For parameters, determine the
+  binding (body / form / path / header / cookie) — if the project uses
+  standard Spring/JAX-RS binding annotations on parameters of the custom
+  controller, reuse them; otherwise default `param.http.type=query`.
+- **Act.** Propose the full `custom.*` rule bundle in ONE
+  `propose_rule_content` call (filename like `custom-framework.rules`).
+  A minimal bundle includes:
+  - `custom.class.is.api` — class recognition
+  - `custom.method.is.api` — method recognition
+  - `custom.http.method` — HTTP verb extraction
+  - `custom.path` — class base path + method path
+  - `method.default.http.method=GET` — fallback when verb cannot be resolved
+  - Parameter binding rules as needed (`custom.param.as.json.body`,
+    `custom.param.as.form.body`, `custom.param.as.path.var`,
+    `custom.param.as.cookie`, `param.http.type`)
+
+## Bundle integrity (CRITICAL)
+
+The `custom.*` rules form a coordinated set — a `custom.method.is.api`
+without a `custom.http.method` leaves the verb unresolved; a `custom.path`
+without `custom.class.is.api` never fires. Propose the full bundle in one
+`propose_rule_content` call. Never propose half a custom-framework set.
+
+## Reference
+
+The bundled test fixture `custom-spring-reference.rules` re-implements
+Spring MVC recognition entirely with `custom.*` rules — it is both a
+learning aid and the completeness proof. Fetch it via `get_plugin_doc` with
+`name="rule-guide"` (the "Custom Framework" section) for the canonical
+recipe. Do NOT reproduce the table from memory.
+
+## Confirm the gap first
+
+Before proposing, confirm the project is NOT already covered by a standard
+framework — Spring MVC / WebFlux / JAX-RS / Feign / gRPC endpoints with
+standard annotations are detected automatically. Only write `custom.*`
+rules for annotations the standard recognizers do not handle.

--- a/skills/easy-api-assistant/ai/detection/hmac-signing.md
+++ b/skills/easy-api-assistant/ai/detection/hmac-signing.md
@@ -1,0 +1,81 @@
+---
+id: hmac-signing
+title: HMAC request signing
+cue: javax.crypto.Mac / HmacSHA256 in a filter, appSecret / appKey config
+---
+
+`javax.crypto.Mac` / `HmacSHA256` in a filter or interceptor, plus
+`appSecret` / `appKey` configuration. The signer computes a signature
+over the request (method, path, body, timestamp) and adds it as a header;
+the consumer side must replicate the signature exactly. This is the most
+contract-sensitive workflow pattern — a byte-wrong signature silently
+rejects every request.
+
+## Detection signals
+
+- `javax.crypto.Mac` / `HmacSHA256` / `HmacSHA1` / `HmacMD5` referenced
+  in a filter or interceptor class.
+- `appSecret` / `appKey` / `secretKey` / `accessKey` configuration fields
+  read in a filter.
+- A signature header name like `X-Signature`, `X-Sign`, `Signature`,
+  `X-HMAC-Signature` set on the request.
+- A canonical-string construction method (building a string from method,
+  path, body, timestamp before signing).
+
+## Discovery
+
+- `find_classes_by_supertype` for filters / interceptors (see the
+  `spring-filters-interceptors` / `jaxrs-filters` detections for the
+  supertype lists).
+- `get_psi_method_info` with `detail="full"` on the signer's signing
+  method to read the canonical-string construction (header order matters);
+  `get_psi_class_info` to find the secret fields (`appSecret`, `appKey`).
+- `get_existing_rules_for_key` for `method.additional.header` and
+  `postman.prerequest` to avoid duplicates.
+
+## Perceive → reason → act
+
+- **Perceive.** Run the discovery tools above. For each hit, read the
+  signing method body via `get_psi_method_info` with `detail="full"` to
+  extract:
+  - The signature header name (e.g. `X-Signature`).
+  - The canonical-string inputs (method? path? body? timestamp? nonce?).
+  - The canonical-string order (header order matters byte-for-byte).
+  - The hash algorithm (`HmacSHA256`, `HmacSHA1`, etc.).
+  - The encoding of the signature (hex? base64?).
+  - The secret field names (`appSecret`, `appKey`).
+- **Reason.** Identify the signature header name and the canonical-string
+  inputs. The Postman pre-request script must replicate the canonical
+  string byte-for-byte (watch for trailing newlines, header casing,
+  URL encoding). Confirm the env-var names for the secrets — reuse
+  existing names where present; otherwise default to `${appSecret}` /
+  `${appKey}`.
+- **Act.** Propose the bundle (signer pre-request script + consumer
+  header) in one `propose_rule_content` call (filename like
+  `hmac-signing.rules`). Bundle integrity applies — a consumer header
+  referencing a signature no script computes is a silent bug.
+
+## Bundle integrity (CRITICAL)
+
+Signer + signed-consumer rules MUST be proposed together in a single
+`propose_rule_content` call. Proposing half a chain is forbidden.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${appSecret}`, `${appKey}`). Never emit a literal secret in rule
+content.
+
+## Script-context isolation (CRITICAL)
+
+`postman.prerequest` rule values MUST be **literal scripts** (NO
+`groovy:` prefix). A `groovy:` prefix routes the value to
+`Jsr223ScriptParser` at export time, where `pm` is NOT bound — the
+script throws and the failure is silently swallowed, so no script
+lands in the Postman collection.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Request signing"
+section). Do NOT reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/detection/jaxrs-filters.md
+++ b/skills/easy-api-assistant/ai/detection/jaxrs-filters.md
@@ -1,0 +1,85 @@
+---
+id: jaxrs-filters
+title: JAX-RS ContainerRequestFilter / ContainerResponseFilter
+cue: ContainerRequestFilter or ContainerResponseFilter implementations that mutate headers invisibly
+framework: jaxrs
+---
+
+EasyApi understands JAX-RS's standard annotations (`@Path`, `@GET`,
+`@QueryParam`, `@PathParam`, `@HeaderParam`, `@FormParam`, `@BeanParam`)
+out of the box. But `ContainerRequestFilter` and `ContainerResponseFilter`
+implementations mutate the request/response contract **invisibly** (auth,
+signing, header injection) — the contract is not visible from the resource
+method signature. Without a rule, the exported documentation will be
+missing those headers.
+
+## Detection signals
+
+Classes implementing:
+- `javax.ws.rs.container.ContainerRequestFilter` /
+  `jakarta.ws.rs.container.ContainerRequestFilter` — runs before the
+  resource method; can mutate request headers, abort with a response, etc.
+- `javax.ws.rs.container.ContainerResponseFilter` /
+  `jakarta.ws.rs.container.ContainerResponseFilter` — runs after the
+  resource method; can mutate response headers.
+
+The filter may be:
+- **Global** (annotated `@Provider`) — applies to all resources.
+- **Name-bound** (annotated with a custom `@NameBinding` meta-annotation) —
+  applies only to resources/methods annotated with the binding annotation.
+
+The mutation to look for: `requestContext.getHeaders().add(...)`,
+`requestContext.getHeaders().putSingle(...)`,
+`responseContext.getHeaders().add(...)`. Not every filter mutates the
+contract — a CORS filter adding `Access-Control-Allow-*` headers may not
+need a rule if those headers are purely informational.
+
+## Supertype to probe
+
+Search via `find_classes_by_supertype` for:
+- `javax.ws.rs.container.ContainerRequestFilter`
+- `jakarta.ws.rs.container.ContainerRequestFilter`
+- `javax.ws.rs.container.ContainerResponseFilter`
+- `jakarta.ws.rs.container.ContainerResponseFilter`
+
+Also `find_classes_by_annotation` for `@Provider`
+(`javax.ws.rs.ext.Provider` / `jakarta.ws.rs.ext.Provider`) and any custom
+`@NameBinding` annotations — name-bound filters only apply to
+resources/methods carrying the binding annotation, so the rule's filter
+must scope to those resources.
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools (above). For each hit, call
+  `get_psi_method_info` with `detail="full"` on the `filter` method to read
+  which headers are added/put. Determine the binding scope:
+  - `@Provider` (no `@NameBinding`) → global → rule applies to all endpoints.
+  - `@NameBinding`-annotated → name-bound → rule applies only to endpoints
+    whose resource class or method carries the binding annotation; use a
+    `groovy:` filter on the `method.additional.header` rule that checks
+    `it.hasAnn("com.example.MyBinding")`.
+  - `get_existing_rules_for_key` for `method.additional.header` and
+    `method.additional.response.header` to avoid duplicates.
+- **Reason.** For each mutation, decide the rule:
+  - Request header set on every request → `method.additional.header`
+    (filtered to the bound resources if name-bound).
+  - Response header set on every response →
+    `method.additional.response.header` (filtered similarly).
+  - Auth filter that aborts with 401 on missing credentials →
+    `method.additional.header` for the credential header; defer to the
+    `static-auth` or `auth-token-chaining` recipe for the auth side.
+- **Act.** Propose the `method.additional.header` /
+  `method.additional.response.header` rule(s) in one
+  `propose_rule_content` call (filename like `jaxrs-filters.rules`).
+
+## Bundle integrity
+
+If a name-bound filter and its binding annotation are both needed, propose
+them together — a rule referencing a binding annotation that no filter
+applies is dead code.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "JAX-RS Patterns" → "Filters" section). Do NOT
+reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/detection/spring-argument-resolvers.md
+++ b/skills/easy-api-assistant/ai/detection/spring-argument-resolvers.md
@@ -1,0 +1,76 @@
+---
+id: spring-argument-resolvers
+title: Spring handler method argument resolvers
+cue: HandlerMethodArgumentResolver implementations that inject hidden params (principal, request context, current user)
+framework: springmvc
+---
+
+EasyApi understands Spring MVC's standard parameter annotations
+(`@RequestParam`, `@PathVariable`, `@RequestBody`, `@RequestHeader`,
+`@CookieValue`, `@ModelAttribute`) out of the box. But
+`HandlerMethodArgumentResolver` implementations inject method parameters
+that the plugin cannot see from the method signature alone — the resolver
+reads the request (principal, header, cookie, session) and supplies the
+argument. Without a rule, the exported documentation will be **missing
+those hidden parameters entirely**.
+
+## Detection signals
+
+Classes implementing `HandlerMethodArgumentResolver`
+(`org.springframework.web.method.support.HandlerMethodArgumentResolver`)
+or extending `HandlerMethodArgumentResolverSupport`. The resolver's
+`supportsParameter` method declares which parameter types it handles; the
+`resolveArgument` method reads the request and supplies the value.
+
+Common examples:
+- `@CurrentUser` → resolves `Principal`/`User` from the security context
+- `@RequestContext` → resolves the request/response/context object
+- `@TenantId` → resolves the tenant from a header or JWT claim
+- `@Pageable` → resolves pagination params (Spring Data's `Pageable` is
+  handled by `PageableHandlerMethodArgumentResolver` — this is **standard**,
+  no rule needed unless customized)
+
+## Supertype to probe
+
+Argument resolvers implement
+`org.springframework.web.method.support.HandlerMethodArgumentResolver`.
+
+Annotation-declared resolvers are rare — the supertype probe is the
+primary path. Search via `find_classes_by_supertype` for the interface FQN
+above.
+
+## Perceive → reason → act
+
+- **Perceive.** `find_classes_by_supertype` for
+  `org.springframework.web.method.support.HandlerMethodArgumentResolver`.
+  For each hit, `get_psi_method_info` with `detail="full"` on
+  `supportsParameter` to read which parameter types are supported, and on
+  `resolveArgument` to read how the value is sourced (header? cookie?
+  principal? session?). Then `find_classes_by_annotation` for the custom
+  annotation the resolver supports (e.g. `@CurrentUser`) to find the
+  controllers consuming it. `get_existing_rules_for_key` for
+  `method.additional.param` and `param.ignore` to avoid duplicates.
+- **Reason.** For each resolver, identify:
+  - The parameter name (from the annotation value or the parameter name).
+  - The parameter type (from `supportsParameter`).
+  - The source (request header? cookie? principal? session?).
+  - Whether the parameter should be **documented** (`method.additional.param`)
+    or **hidden** (`param.ignore`). Hidden parameters are those that are
+    framework-internal (e.g. `HttpServletRequest`, `Principal`) — the
+    consumer doesn't supply them. Documented parameters are those the
+    consumer must supply (e.g. a tenant header extracted by the resolver).
+- **Act.** Propose the `method.additional.param` rule(s) for documented
+  hidden params, or `param.ignore` rules for framework-internal params, in
+  one `propose_rule_content` call (filename like `argument-resolvers.rules`).
+
+## Bundle integrity
+
+If a resolver supports multiple parameter types, propose one rule per type
+in the same call. Do not propose a `method.additional.param` for a
+parameter that should be `param.ignore`d — the two are mutually exclusive.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Argument resolvers" section).
+Do NOT reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/detection/spring-controller-advice.md
+++ b/skills/easy-api-assistant/ai/detection/spring-controller-advice.md
@@ -1,0 +1,81 @@
+---
+id: spring-controller-advice
+title: Spring @RestControllerAdvice exception handlers
+cue: "@RestControllerAdvice with @ExceptionHandler methods that change the error response shape for secured endpoints"
+framework: springmvc
+---
+
+EasyApi documents the success response (2xx) from a controller's return type
+out of the box. But `@RestControllerAdvice` classes with `@ExceptionHandler`
+methods define the **error response shape** (4xx, 5xx) that the plugin
+cannot associate with the controllers that throw those exceptions. Without
+a rule, the exported documentation will miss the error response contract.
+
+## Detection signals
+
+- Classes annotated `@RestControllerAdvice`
+  (`org.springframework.web.bind.annotation.RestControllerAdvice`) or
+  `@ControllerAdvice`
+  (`org.springframework.web.bind.annotation.ControllerAdvice`).
+- Methods annotated `@ExceptionHandler`
+  (`org.springframework.web.bind.annotation.ExceptionHandler`) within those
+  classes. The annotation's `value` attribute names the exception type(s)
+  handled; the method's return type is the error response shape.
+
+The error response is typically an envelope like `ErrorResponse`,
+`ApiError`, `Result<Void>`, or a `ResponseEntity<ErrorDetail>` carrying
+fields like `code`, `message`, `timestamp`, `path`.
+
+## Supertype / annotation to probe
+
+- `find_classes_by_annotation` for:
+  - `org.springframework.web.bind.annotation.RestControllerAdvice`
+  - `org.springframework.web.bind.annotation.ControllerAdvice`
+- For each hit, `get_psi_class_info` to enumerate the `@ExceptionHandler`
+  methods and their return types.
+
+Note: a class can be both `@RestControllerAdvice` AND implement
+`ResponseBodyAdvice` — the `ResponseBodyAdvice` interface is the body
+wrapper case (see the `spring-response-body-advice` detection). This
+detection is specifically about `@ExceptionHandler` methods.
+
+## Perceive → reason → act
+
+- **Perceive.** `find_classes_by_annotation` for the advice annotations
+  above. For each hit, `get_psi_class_info` to list the
+  `@ExceptionHandler` methods; `get_psi_method_info` with `detail="full"`
+  on each handler to read the exception type handled, the HTTP status
+  returned (from `@ResponseStatus` or `ResponseEntity`), and the error
+  response shape. `find_classes_by_supertype` for the exception types to
+  find the controllers that throw them. `get_existing_rules_for_key` for
+  `method.additional.response.header` and `method.doc` to avoid duplicates.
+- **Reason.** For each handler, identify:
+  - The exception type (from `@ExceptionHandler(MyException.class)`).
+  - The HTTP status (from `@ResponseStatus(code=...)` or the
+    `ResponseEntity` status).
+  - The error response shape (the handler's return type).
+  - The controllers that throw this exception (via
+    `find_classes_by_supertype` for the exception type, then scanning
+    their methods for `throw new MyException(...)`).
+- **Act.** The error response contract is documented by annotating the
+  affected endpoints. Propose:
+  - `method.doc[@ann]` rules that append the error response shape to the
+    method documentation of affected endpoints (filter by the throwing
+    annotation or the controller class), OR
+  - `method.additional.response.header` rules if the handler also sets
+    response headers (e.g. `WWW-Authenticate` on 401).
+  Bundle the rules in one `propose_rule_content` call (filename like
+  `error-responses.rules`).
+
+## Bundle integrity
+
+If the same `@RestControllerAdvice` handles multiple exceptions, propose
+one rule per exception→endpoint mapping in the same call. Do not propose
+half a mapping — an error response documented without the triggering
+condition is noise.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Exception handlers" section).
+Do NOT reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/detection/spring-filters-interceptors.md
+++ b/skills/easy-api-assistant/ai/detection/spring-filters-interceptors.md
@@ -1,0 +1,87 @@
+---
+id: spring-filters-interceptors
+title: Spring filters, interceptors, web filters
+cue: classes extending OncePerRequestFilter / HandlerInterceptor / WebFilter that mutate request or response headers
+framework: springmvc
+---
+
+EasyApi understands Spring MVC's standard request flow out of the box —
+`@RequestMapping`, `@GetMapping`, `@RequestBody`, `@PathVariable`, etc. need
+no rules. But servlet filters / interceptors / web filters that mutate the
+request or response contract **invisibly** (auth, signing, header injection,
+response wrapping) are not visible from the controller signature. Without a
+rule, the exported documentation will be missing those headers.
+
+## Detection signals
+
+Components declared by inheritance (the Spring Boot default) or by
+annotation that mutate the request/response contract:
+
+- **Servlet filters** extending `OncePerRequestFilter`
+  (`org.springframework.web.filter.OncePerRequestFilter`) or implementing
+  `jakarta.servlet.Filter` / `javax.servlet.Filter`.
+- **Interceptors** implementing `HandlerInterceptor`
+  (`org.springframework.web.servlet.HandlerInterceptor`) or
+  `AsyncHandlerInterceptor`.
+- **Web filters** annotated `@WebFilter`
+  (`jakarta.servlet.annotation.WebFilter` /
+  `javax.servlet.annotation.WebFilter`).
+
+The mutation to look for: `request.setHeader(...)`,
+`request.addHeader(...)`, `response.setHeader(...)`,
+`exchange.getResponse().getHeaders().add(...)`. Not every filter/interceptor
+mutates the contract — `MappedInterceptor` for logging or metrics does not
+need a rule.
+
+## Discovery
+
+Probe BOTH declaration styles — the Spring Boot default is inheritance, but
+annotation-declared filters exist too. Either may be present.
+
+- `find_classes_by_supertype` for:
+  - `org.springframework.web.filter.OncePerRequestFilter`
+  - `org.springframework.web.servlet.HandlerInterceptor`
+  - `jakarta.servlet.Filter`
+  - `javax.servlet.Filter`
+- `find_classes_by_annotation` for:
+  - `jakarta.servlet.annotation.WebFilter`
+  - `javax.servlet.annotation.WebFilter`
+
+Both discovery tools can return empty — probe the annotation AND the
+supertype before concluding "none found".
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools (above). For each hit, call
+  `get_psi_method_info` with `detail="full"` on the filtering method
+  (`doFilterInternal`, `doFilter`, `preHandle`, `postHandle`) to read which
+  headers are set/added and on which side (request vs response).
+  `get_existing_rules_for_key` for `method.additional.header` and
+  `method.additional.response.header` to avoid duplicates.
+- **Reason.** For each mutation, decide the rule:
+  - Request header set on every request → `method.additional.header`
+    (filtered to the protected path via a `groovy:` filter if the filter
+    scopes to specific URLs).
+  - Response header set on every response → `method.additional.response.header`.
+  - Header value computed from a script (e.g. UUID, timestamp) →
+    `method.additional.header` with a `groovy:` value-block that returns
+    a JSON object whose `value` is the script expression.
+  - Header value computed from an HMAC/signature → defer to the
+    `hmac-signing` detection recipe (bundle signer + consumer together).
+- **Act.** Propose the `method.additional.header` / `method.additional.response.header`
+  rule(s) in one `propose_rule_content` call (filename like
+  `spring-filters.rules`). Bundle integrity applies — if the same filter
+  injects both a request and a response header, both rules go in the same
+  proposal.
+
+## Confirm the contract changed
+
+Confirm a hit with `get_psi_class_info` + `get_psi_method_info`, then ask:
+*does it change the request/response contract invisibly?* If yes, apply the
+catalog recipe. If no (logging, metrics, tracing-only), no rule is needed.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Filters & interceptors"
+section). Do NOT reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/detection/spring-response-body-advice.md
+++ b/skills/easy-api-assistant/ai/detection/spring-response-body-advice.md
@@ -1,0 +1,77 @@
+---
+id: spring-response-body-advice
+title: Spring ResponseBodyAdvice (response envelope wrapping)
+cue: ResponseBodyAdvice implementations or @RestControllerAdvice that wrap responses in a standard envelope like {code, message, data}
+framework: springmvc
+---
+
+EasyApi understands Spring MVC's standard return type wrappers
+(`ResponseEntity<T>`, `Mono<T>`, `Flux<T>`, `Optional<T>`) out of the box —
+those are unwrapped automatically. But `ResponseBodyAdvice`
+implementations wrap the response body in a **standard envelope** (e.g.
+`{code, message, data}`) that the plugin cannot detect from the
+controller's return type alone. Without a rule, the exported documentation
+will show the raw controller return type and **miss the envelope**.
+
+## Detection signals
+
+Two declaration styles, both common — probe both:
+
+- **Interface implementation.** Classes implementing `ResponseBodyAdvice`
+  (`org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice`).
+  The `beforeBodyWrite` method is where the wrapping happens.
+- **Annotation declaration.** Classes annotated `@RestControllerAdvice`
+  (`org.springframework.web.bind.annotation.RestControllerAdvice`) that
+  also implement `ResponseBodyAdvice`. The `@RestControllerAdvice` alone
+  is for exception handlers (see the `spring-controller-advice` detection);
+  the `ResponseBodyAdvice` interface is what makes it a body wrapper.
+
+The wrapper typically wraps in a `Result<T>`, `ApiResponse<T>`, `R<T>`,
+`Response<T>`, or similar envelope with fields like `code`, `message`,
+`data`, `success`, `timestamp`.
+
+## Supertype / annotation to probe
+
+- `find_classes_by_supertype` for
+  `org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice`.
+- `find_classes_by_annotation` for
+  `org.springframework.web.bind.annotation.RestControllerAdvice`.
+
+Both can return empty — probe the annotation AND the supertype before
+concluding "none found". A class can be both `@RestControllerAdvice` AND
+implement `ResponseBodyAdvice` — that is the common combined form.
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools (above). For each hit, call
+  `get_psi_class_info` to read the envelope class (the type returned by
+  `beforeBodyWrite`); `get_psi_method_info` with `detail="full"` on
+  `beforeBodyWrite` to read the wrapping logic (which field holds the
+  payload? which field holds the status code? which field holds the
+  message?). `get_existing_rules_for_key` for `method.return.main` and
+  `json.rule.convert` to avoid duplicates.
+- **Reason.** Identify the envelope class FQN and the inner payload field
+  path. The rule is `method.return.main=<field path>` (e.g. `data` or
+  `result.data`). If the envelope is generic (`Result<T>`), also propose a
+  `json.rule.convert[#regex:com\.example\.Result<(.*?)>]=${1}` rule so the
+  exporter unwraps the generic — this avoids the envelope appearing as the
+  response type in the docs. Wrap the `json.rule.convert` lines in
+  `###set resolveProperty = false … true` so the `${1}` capture group is
+  not treated as a property placeholder.
+- **Act.** Propose the `method.return.main` + optional `json.rule.convert`
+  bundle in one `propose_rule_content` call (filename like
+  `response-envelope.rules`).
+
+## Bundle integrity
+
+The `method.return.main` rule and the `json.rule.convert` rule for the same
+envelope MUST be proposed together — the convert unwraps the generic type
+so the exporter sees the inner payload, and `method.return.main` tells the
+exporter which field of the unwrapped object is the actual response. Half
+a bundle produces confusing docs.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Response body advice"
+section). Do NOT reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/detection/static-auth.md
+++ b/skills/easy-api-assistant/ai/detection/static-auth.md
@@ -1,0 +1,64 @@
+---
+id: static-auth
+title: Static auth (API key / Basic)
+cue: "a filter or annotation reading X-API-Key / Authorization: Basic — static credentials, no login round-trip"
+---
+
+A filter / interceptor / annotation reading `X-API-Key` or
+`Authorization: Basic` — static credentials supplied per request, with no
+login round-trip. Unlike auth-token-chaining, there is no producer
+endpoint; the credential is supplied by the caller out-of-band.
+
+## Detection signals
+
+- A filter / interceptor / annotation reading `X-API-Key` or
+  `Authorization: Basic` from the request.
+- A custom security annotation (`@RequiresApiToken`, `@ApiKey`, `@BasicAuth`)
+  marking secured endpoints.
+- A Spring Security configuration that protects URL patterns with API-key
+  or Basic auth (e.g. `http.httpBasic()` or a custom
+  `OncePerRequestFilter` reading `X-API-Key`).
+
+The credential is **static** (per-caller, supplied out-of-band) — there is
+no login endpoint that returns a token. This distinguishes static-auth
+from auth-token-chaining.
+
+## Discovery
+
+- `find_classes_by_annotation` for security annotations
+  (`@RequiresApiToken`, `@ApiKey`, `@BasicAuth`, custom security
+  annotations).
+- `find_classes_by_supertype` for filters extending `OncePerRequestFilter`
+  that read header values (see the `spring-filters-interceptors` detection
+  for the supertype list).
+- `get_psi_method_info` with `detail="full"` on the filter's
+  `shouldNotFilter` / `doFilterInternal` to confirm the scope (which paths
+  are excluded from auth).
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools. For each hit, `get_psi_method_info`
+  with `detail="full"` on the filtering method to read which header name is
+  read and which paths are excluded. `get_existing_rules_for_key` for
+  `method.additional.header` to avoid duplicates.
+- **Reason.** Identify the credential env-var name. Reuse an existing
+  env-var name when one is already referenced in the project's rules;
+  otherwise default to `apiKey` (for `X-API-Key`) or `Authorization` (for
+  Basic). Confirm the filter's scope so the rule's filter matches exactly
+  the protected controllers — not too broad, not too narrow.
+- **Act.** Propose the `method.additional.header` rule(s) in one
+  `propose_rule_content` call (filename like `static-auth.rules`). Bundle
+  integrity applies: if the same filter also injects a response header
+  (e.g. `WWW-Authenticate` on 401), both rules go in the same proposal.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${apiKey}`, `${Authorization}`). Never emit a literal token, key, or
+password in rule content.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Static auth" section). Do
+NOT reproduce the table from memory.

--- a/skills/easy-api-assistant/ai/rules/field.ignore.md
+++ b/skills/easy-api-assistant/ai/rules/field.ignore.md
@@ -1,0 +1,38 @@
+---
+id: field.ignore
+key: field.ignore
+title: Field ignore
+cue: boolean rule that strips a field from the exported model — never generate blanket patterns automatically
+---
+
+## CRITICAL — never generate blanket field-ignore rules
+
+Do NOT generate `field.ignore` rules based on field-name patterns
+like `.*password.*`, `.*secret.*`, `.*token.*`. These fields are
+often a **legitimate part of the API definition** — a login endpoint
+requires `password`, an OAuth endpoint requires `clientSecret`, a
+token-refresh endpoint requires `refreshToken`. Stripping them
+silently breaks the exported documentation.
+
+Sensitive-field handling is a **project policy** decision, not a
+code-detection decision. If the user explicitly asks for it, you may
+add it — but never invent it on your own, and always warn the user
+that it may hide fields that some endpoints legitimately require.
+
+## Filter examples
+
+When the user has explicitly asked to ignore a specific field on a
+specific class:
+
+```
+field.ignore[$class:com.example.dto.UserResponse]=password
+```
+
+Multiple fields on the same class means multiple lines (the key uses
+default merge semantics — boolean rules do not merge, so each line is
+its own rule).
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for `field.ignore`.
+If an equivalent rule already exists, do NOT write a duplicate.

--- a/skills/easy-api-assistant/ai/rules/json.additional.field.md
+++ b/skills/easy-api-assistant/ai/rules/json.additional.field.md
@@ -1,0 +1,51 @@
+---
+id: json.additional.field
+key: json.additional.field
+title: Additional JSON field
+cue: JSON object field injected into the serialized response (e.g. computed totals, envelope metadata)
+---
+
+## Value format
+
+The value is a single-line JSON object describing the additional field
+to inject into the serialized response:
+
+```json
+{"name":"totalAmount","value":"${total}","desc":"computed","type":"number"}
+```
+
+One object per line — multiple fields means multiple
+`json.additional.field=…` lines (the key uses `StringRuleMode.MERGE`).
+
+## Filter examples
+
+Filter the rule to a class:
+
+```
+json.additional.field[$class:com.example.dto.OrderResponse]={"name":"signature","value":"${sig}","desc":"HMAC","type":"string"}
+```
+
+Filter by annotation:
+
+```
+json.additional.field[@com.example.Signed]={"name":"signature","value":"${sig}","desc":"HMAC","type":"string"}
+```
+
+## Prefer groovy value-blocks for complex conditional logic
+
+When a filter expression grows long — multiple `&&`/`||`, multiple
+exclusions, or nested method calls — switch to the **groovy value-block**
+form (see the `method.additional.header` recipe for the full example).
+The script must `return` the value (string) or `return null` to skip.
+
+## No hardcoded secrets
+
+Every credential in a field value is an env-var reference
+(`${appSecret}`, `${apiKey}`). Never emit a literal token, key, or
+password in rule content.
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for
+`json.additional.field`. If an equivalent rule already exists, do NOT
+write a duplicate.

--- a/skills/easy-api-assistant/ai/rules/markdown.template.md
+++ b/skills/easy-api-assistant/ai/rules/markdown.template.md
@@ -1,0 +1,41 @@
+---
+id: markdown.template
+key: markdown.template
+title: Markdown template & locale
+cue: markdown.template (local file or remote URL) and markdown.template.language (BCP-47 locale tag)
+---
+
+## When to use
+
+Two related keys drive Markdown export:
+
+- `markdown.template` — accepts either a local file path OR a remote
+  `http(s)://` URL. The resolver auto-detects by the `http(s)://`
+  prefix. The separate `.file` and `.url` keys were merged into this
+  single key for simpler configuration.
+- `markdown.template.language` — a BCP-47 locale tag (e.g. `zh-CN`,
+  `ja`) selecting a localized template. A single-line rule.
+
+## Locale proposal workflow
+
+When the ambient `user language` is non-English AND no
+`markdown.template.language` rule is already in effect AND the user's
+request touches Markdown export or asks for localized docs, propose
+`markdown.template.language=<tag>` (a single-line rule).
+
+- Do **not** author a full custom template when a bundled template
+  covers the locale — `zh-CN` ships bundled; `en` (or unset) uses the
+  default English template and needs no rule. A bundled template is
+  always preferred over a hand-authored one because it tracks
+  structural changes to the default.
+- If no bundled template exists for the locale, tell the user, fall
+  back to English for this export, and suggest the "Copy default
+  template" affordance in the Markdown export panel so they can author
+  a localized copy as a starting point.
+- This proposal flows through `propose_rule_content` like any other
+  rule — the user reviews and saves. Never write the rule silently.
+
+## Check existing rules first
+
+Call `get_existing_rules_for_key` for `markdown.template.language` to
+avoid duplicates before proposing.

--- a/skills/easy-api-assistant/ai/rules/method.additional.header.md
+++ b/skills/easy-api-assistant/ai/rules/method.additional.header.md
@@ -1,0 +1,75 @@
+---
+id: method.additional.header
+key: method.additional.header
+title: Additional request header
+cue: JSON object header attached to every matching endpoint's request
+---
+
+## Value format
+
+The value is a single-line JSON object:
+
+```json
+{"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+One object per line — multiple headers means multiple
+`method.additional.header=…` lines (the key uses `StringRuleMode.MERGE`).
+
+## Filter examples
+
+Filter the rule to a class:
+
+```
+method.additional.header[$class:com.example.web.UserController]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+Filter by annotation:
+
+```
+method.additional.header[@com.example.RequiresAuth]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+## Prefer groovy value-blocks for complex conditional logic
+
+When a filter expression grows long — multiple `&&`/`||`, multiple
+exclusions, or nested method calls — switch to the **groovy value-block**
+form: the value itself is a multi-line groovy script that returns the
+value when the condition holds, or `null` when it doesn't.
+
+**Bad (unreadable single-line filter):**
+```
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.merchant.") && !it.containingClass().name().equals("com.example.merchant.AuthController") && !it.containingClass().name().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+**Good (multi-line groovy value-block):**
+```
+method.additional.header=groovy:```
+def cls = it.containingClass()?.name()
+if (cls?.startsWith("com.example.merchant.")
+    && cls != "com.example.merchant.AuthController"
+    && cls != "com.example.merchant.PublicController") {
+    return '{"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}'
+}
+return null
+```
+```
+
+Rules of thumb:
+- **≤ 1 condition** → inline `key[filter]=value` is fine.
+- **≥ 2 conditions or exclusions** → use a groovy value-block.
+- The script must `return` the value (string) or `return null` to skip.
+- Keep the script readable: use local variables, one condition per line.
+
+## No hardcoded secrets
+
+Every credential in a header value is an env-var reference
+(`${Authorization}`, `${token}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for
+`method.additional.header` (or pass `keys` as an array to check multiple
+keys in one request). If an equivalent rule already exists, do NOT write
+a duplicate.

--- a/skills/easy-api-assistant/ai/rules/method.additional.response.header.md
+++ b/skills/easy-api-assistant/ai/rules/method.additional.response.header.md
@@ -1,0 +1,49 @@
+---
+id: method.additional.response.header
+key: method.additional.response.header
+title: Additional response header
+cue: JSON object header attached to every matching endpoint's response
+---
+
+## Value format
+
+The value is a single-line JSON object:
+
+```json
+{"name":"X-RateLimit-Remaining","value":"100","desc":"","required":false}
+```
+
+One object per line — multiple headers means multiple
+`method.additional.response.header=…` lines (the key uses
+`StringRuleMode.MERGE`).
+
+## Filter examples
+
+Filter the rule to a class:
+
+```
+method.additional.response.header[$class:com.example.web.UserController]={"name":"X-Trace-Id","value":"${traceId}","desc":"trace","required":false}
+```
+
+Filter by annotation:
+
+```
+method.additional.response.header[@com.example.Tracked]={"name":"X-Trace-Id","value":"${traceId}","desc":"trace","required":false}
+```
+
+## Prefer groovy value-blocks for complex conditional logic
+
+When a filter expression grows long — multiple `&&`/`||`, multiple
+exclusions, or nested method calls — switch to the **groovy value-block**
+form (see the `method.additional.header` recipe for the full example).
+The script must `return` the value (string) or `return null` to skip.
+
+Rules of thumb:
+- **≤ 1 condition** → inline `key[filter]=value` is fine.
+- **≥ 2 conditions or exclusions** → use a groovy value-block.
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for
+`method.additional.response.header`. If an equivalent rule already
+exists, do NOT write a duplicate.

--- a/skills/easy-api-assistant/ai/rules/postman.prerequest.md
+++ b/skills/easy-api-assistant/ai/rules/postman.prerequest.md
@@ -1,0 +1,50 @@
+---
+id: postman.prerequest
+key: postman.prerequest
+title: Postman pre-request script
+cue: JavaScript fired BEFORE the request, used to inject headers / compute signatures / mutate pm.request
+channel: postman
+---
+
+## When to use
+
+`postman.prerequest` fires BEFORE the request is sent. Use it to:
+
+- Inject headers (compute a signature, attach a bearer token).
+- Mutate `pm.request` (rewrite URL, add query params).
+- Compute request bodies (HMAC canonical string).
+
+## Script-context isolation (CRITICAL — silent-failure trap)
+
+`postman.prerequest` rule values MUST be **literal scripts** (NO
+`groovy:` prefix). A `groovy:` prefix routes the value to
+`Jsr223ScriptParser` at export time, where `pm` is NOT bound — the
+script throws and the failure is **silently swallowed**, so no script
+lands in the Postman collection.
+
+Conversely, `http.call.before` / `http.call.after` rule values MUST use
+the `groovy:` prefix (they run in `Jsr223ScriptParser`, where `pm` is
+NOT available — use `session.set(...)` / `localStorage.set(...)` for
+storage, NEVER `pm.environment.set(...)`).
+
+## postman.test vs postman.prerequest (#1 mistake)
+
+`postman.test` fires AFTER the response (read `pm.response`,
+`pm.environment.set` a token). `postman.prerequest` fires BEFORE the
+request (inject headers, compute signatures, mutate `pm.request`).
+Swapping them is the most common workflow-rule error: a token extracted
+in `prerequest` reads the PREVIOUS response (or none); a header injected
+in `test` lands after the request has gone out.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${Authorization}`, `${appSecret}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Bundle integrity (CRITICAL)
+
+Signer + signed-consumer rules MUST be proposed together in a single
+`propose_rule_content` call. Proposing half a chain is forbidden — a
+consumer header referencing a signature no script computes is a silent
+bug.

--- a/skills/easy-api-assistant/ai/rules/postman.test.md
+++ b/skills/easy-api-assistant/ai/rules/postman.test.md
@@ -1,0 +1,50 @@
+---
+id: postman.test
+key: postman.test
+title: Postman test script
+cue: JavaScript assertion attached to an endpoint, fired AFTER the response
+channel: postman
+---
+
+## When to use
+
+`postman.test` fires AFTER the response is received. Use it to:
+
+- Read `pm.response` and assert on status / body fields.
+- `pm.environment.set("token", …)` to extract a token from the response
+  for use by subsequent requests (auth-token-chaining producer side).
+
+## Script-context isolation (CRITICAL — silent-failure trap)
+
+`postman.test` rule values MUST be **literal scripts** (NO `groovy:`
+prefix). A `groovy:` prefix routes the value to `Jsr223ScriptParser` at
+export time, where `pm` is NOT bound — the script throws and the
+failure is **silently swallowed**, so no script lands in the Postman
+collection.
+
+Conversely, `http.call.before` / `http.call.after` rule values MUST use
+the `groovy:` prefix (they run in `Jsr223ScriptParser`, where `pm` is
+NOT available — use `session.set(...)` / `localStorage.set(...)` for
+storage, NEVER `pm.environment.set(...)`).
+
+## postman.test vs postman.prerequest (#1 mistake)
+
+`postman.test` fires AFTER the response (read `pm.response`,
+`pm.environment.set` a token). `postman.prerequest` fires BEFORE the
+request (inject headers, compute signatures, mutate `pm.request`).
+Swapping them is the most common workflow-rule error: a token extracted
+in `prerequest` reads the PREVIOUS response (or none); a header injected
+in `test` lands after the request has gone out.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${Authorization}`, `${appSecret}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Bundle integrity (CRITICAL)
+
+Workflow rules that form a chain (login-script + consumer-header) MUST
+be proposed together in a single `propose_rule_content` call. Proposing
+half a chain is forbidden — a consumer header that references a token no
+script stores is a silent bug.

--- a/skills/easy-api-assistant/scripts/get_detection_prompt.sh
+++ b/skills/easy-api-assistant/scripts/get_detection_prompt.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# get_detection_prompt.sh — CLI mirror of the in-plugin GetDetectionPromptTool
+#
+# Fetches the full detection recipe for one detection family by id, from the
+# bundled `ai/detection/<id>.md` catalog file. The catalog is kept in sync
+# with `src/main/resources/ai/detection/` by the `syncAgentCatalog` Gradle
+# task. The YAML front-matter header is stripped; only the markdown body is
+# printed to stdout — same contract as the in-plugin tool.
+#
+# Usage:  ./get_detection_prompt.sh <id>
+#   ./get_detection_prompt.sh spring-filters-interceptors
+#   ./get_detection_prompt.sh static-auth
+#
+# Unknown id → "error: unknown detection id: <id>" on stderr, exit 1.
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ -z "${1:-}" ]; then
+    echo "Usage: $0 <id>" >&2
+    echo "  List available ids with: $0 --list   (or scripts/list_detections.sh)" >&2
+    exit 1
+fi
+
+# ── --list shortcut ──────────────────────────────────────────────────────
+if [ "$1" = "--list" ]; then
+    exec "$(dirname "$0")/list_detections.sh"
+fi
+
+ID="$1"
+
+# ── locate the bundled ai/detection/ folder ──────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECTION_DIR="$SCRIPT_DIR/../ai/detection"
+
+if [ ! -d "$DETECTION_DIR" ]; then
+    echo "error: bundled catalog not found at: $DETECTION_DIR" >&2
+    echo "  Run ./gradlew syncAgentCatalog from the easy-api repo to populate it." >&2
+    exit 1
+fi
+
+FILE="$DETECTION_DIR/$ID.md"
+if [ ! -f "$FILE" ]; then
+    echo "error: unknown detection id: $ID" >&2
+    echo "  Available ids:" >&2
+    ls -1 "$DETECTION_DIR" | sed 's/\.md$//' | sed 's/^/    /' >&2
+    exit 1
+fi
+
+# ── strip the YAML front-matter (between the first two `---` lines) ──────
+# The header is `---\n<yaml>\n---\n`; the body follows. Print everything
+# after the second `---` line.
+awk '
+    /^---[[:space:]]*$/ {
+        count++
+        next
+    }
+    count >= 2 { print }
+' "$FILE"

--- a/skills/easy-api-assistant/scripts/get_rule_detail.sh
+++ b/skills/easy-api-assistant/scripts/get_rule_detail.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# get_rule_detail.sh — CLI mirror of the in-plugin GetRuleDetailTool (by-key path)
+#
+# Fetches the full per-key rule recipe from the bundled `ai/rules/<key>.md`
+# catalog file. The catalog is kept in sync with `src/main/resources/ai/rules/`
+# by the `syncAgentCatalog` Gradle task. The YAML front-matter header is
+# stripped; only the markdown body is printed to stdout — same contract as
+# the in-plugin tool's by-key path (`get_rule_detail(key=...)`).
+#
+# Usage:  ./get_rule_detail.sh <key>
+#   ./get_rule_detail.sh postman.test
+#   ./get_rule_detail.sh method.additional.header
+#
+# Unknown key → "error: unknown rule key: <key>" on stderr, exit 1.
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ -z "${1:-}" ]; then
+    echo "Usage: $0 <key>" >&2
+    echo "  List available keys with: $0 --list   (or scripts/list_rule_details.sh)" >&2
+    exit 1
+fi
+
+# ── --list shortcut ──────────────────────────────────────────────────────
+if [ "$1" = "--list" ]; then
+    exec "$(dirname "$0")/list_rule_details.sh"
+fi
+
+KEY="$1"
+
+# ── locate the bundled ai/rules/ folder ──────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../ai/rules"
+
+if [ ! -d "$RULES_DIR" ]; then
+    echo "error: bundled catalog not found at: $RULES_DIR" >&2
+    echo "  Run ./gradlew syncAgentCatalog from the easy-api repo to populate it." >&2
+    exit 1
+fi
+
+FILE="$RULES_DIR/$KEY.md"
+if [ ! -f "$FILE" ]; then
+    echo "error: unknown rule key: $KEY" >&2
+    echo "  Available keys:" >&2
+    ls -1 "$RULES_DIR" | sed 's/\.md$//' | sed 's/^/    /' >&2
+    exit 1
+fi
+
+# ── strip the YAML front-matter (between the first two `---` lines) ──────
+# The header is `---\n<yaml>\n---\n`; the body follows. Print everything
+# after the second `---` line.
+awk '
+    /^---[[:space:]]*$/ {
+        count++
+        next
+    }
+    count >= 2 { print }
+' "$FILE"

--- a/skills/easy-api-assistant/scripts/list_detections.sh
+++ b/skills/easy-api-assistant/scripts/list_detections.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# list_detections.sh — CLI mirror of the in-plugin Reactive detection index
+#                      (SystemPromptBuilder.indexMessage("detection"))
+#
+# Lists every detection family in the bundled `ai/detection/` catalog, in
+# lexicographic-by-filename order (the in-plugin order is also filename-driven
+# via `catalog-manifest.txt`; for the external skill we don't ship the
+# manifest, so lexicographic is the natural fallback).
+#
+# For each detection, prints:  id — title: cue
+# (same shape as the in-plugin index message that's prepended to every
+# Reactive turn's system prompt).
+#
+# Usage:  ./list_detections.sh
+set -euo pipefail
+
+# ── locate the bundled ai/detection/ folder ──────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECTION_DIR="$SCRIPT_DIR/../ai/detection"
+
+if [ ! -d "$DETECTION_DIR" ]; then
+    echo "error: bundled catalog not found at: $DETECTION_DIR" >&2
+    echo "  Run ./gradlew syncAgentCatalog from the easy-api repo to populate it." >&2
+    exit 1
+fi
+
+# ── iterate files in lexicographic order ─────────────────────────────────
+# Each file's YAML front-matter header carries `id`, `title`, `cue` (all
+# required by the catalog spec). Parse them with awk (no yq dependency).
+shopt -s nullglob
+FILES=( "$DETECTION_DIR"/*.md )
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo "(no detection files in bundled catalog)" >&2
+    exit 0
+fi
+
+for FILE in "${FILES[@]}"; do
+    # Extract the YAML front-matter block (between the first two `---` lines).
+    # Then pull id/title/cue out of it. Values may be unquoted scalars.
+    awk '
+        /^---[[:space:]]*$/ {
+            count++
+            next
+        }
+        count == 1 {
+            # Print the YAML line; the outer shell parses key: value.
+            print
+        }
+    ' "$FILE" | awk -F': ' '
+        /^id:/    { id = $0;    sub(/^id:[[:space:]]*/, "", id);    gsub(/^"|"$/, "", id) }
+        /^title:/ { title = $0; sub(/^title:[[:space:]]*/, "", title); gsub(/^"|"$/, "", title) }
+        /^cue:/   { cue = $0;   sub(/^cue:[[:space:]]*/, "", cue);   gsub(/^"|"$/, "", cue) }
+        END {
+            if (id != "" && title != "" && cue != "") {
+                printf "%s — %s: %s\n", id, title, cue
+            }
+        }
+    '
+done

--- a/skills/easy-api-assistant/scripts/list_rule_details.sh
+++ b/skills/easy-api-assistant/scripts/list_rule_details.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# list_rule_details.sh — CLI mirror of the in-plugin Reactive rule-recipe index
+#                        (SystemPromptBuilder.indexMessage("rules"))
+#
+# Lists every per-key rule recipe in the bundled `ai/rules/` catalog, in
+# lexicographic-by-filename order. This is the per-key recipe index — it
+# complements (does NOT replace) the bundled `docs/rule-keys.md` snapshot
+# of `RuleKeys.kt`, which lists every supported rule key (including keys
+# that have no per-key recipe file).
+#
+# For each rule recipe, prints:  key — title: cue
+# (same shape as the in-plugin index message).
+#
+# Usage:  ./list_rule_details.sh
+set -euo pipefail
+
+# ── locate the bundled ai/rules/ folder ───────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../ai/rules"
+
+if [ ! -d "$RULES_DIR" ]; then
+    echo "error: bundled catalog not found at: $RULES_DIR" >&2
+    echo "  Run ./gradlew syncAgentCatalog from the easy-api repo to populate it." >&2
+    exit 1
+fi
+
+# ── iterate files in lexicographic order ─────────────────────────────────
+# Each file's YAML front-matter header carries `id`, `key`, `title`, `cue`.
+# `key` is the rule key this file documents (equals the filename stem by
+# convention, but we read it from the header to be precise).
+shopt -s nullglob
+FILES=( "$RULES_DIR"/*.md )
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo "(no rule-recipe files in bundled catalog)" >&2
+    exit 0
+fi
+
+for FILE in "${FILES[@]}"; do
+    # Extract the YAML front-matter block (between the first two `---` lines),
+    # then pull key/title/cue out of it.
+    awk '
+        /^---[[:space:]]*$/ {
+            count++
+            next
+        }
+        count == 1 {
+            print
+        }
+    ' "$FILE" | awk -F': ' '
+        /^key:/    { key = $0;   sub(/^key:[[:space:]]*/, "", key);   gsub(/^"|"$/, "", key) }
+        /^title:/  { title = $0; sub(/^title:[[:space:]]*/, "", title); gsub(/^"|"$/, "", title) }
+        /^cue:/    { cue = $0;   sub(/^cue:[[:space:]]*/, "", cue);   gsub(/^"|"$/, "", cue) }
+        END {
+            if (key != "" && title != "" && cue != "") {
+                printf "%s — %s: %s\n", key, title, cue
+            }
+        }
+    '
+done

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/AiAssistantService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/AiAssistantService.kt
@@ -10,7 +10,9 @@ import com.itangcent.easyapi.core.ai.agent.ClarificationGate
 import com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent
 import com.itangcent.easyapi.core.ai.tools.ToolContext
 import com.itangcent.easyapi.core.ai.tools.ToolRegistry
+import com.itangcent.easyapi.core.ai.tools.orchestratorToolRegistry
 import com.itangcent.easyapi.core.ai.tools.standardRuleTools
+import com.itangcent.easyapi.core.ai.tools.subAgentToolRegistry
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.core.logging.IdeaLog
@@ -109,11 +111,25 @@ class AiAssistantService(private val project: Project) : Disposable, IdeaLog {
             workingMemory = memory,
             approvals = approvals,
             clarifications = clarifications,
-            readConsents = readConsents
+            readConsents = readConsents,
+            events = events
         )
+        // Reactive-path agent: full tool set (perception + staging + task-list).
         val tools = ToolRegistry(standardRuleTools())
         val agent = RuleAuthoringAgent(aiService, tools, ctx, events)
-        return ConversationSession(agent, memory, events, approvals, clarifications, readConsents)
+        // Magic-path agent (Phase 3 — design §3.5): orchestrator tool set
+        // only (update_task + run_sub_agent + propose_rule_content). The
+        // orchestrator never perceives PSI directly — sub-agents do. The
+        // sub-agent tool registry is built once per session and reused for
+        // every sub-agent spawn in that session.
+        val subAgentTools = ToolRegistry(subAgentToolRegistry())
+        val orchestratorTools = ToolRegistry(
+            orchestratorToolRegistry(aiService, subAgentTools)
+        )
+        val magicAgent = RuleAuthoringAgent(aiService, orchestratorTools, ctx, events)
+        return ConversationSession(
+            agent, memory, events, approvals, clarifications, readConsents, magicAgent
+        )
     }
 
     /** Whether AI is configured and ready (i.e., [session] would return non-null). */
@@ -146,6 +162,14 @@ class AiAssistantService(private val project: Project) : Disposable, IdeaLog {
  * The per-conversation aggregate — agent + memory + events + gates.
  *
  * Held by [AiAssistantService]; the panel reads [events] and drives [agent].
+ *
+ * [magicAgent] is the Phase-3 orchestrator agent — a separate
+ * [RuleAuthoringAgent] instance with the orchestrator tool set
+ * (update_task + run_sub_agent + propose_rule_content, design §3.5). It
+ * shares the same [memory] / [events] / ctx as [agent]; the panel picks
+ * the right one based on [com.itangcent.easyapi.core.ai.agent.EntryPath].
+ * `null` in tests that don't exercise the Magic path — the panel falls
+ * back to [agent] so Phase-1/2 behaviour is preserved.
  */
 data class ConversationSession(
     val agent: RuleAuthoringAgent,
@@ -153,7 +177,8 @@ data class ConversationSession(
     val events: MutableSharedFlow<com.itangcent.easyapi.core.ai.agent.AgentEvent>,
     val approvals: UiApprovalGate,
     val clarifications: UiClarificationGate = UiClarificationGate(events),
-    val readConsents: UiFileReadConsentGate = UiFileReadConsentGate(events)
+    val readConsents: UiFileReadConsentGate = UiFileReadConsentGate(events),
+    val magicAgent: RuleAuthoringAgent? = null
 )
 
 /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/AiProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/AiProvider.kt
@@ -44,7 +44,7 @@ enum class AiProvider(
     AZURE_AI("Azure AI Foundry", "https://models.inference.ai.azure.com", "gpt-5.4-mini", true, openAiCompatible = true, contextWindow = 128_000),
     GITHUB_MODELS("GitHub Models", "https://models.github.ai/inference", "gpt-5.4-mini", true, openAiCompatible = true, contextWindow = 128_000),
     OPENROUTER("OpenRouter", "https://openrouter.ai/api/v1", "openai/gpt-5.4-mini", true, openAiCompatible = true, contextWindow = 128_000),
-    DEEPSEEK("DeepSeek", "https://api.deepseek.com/v1", "deepseek-chat", true, openAiCompatible = true, contextWindow = 128_000),
+    DEEPSEEK("DeepSeek", "https://api.deepseek.com/v1", "deepseek-v4-flash", true, openAiCompatible = true, contextWindow = 128_000),
     GROQ("Groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile", true, openAiCompatible = true, contextWindow = 128_000),
     MISTRAL("Mistral AI", "https://api.mistral.ai/v1", "mistral-small-latest", true, openAiCompatible = true, contextWindow = 32_000),
     XAI("xAI (Grok)", "https://api.x.ai/v1", "grok-4.3", true, openAiCompatible = true, contextWindow = 128_000),

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AgentEvent.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AgentEvent.kt
@@ -65,6 +65,34 @@ sealed class AgentEvent {
      */
     data class Retrying(val attempt: Int, val maxRetries: Int) : AgentEvent()
 
+    /**
+     * The agent committed to a [taskList] for this turn (Magic path).
+     *
+     * Emitted by `create_task_list` once the task list is staged in working
+     * memory, and also by `runTaskList` for programmatic entry. The UI
+     * renders a live checklist card from [taskList] and updates each row on
+     * subsequent [TaskStarted] / [TaskCompleted] / [TaskFailed] /
+     * [TaskSkipped] events.
+     */
+    data class TaskListCreated(val taskList: TaskList) : AgentEvent()
+
+    /** The agent started working task [taskId] of the active task list. */
+    data class TaskStarted(val taskId: String) : AgentEvent()
+
+    /** The agent completed task [taskId] of the active task list. */
+    data class TaskCompleted(val taskId: String) : AgentEvent()
+
+    /**
+     * The agent failed task [taskId] of the active task list.
+     *
+     * Non-terminal — a failed task does not abort the task list; the agent
+     * decides whether to retry, continue, or end.
+     */
+    data class TaskFailed(val taskId: String, val reason: String) : AgentEvent()
+
+    /** The agent skipped task [taskId] of the active task list. */
+    data class TaskSkipped(val taskId: String) : AgentEvent()
+
     /** The current turn completed normally. */
     object TurnComplete : AgentEvent()
 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AgentMemory.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AgentMemory.kt
@@ -20,11 +20,35 @@ class AgentMemory {
     @Volatile
     var ambient: Ambient? = null
 
+    /**
+     * Ephemeral task list for the Magic path. `null` in Reactive turns —
+     * the agent never calls `create_task_list` and the field stays untouched.
+     * Cleared by [reset] so a new conversation starts with no task list.
+     */
+    @Volatile
+    var taskList: TaskList? = null
+
+    /**
+     * Sub-agent results collected by `RunSubAgentTool` during one Magic
+     * detection turn (Phase 3 — design §3.9 / D3). Each entry pairs the
+     * [Task] with the [TaskResult] its sub-agent reported via
+     * `report_findings`. The orchestrator's `propose_rule_content` tool
+     * reads this list and merges it via [mergeTaskResults] (concatenate-
+     * with-tags) so the LLM does not have to compose the merged content
+     * itself — the merge is deterministic, "no LLM round-trip" (D3).
+     *
+     * Empty in Reactive turns and in sub-agent contexts (sub-agents don't
+     * spawn sub-agents). Cleared by [reset].
+     */
+    val collectedSubAgentResults: MutableList<Pair<Task, TaskResult>> = mutableListOf()
+
     /** Clear all state — invoked on "New Conversation". */
     fun reset() {
         messages.clear()
         proposal = null
         ambient = null
+        taskList = null
+        collectedSubAgentResults.clear()
     }
 }
 
@@ -72,5 +96,29 @@ data class Ambient(
      * Privacy: carries only short framework labels — never env-var keys or
      * values from the Environments panel.
      */
-    val frameworkHints: List<String> = emptyList()
+    val frameworkHints: List<String> = emptyList(),
+    /**
+     * Ids of the currently-enabled [com.itangcent.easyapi.channel.spi.Channel]s
+     * (e.g. `"postman"`, `"markdown"`), resolved from
+     * [com.itangcent.easyapi.channel.spi.ChannelRegistry] in
+     * [AmbientPerception.capture]. Cheap settings read — no PSI. Used by
+     * [SystemPromptBuilder.indexMessage] to filter the detection/rule catalog
+     * to only entries whose `channel:` scope matches an enabled channel (AC-S7).
+     *
+     * Privacy: carries only short channel ids — never env-var keys or values
+     * from the Environments panel.
+     */
+    val enabledChannels: List<String> = emptyList(),
+    /**
+     * Ids of the currently-enabled
+     * [com.itangcent.easyapi.format.spi.FieldFormatChannel]s (e.g. `"json"`,
+     * `"yaml"`), resolved from [com.itangcent.easyapi.format.spi.FieldFormatChannelRegistry]
+     * in [AmbientPerception.capture]. Cheap settings read — no PSI. Used by
+     * [SystemPromptBuilder.indexMessage] to filter the rule catalog to only
+     * entries whose `format:` scope matches an enabled format.
+     *
+     * Privacy: carries only short format ids — never env-var keys or values
+     * from the Environments panel.
+     */
+    val enabledFormats: List<String> = emptyList()
 )

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AmbientPerception.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/AmbientPerception.kt
@@ -1,9 +1,11 @@
 package com.itangcent.easyapi.core.ai.agent
 
+import com.itangcent.easyapi.channel.spi.ChannelRegistry
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.core.internal.threading.readSync
 import com.itangcent.easyapi.core.export.recognizer.CompositeApiClassRecognizer
 import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.format.spi.FieldFormatChannelRegistry
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
@@ -54,13 +56,31 @@ object AmbientPerception : IdeaLog {
         val perception = runCatching { captureApiPerception(project) }
             .onFailure { LOG.warn("Ambient perception capture failed", it) }
             .getOrDefault(ApiPerception(emptyList(), emptyList()))
+        // Cheap settings reads — no PSI. Resolved here (not in
+        // captureApiPerception) so a PSI-scan failure can't mask them.
+        // Used by SystemPromptBuilder.indexMessage to filter the catalog
+        // to only entries whose channel/format scope matches an enabled
+        // feature (AC-S7). Best-effort: a registry failure yields an empty
+        // list, never an exception.
+        val enabledChannels = runCatching {
+            val registry = ChannelRegistry.getInstance(project)
+            registry.allChannels().filter { registry.isEnabled(it) }.map { it.id }
+        }.onFailure { LOG.warn("Ambient capture: failed to resolve enabled channels", it) }
+            .getOrDefault(emptyList())
+        val enabledFormats = runCatching {
+            val registry = FieldFormatChannelRegistry.getInstance(project)
+            registry.allChannels().filter { registry.isEnabled(it) }.map { it.id }
+        }.onFailure { LOG.warn("Ambient capture: failed to resolve enabled formats", it) }
+            .getOrDefault(emptyList())
         // Trace what the agent "saw" at turn start.
         LOG.info("ambient capture: project=$projectName " +
             "editingRuleFile=${editingRuleFile ?: "<none>"} " +
             "existingRuleFiles=${existingRuleFiles.size} " +
             "userLanguage=${userLanguage ?: "<none>"} " +
             "moduleNames=${perception.moduleNames.size} " +
-            "frameworkHints=${perception.frameworkHints.size}")
+            "frameworkHints=${perception.frameworkHints.size} " +
+            "enabledChannels=${enabledChannels.size} " +
+            "enabledFormats=${enabledFormats.size}")
         LOG.info("Ambient captured ${perception.moduleNames.size} API-bearing module(s), " +
             "${perception.frameworkHints.size} framework(s)")
         return Ambient(
@@ -69,7 +89,9 @@ object AmbientPerception : IdeaLog {
             existingRuleFiles,
             userLanguage,
             perception.moduleNames,
-            perception.frameworkHints
+            perception.frameworkHints,
+            enabledChannels,
+            enabledFormats
         )
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/EntryPath.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/EntryPath.kt
@@ -1,0 +1,36 @@
+package com.itangcent.easyapi.core.ai.agent
+
+/**
+ * Entry path selects how [SystemPromptBuilder] composes the opening system
+ * messages for a turn. The agent loop is shared across all three paths
+ * (design principle "two paths, one loop"); only the seed prompt and the
+ * available tools differ.
+ *
+ * - [REACTIVE] — plain chat. The agent gets the base prompt plus the
+ *   derived detection and rule-detail indexes (enablement-aware). It uses
+ *   `get_detection_prompt` / `get_rule_detail` to pull full recipes on
+ *   demand. Task-list tools are not used.
+ * - [TASK_LIST_MAGIC] — invoked by the Magic button. The agent gets
+ *   the base prompt only; detection/rule detail is pulled inside tasks
+ *   as needed. `create_task_list` / `update_task` are intended to be
+ *   used here.
+ * - [TASK_LIST_PROGRAMMATIC] — reserved for the future programmatic
+ *   task-list entry seam. Same prompt shape as [TASK_LIST_MAGIC].
+ *
+ * - [SUB_AGENT] — used by [com.itangcent.easyapi.core.ai.tools.RunSubAgentTool]
+ *   when it spawns a sub-agent for one detection task. The sub-agent gets
+ *   its own base prompt (`sub-agent-base.md`) that advertises **only** the
+ *   tools in [com.itangcent.easyapi.core.ai.tools.subAgentToolRegistry]
+ *   (perception + `report_findings`); the orchestrator/Reactive tools it
+ *   cannot call are deliberately omitted so the model never invokes a tool
+ *   that isn't in its `ToolRegistry` (which would surface as "Unknown tool").
+ *
+ * Entrance-driven, not agent-detected (design D1): the caller picks the
+ * path; the agent never decides "this is complex, switch mode."
+ */
+enum class EntryPath {
+    REACTIVE,
+    TASK_LIST_MAGIC,
+    TASK_LIST_PROGRAMMATIC,
+    SUB_AGENT
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuard.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuard.kt
@@ -30,6 +30,30 @@ class LoopGuard(private val cfg: LoopSafetyConfig) {
     private val reasoningHashes = ArrayList<Int>()
 
     /**
+     * `true` at turn start and after each [beginBatch] call, until the first
+     * [observeResult] of the new batch clears it. Used by the output-stagnation
+     * detector to distinguish **across-batch** repetition (a real loop — the
+     * model got the same result last batch and is repeating itself) from
+     * **within-batch** repetition (parallel probes that legitimately return
+     * the same result, e.g. probing 4 different supertypes that all return `[]`).
+     */
+    private var newBatchStarted: Boolean = true
+
+    /**
+     * Mark the start of a new tool-call batch (one LLM assistant message may
+     * carry multiple tool calls — a "batch"). Called by the agent loop at the
+     * top of each step, before processing the assistant's tool calls.
+     *
+     * This resets the within-batch stagnation guard so that parallel probes
+     * in a single batch do NOT accumulate stagnation. Stagnation is only
+     * detected **across** batch boundaries: the first call of a new batch
+     * is compared against the last result of the previous batch.
+     */
+    fun beginBatch() {
+        newBatchStarted = true
+    }
+
+    /**
      * Pre-dispatch verdict: debounce an identical-to-last call.
      *
      * If debounce is enabled and the fingerprint of [tc] matches the last
@@ -88,11 +112,27 @@ class LoopGuard(private val cfg: LoopSafetyConfig) {
         // longer repeating sequences.
         detectCycle()?.let { return Verdict.Terminate(it) }
 
-        // --- C. Output stagnation (identical results) ---
+        // --- C. Output stagnation (identical results across batches) ---
+        // Within a single batch (one assistant message with multiple tool
+        // calls), the model is making parallel probes — identical results
+        // are legitimate (e.g. probing different supertypes that all return
+        // `[]`). Only count stagnation across batch boundaries: the first
+        // call of a new batch is compared against the last result of the
+        // previous batch; subsequent calls within the same batch reset the
+        // counter to 1.
         val h = resultFingerprint(result)
-        if (h == lastResultHash) {
-            stagnationCount++
+        if (newBatchStarted) {
+            // First call in a new batch — compare with the last result of
+            // the previous batch (across-batch stagnation check).
+            if (h == lastResultHash) {
+                stagnationCount++
+            } else {
+                stagnationCount = 1
+            }
+            newBatchStarted = false
         } else {
+            // Subsequent call within the same batch — parallel probe,
+            // never accumulate stagnation.
             stagnationCount = 1
         }
         lastResultHash = h

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/MagicInstructionBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/MagicInstructionBuilder.kt
@@ -1,0 +1,184 @@
+package com.itangcent.easyapi.core.ai.agent
+
+/**
+ * Builds the two distinct instruction bodies used by Magic.
+ *
+ * Magic is not a single uniform flow: an empty rule file goes straight to
+ * the detection-pass contract (Route A), while a non-empty file runs a
+ * single Reactive review turn first and gates the user before optional
+ * detections (Route B). The two flows need different instruction bodies,
+ * each pure of side effect so it can be unit-tested in isolation.
+ *
+ * - [detectionInstruction] — the empty-file Magic body (Phase 3 final
+ *   directive). Tells the agent a task list has already been seeded into
+ *   working memory, forbids `create_task_list`, and directs it to walk
+ *   `PENDING` tasks one at a time by calling `run_sub_agent(taskId=...)`
+ *   for each — the sub-agent runs the detection recipe in an isolated
+ *   context and reports findings back. `run_sub_agent` auto-records the
+ *   task status (completed if the sub-agent ran successfully, failed on
+ *   error) and ticks the checklist card, so the orchestrator does NOT
+ *   need to call `update_task` for the status afterwards. After all
+ *   tasks close, the orchestrator calls `propose_rule_content` once with
+ *   the merged findings. The orchestrator never calls perception tools
+ *   itself (FR-3.2/3.3).
+ *
+ *   Crucially, the seeded task ids (e.g. `detect_spring_filters_interceptors`)
+ *   are rendered into this body as an explicit manifest — the orchestrator
+ *   LLM has no other way to discover them (the `TaskList` lives only in
+ *   working memory + the UI panel; it is never serialized into the LLM
+ *   transcript by the agent loop).
+ *
+ * - [reviewInstruction] — the non-empty Magic Stage-1 body. A single
+ *   Reactive review turn that directs the agent to review and improve the
+ *   file. The file's current content is embedded in a fenced block. It
+ *   contains no task-list directive, no `update_task`, and no detection
+ *   language — the gate (Route B Stage 2) decides whether to enter the
+ *   detection-pass contract.
+ */
+object MagicInstructionBuilder {
+
+    /**
+     * The instruction body for the empty-file Magic flow (Route A) —
+     * Phase 3 final directive (design §3.8 / FR-3.8).
+     *
+     * Tells the agent a task list has been seeded with one `PENDING` task
+     * per detection pattern; forbids `create_task_list`; directs it to
+     * walk each `PENDING` task by calling `run_sub_agent(taskId=...)` —
+     * the sub-agent perceives the PSI, decides whether the pattern is
+     * present, and reports back via `report_findings`. `run_sub_agent`
+     * **auto-records** the task status (`completed` if the sub-agent ran
+     * successfully — whether or not it detected the pattern; `failed` on
+     * error) and ticks the checklist card in the UI, so the orchestrator
+     * does NOT need to call `update_task` for the status afterwards.
+     * "Nothing detected" is a valid finding, not a skip. After every task
+     * is closed, the orchestrator calls `propose_rule_content` **once** —
+     * the tool automatically merges the collected sub-agent findings via
+     * concatenate-with-tags (design §3.9 / D3), so the orchestrator does
+     * NOT need to compose the merged content itself. If the merged
+     * findings are empty (no pattern detected), the tool stages no
+     * proposal and the turn ends without prompting the user.
+     *
+     * The orchestrator has **no perception tools** (FR-3.2) — it must not
+     * call `find_classes_by_annotation`, `get_detection_prompt`, etc.
+     * All perception happens inside sub-agents. The orchestrator only
+     * coordinates: `run_sub_agent` → `update_task` → `propose_rule_content`.
+     *
+     * The seeded [taskList] is rendered into the body as an explicit
+     * manifest of `(id, title)` pairs. This is the **only** channel by
+     * which the orchestrator LLM learns the exact task ids — the
+     * `TaskList` lives in `AgentMemory` and the UI panel but is never
+     * serialized into the LLM transcript by `RuleAuthoringAgent.runTurn`.
+     * Without the manifest the LLM would have to guess the ids and
+     * `run_sub_agent` would reject every guess with "unknown task id".
+     *
+     * Empty task list (no detection matched the enabled features, FR-2.5):
+     * the body short-circuits to a single directive — call
+     * `propose_rule_content` once with no findings — so the turn still
+     * terminates normally instead of looping on a zero-task manifest.
+     *
+     * @param name the rule file's display name (used in the opening line).
+     * @param taskList the seeded task list. Its ids are rendered verbatim
+     *   into the manifest; the orchestrator must use them unchanged in
+     *   `run_sub_agent(taskId=...)` and `update_task(taskId, ...)`.
+     */
+    fun detectionInstruction(name: String, taskList: TaskList): String = buildString {
+        appendLine(
+            "I'm starting a new rule file '$name' (currently empty). " +
+                "Detect any custom framework patterns in this project that lack a rule, " +
+                "then propose initial rule content for them."
+        )
+        appendLine()
+        appendLine(
+            "Standard HTTP frameworks (Spring MVC, WebFlux, JAX-RS, Feign) need no rules. " +
+                "The task list seeded below covers Custom-Pattern and Workflow-Pattern " +
+                "Catalog detections (Filter/HandlerInterceptor/WebFilter, " +
+                "ResponseBodyAdvice, HandlerMethodArgumentResolver, custom annotations, " +
+                "auth-token chaining, static auth, correlation/idempotency headers, HMAC " +
+                "signing) — one task per detection family."
+        )
+        appendLine()
+        if (taskList.tasks.isEmpty()) {
+            // FR-2.5 — no detection matched the enabled features. Direct the
+            // orchestrator straight to the terminal action so the turn ends
+            // normally instead of looping on an empty manifest.
+            appendLine(
+                "No detection tasks were seeded for this project's enabled features " +
+                    "(the catalog had no matching entry). Skip run_sub_agent and " +
+                    "update_task entirely and call propose_rule_content ONCE with a " +
+                    "suggestedFileName and empty findings to end the turn. The tool " +
+                    "will stage no proposal (nothing to apply) and the turn will end."
+            )
+            return@buildString
+        }
+        appendLine(
+            "A task list has been seeded for you with one task per detection pattern. " +
+                "Do NOT call create_task_list — the task list is already in working memory. " +
+                "You are the ORCHESTRATOR: you have three tools (run_sub_agent, update_task, " +
+                "propose_rule_content) and NO perception tools."
+        )
+        appendLine()
+        appendLine(
+            "Seeded tasks — use these EXACT ids verbatim as the taskId argument to " +
+                "run_sub_agent and update_task. Do NOT invent, abbreviate, reformat, " +
+                "or guess ids; a wrong id is rejected with \"unknown task id\"."
+        )
+        taskList.tasks.forEachIndexed { index, task ->
+            appendLine("${index + 1}. ${task.id} — ${task.title}")
+        }
+        appendLine()
+        appendLine("For each PENDING task:")
+        appendLine()
+        appendLine("1. Call run_sub_agent(taskId=...) to spawn a sub-agent for that task.")
+        appendLine("   The sub-agent perceives the project's PSI in isolation, decides")
+        appendLine("   whether the pattern is present, and reports back via report_findings.")
+        appendLine("   run_sub_agent returns the sub-agent's findings (detected, findings,")
+        appendLine("   proposedRules) as text. It ALSO automatically records the task")
+        appendLine("   status (completed if the sub-agent ran successfully — whether or")
+        appendLine("   not it detected the pattern; failed on error) and ticks the")
+        appendLine("   checklist card in the UI, so you do NOT need to call update_task")
+        appendLine("   afterwards for the status. \"Nothing detected\" is a valid finding,")
+        appendLine("   NOT a skip.")
+        appendLine("2. After EVERY task is closed (run_sub_agent returned for all of")
+        appendLine("   them), call propose_rule_content ONCE with a suggestedFileName.")
+        appendLine("   You do NOT need to compose the merged content yourself — the tool")
+        appendLine("   automatically merges the collected sub-agent findings via")
+        appendLine("   concatenate-with-tags (each detection's findings tagged")
+        appendLine("   `source: detection:<id>`). If no pattern was detected, the tool")
+        appendLine("   stages no proposal and the turn ends without prompting the user.")
+        appendLine()
+        appendLine(
+            "Do NOT call propose_rule_content until all tasks are closed. Do NOT call " +
+                "perception tools (find_classes_by_annotation, get_detection_prompt, " +
+                "get_psi_class_info, etc.) — they are not in your tool set. Each " +
+                "detection runs inside its own sub-agent with a fresh memory; the " +
+                "results are merged for you."
+        )
+    }
+
+    /**
+     * The instruction body for the non-empty Magic flow (Route B Stage 1).
+     *
+     * Directs the agent to review and improve the file. The file's current
+     * content is embedded in a fenced block. Contains no task-list
+     * directive, no `update_task`, and no detection language — the gate
+     * decides whether to enter the detection-pass contract (Route B
+     * Stage 2), and Stage 2 itself runs the [detectionInstruction] body
+     * with the file content read at gate-Yes time.
+     *
+     * @param name the rule file's display name (used in the opening line).
+     * @param content the file's current content (embedded in a fenced
+     *   block so the agent can review it).
+     */
+    fun reviewInstruction(name: String, content: String): String = buildString {
+        appendLine(
+            "Review and improve the rule file '$name' that I'm editing. " +
+                "Fix anything broken or incomplete, then propose the full updated file content."
+        )
+        appendLine()
+        appendLine("Current content of '$name':")
+        appendLine("```")
+        append(content)
+        appendLine()
+        appendLine("```")
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/MagicTaskListBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/MagicTaskListBuilder.kt
@@ -1,0 +1,71 @@
+package com.itangcent.easyapi.core.ai.agent
+
+/**
+ * Builds the entrance-driven task list for a Magic run.
+ *
+ * Magic is the task-list entry path for "full audit" tasks: instead of
+ * letting the agent decide which detections to run (and burning a turn on
+ * `create_task_list`), the caller pre-builds a [TaskList] with one [Task] per
+ * detection file in `ai/detection/`, in catalog-manifest order. The task list
+ * is seeded into `AgentMemory` via `AiChatPanel.runTaskList` before the first
+ * LLM round-trip, so the Todo List renders immediately and the agent executes
+ * the seeded tasks directly (entrance-driven, not agent-driven).
+ *
+ * ## Feature filtering (AC-S7)
+ *
+ * The task list is **enablement-aware**: only detections whose `channel:` /
+ * `format:` / `framework:` scope matches the currently-enabled features
+ * become tasks. A `framework: springmvc` detection is excluded when Spring
+ * MVC is disabled (or absent from the project) — there is nothing to scan,
+ * so seeding a task would only waste a turn on `update_task(skipped)`. The
+ * same filter that [SystemPromptBuilder.indexMessage] applies to the
+ * Reactive menu is applied here, so Magic and Reactive agree on which
+ * detections exist for this turn.
+ */
+object MagicTaskListBuilder {
+
+    /**
+     * Builds a [TaskList] with one [Task] per detection catalog entry whose
+     * scope matches the supplied active-feature sets.
+     *
+     * - Task id: `"detect_" + ` detection id with non-alphanumeric chars
+     *   replaced by `_` (keeps `update_task`'s `taskId` simple and stable).
+     * - Task title: detection `title`.
+     * - Task detail: detection `cue` (one-line "when to use").
+     * - Task status: [TaskStatus.PENDING].
+     *
+     * @param activeChannels ids of the currently-enabled export channels
+     *   (e.g. `"postman"`, `"markdown"`). Detections with `channel:` scope
+     *   not in this set are excluded.
+     * @param activeFormats ids of the currently-enabled field-format
+     *   channels (e.g. `"json"`, `"yaml"`). Detections with `format:` scope
+     *   not in this set are excluded.
+     * @param activeFrameworks framework labels of the currently-enabled AND
+     *   PSI-detected web frameworks (e.g. `"springmvc"`, `"jaxrs"`). These
+     *   come from [Ambient.frameworkHints]. Detections with `framework:`
+     *   scope not in this set are excluded.
+     * @return the task list. Empty (zero tasks) if no detection matches the
+     *   enabled features; the caller still seeds it and the agent proceeds
+     *   straight to `propose_rule_content`.
+     */
+    fun buildDetectionPlan(
+        activeChannels: Set<String>,
+        activeFormats: Set<String>,
+        activeFrameworks: Set<String>
+    ): TaskList {
+        val tasks = PromptCatalog.listFor(
+            "detection",
+            activeChannels,
+            activeFormats,
+            activeFrameworks
+        ).map { entry ->
+            Task(
+                id = "detect_" + entry.id.replace(Regex("[^A-Za-z0-9]"), "_"),
+                title = entry.title,
+                detail = entry.cue,
+                status = TaskStatus.PENDING
+            )
+        }
+        return TaskList(tasks)
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/PromptCatalog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/PromptCatalog.kt
@@ -1,0 +1,266 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import com.itangcent.easyapi.core.logging.IdeaLog
+import org.yaml.snakeyaml.Yaml
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Optional scope constraint for a catalog file. A `null` field means
+ * "applies to all" for that dimension.
+ */
+data class CatalogScope(
+    val channel: String? = null,
+    val format: String? = null,
+    val framework: String? = null
+) {
+    /**
+     * `true` when each non-null scope field is in the corresponding active
+     * set. A file with no scope fields (`channel=null, format=null,
+     * framework=null`) always matches.
+     *
+     * Matching is **case-insensitive** to bridge the gap between catalog
+     * files (which conventionally use lowercase ids like `springmvc`) and
+     * the recognizer-supplied framework labels (which use mixed case like
+     * `SpringMVC`, `JAX-RS`, `gRPC`). Channel and format ids are already
+     * lowercase by convention; the case-insensitive compare is a no-op for
+     * them but keeps the contract uniform and robust.
+     */
+    fun matches(
+        activeChannels: Set<String>,
+        activeFormats: Set<String>,
+        activeFrameworks: Set<String>
+    ): Boolean {
+        val lcChannels = activeChannels.mapTo(HashSet()) { it.lowercase() }
+        val lcFormats = activeFormats.mapTo(HashSet()) { it.lowercase() }
+        val lcFrameworks = activeFrameworks.mapTo(HashSet()) { it.lowercase() }
+        return (channel == null || channel.lowercase() in lcChannels) &&
+            (format == null || format.lowercase() in lcFormats) &&
+            (framework == null || framework.lowercase() in lcFrameworks)
+    }
+}
+
+/**
+ * One catalog entry parsed from a file under `ai/detection/` or `ai/rules/`.
+ *
+ * @param category `"detection"` or `"rules"` (derived from the resource path)
+ * @param id unique within `category`; for rule files, equals `key` by convention
+ * @param title one-line human title
+ * @param cue one-line "when to use"
+ * @param key the rule key this file documents (rule files only; `null` for detection)
+ * @param scope optional channel/format/framework constraint
+ * @param resourcePath classpath path of the source file (e.g. `ai/rules/postman.test.md`)
+ */
+data class CatalogEntry(
+    val category: String,
+    val id: String,
+    val title: String,
+    val cue: String,
+    val key: String?,
+    val scope: CatalogScope,
+    val resourcePath: String
+)
+
+/**
+ * File-based catalog of detection and rule-detail prompts under
+ * `src/main/resources/ai/`.
+ *
+ * Each catalog file begins with a YAML front-matter header (delimited by
+ * `---` lines) carrying `id`, `title`, `cue` (required), `key` (rules only),
+ * and optional `channel`/`format`/`framework` scope. The header is parsed
+ * via SnakeYAML; the markdown body follows the closing `---`.
+ *
+ * Discovery is driven by `ai/catalog-manifest.txt` (one file path per line,
+ * relative to `src/main/resources/`). This avoids any JarFile/Path coupling
+ * in production code.
+ *
+ * ## Robustness
+ *
+ * Malformed YAML, a missing required field, or an unreadable file → the
+ * entry is skipped with `LOG.warn` (never throws). An empty/missing
+ * manifest → `list(...)` returns `emptyList()` + `LOG.warn`.
+ *
+ * ## Caching
+ *
+ * Parsed entries are loaded once (lazy) and cached. Body strings are loaded
+ * on demand and cached in a [ConcurrentHashMap]. Files are immutable in the
+ * JAR, so no invalidation is needed.
+ */
+object PromptCatalog : IdeaLog {
+
+    private const val MANIFEST_RESOURCE = "/ai/catalog-manifest.txt"
+
+    /** Parsed entries grouped by category, loaded once on first access. */
+    private val entriesByCategory: Map<String, List<CatalogEntry>> by lazy { loadCatalog() }
+
+    /** Cached bodies, keyed by `"$category/$id"`. Only non-null results are cached. */
+    private val bodyCache: ConcurrentHashMap<String, String> = ConcurrentHashMap()
+
+    /** All entries in [category], or an empty list if the category is empty/unknown. */
+    fun list(category: String): List<CatalogEntry> =
+        entriesByCategory[category] ?: emptyList()
+
+    /** The entry for [id] within [category], or `null` if not found. */
+    fun entry(category: String, id: String): CatalogEntry? =
+        entriesByCategory[category]?.firstOrNull { it.id == id }
+
+    /**
+     * The markdown body for [id] within [category], or `null` if not found.
+     * Cached after first access.
+     *
+     * `null` results are NOT cached ([ConcurrentHashMap] rejects null values),
+     * so a miss re-resolves on each call — cheap since [entry] is a list scan
+     * over already-parsed headers.
+     */
+    fun body(category: String, id: String): String? {
+        val cacheKey = "$category/$id"
+        // Fast path: already cached.
+        bodyCache[cacheKey]?.let { return it }
+        // Miss → resolve and cache only when non-null.
+        val resolved = entry(category, id)?.let { loadBody(it.resourcePath) }
+        if (resolved != null) {
+            bodyCache[cacheKey] = resolved
+        }
+        return resolved
+    }
+
+    /**
+     * Entries in [category] whose [CatalogScope] matches the supplied active
+     * feature sets. Used by [SystemPromptBuilder] to build enablement-aware
+     * indexes for the Reactive path.
+     */
+    fun listFor(
+        category: String,
+        activeChannels: Set<String>,
+        activeFormats: Set<String>,
+        activeFrameworks: Set<String>
+    ): List<CatalogEntry> =
+        list(category).filter {
+            it.scope.matches(activeChannels, activeFormats, activeFrameworks)
+        }
+
+    // -------------------------------------------------------------------
+    // Internal parsing helpers (pure — testable without classpath access)
+    // -------------------------------------------------------------------
+
+    /**
+     * Splits catalog file content into the YAML front-matter header and the
+     * markdown body. Returns `null` if the content does not start with a
+     * valid `---`-delimited header or the YAML is malformed.
+     *
+     * @param content the raw file content (UTF-8)
+     * @param yaml the [Yaml] instance to use for parsing (injectable for tests)
+     */
+    internal fun parseFrontMatter(content: String, yaml: Yaml = Yaml()): ParsedCatalogFile? {
+        val lines = content.lines()
+        if (lines.isEmpty() || lines[0].trim() != "---") return null
+        // Skip the opening `---` at index 0; find the closing `---` after it.
+        val closeIndex = (1 until lines.size).firstOrNull { lines[it].trim() == "---" } ?: -1
+        if (closeIndex == -1) return null
+        val yamlText = lines.subList(1, closeIndex).joinToString("\n")
+        val body = lines.subList(closeIndex + 1, lines.size)
+            .joinToString("\n").trim()
+        val header: Map<String, Any?> = try {
+            @Suppress("UNCHECKED_CAST")
+            yaml.load<Map<String, Any?>>(yamlText) ?: emptyMap()
+        } catch (e: Exception) {
+            return null
+        }
+        return ParsedCatalogFile(header, body)
+    }
+
+    /**
+     * Builds a [CatalogEntry] from a parsed header, deriving the category
+     * from the resource path. Returns `null` if a required field (`id`,
+     * `title`, `cue`) is missing or the category cannot be derived.
+     */
+    internal fun buildEntry(resourcePath: String, parsed: ParsedCatalogFile): CatalogEntry? {
+        val header = parsed.header
+        val id = header["id"] as? String ?: return null
+        val title = header["title"] as? String ?: return null
+        val cue = header["cue"] as? String ?: return null
+        val key = header["key"] as? String
+        val channel = header["channel"] as? String
+        val format = header["format"] as? String
+        val framework = header["framework"] as? String
+        val category = deriveCategory(resourcePath) ?: return null
+        return CatalogEntry(
+            category = category,
+            id = id,
+            title = title,
+            cue = cue,
+            key = key,
+            scope = CatalogScope(channel, format, framework),
+            resourcePath = resourcePath
+        )
+    }
+
+    /**
+     * Derives the category (`"detection"` or `"rules"`) from a resource path
+     * like `ai/detection/spring-filters-interceptors.md`. Returns `null` if
+     * the path doesn't follow the `ai/<category>/...` pattern.
+     */
+    internal fun deriveCategory(resourcePath: String): String? {
+        val parts = resourcePath.split("/")
+        return if (parts.size >= 2 && parts[0] == "ai") parts[1] else null
+    }
+
+    /** Parsed front-matter + body pair (internal transport type). */
+    internal data class ParsedCatalogFile(
+        val header: Map<String, Any?>,
+        val body: String
+    )
+
+    // -------------------------------------------------------------------
+    // Classpath loading (production path)
+    // -------------------------------------------------------------------
+
+    private fun loadCatalog(): Map<String, List<CatalogEntry>> {
+        val manifestText = javaClass.getResourceAsStream(MANIFEST_RESOURCE)?.use { stream ->
+            stream.readBytes().toString(Charsets.UTF_8)
+        } ?: run {
+            LOG.warn("catalog-manifest.txt not found on classpath; catalog is empty")
+            return emptyMap()
+        }
+
+        val yaml = Yaml()
+        val result = mutableMapOf<String, MutableList<CatalogEntry>>()
+        manifestText.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+            .forEach { path ->
+                val entry = loadEntry("/$path", yaml)
+                if (entry != null) {
+                    result.getOrPut(entry.category) { mutableListOf() }.add(entry)
+                }
+            }
+        return result
+    }
+
+    private fun loadEntry(resourcePath: String, yaml: Yaml): CatalogEntry? {
+        val content = javaClass.getResourceAsStream(resourcePath)?.use { stream ->
+            stream.readBytes().toString(Charsets.UTF_8)
+        } ?: run {
+            LOG.warn("catalog file not found on classpath: $resourcePath")
+            return null
+        }
+        val parsed = parseFrontMatter(content, yaml) ?: run {
+            LOG.warn("skipping catalog file (malformed front-matter): $resourcePath")
+            return null
+        }
+        return buildEntry(resourcePath.removePrefix("/"), parsed) ?: run {
+            LOG.warn("skipping catalog file (missing required field): $resourcePath")
+            return null
+        }
+    }
+
+    private fun loadBody(resourcePath: String): String? {
+        val fullResourcePath = if (resourcePath.startsWith("/")) resourcePath else "/$resourcePath"
+        val content = javaClass.getResourceAsStream(fullResourcePath)?.use { stream ->
+            stream.readBytes().toString(Charsets.UTF_8)
+        } ?: run {
+            LOG.warn("catalog body not found on classpath: $fullResourcePath")
+            return null
+        }
+        return parseFrontMatter(content)?.body ?: content.trim()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgent.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgent.kt
@@ -54,22 +54,33 @@ class RuleAuthoringAgent(
      * which rule file is being edited (the rule-file edit dialog) should
      * pass an [Ambient] captured with that file path; `null` (the default)
      * captures an editing-file-less ambient for [ctx.project].
+     * @param entryPath The entry path selecting the seed-prompt shape (design
+     * C9). Defaults to [EntryPath.REACTIVE] so existing callers (plain chat)
+     * are unchanged; `runTaskList` passes
+     * [EntryPath.TASK_LIST_PROGRAMMATIC]. The path only affects which system
+     * messages seed an empty transcript — the loop body is shared.
      */
     suspend fun runTurn(
         userMessage: String,
         memory: AgentMemory,
-        ambient: Ambient? = null
+        ambient: Ambient? = null,
+        entryPath: EntryPath = EntryPath.REACTIVE
     ): TurnOutcome {
-        // First-turn setup: the role/policy preamble is added once at the
-        // start of a conversation (and re-asserted after a reset()).
-        if (memory.messages.isEmpty()) {
-            memory.messages.add(SystemPromptBuilder.build())
-        }
-
-        // PERCEPTION (ambient) — use the caller-supplied perception, or
-        // capture an editing-file-less one for this project.
+        // PERCEPTION (ambient) — captured BEFORE the preamble block because
+        // SystemPromptBuilder.build(entryPath, amb) needs the enabled-feature
+        // sets to filter the derived indexes (design C9 reorder). Use the
+        // caller-supplied perception, or capture an editing-file-less one
+        // for this project.
         val amb = ambient ?: AmbientPerception.capture(ctx.project)
         memory.ambient = amb
+
+        // First-turn setup: the role/policy preamble (and entry-path-specific
+        // indexes for the Reactive path) is added once at the start of a
+        // conversation (and re-asserted after a reset()).
+        if (memory.messages.isEmpty()) {
+            SystemPromptBuilder.build(entryPath, amb).forEach { memory.messages.add(it) }
+        }
+
         memory.messages.add(SystemPromptBuilder.ambient(amb))
         memory.messages.add(AiMessage.User(userMessage))
 
@@ -139,7 +150,15 @@ class RuleAuthoringAgent(
             // Reasoning repetition — check before tool-call dispatch so a
             // looping assistant message is caught even if it carries tool calls.
             when (val v = guard.observeReasoning(assistant)) {
-                is LoopGuard.Verdict.Terminate -> return endLoopDetected(guard, v.reason, memory)
+                is LoopGuard.Verdict.Terminate -> {
+                    // The assistant message may carry tool_calls that now have
+                    // no corresponding tool result messages. Fill in synthetic
+                    // results for ALL of them so the conversation history stays
+                    // valid for the next chat request (the API requires every
+                    // tool_call_id to have a matching tool result message).
+                    assistant.toolCalls?.let { fillSkippedToolResults(it, 0, memory) }
+                    return endLoopDetected(guard, v.reason, memory)
+                }
                 else -> { }
             }
 
@@ -156,7 +175,13 @@ class RuleAuthoringAgent(
             LOG.info("agent step ${step + 1}: model requested ${calls.size} tool call(s): " +
                 calls.joinToString(",") { it.name })
 
-            for (tc in calls!!) {
+            // Mark the start of a new tool-call batch so the LoopGuard's
+            // output-stagnation detector only fires across batch boundaries
+            // (not within a batch of parallel probes).
+            guard.beginBatch()
+
+            for (i in calls.indices) {
+                val tc = calls[i]
                 // Debounce: skip dispatch for provably-identical repeats and
                 // feed an instructive error back to the model instead. The
                 // streak counter still advances via observeResult below.
@@ -166,8 +191,10 @@ class RuleAuthoringAgent(
                         events.emit(AgentEvent.Observed(tc.name, pre.result.summary()))
                         LOG.info("agent tool debounced: ${tc.name}")
                         when (val post = guard.observeResult(tc, pre.result)) {
-                            is LoopGuard.Verdict.Terminate ->
+                            is LoopGuard.Verdict.Terminate -> {
+                                fillSkippedToolResults(calls, i + 1, memory)
                                 return endLoopDetected(guard, post.reason, memory)
+                            }
                             else -> { }
                         }
                         continue
@@ -205,13 +232,20 @@ class RuleAuthoringAgent(
 
                 // Loop detection: consecutive duplicate / call cycle / output stagnation.
                 when (val post = guard.observeResult(tc, result)) {
-                    is LoopGuard.Verdict.Terminate ->
+                    is LoopGuard.Verdict.Terminate -> {
+                        fillSkippedToolResults(calls, i + 1, memory)
                         return endLoopDetected(guard, post.reason, memory)
+                    }
                     else -> { }
                 }
 
-                if (tc.name == PROPOSE_RULE_CONTENT) {
-                    // Terminal action — proposal is staged in working memory.
+                if (tc.name == PROPOSE_RULE_CONTENT || tc.name == REPORT_FINDINGS) {
+                    // Terminal action — proposal is staged in working memory
+                    // (orchestrator via propose_rule_content), or findings are
+                    // staged in the sub-agent result slot (sub-agent via
+                    // report_findings). Each role's tool registry includes
+                    // only its own terminal action, so this check is harmless
+                    // for the other role.
                     return finish(memory)
                 }
             }
@@ -284,9 +318,49 @@ class RuleAuthoringAgent(
         }.getOrDefault(emptyMap())
     }
 
+    /**
+     * Fill in synthetic tool-result messages for tool calls in [calls] that
+     * were not dispatched (indices [startIndex] onward), because the
+     * [LoopGuard] terminated the turn mid-batch.
+     *
+     * The OpenAI API requires every `tool_call_id` in an assistant message to
+     * have a corresponding tool-result message immediately following. When the
+     * guard terminates mid-batch, the remaining tool calls in the batch have
+     * no results — without this fill-in, the next `aiService.chat()` call
+     * fails with "insufficient tool messages following tool_calls message".
+     *
+     * Each skipped call gets a synthetic [ToolResult.Error] explaining that the
+     * turn was terminated; the model sees the error and can adjust on retry.
+     */
+    private fun fillSkippedToolResults(
+        calls: List<com.itangcent.easyapi.core.ai.AiToolCall>,
+        startIndex: Int,
+        memory: AgentMemory
+    ) {
+        if (startIndex >= calls.size) return
+        for (i in startIndex until calls.size) {
+            val tc = calls[i]
+            val skipped = ToolResult.Error(
+                "Tool call skipped: the agent turn was terminated (loop detected) " +
+                    "before this call was dispatched."
+            )
+            memory.messages.add(AiMessage.ToolResult(tc.id, tc.name, skipped.toJson()))
+            LOG.info("agent tool skipped (loop termination): ${tc.name}")
+        }
+    }
+
     companion object {
         /** The terminal staging action's tool name. */
         const val PROPOSE_RULE_CONTENT = "propose_rule_content"
+
+        /**
+         * The sub-agent's terminal action's tool name. Sub-agents stage their
+         * [TaskResult] via `report_findings` (see
+         * [com.itangcent.easyapi.core.ai.tools.ReportFindingsTool]); the
+         * orchestrator's `run_sub_agent` tool awaits it. Terminal for
+         * sub-agents only — never registered in the orchestrator's tool set.
+         */
+        const val REPORT_FINDINGS = "report_findings"
     }
 }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilder.kt
@@ -4,33 +4,102 @@ import com.itangcent.easyapi.core.ai.AiMessage
 import com.itangcent.easyapi.core.logging.IdeaLog
 
 /**
- * Builds the two system-prompt pieces consumed by [RuleAuthoringAgent]
- *.
+ * Builds the system-prompt pieces consumed by [RuleAuthoringAgent].
  *
- * - [build] is the fixed role/policy preamble appended once at the start of
- * a conversation (and re-asserted after a `reset()`). It frames the
- * Perception→Reasoning→Action loop, names the tools available to the agent,
- * and identifies `propose_rule_content` as the single state-changing action.
- * The text lives in `resources/ai/agent-preamble.md` (kept out of
- * `docs/knowledge-base/` so the `get_plugin_doc` tool does not expose it).
+ * Three concerns are split out (design C2):
  *
- * - [ambient] is the per-turn free perception: the rule file being edited and
- * the other rule files that exist. The agent loop appends it before each
- * reasoning step.
+ * - [build] is the fixed base prompt (role/policy loop contract, tool index,
+ *   rule-file format, writing-quality rules). Loaded once from
+ *   `resources/ai/agent-base.md` (kept out of `docs/knowledge-base/` so the
+ *   `get_plugin_doc` tool does not expose it). Always appended once at the
+ *   start of a conversation (and re-asserted after a `reset()`).
+ *
+ * - [build] with an [EntryPath] composes the entry-path-specific opening
+ *   messages. The Reactive path appends two derived indexes (detection +
+ *   rule-detail) so the agent has a menu to browse; the Task-List paths
+ *   append only the base prompt (detection/rule detail is pulled inside
+ *   tasks as needed). The indexes are enablement-aware: a `channel: postman`
+ *   rule file is absent from the rule index when Postman is disabled (AC-S7).
+ *
+ * - [ambient] is the per-turn free perception: the rule file being edited,
+ *   the other rule files that exist, the detected modules/frameworks, and the
+ *   enabled channels/formats. The agent loop appends it before each
+ *   reasoning step.
  *
  * Both are intentionally short — the agent pulls the full guide via the
- * `get_plugin_doc` tool rather than baking it into every request (saves
- * tokens).
+ * `get_plugin_doc` / `get_detection_prompt` / `get_rule_detail` tools rather
+ * than baking it into every request (saves tokens).
  */
 object SystemPromptBuilder : IdeaLog {
 
-    private const val PREAMBLE_RESOURCE = "/ai/agent-preamble.md"
+    private const val BASE_RESOURCE = "/ai/agent-base.md"
 
-    /** Fixed role/policy preamble (loaded once from the classpath resource). */
-    private val PREAMBLE: String by lazy { loadPreamble() }
+    /**
+     * Fixed base prompt for a sub-agent (one detection task).
+     *
+     * Loaded once from `resources/ai/sub-agent-base.md`. It advertises **only**
+     * the tools in
+     * [com.itangcent.easyapi.core.ai.tools.subAgentToolRegistry] (perception +
+     * `report_findings`), so a sub-agent never sees the orchestrator/Reactive
+     * tools it cannot call (e.g. `list_project_endpoints`, `get_plugin_doc`,
+     * `find_classes_by_name`, `get_existing_rules_for_key`,
+     * `propose_rule_content`). Without this, the sub-agent was seeded with the
+     * shared [BASE] prompt whose tool index lists ~14 tools — the LLM trusted
+     * the prompt over its 6-entry `tools` schema array and called tools not in
+     * its registry, surfacing as "Unknown tool: <name>" in `ToolRegistry`.
+     */
+    private const val SUB_AGENT_BASE_RESOURCE = "/ai/sub-agent-base.md"
 
-    /** Fixed role/policy preamble. */
-    fun build(): AiMessage.System = AiMessage.System(PREAMBLE)
+    /** Fixed base prompt (loaded once from the classpath resource). */
+    private val BASE: String by lazy { loadBase() }
+
+    /** Fixed sub-agent base prompt (loaded once from the classpath resource). */
+    private val SUB_AGENT_BASE: String by lazy { loadSubAgentBase() }
+
+    /** Fixed base prompt. */
+    fun build(): AiMessage.System = AiMessage.System(BASE)
+
+    /**
+     * Fixed base prompt for a sub-agent (one detection task).
+     *
+     * @see SUB_AGENT_BASE_RESOURCE
+     */
+    fun buildSubAgent(): AiMessage.System = AiMessage.System(SUB_AGENT_BASE)
+
+    /**
+     * Compose opening system messages based on [entryPath].
+     *
+     * - [EntryPath.REACTIVE] → base prompt + detection index + rule index.
+     *   Agent has a menu to browse; pulls detail on demand.
+     * - [EntryPath.TASK_LIST_MAGIC] / [EntryPath.TASK_LIST_PROGRAMMATIC]
+     *   → base prompt only. Detection/rule detail is pulled inside tasks
+     *   as needed.
+     * - [EntryPath.SUB_AGENT] → the sub-agent base prompt only. It advertises
+     *   only the sub-agent's registered tools (perception + `report_findings`)
+     *   and omits the orchestrator/Reactive tools it cannot call, so the model
+     *   never invokes a tool not in its registry. No detection/rule index —
+     *   the assigned detection's recipe is embedded in the sub-agent's user
+     *   instruction by [com.itangcent.easyapi.core.ai.tools.RunSubAgentTool],
+     *   and per-key recipes are pulled via `get_rule_detail` as needed.
+     *
+     * The indexes are derived from [PromptCatalog] and filtered by the
+     * ambient-enabled features (channels/formats/frameworks). The body of an
+     * index message is `(none for the currently enabled features)` when no
+     * catalog entries match.
+     *
+     * @param entryPath the entry path selecting prompt shape.
+     * @param amb the ambient observation carrying the enabled-feature sets
+     *   used to filter the indexes.
+     */
+    fun build(entryPath: EntryPath, amb: Ambient): List<AiMessage.System> = when (entryPath) {
+        EntryPath.REACTIVE -> listOf(
+            build(),
+            indexMessage("detection", amb),
+            indexMessage("rules", amb)
+        )
+        EntryPath.TASK_LIST_MAGIC, EntryPath.TASK_LIST_PROGRAMMATIC -> listOf(build())
+        EntryPath.SUB_AGENT -> listOf(buildSubAgent())
+    }
 
     /**
      * Per-turn ambient context message.
@@ -56,6 +125,18 @@ object SystemPromptBuilder : IdeaLog {
         if (amb.frameworkHints.isNotEmpty()) {
             parts += "frameworks active: ${amb.frameworkHints.joinToString(", ")}"
         }
+        // Surface the enabled channels so the agent knows which export
+        // destinations are turned on (AC-S7). Cheap settings read resolved in
+        // AmbientPerception.capture. Empty list → no hint.
+        if (amb.enabledChannels.isNotEmpty()) {
+            parts += "enabled channels: ${amb.enabledChannels.joinToString(", ")}"
+        }
+        // Surface the enabled field-format channels so the agent knows which
+        // serialization formats are turned on. Cheap settings read resolved in
+        // AmbientPerception.capture. Empty list → no hint.
+        if (amb.enabledFormats.isNotEmpty()) {
+            parts += "enabled formats: ${amb.enabledFormats.joinToString(", ")}"
+        }
         // Surface the detected Markdown template locale so the agent can decide
         // whether to propose `markdown.template.language=<tag>`. `en`/null
         // mean "default (English) template" — no hint, no proposal.
@@ -66,13 +147,58 @@ object SystemPromptBuilder : IdeaLog {
         return AiMessage.System(parts.joinToString("; ") + ".")
     }
 
-    private fun loadPreamble(): String {
-        return javaClass.getResourceAsStream(PREAMBLE_RESOURCE)?.use { stream ->
+    /**
+     * Enablement-aware index message for one catalog [category]
+     * (`"detection"` or `"rules"`).
+     *
+     * Lists each matching catalog entry as `- `id` — title: cue`, prefixed
+     * by a header that names the tool used to fetch the full recipe. When no
+     * entries match the ambient-enabled features, the body becomes
+     * `(none for the currently enabled features)` so the agent knows the
+     * catalog is empty for this turn rather than missing entirely.
+     */
+    private fun indexMessage(category: String, amb: Ambient): AiMessage.System {
+        val entries = PromptCatalog.listFor(
+            category,
+            activeChannels = amb.enabledChannels.toSet(),
+            activeFormats = amb.enabledFormats.toSet(),
+            activeFrameworks = amb.frameworkHints.toSet()
+        )
+        val header = when (category) {
+            "detection" -> "Available detection prompts (fetch with `get_detection_prompt(id)` when relevant):"
+            "rules" -> "Available rule-detail prompts (fetch with `get_rule_detail(key=...)` when relevant):"
+            else -> "Available $category prompts:"
+        }
+        val body = if (entries.isEmpty()) {
+            "(none for the currently enabled features)"
+        } else {
+            entries.joinToString("\n") { "- `${it.id}` — ${it.title}: ${it.cue}" }
+        }
+        return AiMessage.System("$header\n$body")
+    }
+
+    private fun loadBase(): String {
+        return javaClass.getResourceAsStream(BASE_RESOURCE)?.use { stream ->
             stream.readBytes().toString(Charsets.UTF_8).trim()
         } ?: run {
             // Should never happen — the resource ships in the JAR.
-            LOG.warn("agent-preamble.md resource not found on classpath; falling back to empty preamble")
+            LOG.warn("agent-base.md resource not found on classpath; falling back to empty base prompt")
             ""
+        }
+    }
+
+    private fun loadSubAgentBase(): String {
+        return javaClass.getResourceAsStream(SUB_AGENT_BASE_RESOURCE)?.use { stream ->
+            stream.readBytes().toString(Charsets.UTF_8).trim()
+        } ?: run {
+            // Should never happen — the resource ships in the JAR. Falling back
+            // to the orchestrator's base prompt keeps the sub-agent runnable,
+            // but re-introduces the "unknown tool" mismatch this split fixes.
+            LOG.warn(
+                "sub-agent-base.md resource not found on classpath; " +
+                    "falling back to agent-base.md (sub-agent may call unknown tools)"
+            )
+            BASE
         }
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/TaskList.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/TaskList.kt
@@ -1,0 +1,53 @@
+package com.itangcent.easyapi.core.ai.agent
+
+/**
+ * An ordered, ephemeral task list the agent commits to before working a complex
+ * task in the Magic path.
+ *
+ * Lives in [AgentMemory.taskList] only for the duration of a conversation; never
+ * persisted to disk. Tasks are addressed by [Task.id] so lifecycle events
+ * ([TaskStarted], [TaskCompleted], [TaskFailed], [TaskSkipped]) can reference
+ * a row without carrying the whole list.
+ *
+ * @property tasks Ordered list — order is presentation order; status changes
+ *   are addressed by id, not by index.
+ */
+data class TaskList(val tasks: List<Task>) {
+    init {
+        require(tasks.distinctBy { it.id }.size == tasks.size) {
+            "duplicate task ids: ${tasks.map { it.id }}"
+        }
+    }
+
+    /** @return the task with [id], or `null` if no such task exists. */
+    fun byId(id: String): Task? = tasks.firstOrNull { it.id == id }
+}
+
+/**
+ * One unit of work in a [TaskList].
+ *
+ * @property id Stable identifier the agent uses in `update_task` calls and
+ *   the lifecycle events carry back. Short, e.g. `s1`, `s2`.
+ * @property title Single short line describing what this task does.
+ * @property detail Optional 1–2 sentence elaboration. May be `null`.
+ * @property status Lifecycle state. New task lists start every task at
+ *   [TaskStatus.PENDING].
+ */
+data class Task(
+    val id: String,
+    val title: String,
+    val detail: String? = null,
+    val status: TaskStatus = TaskStatus.PENDING
+)
+
+/**
+ * Lifecycle state of a [Task].
+ *
+ * Glyphs are the UI rendering for each state (design C11):
+ * - PENDING → `[ ]`
+ * - IN_PROGRESS → `[~]`
+ * - COMPLETED → `[X]`
+ * - FAILED → `[!]`
+ * - SKIPPED → `[-]`
+ */
+enum class TaskStatus { PENDING, IN_PROGRESS, COMPLETED, FAILED, SKIPPED }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/TaskResult.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/agent/TaskResult.kt
@@ -1,0 +1,82 @@
+package com.itangcent.easyapi.core.ai.agent
+
+/**
+ * Result a sub-agent reports back to the orchestrator for one [Task].
+ *
+ * Sub-agents stage a [TaskResult] via `report_findings` (see
+ * [com.itangcent.easyapi.core.ai.tools.ReportFindingsTool]); the
+ * orchestrator's `run_sub_agent` tool awaits it and serialises it back to the
+ * orchestrator's LLM as a `ToolResult.Text`. After every task closes the
+ * orchestrator merges the collected [TaskResult]s via
+ * [mergeTaskResults] (concatenate-with-tags, design §3.9 / D3) and calls
+ * `propose_rule_content` exactly once with the merged findings.
+ *
+ * @property detected `true` if the detection pattern was found in the
+ *   project's PSI; `false` if the sub-agent searched and found nothing.
+ *   Drives the orchestrator's [TaskStatus] decision: `COMPLETED` in both
+ *   cases (the sub-agent ran successfully); `FAILED` only when the
+ *   sub-agent errored (FR-3.5 / FR-3.6). "Nothing detected" is a valid
+ *   finding, not a skip.
+ * @property findings Free-form markdown the sub-agent produced — search
+ *   evidence,located classes, why the pattern applies. Concatenated verbatim
+ *   into the orchestrator's final `propose_rule_content` payload, tagged
+ *   `source: detection:<task.id>`.
+ * @property proposedRules Concrete rule proposals the sub-agent drafted
+ *   from its findings. Empty when `detected=false`. Each entry is a
+ *   [RuleProposal] keyed by rule key with a short preview.
+ */
+data class TaskResult(
+    val detected: Boolean,
+    val findings: String,
+    val proposedRules: List<RuleProposal> = emptyList()
+)
+
+/**
+ * One concrete rule proposal a sub-agent stages via [TaskResult].
+ *
+ * The orchestrator's merge (design §3.9) lists each proposed rule under its
+ * detection's findings block as `- <key>: <preview>`. The full rule body
+ * lives inside [findings]; this entry is the catalog-facing summary the
+ * user sees in the merged `propose_rule_content` payload.
+ *
+ * @property key The rule key this proposal targets (e.g.
+ *   `method.additional.header`). Matches a key surfaced by `list_rule_keys`.
+ * @property preview Short human-readable preview of the proposed value
+ *   (e.g. the JSON body or a one-liner). Truncated if long — the full value
+ *   is in [TaskResult.findings].
+ */
+data class RuleProposal(
+    val key: String,
+    val preview: String
+)
+
+/**
+ * Merge a list of `(Task, TaskResult)` pairs into the single string payload
+ * the orchestrator passes to `propose_rule_content` (design §3.9 / D3).
+ *
+ * Concatenate-with-tags: each task whose `detected=true` contributes a
+ * `## <title>` block tagged `source: detection:<id>` containing its findings
+ * and a bulleted list of proposed rules. Non-detected tasks are filtered
+ * out — they contribute nothing to the merged payload (their `COMPLETED`
+ * status is already recorded in the task list). When every task is
+ * non-detected, the merged string is empty and
+ * `OrchestratorProposeRuleContentTool` stages no proposal (FR-2.5).
+ *
+ * No deduplication, no LLM round-trip. Revisit if concatenated output proves
+ * noisy (D3 options b/c, deferred).
+ */
+fun mergeTaskResults(results: List<Pair<Task, TaskResult>>): String =
+    results.filter { it.second.detected }
+        .joinToString("\n\n") { (task, r) ->
+            buildString {
+                appendLine("## ${task.title}")
+                appendLine("source: detection:${task.id}")
+                appendLine()
+                appendLine(r.findings.trim())
+                if (r.proposedRules.isNotEmpty()) {
+                    appendLine()
+                    appendLine("Proposed rules:")
+                    r.proposedRules.forEach { appendLine("- ${it.key}: ${it.preview}") }
+                }
+            }
+        }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/AiTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/AiTool.kt
@@ -2,11 +2,15 @@ package com.itangcent.easyapi.core.ai.tools
 
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.ai.agent.ClarificationGate
+import com.itangcent.easyapi.core.ai.agent.TaskResult
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableSharedFlow
 
 /**
  * Classifies a tool as a sense (read-only) or a hand (state-changing).
@@ -76,7 +80,32 @@ data class ToolContext(
      * wire a gate preserve the original refuse-outside-allow-list behavior.
      */
     val readConsents: com.itangcent.easyapi.core.ai.agent.FileReadConsentGate =
-        com.itangcent.easyapi.core.ai.agent.FileReadConsentGate.NOOP
+        com.itangcent.easyapi.core.ai.agent.FileReadConsentGate.NOOP,
+    /**
+     * Sink for [AgentEvent]s emitted directly from tool bodies — currently
+     * used only by the Task-List-path tools (`create_task_list`,
+     * `update_task`) so they can signal `TaskListCreated` / `Task*`
+     * lifecycle events to the UI without going through the agent loop's
+     * per-call `Acting`/`Observed` cards.
+     *
+     * No default — every context MUST wire this to the same
+     * `MutableSharedFlow` the owning [com.itangcent.easyapi.core.ai.ConversationSession]
+     * uses so tool-emitted events reach the chat panel. Tests that don't
+     * care about events pass a no-op `MutableSharedFlow(extraBufferCapacity = 64)`.
+     */
+    val events: MutableSharedFlow<AgentEvent>,
+    /**
+     * Sub-agent result slot — `null` for orchestrator / Reactive contexts;
+     * non-`null` for sub-agent contexts created by `RunSubAgentTool`.
+     *
+     * `ReportFindingsTool` completes this deferred with the sub-agent's
+     * [TaskResult] when the sub-agent calls `report_findings`; the
+     * orchestrator's `RunSubAgentTool` awaits it. Defaults to `null` so
+     * non-sub-agent contexts (orchestrator, Reactive, tests that don't
+     * exercise sub-agents) are unaffected. Completing a `null` slot is a
+     * no-op — `ReportFindingsTool` returns an Error in that case.
+     */
+    val subAgentResult: CompletableDeferred<TaskResult>? = null
 )
 
 /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/CreateTaskListTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/CreateTaskListTool.kt
@@ -1,0 +1,117 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
+import com.itangcent.easyapi.core.ai.agent.Task
+import com.itangcent.easyapi.core.ai.agent.TaskList
+import com.itangcent.easyapi.core.ai.agent.TaskStatus
+import com.itangcent.easyapi.core.logging.IdeaLog
+
+/**
+ * Magic-path tool that commits the agent to a concrete task list before it
+ * starts producing rules (design C7 / task B4).
+ *
+ * - `name = "create_task_list"`, `kind = PERCEPTION`, `requiresApproval = false`.
+ * - Schema: `{ tasks: [{ id, title, detail? }] }`.
+ * - Behaviour: builds a [TaskList] with every task at [TaskStatus.PENDING],
+ *   stores it in `ctx.workingMemory.taskList`, emits
+ *   [AgentEvent.TaskListCreated] via `ctx.events` so the UI renders a live
+ *   checklist card, and returns a one-line confirmation fed back to the LLM.
+ *
+ * If a task list is already staged the call still replaces it (edge case)
+ * and logs `console.info("task list replaced")` so the replacement is
+ * observable. The previous task list's progress is discarded —
+ * `create_task_list` is a fresh commitment, not a merge.
+ *
+ * The agent is instructed (in `agent-base.md`) to use this tool only for
+ * Magic tasks (≥2 distinct steps). Reactive chat turns never call it.
+ */
+class CreateTaskListTool : AiTool, IdeaLog {
+
+    override val name: String = "create_task_list"
+
+    override val description: String =
+        "Commit to a concrete task list before working a complex (Magic) " +
+            "task. Pass an ordered list of tasks, each with a short stable " +
+            "id (e.g. \"s1\", \"s2\"), a one-line title, and an optional " +
+            "1-2 sentence detail. All tasks start PENDING; use update_task " +
+            "to mark them in_progress / completed / failed / skipped as you " +
+            "work. Use this ONLY for Magic tasks with ≥2 distinct " +
+            "steps; plain chat does not need a task list."
+
+    override val kind: ToolKind = ToolKind.PERCEPTION
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "tasks" to mapOf(
+                "type" to "array",
+                "description" to "Ordered list of tasks. Each task has " +
+                    "an id (short, stable, e.g. \"s1\"), a title (one line), " +
+                    "and an optional detail (1-2 sentences). Task ids MUST be " +
+                    "unique within the task list.",
+                "items" to mapOf(
+                    "type" to "object",
+                    "properties" to mapOf(
+                        "id" to mapOf(
+                            "type" to "string",
+                            "description" to "Short stable identifier used in " +
+                                "subsequent update_task calls and lifecycle " +
+                                "events."
+                        ),
+                        "title" to mapOf(
+                            "type" to "string",
+                            "description" to "One-line description of what " +
+                                "this task does."
+                        ),
+                        "detail" to mapOf(
+                            "type" to "string",
+                            "description" to "Optional 1-2 sentence elaboration."
+                        )
+                    ),
+                    "required" to listOf("id", "title")
+                ),
+                "minItems" to 1
+            )
+        ),
+        "required" to listOf("tasks")
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        @Suppress("UNCHECKED_CAST")
+        val rawTasks = args["tasks"] as? List<Map<String, Any?>>
+        if (rawTasks.isNullOrEmpty()) {
+            return ToolResult.Error("missing required parameter: tasks (non-empty array)")
+        }
+
+        // Parse + validate each task. Missing id/title is a recoverable error
+        // so the agent can retry with a corrected call.
+        val parsed = mutableListOf<Task>()
+        for ((index, raw) in rawTasks.withIndex()) {
+            val id = (raw["id"] as? String)?.trim()
+            if (id.isNullOrBlank()) {
+                return ToolResult.Error("tasks[$index].id is missing or blank")
+            }
+            val title = (raw["title"] as? String)?.trim()
+            if (title.isNullOrBlank()) {
+                return ToolResult.Error("tasks[$index].title is missing or blank")
+            }
+            val detail = (raw["detail"] as? String)?.trim()?.takeIf { it.isNotEmpty() }
+            parsed += Task(id = id, title = title, detail = detail, status = TaskStatus.PENDING)
+        }
+
+        // TaskList.init rejects duplicate ids — surface as a recoverable Error
+        // so the agent can correct the call rather than crash the turn.
+        val taskList = try {
+            TaskList(parsed)
+        } catch (e: IllegalArgumentException) {
+            return ToolResult.Error(e.message ?: "duplicate task ids")
+        }
+
+        if (ctx.workingMemory.taskList != null) {
+            LOG.info("create_task_list: task list replaced (prev=${ctx.workingMemory.taskList!!.tasks.size} tasks)")
+        }
+        ctx.workingMemory.taskList = taskList
+        ctx.events.emit(AgentEvent.TaskListCreated(taskList))
+        return ToolResult.Text("task list created with ${taskList.tasks.size} tasks")
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetDetectionPromptTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetDetectionPromptTool.kt
@@ -1,0 +1,53 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.agent.PromptCatalog
+
+/**
+ * Perception tool that fetches the full detection recipe for one detection
+ * family by `id` (design C3 / task A4).
+ *
+ * The Reactive path's seed prompt lists the available detection ids at
+ * conversation start (enablement-aware — only entries whose `channel:` /
+ * `format:` / `framework:` scope matches an enabled feature appear). The
+ * agent fetches the full recipe on demand via this tool when the user's
+ * request touches that family.
+ *
+ * Returns the markdown body of the catalog file, or `Error` when the id is
+ * unknown. Unknown ids are not hard failures in the agent loop — the agent
+ * may retry with a different id or fall back to `get_plugin_doc name="rule-guide"`.
+ */
+class GetDetectionPromptTool : AiTool {
+
+    override val name: String = "get_detection_prompt"
+
+    override val description: String =
+        "Fetch the full detection recipe for one detection family by id " +
+            "(e.g. \"static-auth\", \"auth-token-chaining\", " +
+            "\"spring-filters-interceptors\"). Returns the recipe as Markdown. " +
+            "Use this when the user's request touches a detection family " +
+            "before proposing rules for it."
+
+    override val kind: ToolKind = ToolKind.PERCEPTION
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "id" to mapOf(
+                "type" to "string",
+                "description" to "The detection family id (one of the ids " +
+                    "listed in the detection index at conversation start)."
+            )
+        ),
+        "required" to listOf("id")
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val id = args["id"] as? String
+        if (id.isNullOrBlank()) {
+            return ToolResult.Error("missing required parameter: id")
+        }
+        val body = PromptCatalog.body("detection", id)
+            ?: return ToolResult.Error("unknown detection id: $id")
+        return ToolResult.Text(body)
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetRuleDetailTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetRuleDetailTool.kt
@@ -1,0 +1,124 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.agent.Ambient
+import com.itangcent.easyapi.core.ai.agent.AmbientPerception
+import com.itangcent.easyapi.core.ai.agent.PromptCatalog
+
+/**
+ * Perception tool that fetches per-key rule recipes from the catalog
+ * (design C3 / task A4).
+ *
+ * Two access patterns:
+ *
+ * - **By key** — `get_rule_detail(key="postman.test")` returns the single
+ *   per-key recipe. `key` takes precedence over any scope args; this is the
+ *   pattern to use when the agent knows which key it is about to set.
+ *
+ * - **By scope** — `get_rule_detail(channel="postman")` returns the
+ *   concatenated recipes of every rule file whose `CatalogScope` matches the
+ *   supplied args **and** the ambient-enabled features. Use this when the
+ *   agent wants a tour of what a channel/format/framework supports (e.g.
+ *   before proposing a Postman workflow bundle).
+ *
+ * At least one of `key` / `channel` / `format` / `framework` is required;
+ * calling with no args returns `Error`.
+ *
+ * An empty scope match (e.g. `channel="postman"` when Postman is disabled)
+ * returns `Text("(no rule-detail files match the given scope)")` — not
+ * `Error` — so the agent can react gracefully.
+ */
+class GetRuleDetailTool : AiTool {
+
+    override val name: String = "get_rule_detail"
+
+    override val description: String =
+        "Fetch the full recipe for one rule key (by `key`) or every rule " +
+            "file matching a scope (by `channel` / `format` / `framework`). " +
+            "At least one argument is required. `key` takes precedence over " +
+            "scope args. Returns Markdown."
+
+    override val kind: ToolKind = ToolKind.PERCEPTION
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "key" to mapOf(
+                "type" to "string",
+                "description" to "The rule key whose recipe to fetch " +
+                    "(e.g. \"postman.test\"). Takes precedence over scope args."
+            ),
+            "channel" to mapOf(
+                "type" to "string",
+                "description" to "Scope query: concatenate recipes of every " +
+                    "rule file scoped to this channel id (e.g. \"postman\")."
+            ),
+            "format" to mapOf(
+                "type" to "string",
+                "description" to "Scope query: concatenate recipes of every " +
+                    "rule file scoped to this field-format id."
+            ),
+            "framework" to mapOf(
+                "type" to "string",
+                "description" to "Scope query: concatenate recipes of every " +
+                    "rule file scoped to this framework id."
+            )
+        ),
+        "required" to emptyList<String>()
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val key = args["key"] as? String
+        val channel = args["channel"] as? String
+        val format = args["format"] as? String
+        val framework = args["framework"] as? String
+
+        // 1. By-key lookup — key wins over scope args.
+        if (!key.isNullOrBlank()) {
+            val body = PromptCatalog.body("rules", key)
+                ?: return ToolResult.Error("unknown rule key (no catalog file): $key")
+            return ToolResult.Text(body)
+        }
+
+        // 2. Scope query — at least one scope arg is required.
+        if (channel.isNullOrBlank() && format.isNullOrBlank() && framework.isNullOrBlank()) {
+            return ToolResult.Error("provide at least one of key / channel / format / framework")
+        }
+
+        // The ambient-enabled features gate the scope match so a disabled
+        // channel's recipes are not surfaced (mirrors the index message
+        // filtering). Reuse the ambient cached on working memory by the agent
+        // loop; fall back to a fresh capture when no turn has run yet (e.g.
+        // ad-hoc tool unit tests that build their own ToolContext).
+        val amb: Ambient = ctx.workingMemory.ambient
+            ?: AmbientPerception.capture(ctx.project)
+        val entries = PromptCatalog.listFor(
+            "rules",
+            activeChannels = amb.enabledChannels.toSet(),
+            activeFormats = amb.enabledFormats.toSet(),
+            activeFrameworks = amb.frameworkHints.toSet()
+        ).filter { e ->
+            // Apply the supplied scope args on top of the ambient-enabled
+            // filter: a `channel=postman` query returns only postman-scoped
+            // entries (and only when postman is enabled).
+            (channel.isNullOrBlank() || e.scope.channel == channel) &&
+                (format.isNullOrBlank() || e.scope.format == format) &&
+                (framework.isNullOrBlank() || e.scope.framework == framework)
+        }
+
+        if (entries.isEmpty()) {
+            return ToolResult.Text("(no rule-detail files match the given scope)")
+        }
+        // Concatenate bodies with a clear separator so the agent can
+        // distinguish multiple recipes in one response.
+        val sb = StringBuilder()
+        for ((idx, entry) in entries.withIndex()) {
+            if (idx > 0) sb.append("\n\n---\n\n")
+            val body = PromptCatalog.body("rules", entry.id)
+            if (body != null) {
+                sb.append("# ").append(entry.title).append("\n\n")
+                sb.append(body)
+            }
+        }
+        return ToolResult.Text(sb.toString())
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ListRuleKeysTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ListRuleKeysTool.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.core.ai.tools
 
+import com.itangcent.easyapi.core.ai.agent.PromptCatalog
 import com.itangcent.easyapi.core.rule.RuleKeyRegistry
 import com.itangcent.easyapi.core.util.json.GsonUtils
 
@@ -20,6 +21,19 @@ import com.itangcent.easyapi.core.util.json.GsonUtils
  * The `RuleKeys.kt` source file groups keys by Kotlin comment sections; those
  * comments aren't visible to reflection, so this tool returns a flat list
  * (the `source` field is the closest thing to grouping).
+ *
+ * ## Catalog join (design C4 / task A5)
+ *
+ * For each key, the tool looks up [PromptCatalog.entry] in the `"rules"`
+ * category by exact key name. When a per-key catalog file exists, two extra
+ * fields are attached to the JSON object:
+ * - `description` — the entry's `cue` (one-line "when to use").
+ * - `detailPromptId` — the entry's `id` (fetch the full recipe via
+ *   `get_rule_detail(key=…)`).
+ *
+ * Keys with no per-key catalog file still return `{name, type, source}`. The
+ * catalog lookup is best-effort: a missing/empty/stale catalog leaves all keys
+ * at the basic shape (no throw).
  */
 class ListRuleKeysTool : AiTool {
 
@@ -27,19 +41,30 @@ class ListRuleKeysTool : AiTool {
 
     override val description: String =
         "List all known EasyAPI rule keys. Returns a JSON array of " +
-            "{name, type, source}. Use this to discover what can be configured."
+            "{name, type, source, description?, detailPromptId?}. " +
+            "Use this to discover what can be configured."
 
     override val kind: ToolKind = ToolKind.PERCEPTION
 
     override val parametersSchema: Map<String, Any?> = emptyMap()
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val keys = RuleKeyRegistry.getInstance(ctx.project).allKeys().map { info ->
-            mapOf(
+        val keys = RuleKeyRegistry.getInstance(ctx.project).enabledKeys().map { info ->
+            val base = mutableMapOf(
                 "name" to info.key.name,
                 "type" to info.key::class.simpleName,
                 "source" to info.source
             )
+            // Best-effort catalog join: attach description + detailPromptId
+            // when a per-key recipe file exists. A missing/empty catalog
+            // leaves the base shape unchanged (no throw).
+            runCatching { PromptCatalog.entry("rules", info.key.name) }
+                .getOrNull()
+                ?.let { entry ->
+                    base["description"] = entry.cue
+                    base["detailPromptId"] = entry.id
+                }
+            base
         }
         return ToolResult.Text(GsonUtils.toJson(keys))
     }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/OrchestratorProposeRuleContentTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/OrchestratorProposeRuleContentTool.kt
@@ -1,0 +1,162 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.agent.Proposal
+import com.itangcent.easyapi.core.ai.agent.mergeTaskResults
+import com.itangcent.easyapi.core.rule.RuleProposalValidator
+
+/**
+ * The orchestrator's terminal staging action — merges collected sub-agent
+ * [com.itangcent.easyapi.core.ai.agent.TaskResult]s and stages the merged
+ * rule content (Phase 3 — design §3.9 / D3 / FR-3.8).
+ *
+ * This tool has the **same name** (`propose_rule_content`) as the Reactive
+ * path's [ProposeRuleContentTool] so the orchestrator LLM uses it the same
+ * way, but its behaviour differs: when the orchestrator has collected
+ * sub-agent results (via [RunSubAgentTool] writing into
+ * [com.itangcent.easyapi.core.ai.agent.AgentMemory.collectedSubAgentResults]),
+ * this tool **ignores the LLM-provided `content` parameter** and uses
+ * [mergeTaskResults] to compose the merged payload deterministically.
+ *
+ * Rationale (design §3.9 / D3): "No LLM round-trip" for the merge — the
+ * merge is pure computation (concatenate-with-tags), so the LLM does not
+ * have to compose the merged content itself. This keeps the merge
+ * reproducible and avoids the LLM dropping or rewriting sub-agent findings.
+ *
+ * When `collectedSubAgentResults` is empty (e.g. all sub-agents failed
+ * before staging a result, or the orchestrator was invoked without
+ * spawning any sub-agent), the tool falls back to the LLM-provided
+ * `content` parameter so the orchestrator can still surface a manual
+ * proposal.
+ *
+ * **Empty merged content (FR-2.5).** When the merged content is blank —
+ * either because every sub-agent returned `detected=false`, or because no
+ * sub-agent results were collected and no fallback content was provided —
+ * the tool **stages no `Proposal`** (leaves `ctx.workingMemory.proposal`
+ * `null`), returns a `ToolResult.Text` explaining "no detections found",
+ * and the orchestrator's turn ends via
+ * [com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent.finish] with no
+ * `ProposalReady` emitted and `TurnOutcome.Answered`. The user is never
+ * prompted to apply an empty proposition.
+ *
+ * Like [ProposeRuleContentTool], this tool:
+ * - `kind = ACTION`, `requiresApproval = false` (staging only — no disk write).
+ * - Validates the merged content via [RuleProposalValidator] before staging.
+ * - Stages the proposal in `ctx.workingMemory.proposal`.
+ * - Is terminal: the agent loop exits after this tool returns (see
+ *   [com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent.PROPOSE_RULE_CONTENT]).
+ */
+class OrchestratorProposeRuleContentTool : AiTool {
+
+    override val name: String = "propose_rule_content"
+
+    override val description: String =
+        "Stage the merged rule content from all sub-agent findings. " +
+            "Call this ONCE after every task is closed (completed or failed). " +
+            "The tool automatically merges the collected sub-agent findings " +
+            "via concatenate-with-tags — you do NOT need to compose the " +
+            "merged content yourself. Pass a suggestedFileName for the " +
+            "proposed rule file. If no sub-agent findings were collected " +
+            "(all failed or none spawned), pass a fallback content as well. " +
+            "If the merged content is blank (no pattern detected), the tool " +
+            "stages no proposal and the turn ends without prompting the user."
+
+    override val kind: ToolKind = ToolKind.ACTION
+
+    override val requiresApproval: Boolean = false
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "content" to mapOf(
+                "type" to "string",
+                "description" to "Fallback content — used ONLY when no " +
+                    "sub-agent findings were collected (all sub-agents " +
+                    "failed or none spawned). Ignored when sub-agent " +
+                    "findings are available; the tool merges them " +
+                    "deterministically."
+            ),
+            "suggestedFileName" to mapOf(
+                "type" to "string",
+                "description" to "Suggested file name (e.g. \"custom.rules\")."
+            )
+        ),
+        "required" to listOf("suggestedFileName")
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val suggestedFileName = (args["suggestedFileName"] as? String)?.trim()
+        if (suggestedFileName.isNullOrBlank()) {
+            return ToolResult.Error("missing required parameter: suggestedFileName")
+        }
+
+        val collected = ctx.workingMemory.collectedSubAgentResults
+        val mergedContent = if (collected.isNotEmpty()) {
+            // Deterministic merge — "no LLM round-trip" (design §3.9 / D3).
+            mergeTaskResults(collected)
+        } else {
+            // Fallback: no sub-agent results collected (all failed or none
+            // spawned). Use the LLM-provided content so the orchestrator
+            // can still surface a manual proposal. Blank fallback is
+            // handled by the empty-content guard below (FR-2.5).
+            (args["content"] as? String)?.trim().orEmpty()
+        }
+
+        if (mergedContent.isBlank()) {
+            // FR-2.5 — no detections found. Either every sub-agent returned
+            // detected=false (mergeTaskResults filtered them all out), or
+            // no sub-agent results were collected and no fallback content
+            // was provided. Stage NO proposal so the user is never prompted
+            // to apply an empty proposition. The orchestrator's turn ends
+            // via finish() with no ProposalReady and TurnOutcome.Answered.
+            return ToolResult.Text(
+                "No detections found for $suggestedFileName — nothing to propose. " +
+                    if (collected.isNotEmpty())
+                        "All ${collected.size} sub-agent(s) returned detected=false."
+                    else
+                        "No sub-agent findings were collected."
+            )
+        }
+
+        // The merged content is intentionally markdown findings (design §3.9:
+        // `## <title>`, `source: detection:<id>`, `Proposed rules:` bullets),
+        // NOT rule-file syntax — [RuleProposalValidator] would reject the
+        // `source:` / `Proposed rules:` lines as unknown rule keys. Validation
+        // applies only to the LLM-authored fallback content, which IS
+        // rule-file syntax.
+        if (collected.isEmpty()) {
+            val review = RuleProposalValidator.validate(mergedContent, ctx.project)
+            if (!review.ok) {
+                return ToolResult.Error(
+                    "Proposal rejected by review — fix these and retry:\n" +
+                        review.errors.joinToString("\n")
+                )
+            }
+            val stagedContent = if (review.warnings.isEmpty()) mergedContent
+            else buildString {
+                append("# Reviewer notes:\n")
+                review.warnings.forEach { append("# - ").append(it).append('\n') }
+                append("# (Non-blocking warnings — review before saving.)\n")
+                append(mergedContent)
+            }
+            ctx.workingMemory.proposal = Proposal(
+                content = stagedContent,
+                suggestedFileName = suggestedFileName
+            )
+            return ToolResult.Text(
+                "Staged proposal for $suggestedFileName (${mergedContent.length} chars). " +
+                    "Awaiting user confirmation to save." +
+                    if (review.warnings.isEmpty()) ""
+                    else " ${review.warnings.size} reviewer warning(s) attached."
+            )
+        }
+
+        ctx.workingMemory.proposal = Proposal(
+            content = mergedContent,
+            suggestedFileName = suggestedFileName
+        )
+        return ToolResult.Text(
+            "Staged merged proposal for $suggestedFileName " +
+                "(${mergedContent.length} chars from ${collected.size} sub-agent result(s))."
+        )
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ReportFindingsTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ReportFindingsTool.kt
@@ -1,0 +1,134 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.agent.RuleProposal
+import com.itangcent.easyapi.core.ai.agent.TaskResult
+import com.itangcent.easyapi.core.logging.IdeaLog
+
+/**
+ * Sub-agent terminal action — stages the sub-agent's [TaskResult] for the
+ * orchestrator to consume via `run_sub_agent` (design §3.7 / FR-3.4).
+ *
+ * - `name = "report_findings"`, `kind = ACTION`, `requiresApproval = false`.
+ * - Schema: `{ detected: bool, findings: string, proposedRules: array }`.
+ * - On execute: builds a [TaskResult] from the args, completes
+ *   `ctx.subAgentResult` (the [kotlinx.coroutines.CompletableDeferred] the
+ *   orchestrator's `RunSubAgentTool` is awaiting), and returns
+ *   `ToolResult.Text("findings reported")`.
+ *
+ * Terminal for sub-agents: the agent loop's terminal-action detection must
+ * treat `report_findings` as terminal in sub-agent contexts, mirroring how
+ * `propose_rule_content` is terminal for the orchestrator. The orchestrator's
+ * tool registry does NOT include this tool, and the sub-agent's registry
+ * does NOT include `propose_rule_content` — each role has its own terminal
+ * action.
+ *
+ * Calling `report_findings` from a non-sub-agent context (where
+ * `ctx.subAgentResult == null`) is a recoverable error — the tool returns
+ * `ToolResult.Error("report_findings is only available in sub-agent contexts")`
+ * so a misbehaving Reactive-path agent gets a clear correction.
+ */
+class ReportFindingsTool : AiTool, IdeaLog {
+
+    override val name: String = "report_findings"
+
+    override val description: String =
+        "Report the detection findings for this sub-agent's task and end the " +
+            "sub-agent turn. Pass `detected=true` if the pattern was found in " +
+            "the project's PSI (with evidence in `findings` and any concrete " +
+            "rule proposals in `proposedRules`), or `detected=false` if the " +
+            "search came up empty. Sub-agent-only — never call from the " +
+            "orchestrator or Reactive chat."
+
+    override val kind: ToolKind = ToolKind.ACTION
+
+    override val requiresApproval: Boolean = false
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "detected" to mapOf(
+                "type" to "boolean",
+                "description" to "Whether the detection pattern was found " +
+                    "in the project's PSI."
+            ),
+            "findings" to mapOf(
+                "type" to "string",
+                "description" to "Free-form markdown — search evidence, " +
+                    "located classes, why the pattern applies (or doesn't). " +
+                    "Concatenated verbatim into the orchestrator's final " +
+                    "propose_rule_content payload."
+            ),
+            "proposedRules" to mapOf(
+                "type" to "array",
+                "description" to "Concrete rule proposals drafted from the " +
+                    "findings. Empty when detected=false. Each entry has a " +
+                    "`key` (rule key, e.g. method.additional.header) and a " +
+                    "short `preview` of the proposed value.",
+                "items" to mapOf(
+                    "type" to "object",
+                    "properties" to mapOf(
+                        "key" to mapOf(
+                            "type" to "string",
+                            "description" to "Rule key this proposal targets " +
+                                "(matches a key from list_rule_keys)."
+                        ),
+                        "preview" to mapOf(
+                            "type" to "string",
+                            "description" to "Short human-readable preview of " +
+                                "the proposed value (full body lives in findings)."
+                        )
+                    ),
+                    "required" to listOf("key", "preview")
+                )
+            )
+        ),
+        "required" to listOf("detected", "findings")
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val slot = ctx.subAgentResult
+            ?: return ToolResult.Error(
+                "report_findings is only available in sub-agent contexts"
+            )
+
+        val detected = args["detected"] as? Boolean
+            ?: return ToolResult.Error("missing required parameter: detected (boolean)")
+        val findings = (args["findings"] as? String)?.trim()
+            ?: return ToolResult.Error("missing required parameter: findings (string)")
+
+        @Suppress("UNCHECKED_CAST")
+        val rawRules = args["proposedRules"] as? List<Map<String, Any?>>
+        val proposedRules = mutableListOf<RuleProposal>()
+        for ((index, raw) in (rawRules ?: emptyList()).withIndex()) {
+            val key = (raw["key"] as? String)?.trim()
+            if (key.isNullOrBlank()) {
+                return ToolResult.Error("proposedRules[$index].key is missing or blank")
+            }
+            val preview = (raw["preview"] as? String)?.trim()
+                ?: return ToolResult.Error("proposedRules[$index].preview is missing")
+            proposedRules += RuleProposal(key = key, preview = preview)
+        }
+
+        val result = TaskResult(
+            detected = detected,
+            findings = findings,
+            proposedRules = proposedRules
+        )
+        // Complete the deferred — `RunSubAgentTool` is awaiting it. Use
+        // `complete` (not `await`); if the slot is already completed (e.g.
+        // the sub-agent called report_findings twice) the second call is a
+        // no-op and the tool returns a recoverable Error.
+        val firstWriter = slot.complete(result)
+        if (!firstWriter) {
+            LOG.info("report_findings: subAgentResult already completed — duplicate call ignored")
+            return ToolResult.Error(
+                "findings already reported for this sub-agent — do not call report_findings twice"
+            )
+        }
+        LOG.info(
+            "report_findings: detected=$detected findingsLen=${findings.length} " +
+                "proposedRules=${proposedRules.size}"
+        )
+        return ToolResult.Text("findings reported")
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/RuleTools.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/RuleTools.kt
@@ -1,10 +1,12 @@
 package com.itangcent.easyapi.core.ai.tools
 
+import com.itangcent.easyapi.core.ai.AIService
+
 /**
  * The standard set of tools handed to the [ToolRegistry] for a real
  * conversation.
  *
- * 12 perception tools + 1 staging action (`propose_rule_content`).
+ * 14 perception tools + 1 staging action (`propose_rule_content`).
  * `write_rule_file` is intentionally NOT registered in v1 — the disk write
  * happens only through the user-confirmed "Save…" UI flow.
  *
@@ -17,10 +19,18 @@ package com.itangcent.easyapi.core.ai.tools
  * like "no Filters" for the standard Spring Boot declaration style.
  * - [FindClassesByNameTool] — resolves class simple names to FQNs via
  * `PsiShortNamesCache`, with an FQN short-circuit and batch mode.
+ *
+ * Catalog detail tools (Phase A — design C3):
+ * - [GetDetectionPromptTool] — full detection recipe by family id.
+ * - [GetRuleDetailTool] — per-key recipe lookup or scope-query concatenation.
+ * Both are perception tools; the Reactive path's seed prompt lists the
+ * available catalog ids so the agent knows what to fetch.
  */
 fun standardRuleTools(): List<AiTool> = listOf(
     ListRuleKeysTool(),
     GetPluginDocTool(),
+    GetDetectionPromptTool(),
+    GetRuleDetailTool(),
     ReadRuleFileTool(),
     ListProjectEndpointsTool(),
     GetPsiClassInfoTool(),
@@ -31,6 +41,88 @@ fun standardRuleTools(): List<AiTool> = listOf(
     GetExistingRulesForKeyTool(),
     GetModuleDependencyGraphTool(),
     AskClarificationTool(),
-    ProposeRuleContentTool()
+    ProposeRuleContentTool(),
+    // Phase B — Magic-path task-list tools (design C7). Registered
+    // unconditionally; the agent is instructed (agent-base.md) to use them
+    // only for Magic tasks with ≥2 distinct steps.
+    CreateTaskListTool(),
+    UpdateTaskTool()
     // WriteRuleFileTool() is reserved — not registered in v1.
+)
+
+/**
+ * The orchestrator's tool set for a Magic detection turn (Phase 3 —
+ * design §3.5 / FR-3.2, FR-3.3, D6).
+ *
+ * Three tools, all staging-only (`requiresApproval = false`):
+ * - [UpdateTaskTool] — tick each task's status as the orchestrator walks
+ *   the seeded list.
+ * - [RunSubAgentTool] — spawn a sub-agent for one PENDING task and await
+ *   its [com.itangcent.easyapi.core.ai.agent.TaskResult]. Collects each
+ *   result into [com.itangcent.easyapi.core.ai.agent.AgentMemory.collectedSubAgentResults]
+ *   so the orchestrator's terminal action can merge them deterministically.
+ * - [OrchestratorProposeRuleContentTool] — terminal; merges collected
+ *   sub-agent findings via [com.itangcent.easyapi.core.ai.agent.mergeTaskResults]
+ *   (concatenate-with-tags, design §3.9 / D3) and stages the merged rule
+ *   content once after all tasks close. "No LLM round-trip" for the merge
+ *   — the LLM does not compose the merged content itself.
+ *
+ * The orchestrator has **no perception tools** — it never touches PSI
+ * directly. All perception happens inside sub-agents (which have their
+ * own tool set via [subAgentToolRegistry]). This enforces the role split
+ * (FR-3.2/3.3): the orchestrator coordinates, sub-agents perceive.
+ *
+ * `create_task_list` is intentionally absent — the task list is seeded
+ * by the caller (FR-2.4); the orchestrator must not call it.
+ *
+ * @param aiService The shared LLM backend — passed to [RunSubAgentTool]
+ *   so it can construct sub-agents. Stateless (HTTP client), safe to
+ *   share across orchestrator + sub-agents.
+ * @param subAgentTools The sub-agent [ToolRegistry] (built via
+ *   [subAgentToolRegistry]), passed to [RunSubAgentTool] so each
+ *   spawned sub-agent gets the perception + report_findings set.
+ */
+fun orchestratorToolRegistry(
+    aiService: AIService,
+    subAgentTools: ToolRegistry
+): List<AiTool> = listOf(
+    UpdateTaskTool(),
+    RunSubAgentTool(aiService, subAgentTools),
+    OrchestratorProposeRuleContentTool()
+)
+
+/**
+ * The sub-agent's tool set for a Magic detection turn (Phase 3 —
+ * design §3.5 / FR-3.2, FR-3.3).
+ *
+ * Five perception tools + one terminal action:
+ * - [FindClassesByAnnotationTool] / [FindClassesBySupertypeTool] — locate
+ *   candidate classes by annotation or supertype.
+ * - [GetPsiClassInfoTool] — drill into a class's methods/fields/signature.
+ * - [GetRuleDetailTool] — fetch the per-key rule recipe so the sub-agent
+ *   can draft concrete rule proposals.
+ * - [ListRuleKeysTool] — enumerate known rule keys (for proposal shape).
+ * - [ReportFindingsTool] — terminal; stages the sub-agent's
+ *   [com.itangcent.easyapi.core.ai.agent.TaskResult] and ends the
+ *   sub-agent's turn.
+ *
+ * The sub-agent has **no** `propose_rule_content`, `run_sub_agent`,
+ * `update_task`, or `create_task_list` — it cannot recurse, cannot
+ * update the orchestrator's task list, and cannot propose final rule
+ * content. It only perceives and reports (FR-3.2/3.3).
+ *
+ * `get_detection_prompt` is intentionally absent — the sub-agent's
+ * detection recipe is already embedded in its seed instruction by
+ * [RunSubAgentTool] (fetched in-process from
+ * [com.itangcent.easyapi.core.ai.agent.PromptCatalog], design §3.6).
+ * Exposing `get_detection_prompt` would let a sub-agent fetch other
+ * detections' recipes and wander off-task.
+ */
+fun subAgentToolRegistry(): List<AiTool> = listOf(
+    FindClassesByAnnotationTool(),
+    FindClassesBySupertypeTool(),
+    GetPsiClassInfoTool(),
+    GetRuleDetailTool(),
+    ListRuleKeysTool(),
+    ReportFindingsTool()
 )

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/RunSubAgentTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/RunSubAgentTool.kt
@@ -1,0 +1,347 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.AIService
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
+import com.itangcent.easyapi.core.ai.agent.AgentMemory
+import com.itangcent.easyapi.core.ai.agent.EntryPath
+import com.itangcent.easyapi.core.ai.agent.PromptCatalog
+import com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent
+import com.itangcent.easyapi.core.ai.agent.Task
+import com.itangcent.easyapi.core.ai.agent.TaskList
+import com.itangcent.easyapi.core.ai.agent.TaskResult
+import com.itangcent.easyapi.core.ai.agent.TaskStatus
+import com.itangcent.easyapi.core.logging.IdeaLog
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Orchestrator-only action — spawns a sub-agent for one [Task] and awaits
+ * its [TaskResult] (design §3.6 / FR-3.1, FR-3.2, FR-3.4).
+ *
+ * - `name = "run_sub_agent"`, `kind = ACTION`, `requiresApproval = false`.
+ * - Schema: `{ taskId: string }`.
+ * - On execute: looks up the [Task] by id in `ctx.workingMemory.taskList`;
+ *   builds the sub-agent seed (detection recipe fetched in-process from
+ *   [PromptCatalog] — **not** via the LLM-facing `get_detection_prompt`
+ *   tool, which isn't in the orchestrator's set); constructs a fresh
+ *   [AgentMemory] and a sub-[ToolContext] carrying the same sinks
+ *   (project / configReader / aiSettings / ruleFileResolver / approvals /
+ *   events) but the new memory and a new [CompletableDeferred] for the
+ *   result; runs [RuleAuthoringAgent.runTurn] under the step ceiling
+ *   (D4 — defaults to `aiSettings.maxRequests`, no per-detection override
+ *   in v1); awaits the [TaskResult] the sub-agent stages via
+ *   `report_findings`; serialises it to [ToolResult.Text].
+ *
+ * **Auto-marks task status (FR-3.5 / FR-3.6 post-ship fix-up).** When the
+ * sub-agent finishes, this tool **automatically** updates the task's
+ * status in `ctx.workingMemory.taskList` and emits the matching
+ * [AgentEvent] (`TaskCompleted` / `TaskFailed`) — the UI checkbox updates
+ * deterministically, without depending on the orchestrator LLM remembering
+ * to call `update_task` afterwards:
+ * - Sub-agent called `report_findings` (deferred completed) → `COMPLETED`,
+ *   regardless of `detected`. "Nothing detected" is a valid finding, not
+ *   a skip (FR-3.5).
+ * - Sub-agent ended without `report_findings` (step limit / loop / plain
+ *   answer) → `FAILED` with a reason.
+ * - Sub-agent threw an exception → `FAILED` with a reason.
+ *
+ * The orchestrator's `update_task` call is therefore **optional** after
+ * `run_sub_agent` — the status is already recorded. The orchestrator may
+ * still call it to add a `reason` or to mark a deliberately-skipped task
+ * (one for which `run_sub_agent` was never called).
+ *
+ * Orchestrator-only — not registered in any sub-agent's [ToolRegistry], so
+ * sub-agents cannot recurse. The sub-agent's tool set (perception tools +
+ * `report_findings`) is supplied at construction time via [subAgentTools].
+ *
+ * Shares the orchestrator's [MutableSharedFlow] of
+ * [com.itangcent.easyapi.core.ai.agent.AgentEvent]s — the chat panel sees
+ * each sub-agent's `Thinking` / `Perceiving` / `Acting` / `Observed`
+ * events as they happen, giving the user live visibility into each
+ * detection's progress.
+ *
+ * @param aiService Provider-neutral LLM backend shared with the
+ *   orchestrator. `AIService` is stateless (an HTTP client), so sharing
+ *   one instance across orchestrator + sub-agents is safe.
+ * @param subAgentTools The sub-agent's [ToolRegistry] — perception tools
+ *   + [ReportFindingsTool]. Built once per Magic turn via
+ *   `subAgentToolRegistry()` (T3.5) and reused for every sub-agent spawn
+ *   in that turn.
+ */
+class RunSubAgentTool(
+    private val aiService: AIService,
+    private val subAgentTools: ToolRegistry
+) : AiTool, IdeaLog {
+
+    override val name: String = "run_sub_agent"
+
+    override val description: String =
+        "Spawn a sub-agent to run one detection task in isolation, and wait " +
+            "for its findings. Pass the task id from the seeded task list. " +
+            "The sub-agent perceives the project's PSI, decides whether the " +
+            "pattern is present, and reports back via report_findings. " +
+            "This tool automatically records the task status (completed if " +
+            "the sub-agent ran successfully — whether or not it detected " +
+            "the pattern; failed on error) and ticks the checklist card " +
+            "in the UI, so you do NOT need to call update_task afterwards " +
+            "for the status. Orchestrator-only — never call from a " +
+            "sub-agent or Reactive chat."
+
+    override val kind: ToolKind = ToolKind.ACTION
+
+    override val requiresApproval: Boolean = false
+
+    /**
+     * Disable the per-tool timeout — the sub-agent has its own step ceiling
+     * (`aiSettings.maxRequests`, D4) and may legitimately run multiple LLM
+     * round-trips. The orchestrator's [ToolRegistry.dispatch] timeout would
+     * otherwise cut a long detection short.
+     */
+    override val timeoutMs: Long = 0L
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+                "taskId" to mapOf(
+                "type" to "string",
+                "description" to "The id of the PENDING task to run (from the " +
+                    "seeded task list, e.g. \"detect_spring_filters_interceptors\"). " +
+                    "Use the exact ids listed in the seeded task manifest; a wrong " +
+                    "id is rejected with \"unknown task id\"."
+            )
+        ),
+        "required" to listOf("taskId")
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val taskId = (args["taskId"] as? String)?.trim()
+            ?: return ToolResult.Error("missing required parameter: taskId (string)")
+        if (taskId.isEmpty()) {
+            return ToolResult.Error("taskId must not be empty")
+        }
+
+        val taskList = ctx.workingMemory.taskList
+            ?: return ToolResult.Error(
+                "no task list in working memory — run_sub_agent is only valid " +
+                    "in a Magic detection turn"
+            )
+        val task = taskList.byId(taskId)
+            ?: return ToolResult.Error(
+                "unknown task id: $taskId (not in seeded task list). " +
+                    "Valid ids: ${taskList.tasks.joinToString(", ") { it.id }}"
+            )
+
+        // Build the sub-agent's user-message instruction = detection recipe.
+        // Fetched in-process from PromptCatalog (not via get_detection_prompt
+        // — that tool isn't in the orchestrator's set, design §3.6).
+        val instruction = buildSubAgentInstruction(task)
+            ?: return ToolResult.Error(
+                "could not resolve detection recipe for task ${task.id} " +
+                    "(task id must start with '$DETECT_PREFIX' and map to a " +
+                    "catalog entry under ai/detection/)"
+            )
+
+        // Fresh memory per sub-agent (FR-3.1 / G3 — no carry-over from
+        // sibling sub-agents). The sub-agent's transcript starts empty.
+        val subMemory = AgentMemory()
+
+        // The deferred the sub-agent completes via report_findings. Null
+        // for orchestrator / Reactive contexts; non-null here.
+        val subAgentResult = CompletableDeferred<TaskResult>()
+
+        // Sub-context: same sinks, new memory + result slot. The events
+        // flow is shared so the UI sees the sub-agent's activity.
+        val subCtx = ctx.copy(
+            workingMemory = subMemory,
+            subAgentResult = subAgentResult
+        )
+
+        // Construct the sub-agent. Reuses the orchestrator's AIService
+        // (stateless HTTP client) + the shared sub-agent tool registry.
+        val subAgent = RuleAuthoringAgent(aiService, subAgentTools, subCtx, ctx.events)
+
+        LOG.info("sub-agent start: ${task.id} (${task.title})")
+        val outcome = try {
+            subAgent.runTurn(
+                userMessage = instruction,
+                memory = subMemory,
+                // Reuse the orchestrator's ambient (editing file, enabled
+                // features, framework hints) — the sub-agent needs this
+                // context and re-capturing would re-do PSI work.
+                ambient = ctx.workingMemory.ambient,
+                // SUB_AGENT seeds the sub-agent-specific base prompt
+                // (`sub-agent-base.md`), which advertises ONLY this registry's
+                // tools (perception + report_findings). The orchestrator/
+                // Reactive tools it cannot call (list_project_endpoints,
+                // get_plugin_doc, find_classes_by_name,
+                // get_existing_rules_for_key, propose_rule_content, ...) are
+                // omitted so the model never invokes a tool not in its
+                // registry — otherwise it trusts the shared prompt's tool
+                // index over the 6-entry tools schema and calls unknown tools.
+                entryPath = EntryPath.SUB_AGENT
+            )
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LOG.warn("sub-agent '${task.id}' threw during runTurn", e)
+            // FR-3.5/FR-3.6 fix-up — auto-mark FAILED so the UI checkbox
+            // updates deterministically, without depending on the
+            // orchestrator LLM calling update_task afterwards.
+            markTaskStatus(ctx, task, TaskStatus.FAILED, "sub-agent threw: ${e.message}")
+            return ToolResult.Error(
+                "sub-agent '${task.id}' failed: ${e::class.simpleName}: ${e.message}"
+            )
+        }
+
+        // The sub-agent's runTurn has returned. If it called report_findings,
+        // the deferred is completed; otherwise (step limit / loop / plain
+        // answer) it is not — synthesise a not-detected result so the
+        // orchestrator can mark the task skipped/failed and continue.
+        val result: TaskResult = if (subAgentResult.isCompleted) {
+            subAgentResult.await()
+        } else {
+            LOG.warn(
+                "sub-agent '${task.id}' ended without report_findings " +
+                    "(outcome=${outcome::class.simpleName})"
+            )
+            TaskResult(
+                detected = false,
+                findings = "(sub-agent ended without calling report_findings; " +
+                    "outcome=${outcome::class.simpleName})",
+                proposedRules = emptyList()
+            )
+        }
+
+        LOG.info(
+            "sub-agent done: ${task.id} detected=${result.detected} " +
+                "findingsLen=${result.findings.length} " +
+                "proposedRules=${result.proposedRules.size}"
+        )
+
+        // FR-3.5/FR-3.6 post-ship fix-up — auto-mark the task status so the
+        // UI checkbox updates deterministically. The sub-agent ran to
+        // completion (called report_findings) → COMPLETED, regardless of
+        // `detected`. "Nothing detected" is a valid finding, not a skip.
+        // (The not-completed case is handled below — it's FAILED.)
+        if (subAgentResult.isCompleted) {
+            markTaskStatus(ctx, task, TaskStatus.COMPLETED, null)
+        } else {
+            markTaskStatus(
+                ctx, task, TaskStatus.FAILED,
+                "sub-agent ended without calling report_findings " +
+                    "(outcome=${outcome::class.simpleName})"
+            )
+        }
+
+        // Collect the result so the orchestrator's propose_rule_content
+        // can merge all sub-agent findings deterministically (design §3.9 /
+        // D3 — "no LLM round-trip" for the merge). The merge is done by
+        // mergeTaskResults, wired into OrchestratorProposeRuleContentTool.
+        ctx.workingMemory.collectedSubAgentResults.add(task to result)
+
+        return ToolResult.Text(serialize(task, result))
+    }
+
+    /**
+     * Update the task's status in `ctx.workingMemory.taskList` and emit the
+     * matching [AgentEvent] — mirrors [UpdateTaskTool]'s status-swap logic
+     * (build a fresh [TaskList] with the updated row, emit
+     * [AgentEvent.TaskCompleted] / [AgentEvent.TaskFailed]).
+     *
+     * Called by [execute] when the sub-agent finishes, so the UI checkbox
+     * updates deterministically without depending on the orchestrator LLM
+     * calling `update_task` afterwards (FR-3.5 / FR-3.6 post-ship fix-up).
+     * If the orchestrator does call `update_task` with the same status
+     * afterwards, the second call is idempotent (the UI just re-sets the
+     * same checkbox state).
+     */
+    private suspend fun markTaskStatus(
+        ctx: ToolContext,
+        task: Task,
+        newStatus: TaskStatus,
+        reason: String?
+    ) {
+        val taskList = ctx.workingMemory.taskList ?: return
+        val updated = task.copy(status = newStatus)
+        val newTasks = taskList.tasks.map { if (it.id == task.id) updated else it }
+        ctx.workingMemory.taskList = TaskList(newTasks)
+        val event = when (newStatus) {
+            TaskStatus.COMPLETED -> AgentEvent.TaskCompleted(task.id)
+            TaskStatus.FAILED -> AgentEvent.TaskFailed(task.id, reason ?: "")
+            TaskStatus.IN_PROGRESS -> AgentEvent.TaskStarted(task.id)
+            TaskStatus.SKIPPED -> AgentEvent.TaskSkipped(task.id)
+            TaskStatus.PENDING -> null
+        }
+        if (event != null) {
+            ctx.events.emit(event)
+        }
+    }
+
+    /**
+     * Build the sub-agent's user-message instruction from the detection
+     * recipe in [PromptCatalog].
+     *
+     * Task ids follow the pattern `detect_<detection-id>` (see
+     * [com.itangcent.easyapi.core.ai.agent.MagicTaskListBuilder]); the
+     * detection id is the catalog entry's id under `ai/detection/`.
+     *
+     * [MagicTaskListBuilder] replaces non-alphanumeric chars in the detection
+     * id with `_` (e.g. `spring-filters-interceptors` becomes
+     * `spring_filters_interceptors`) to keep `update_task`'s `taskId` stable.
+     * We invert that here by converting `_` back to `-`, since every catalog
+     * detection id uses hyphens (verified across the detection markdown
+     * files under `ai/detection/`).
+     *
+     * @return the instruction body, or `null` if the task id doesn't
+     *   follow the pattern or the detection recipe can't be found.
+     */
+    private fun buildSubAgentInstruction(task: Task): String? {
+        if (!task.id.startsWith(DETECT_PREFIX)) return null
+        val detectionId = task.id.removePrefix(DETECT_PREFIX).replace('_', '-')
+        val body = PromptCatalog.body("detection", detectionId) ?: return null
+        return buildString {
+            appendLine("You are a sub-agent running one detection task: ${task.title}.")
+            if (!task.detail.isNullOrBlank()) {
+                appendLine("Cue: ${task.detail}")
+            }
+            appendLine()
+            appendLine("Detection recipe:")
+            appendLine(body)
+            appendLine()
+            appendLine(
+                "Run the suggested searches to confirm whether the pattern is " +
+                    "present in this project's PSI. When done, call " +
+                    "report_findings with detected=true (if found, include " +
+                    "evidence in findings and any concrete rule proposals in " +
+                    "proposedRules) or detected=false (if not found). Do NOT " +
+                    "call propose_rule_content — the orchestrator merges " +
+                    "findings from all sub-agents and proposes the final " +
+                    "rule content once."
+            )
+        }
+    }
+
+    /**
+     * Serialise a [TaskResult] to the text fed back to the orchestrator's
+     * LLM. The orchestrator uses this to decide the task's final status
+     * (via update_task) and to compose the merged propose_rule_content
+     * payload.
+     */
+    private fun serialize(task: Task, result: TaskResult): String = buildString {
+        appendLine("taskId: ${task.id}")
+        appendLine("detected: ${result.detected}")
+        appendLine("findings:")
+        appendLine(result.findings.trim())
+        if (result.proposedRules.isNotEmpty()) {
+            appendLine()
+            appendLine("proposedRules:")
+            result.proposedRules.forEach { rp ->
+                appendLine("- ${rp.key}: ${rp.preview}")
+            }
+        }
+    }
+
+    companion object {
+        /** Prefix for detection-task ids (see [MagicTaskListBuilder]). */
+        private const val DETECT_PREFIX = "detect_"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/UpdateTaskTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/UpdateTaskTool.kt
@@ -1,0 +1,116 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
+import com.itangcent.easyapi.core.ai.agent.TaskList
+import com.itangcent.easyapi.core.ai.agent.TaskStatus
+import com.itangcent.easyapi.core.logging.IdeaLog
+
+/**
+ * Magic-path tool that ticks a task in the active task list (design C7 /
+ * task B5).
+ *
+ * - `name = "update_task"`, `kind = PERCEPTION`, `requiresApproval = false`.
+ * - Schema: `{ taskId, status, reason? }` where `status` ∈
+ *   `in_progress | completed | failed | skipped`.
+ * - Behaviour: looks up [taskId] in `ctx.workingMemory.taskList`; on miss →
+ *   `Error("unknown task id: <id>")`; on no-task-list →
+ *   `Error("no active task list")`. On hit: replaces the task's status,
+ *   emits the matching [AgentEvent] (`TaskStarted` for `in_progress`,
+ *   `TaskCompleted` for `completed`, `TaskFailed` for `failed`,
+ *   `TaskSkipped` for `skipped`), and returns `Text("task <id> now <status>")`.
+ *
+ * `reason` is only meaningful for `failed` (it is carried on the
+ * [AgentEvent.TaskFailed] event); for other statuses it is ignored.
+ *
+ * The agent is instructed (in `agent-base.md`) to use this tool only for
+ * Magic tasks. Reactive chat turns never call it; if called without a
+ * task list staged, the tool returns a recoverable `Error`.
+ */
+class UpdateTaskTool : AiTool, IdeaLog {
+
+    override val name: String = "update_task"
+
+    override val description: String =
+        "Update the status of one task in the active task list. Pass the " +
+            "task id (as given to create_task_list), the new status (one of " +
+            "\"in_progress\", \"completed\", \"failed\", \"skipped\"), and " +
+            "an optional reason (only used for \"failed\"). Marks the task " +
+            "and ticks the checklist card in the UI. Use this ONLY for " +
+            "Magic tasks with an active task list."
+
+    override val kind: ToolKind = ToolKind.PERCEPTION
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "taskId" to mapOf(
+                "type" to "string",
+                "description" to "The id of the task to update (as given to " +
+                    "create_task_list)."
+            ),
+            "status" to mapOf(
+                "type" to "string",
+                "enum" to listOf("in_progress", "completed", "failed", "skipped"),
+                "description" to "The new status. in_progress when starting " +
+                    "the task, completed when done, failed if it could not be " +
+                    "finished (pass a reason), skipped if deliberately skipped."
+            ),
+            "reason" to mapOf(
+                "type" to "string",
+                "description" to "Optional. Only meaningful for status " +
+                    "\"failed\" — carried on the TaskFailed event for the UI."
+            )
+        ),
+        "required" to listOf("taskId", "status")
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val taskId = (args["taskId"] as? String)?.trim()
+        if (taskId.isNullOrBlank()) {
+            return ToolResult.Error("missing required parameter: taskId")
+        }
+        val statusStr = (args["status"] as? String)?.trim()
+        if (statusStr.isNullOrBlank()) {
+            return ToolResult.Error("missing required parameter: status")
+        }
+        val newStatus = parseStatus(statusStr)
+            ?: return ToolResult.Error(
+                "invalid status: $statusStr (expected one of " +
+                    "in_progress, completed, failed, skipped)"
+            )
+
+        val taskList = ctx.workingMemory.taskList
+            ?: return ToolResult.Error("no active task list")
+        val task = taskList.byId(taskId)
+            ?: return ToolResult.Error("unknown task id: $taskId")
+
+        // Replace the task in-place by building a fresh task list with the
+        // updated row. Task is a data class — copy + replace keeps the task
+        // list immutable from the consumer's POV. TaskList.init re-validates
+        // ids.
+        val reason = (args["reason"] as? String)?.trim()?.takeIf { it.isNotEmpty() }
+        val updated = task.copy(status = newStatus)
+        val newTasks = taskList.tasks.map { if (it.id == taskId) updated else it }
+        ctx.workingMemory.taskList = TaskList(newTasks)
+
+        val event = when (newStatus) {
+            TaskStatus.IN_PROGRESS -> AgentEvent.TaskStarted(taskId)
+            TaskStatus.COMPLETED -> AgentEvent.TaskCompleted(taskId)
+            TaskStatus.FAILED -> AgentEvent.TaskFailed(taskId, reason ?: "")
+            TaskStatus.SKIPPED -> AgentEvent.TaskSkipped(taskId)
+            TaskStatus.PENDING -> null // not emit-worthy; treat as no-op
+        }
+        if (event != null) {
+            ctx.events.emit(event)
+        }
+        return ToolResult.Text("task $taskId now $statusStr")
+    }
+
+    private fun parseStatus(value: String): TaskStatus? = when (value) {
+        "in_progress" -> TaskStatus.IN_PROGRESS
+        "completed" -> TaskStatus.COMPLETED
+        "failed" -> TaskStatus.FAILED
+        "skipped" -> TaskStatus.SKIPPED
+        else -> null
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanel.kt
@@ -15,7 +15,11 @@ import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AmbientPerception
 import com.itangcent.easyapi.core.ai.agent.Clarification
 import com.itangcent.easyapi.core.ai.agent.ClarificationAnswers
+import com.itangcent.easyapi.core.ai.agent.EntryPath
 import com.itangcent.easyapi.core.ai.agent.QuestionKind
+import com.itangcent.easyapi.core.ai.agent.Task
+import com.itangcent.easyapi.core.ai.agent.TaskList
+import com.itangcent.easyapi.core.ai.agent.TaskStatus
 import com.itangcent.easyapi.core.ai.agent.TurnOutcome
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.ide.support.NotificationUtils
@@ -37,6 +41,7 @@ import java.awt.Font
 import java.awt.HeadlessException
 import java.awt.Rectangle
 import java.awt.Toolkit
+import java.awt.Window
 import java.awt.event.ActionEvent
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
@@ -49,6 +54,7 @@ import javax.swing.JButton
 import javax.swing.ButtonGroup
 import javax.swing.JCheckBox
 import javax.swing.JComponent
+import javax.swing.JDialog
 import javax.swing.JLabel
 import javax.swing.JOptionPane
 import javax.swing.JPanel
@@ -113,6 +119,26 @@ class AiChatPanel(
     private var turnJob: Job? = null
     private var eventCollectorJob: Job? = null
 
+    /**
+     * Set to `true` by [dispose]. Checked by [offerContinueOrCancel] /
+     * [offerLoopRecovery] before showing a modal dialog, so a panel that is
+     * disposed while a `StepLimitHit` / `LoopDetected` outcome is still
+     * pending on the EDT does not pop a dangling dialog after teardown.
+     */
+    @Volatile
+    private var disposed: Boolean = false
+
+    /**
+     * Test seam: when non-null, [offerContinueOrCancel] delegates to this
+     * instead of showing a modal `JOptionPane`. Lets tests verify the
+     * `StepLimitHit` outcome path without popping a blocking dialog that
+     * would hang the EDT for the rest of the suite. `null` in production.
+     */
+    internal var offerContinueOrCancelHandler: ((ConversationSession) -> Unit)? = null
+
+    /** Test seam for [offerLoopRecovery] — see [offerContinueOrCancelHandler]. */
+    internal var offerLoopRecoveryHandler: ((ConversationSession) -> Unit)? = null
+
     /** The session this panel is bound to (re-resolved on each send). */
     private var session: ConversationSession? = null
 
@@ -141,6 +167,36 @@ class AiChatPanel(
     private var lastLoopTool: String? = null
 
     /**
+     * Tracks the tool name of the most recent [AgentEvent.Perceiving] or
+     * [AgentEvent.Acting] when that tool is `create_task_list` or `update_task`.
+     *
+     * Per design C11's double-emission handling: these two task-list tools emit
+     * both the standard `Perceiving`/`Acting` + `Observed` cards (from the
+     * agent loop) AND a `TaskListCreated`/`Task*` card (from the tool itself via
+     * `ctx.events`). To avoid a noisy double-card transcript, the matching
+     * [AgentEvent.Observed] for these two tools is suppressed — the
+     * `TaskListCreated`/`Task*` event already drives the UI. The field is cleared
+     * on the next non-task-list `Perceiving`/`Acting` and on [AgentEvent.TurnComplete].
+     */
+    private var pendingTaskListToolCallName: String? = null
+
+    /**
+     * Route B ReviewGate arm flag.
+     *
+     * Set by [runReviewTurn] when Magic is invoked on a **non-empty** rule
+     * file. While armed, the next normal [AgentEvent.TurnComplete] renders the
+     * *"Review complete. Continue to detection pass?"* Yes/No card and clears
+     * the flag (so the gate fires at most once per run).
+     *
+     * Cleared without firing on abnormal end ([AgentEvent.Failed],
+     * [AgentEvent.LoopDetected], `TurnOutcome.StepLimitHit`, cancellation, or
+     * thrown turn).
+     *
+     * Not set on empty-file Magic, Chat, or turn-2+ custom messages.
+     */
+    private var reviewGatePending: Boolean = false
+
+    /**
      * Optional hook. When set, a staged proposal
      * card shows an **"Apply to editor"** button that calls this with the
      * proposal content — used by [com.itangcent.easyapi.core.settings.ui.RuleFileEditDialog]
@@ -154,6 +210,23 @@ class AiChatPanel(
      * this — wired by the host to open Settings → EasyApi → AI.
      */
     var onConfigureAi: (() -> Unit)? = null
+
+    /**
+     * Optional hook invoked when the user clicks **Yes** at the ReviewGate
+     * (Route B Stage-2 entry).
+     *
+     * The host reads the file content **at this time** (reflecting any Stage-1
+     * proposal applied in between), builds the detection task list
+     * via `MagicTaskListBuilder.buildDetectionPlan`, and calls back into
+     * [runTaskList] with the **empty-file** detection instruction body
+     * (`MagicInstructionBuilder.detectionInstruction(name, taskList)`). Stage 2 then
+     * runs the same detection-pass contract as Route A.
+     *
+     * When `null`, the gate's Yes button is a no-op (the card still renders
+     * so the user sees the question; only the action is suppressed). Wired
+     * by [com.itangcent.easyapi.core.settings.ui.RuleFileEditDialog].
+     */
+    var onReviewGateYes: (() -> Unit)? = null
 
     // --- UI components ---
 
@@ -251,7 +324,13 @@ class AiChatPanel(
         isVisible = false
     }
 
-    val component: JPanel = JPanel(BorderLayout()).apply {
+    /**
+     * The conversation side of the split: transcript + status + input.
+     * Behaviour is unchanged from v1 — this is the same `JPanel(BorderLayout())`
+     * that used to be the whole `component`, now wrapped as the left pane of
+     * [splitPane] (design R2-C3).
+     */
+    private val conversationPanel: JPanel = JPanel(BorderLayout()).apply {
         add(transcriptScroll, BorderLayout.CENTER)
         val north = JPanel(BorderLayout()).apply {
             add(notConfiguredBanner, BorderLayout.NORTH)
@@ -260,6 +339,96 @@ class AiChatPanel(
         add(north, BorderLayout.NORTH)
         add(inputRow(), BorderLayout.SOUTH)
     }
+
+    /**
+     * The right-side Todo List panel (design R2-C3). Invisible until a task
+     * list arrives via [AgentEvent.TaskListCreated]; populated by
+     * [TodoListPanel.setTaskList] and updated row-by-row on `Task*` events.
+     * Cleared on `resetConversation`.
+     */
+    private val todoListPanel: TodoListPanel = TodoListPanel()
+
+    /**
+     * Horizontal split: conversation (left, 5) + Todo List (right, 3).
+     *
+     * `resizeWeight = 0.625` keeps the 5:3 ratio on window resize. The right
+     * pane is hidden (via [TodoListPanel] visibility) until a task list
+     * arrives, so the layout is visually indistinguishable from v1 for plain
+     * chat.
+     *
+     * **Initial divider location (R3-C1):** `resizeWeight` alone is not
+     * enough on first paint — `JSplitPane` computes the initial divider
+     * position from the children's preferred sizes when the divider location
+     * is unset, which collapses the Todo List to its minimum width until the
+     * first window resize. `addNotify()` sets the divider to `0.625` once,
+     * after the host has sized the pane, so the 5:3 ratio holds from the
+     * first paint. Subsequent resizes are handled by `resizeWeight`.
+     *
+     * **Child-visibility relayout:** `JSplitPane` does NOT recompute its
+     * divider when a child's visibility is toggled from inside the child's
+     * own `revalidate()` — a known Swing pitfall. The pane is initially
+     * laid out with the Todo List hidden, so the divider sits where that
+     * layout left it; flipping the Todo List to visible without telling the
+     * split pane leaves it at zero width (effectively unrendered).
+     * [relayoutForTodoList] is therefore called from
+     * [TodoListPanel.setTaskList] / [clear] whenever visibility changes — it
+     * re-applies the proportional divider and forces the split pane itself
+     * to lay out.
+     */
+    private inner class ChatSplitPane : javax.swing.JSplitPane(
+        javax.swing.JSplitPane.HORIZONTAL_SPLIT,
+        conversationPanel,
+        todoListPanel
+    ) {
+        /** Guards against re-stomping a divider the user has dragged. */
+        private var initialDividerSet = false
+
+        init {
+            dividerSize = 6
+            resizeWeight = 0.625 // 5 / (5 + 3)
+            isOneTouchExpandable = false
+            // The right pane starts hidden; TodoListPanel.setTaskList makes it visible.
+            todoListPanel.isVisible = false
+        }
+
+        override fun addNotify() {
+            super.addNotify()
+            if (!initialDividerSet) {
+                // setDividerLocation(proportional) is only meaningful once the
+                // peer has sized the pane. addNotify fires after the host has
+                // laid the pane out, so the call lands on a real width.
+                setDividerLocation(0.625)
+                initialDividerSet = true
+            }
+        }
+
+        /**
+         * Re-apply the 5:3 divider and force this split pane to lay out, so the
+         * Todo List actually receives width when [TodoListPanel] becomes visible
+         * (and the conversation pane reclaims it when the Todo List is hidden).
+         *
+         * Called whenever the Todo List's visibility changes. `revalidate()` on
+         * the child alone does not move the divider — `JSplitPane`'s layout
+         * manager must run on the pane itself.
+         */
+        fun relayoutForTodoList() {
+            if (todoListPanel.isVisible) {
+                // Re-assert the proportional divider so the now-visible right
+                // pane gets its 3/8 share. Only meaningful once the pane has a
+                // real width; otherwise addNotify's initial set still applies.
+                if (width > 0) {
+                    setDividerLocation(0.625)
+                }
+            }
+            revalidate()
+            repaint()
+        }
+    }
+
+    private val splitPane: ChatSplitPane = ChatSplitPane()
+
+    /** The tool-window host component (the split pane, or just conversation when no plan). */
+    val component: JComponent = splitPane
 
     init {
         refreshConfiguredState()
@@ -331,12 +500,82 @@ class AiChatPanel(
     }
 
     /**
-     * Magic run (issue 3): show a short, constant [displayText] in the
-     * transcript while sending the richer [instruction] (file + project
-     * context) to the agent implicitly.
+     * Programmatic task-list-entry seam (design C10 / task B7, R2-C2).
+     *
+     * Seeds [taskList] into the session's working memory and emits
+     * [AgentEvent.TaskListCreated] *before* the turn starts, so the Todo List
+     * renders in the right-side panel before the first LLM round-trip. Then
+     * drives the turn with [EntryPath.TASK_LIST_PROGRAMMATIC].
+     *
+     * Wired to the Magic button in `RuleFileEditDialog.onMagic` (design
+     * R2-C2): Magic builds a task list with one task per detection pattern via
+     * `MagicTaskListBuilder.buildDetectionPlan()` and passes it here. The agent
+     * executes the seeded task list directly — it is instructed not to call
+     * `create_task_list` itself.
+     *
+     * @param taskList The task list to seed into working memory. Task statuses
+     *   are ignored — the Todo List renders from the task list as-is, then
+     *   `Task*` events update rows as the agent works.
+     * @param displayText What the user sees in the transcript.
+     * @param instruction The rich instruction sent to the agent (file +
+     *   project context).
      */
-    fun runMagic(displayText: String, instruction: String) {
-        startTurn(displayText = displayText, agentMessage = instruction)
+    fun runTaskList(taskList: TaskList, displayText: String, instruction: String) {
+        if (turnJob?.isActive == true) return
+        // Use the already-bound session if available (e.g. bound by a prior
+        // bindSession call or bindSessionForTest in tests); otherwise bind now.
+        val sess = session ?: bindSession() ?: run {
+            // AI not configured — show the banner instead of emitting into a void.
+            refreshConfiguredState()
+            return
+        }
+        sess.memory.taskList = taskList
+        // tryEmit: non-suspending; the session's SharedFlow has a 64-slot
+        // buffer so this never drops. Emitting before startTurn guarantees the
+        // TaskListCreated card renders before the first LLM round-trip.
+        sess.events.tryEmit(AgentEvent.TaskListCreated(taskList))
+        startTurn(
+            displayText = displayText,
+            agentMessage = instruction,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+    }
+
+    /**
+     * Route B Stage-1 entry.
+     *
+     * Starts a single Reactive review turn for a **non-empty** rule file.
+     * Does NOT seed a task list, does NOT emit [AgentEvent.TaskListCreated],
+     * and does NOT use the `TASK_LIST_PROGRAMMATIC` entry path. Arms the
+     * [ReviewGate][reviewGatePending] so the gate fires on the next normal
+     * [AgentEvent.TurnComplete].
+     *
+     * The host ([com.itangcent.easyapi.core.settings.ui.RuleFileEditDialog])
+     * builds [instruction] via
+     * `MagicInstructionBuilder.reviewInstruction(name, content)` — a body that
+     * contains no task-list directive, no `update_task`, and no detection
+     * language. Stage 2 (detection pass) is decided by the gate.
+     *
+     * @param displayText What the user sees in the transcript.
+     * @param instruction The review instruction body (Route B Stage-1 body
+     *   from [com.itangcent.easyapi.core.ai.agent.MagicInstructionBuilder.reviewInstruction]).
+     */
+    fun runReviewTurn(displayText: String, instruction: String) {
+        if (turnJob?.isActive == true) return
+        val sess = session ?: bindSession() ?: run {
+            // AI not configured — show the banner instead of emitting into a void.
+            refreshConfiguredState()
+            return
+        }
+        // Arm the gate — the next normal TurnComplete renders the Yes/No card.
+        // Abnormal end (Failed/LoopDetected/StepLimitHit/cancel) clears it
+        // without firing.
+        reviewGatePending = true
+        startTurn(
+            displayText = displayText,
+            agentMessage = instruction,
+            entryPath = EntryPath.REACTIVE
+        )
     }
 
     private fun sendCurrentInput() {
@@ -364,13 +603,25 @@ class AiChatPanel(
      *
      * The turn runs on [workScope] (background) so it never blocks the EDT or
      * stalls inside a modal dialog; UI updates marshal back via [uiScope].
+     *
+     * @param entryPath The entry path selecting the seed-prompt shape (design
+     * C9). Defaults to [EntryPath.REACTIVE] for plain chat; `runTaskList`
+     * passes [EntryPath.TASK_LIST_PROGRAMMATIC].
      */
-    private fun startTurn(displayText: String, agentMessage: String) {
+    private fun startTurn(
+        displayText: String,
+        agentMessage: String,
+        entryPath: EntryPath = EntryPath.REACTIVE
+    ) {
         if (turnJob?.isActive == true) return
         // Committing to a new turn supersedes any pending proposal — freeze its
         // actions before doing anything else, so a stale card can't be acted on.
         freezeLiveProposalButtons(outdated = true)
-        val sess = bindSession() ?: run {
+        // Use the already-bound session if one is set (runTaskList/runReviewTurn
+        // bind it before calling startTurn; tests bind via bindSessionForTest).
+        // Only fall back to bindSession() — which resolves via AiAssistantService
+        // — when no session is bound yet (plain chat via sendCurrentInput).
+        val sess = session ?: bindSession() ?: run {
             // AI not configured — show the banner instead of a (suppressed) balloon.
             refreshConfiguredState()
             return
@@ -382,30 +633,59 @@ class AiChatPanel(
 
         turnJob = workScope.launch {
             try {
-                val outcome = sess.agent.runTurn(
+                // Phase 3 — pick the orchestrator agent for Magic detection
+                // turns (TASK_LIST_PROGRAMMATIC). The orchestrator has the
+                // split tool set (update_task + run_sub_agent +
+                // propose_rule_content); the Reactive agent has the full set.
+                // Falls back to sess.agent when magicAgent is null (tests
+                // that don't exercise the Magic path).
+                val agent = if (entryPath == EntryPath.TASK_LIST_PROGRAMMATIC) {
+                    sess.magicAgent ?: sess.agent
+                } else {
+                    sess.agent
+                }
+                val outcome = agent.runTurn(
                     agentMessage, sess.memory,
-                    AmbientPerception.capture(project, editingFilePath)
+                    AmbientPerception.capture(project, editingFilePath),
+                    entryPath
                 )
                 ui {
                     when (outcome) {
                         TurnOutcome.Proposed -> statusLabel.text = "Proposal ready — review below."
                         TurnOutcome.Answered -> statusLabel.text = "Ready."
                         TurnOutcome.StepLimitHit -> {
+                            // Abnormal end — clear the ReviewGate arm without
+                            // firing. StepLimitHit does not emit
+                            // TurnComplete, so the gate's TurnComplete handler
+                            // never runs.
+                            reviewGatePending = false
                             statusLabel.text = "Request limit reached."
                             offerContinueOrCancel(sess)
                         }
                         TurnOutcome.LoopDetected -> {
+                            // Defensive: renderEvent(LoopDetected) already
+                            // cleared the arm, but clear again in case the
+                            // event collector hasn't drained yet.
+                            reviewGatePending = false
                             statusLabel.text = "Agent appears stuck."
                             offerLoopRecovery(sess)
                         }
                     }
                 }
             } catch (e: kotlinx.coroutines.CancellationException) {
-                ui { statusLabel.text = "Cancelled." }
+                ui {
+                    statusLabel.text = "Cancelled."
+                    // Cancellation is an abnormal end — clear the arm without firing.
+                    reviewGatePending = false
+                }
                 throw e
             } catch (e: Throwable) {
                 LOG.warn("AI agent turn failed", e)
-                ui { statusLabel.text = "Failed: ${e.message}" }
+                ui {
+                    statusLabel.text = "Failed: ${e.message}"
+                    // Thrown turn is an abnormal end — clear the arm without firing.
+                    reviewGatePending = false
+                }
             } finally {
                 ui { setRunning(false) }
             }
@@ -440,14 +720,28 @@ class AiChatPanel(
             }
             is AgentEvent.Perceiving -> {
                 statusLabel.text = "Perceiving ${ev.tool}…"
+                // Track task-list-tool calls so the matching Observed can be
+                // suppressed (design C11 double-emission handling). The
+                // Perceiving card itself is still rendered — only the
+                // redundant Observed line is dropped.
+                pendingTaskListToolCallName = if (ev.tool == CREATE_TASK_LIST || ev.tool == UPDATE_TASK) ev.tool else null
                 appendToolActivityCard("🔍", ev.tool, ev.args, null)
             }
             is AgentEvent.Acting -> {
                 statusLabel.text = "Acting ${ev.tool}…"
+                pendingTaskListToolCallName = if (ev.tool == CREATE_TASK_LIST || ev.tool == UPDATE_TASK) ev.tool else null
                 appendToolActivityCard("⚙", ev.tool, ev.args, null)
             }
             is AgentEvent.Observed -> {
-                appendToolObservation(ev.tool, ev.resultSummary)
+                // Suppress the redundant Observed line for create_task_list /
+                // update_task — the TaskListCreated / Task* event already drives
+                // the UI (design C11). Clear the tracker either way.
+                val suppress = pendingTaskListToolCallName == ev.tool &&
+                    (ev.tool == CREATE_TASK_LIST || ev.tool == UPDATE_TASK)
+                pendingTaskListToolCallName = null
+                if (!suppress) {
+                    appendToolObservation(ev.tool, ev.resultSummary)
+                }
                 statusLabel.text = "Ready."
             }
             is AgentEvent.ApprovalRequested -> {
@@ -467,6 +761,8 @@ class AiChatPanel(
             }
             is AgentEvent.Failed -> {
                 statusLabel.text = "Failed: ${ev.reason}"
+                // Abnormal end — clear the ReviewGate arm without firing.
+                reviewGatePending = false
                 NotificationUtils.notifyError(
                     project,
                     "EasyApi AI Assistant",
@@ -479,12 +775,48 @@ class AiChatPanel(
                 // TurnOutcome.LoopDetected branch after the turn ends.
                 lastLoopReason = ev.reason
                 lastLoopTool = ev.tool
+                // Abnormal end — clear the ReviewGate arm without firing.
+                reviewGatePending = false
             }
             is AgentEvent.Retrying -> {
                 statusLabel.text = "Retrying chat (attempt ${ev.attempt}/${ev.maxRetries})…"
             }
+            // Phase B task-list lifecycle (design C11, R2-C3) — Todo List panel.
+            is AgentEvent.TaskListCreated -> {
+                statusLabel.text = "Task list committed (${ev.taskList.tasks.size} tasks)."
+                todoListPanel.setTaskList(ev.taskList)
+            }
+            is AgentEvent.TaskStarted -> {
+                statusLabel.text = "Working task ${ev.taskId}…"
+                todoListPanel.updateTask(ev.taskId, TaskStatus.IN_PROGRESS)
+            }
+            is AgentEvent.TaskCompleted -> {
+                statusLabel.text = "Task ${ev.taskId} completed."
+                todoListPanel.updateTask(ev.taskId, TaskStatus.COMPLETED)
+            }
+            is AgentEvent.TaskFailed -> {
+                statusLabel.text = "Task ${ev.taskId} failed: ${ev.reason}"
+                todoListPanel.updateTask(ev.taskId, TaskStatus.FAILED)
+            }
+            is AgentEvent.TaskSkipped -> {
+                statusLabel.text = "Task ${ev.taskId} skipped."
+                todoListPanel.updateTask(ev.taskId, TaskStatus.SKIPPED)
+            }
             AgentEvent.TurnComplete -> {
                 // Turn finished — status already updated in sendCurrentInput.
+                // The Todo List stays visible so the user can review what was
+                // done; it is cleared on `resetConversation`. Clear the
+                // redundant-tool-card suppression tracker.
+                pendingTaskListToolCallName = null
+                // Route B ReviewGate: on normal
+                // TurnComplete while armed, render the Yes/No card exactly
+                // once and clear the arm. Abnormal ends (Failed/LoopDetected/
+                // StepLimitHit) clear the arm without firing (handled above
+                // and in startTurn's outcome branch).
+                if (reviewGatePending) {
+                    reviewGatePending = false
+                    appendReviewGateCard()
+                }
             }
         }
         scrollToBottom()
@@ -566,6 +898,159 @@ class AiChatPanel(
         transcriptBox.add(obs)
     }
 
+    /**
+     * The right-side Todo List panel (design R2-C3). Replaces the v1
+     * in-transcript `PlanCard`: the task list lives in a persistent side panel
+     * so it stops pushing conversation off-screen.
+     *
+     * One row per [Task], **real [JCheckBox]** + title, updating live as
+     * `Task*` events arrive. The checkbox reflects COMPLETED (selected) vs
+     * all other states (not selected); the title's foreground colour carries
+     * the finer status:
+     *
+     * - PENDING — checkbox off, normal text
+     * - IN_PROGRESS — checkbox off, blue text
+     * - COMPLETED — checkbox on, normal text
+     * - FAILED — checkbox off, red text
+     * - SKIPPED — checkbox off, gray text
+     *
+     * The checkboxes are display-only (the agent drives status updates); user
+     * clicks are absorbed so the check state always matches the agent's
+     * [TaskStatus].
+     *
+     * The panel is invisible until [setTaskList] is called (i.e. a task list
+     * is committed via [AgentEvent.TaskListCreated]). [clear] hides it again —
+     * used by `resetConversation` (New Conversation button).
+     */
+    private inner class TodoListPanel : JPanel(BorderLayout()) {
+        private val rowsBox: JPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+        }
+        private val checkboxes: MutableMap<String, JCheckBox> = mutableMapOf()
+        private val titles: MutableMap<String, JLabel> = mutableMapOf()
+        // Status per task — kept in sync with the checkbox + title colour so
+        // test helpers can resolve a glyph even though the UI now uses real
+        // JCheckBoxes (which only expose a binary selected state).
+        private val statuses: MutableMap<String, TaskStatus> = mutableMapOf()
+
+        init {
+            border = EmptyBorder(6, 8, 6, 8)
+            add(JLabel("Todo List").apply {
+                font = font.deriveFont(Font.BOLD)
+                border = EmptyBorder(0, 0, 4, 0)
+            }, BorderLayout.NORTH)
+            add(JBScrollPane(
+                rowsBox,
+                ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+            ), BorderLayout.CENTER)
+            isVisible = false
+        }
+
+        /** Rebuild the row list from [taskList] and make the panel visible. */
+        fun setTaskList(taskList: TaskList) {
+            rowsBox.removeAll()
+            checkboxes.clear()
+            titles.clear()
+            statuses.clear()
+            if (taskList.tasks.isEmpty()) {
+                rowsBox.add(JLabel("No detection tasks").apply {
+                    foreground = Color.GRAY
+                    border = EmptyBorder(2, 2, 2, 2)
+                })
+            } else {
+                for (task in taskList.tasks) {
+                    statuses[task.id] = task.status
+                    val cb = JCheckBox().apply {
+                        isOpaque = false
+                        isFocusPainted = false
+                        isFocusable = false
+                        isBorderPainted = false
+                        isContentAreaFilled = false
+                        // Display-only: absorb clicks so the check state always
+                        // matches the agent's TaskStatus (issue: user clicks
+                        // must not toggle the visual state).
+                        isEnabled = false
+                        isSelected = task.status == TaskStatus.COMPLETED
+                    }
+                    val title = JLabel(task.title).apply {
+                        foreground = statusForeground(task.status)
+                        if (task.detail != null) toolTipText = task.detail
+                    }
+                    val taskRow = JPanel(BorderLayout(4, 0)).apply {
+                        isOpaque = false
+                        border = EmptyBorder(1, 0, 1, 0)
+                        add(cb, BorderLayout.WEST)
+                        add(title, BorderLayout.CENTER)
+                    }
+                    rowsBox.add(taskRow)
+                    checkboxes[task.id] = cb
+                    titles[task.id] = title
+                }
+            }
+            isVisible = true
+            // JSplitPane does not move its divider when a child flips visible
+            // inside its own revalidate(); tell the split pane to re-layout so
+            // the Todo List actually receives width.
+            splitPane.relayoutForTodoList()
+        }
+
+        /** Update the checkbox + title colour for [taskId]. */
+        fun updateTask(taskId: String, status: TaskStatus) {
+            val cb = checkboxes[taskId] ?: return
+            val title = titles[taskId] ?: return
+            statuses[taskId] = status
+            cb.isSelected = status == TaskStatus.COMPLETED
+            title.foreground = statusForeground(status)
+            cb.repaint()
+            title.repaint()
+        }
+
+        /** Empty the row list and hide the panel. */
+        fun clear() {
+            rowsBox.removeAll()
+            checkboxes.clear()
+            titles.clear()
+            statuses.clear()
+            isVisible = false
+            // Symmetric to setTaskList: let the split pane reclaim the right
+            // pane's width for the conversation side.
+            splitPane.relayoutForTodoList()
+        }
+
+        /** Whether the checkbox for [taskId] is selected (test-only). */
+        internal fun checkBoxSelectedForTest(taskId: String): Boolean? =
+            checkboxes[taskId]?.isSelected
+
+        /**
+         * Status glyph for [taskId] (test-only). Mirrors the pre-checkbox
+         * glyphs so existing tests keep working after the real-JCheckBox
+         * refactor: `[ ]` PENDING, `[~]` IN_PROGRESS, `[X]` COMPLETED,
+         * `[!]` FAILED, `[-]` SKIPPED. Returns `null` when the task id is
+         * unknown or no task list is active.
+         */
+        internal fun glyphForTest(taskId: String): String? {
+            val status = statuses[taskId] ?: return null
+            return when (status) {
+                TaskStatus.PENDING -> "[ ]"
+                TaskStatus.IN_PROGRESS -> "[~]"
+                TaskStatus.COMPLETED -> "[X]"
+                TaskStatus.FAILED -> "[!]"
+                TaskStatus.SKIPPED -> "[-]"
+            }
+        }
+
+        /** Foreground colour for a [TaskStatus]. */
+        private fun statusForeground(status: TaskStatus): Color = when (status) {
+            TaskStatus.PENDING -> JBColor.foreground()
+            TaskStatus.IN_PROGRESS -> JBColor(Color(0, 0, 180), Color(120, 160, 255))
+            TaskStatus.COMPLETED -> JBColor.foreground()
+            TaskStatus.FAILED -> JBColor(Color(180, 0, 0), Color(255, 120, 120))
+            TaskStatus.SKIPPED -> Color.GRAY
+        }
+    }
+
     private fun appendApprovalCard(tool: String, args: String) {
         val sess = session ?: return
         val row = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
@@ -618,6 +1103,49 @@ class AiChatPanel(
         }
         row.add(approveBtn)
         row.add(rejectBtn)
+        transcriptBox.add(row)
+        transcriptBox.add(Box.createVerticalStrut(2))
+    }
+
+    /**
+     * Render the Route B ReviewGate card.
+     *
+     * Fired exactly once by the [AgentEvent.TurnComplete] handler while
+     * [reviewGatePending] is armed. Presents *"Review complete. Continue to
+     * detection pass?"* with **Yes / No** buttons:
+     *
+     * - **Yes** — invokes [onReviewGateYes], which reads the file content at
+     *   this time, builds the detection task list, and calls [runTaskList]
+     *   with the empty-file detection instruction. Stage 2
+     *   then runs the same detection-pass contract as Route A.
+     * - **No** — terminates; no Stage 2. The Stage-1 outcome
+     *   (proposal or answer) stands as-is.
+     *
+     * Either button collapses the card. The arm flag is already cleared by
+     * the caller (the TurnComplete handler), so the gate cannot re-fire.
+     */
+    private fun appendReviewGateCard() {
+        val row = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
+            border = EmptyBorder(6, 12, 6, 6)
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
+        row.add(JLabel("✨ Review complete. Continue to detection pass?"))
+        val yesBtn = JButton("Yes").apply {
+            toolTipText = "Run the detection pass (same as Magic on an empty file)"
+            addActionListener {
+                row.isVisible = false
+                onReviewGateYes?.invoke()
+            }
+        }
+        val noBtn = JButton("No").apply {
+            toolTipText = "Keep the review outcome as-is; do not run detections"
+            addActionListener {
+                // No Stage 2 — terminate.
+                row.isVisible = false
+            }
+        }
+        row.add(yesBtn)
+        row.add(noBtn)
         transcriptBox.add(row)
         transcriptBox.add(Box.createVerticalStrut(2))
     }
@@ -905,6 +1433,9 @@ class AiChatPanel(
         AiAssistantService.getInstance(project).resetConversation()
         session = null
         liveProposalButtonPanel = null
+        todoListPanel.clear()
+        pendingTaskListToolCallName = null
+        reviewGatePending = false
         transcriptBox.removeAll()
         transcriptBox.revalidate()
         transcriptBox.repaint()
@@ -912,6 +1443,11 @@ class AiChatPanel(
     }
 
     private fun offerContinueOrCancel(sess: ConversationSession) {
+        if (disposed) return
+        // Test seam: when set, skip the modal dialog (which would block the
+        // EDT and hang subsequent tests). Used by AiChatPanelTest to verify
+        // the StepLimitHit outcome without popping a real JOptionPane.
+        offerContinueOrCancelHandler?.let { it(sess); return }
         val options = arrayOf("Continue", "Cancel")
         val choice = JOptionPane.showOptionDialog(
             null,
@@ -954,6 +1490,8 @@ class AiChatPanel(
      * Recovery is user-initiated; there is no auto-retry.
      */
     private fun offerLoopRecovery(sess: ConversationSession) {
+        if (disposed) return
+        offerLoopRecoveryHandler?.let { it(sess); return }
         val tool = lastLoopTool
         val dialogText = if (tool != null) {
             "The agent was repeating the same action ($tool). Retry with guidance, or stop?"
@@ -1002,10 +1540,21 @@ class AiChatPanel(
     }
 
     override fun dispose() {
+        disposed = true
         cancelRunningTurn()
         eventCollectorJob?.cancel()
         uiScope.cancel()
         workScope.cancel()
+        // Dismiss any modal dialog opened by offerContinueOrCancel /
+        // offerLoopRecovery (StepLimitHit / LoopDetected outcomes).
+        // JOptionPane.showOptionDialog is a blocking native call that survives
+        // coroutine-scope cancellation — without this, a disposed panel can
+        // leave a dangling modal dialog that blocks the EDT for all subsequent
+        // UI operations.
+        Window.getWindows()
+            .filterIsInstance<JDialog>()
+            .filter { it.isShowing }
+            .forEach { it.dispose() }
     }
 
     // --- Test helpers ---
@@ -1017,6 +1566,33 @@ class AiChatPanel(
 
     /** Number of components in the transcript (test-only). */
     internal fun transcriptComponentCount(): Int = transcriptBox.componentCount
+
+    /**
+     * The split pane's divider location in pixels, or `-1` when the divider
+     * has not been positioned yet (test-only — used to verify R3-C1's
+     * `addNotify` initial-divider-set).
+     */
+    internal fun splitPaneDividerLocationForTest(): Int = splitPane.dividerLocation
+
+    /** The split pane's total width (test-only). */
+    internal fun splitPaneWidthForTest(): Int = splitPane.width
+
+    /**
+     * The split pane's divider size in pixels (test-only). `setDividerLocation(double)`
+     * factors this out of the available space, so tests that assert on the resulting
+     * pixel location must use `(width - dividerSize) * proportion` as the expected value.
+     */
+    internal fun splitPaneDividerSizeForTest(): Int = splitPane.dividerSize
+
+    /**
+     * Current glyph text for [taskId] in the live [TodoListPanel], or `null`
+     * when no task list is active / the task id is unknown (test-only).
+     */
+    internal fun taskListGlyphForTest(taskId: String): String? =
+        todoListPanel.glyphForTest(taskId)
+
+    /** Whether the Todo List side panel is currently visible (test-only). */
+    internal fun isTodoListPanelVisibleForTest(): Boolean = todoListPanel.isVisible
 
     /** Bind a pre-built session without going through the service (test-only). */
     internal fun bindSessionForTest(sess: ConversationSession) {
@@ -1048,6 +1624,48 @@ class AiChatPanel(
         return true
     }
 
+    // --- Route B ReviewGate test helpers ---
+
+    /** Test-only: whether the ReviewGate arm flag is currently set. */
+    internal fun isReviewGatePendingForTest(): Boolean = reviewGatePending
+
+    /**
+     * Test-only: set the ReviewGate arm flag directly (without driving a full
+     * `runReviewTurn`). Used by gate-rendering tests that drive events via
+     * [renderEventForTest] rather than starting a real agent turn.
+     */
+    internal fun armReviewGateForTest() {
+        reviewGatePending = true
+    }
+
+    /**
+     * Test-only: click the "Yes" button on a rendered ReviewGate card.
+     * Returns false if no such button is present.
+     */
+    internal fun clickReviewGateYesForTest(): Boolean {
+        val btn = findButtonByText(component, "Yes") ?: return false
+        btn.doClick()
+        return true
+    }
+
+    /**
+     * Test-only: click the "No" button on a rendered ReviewGate card.
+     * Returns false if no such button is present.
+     */
+    internal fun clickReviewGateNoForTest(): Boolean {
+        val btn = findButtonByText(component, "No") ?: return false
+        btn.doClick()
+        return true
+    }
+
+    /**
+     * Test-only: whether a ReviewGate card (containing the "Continue to
+     * detection pass?" label) is currently rendered in the transcript.
+     */
+    internal fun isReviewGateCardRenderedForTest(): Boolean {
+        return findLabelContaining(component, "Continue to detection pass?") != null
+    }
+
     /** Test-only: set the input text then trigger a send (typed-reply path). */
     internal fun typeAndSendForTest(text: String) {
         inputArea.text = text
@@ -1064,10 +1682,25 @@ class AiChatPanel(
         return null
     }
 
+    /** Recursively find a JLabel whose text contains [substring] (test-only). */
+    private fun findLabelContaining(c: Component, substring: String): JLabel? {
+        if (c is JLabel && c.text?.contains(substring) == true) return c
+        if (c is java.awt.Container) {
+            for (child in c.components) {
+                findLabelContaining(child, substring)?.let { return it }
+            }
+        }
+        return null
+    }
+
     private companion object {
         /** Theme-aware chat bubble backgrounds (light, dark). */
         val USER_BUBBLE = JBColor(Color(0xE8, 0xF0, 0xFE), Color(0x2B, 0x3A, 0x55))
         val ASSISTANT_BUBBLE = JBColor(Color(0xF2, 0xF2, 0xF2), Color(0x3C, 0x3F, 0x41))
+
+        /** Tool names whose `Observed` card is suppressed (design C11). */
+        const val CREATE_TASK_LIST = "create_task_list"
+        const val UPDATE_TASK = "update_task"
     }
 }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistry.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.channel.spi.ChannelRegistry
 import com.itangcent.easyapi.core.export.recognizer.CompositeApiClassRecognizer
+import com.itangcent.easyapi.framework.spi.FrameworkRegistry
 
 /**
  * Project-level registry of every rule key known to the plugin.
@@ -75,6 +76,50 @@ class RuleKeyRegistry(private val project: Project) {
         val frameworkKeys = CompositeApiClassRecognizer.getInstance(project)
             .allRecognizers().map { it.frameworkName to it.ruleKeys() }
         return assembleKeys(channelKeys, frameworkKeys)
+    }
+
+    /**
+     * The subset of [allKeys] whose owning channel/framework is enabled.
+     *
+     * This is the enablement-aware view consumed by the AI tooling
+     * ([com.itangcent.easyapi.core.ai.tools.ListRuleKeysTool]). The Settings
+     * UI continues to use [allKeys] so disabled-source keys remain browsable
+     * and re-enableable (design D8 — enablement at the AI view layer, not the
+     * registry).
+     *
+     * Resolution rules (design C4a + AC-S4 prefix check):
+     * - **General/implicit keys**: enabled unless the key name belongs to a
+     *   disabled channel via prefix matching (e.g. `postman.test` → Postman
+     *   channel). The `postman.*` and `markdown.*` keys are declared in
+     *   [RuleKeys] (general source) but semantically owned by their
+     *   respective channels — the prefix check enforces AC-S4.
+     * - **Channel-sourced keys** (`info.source` is a registered channel id):
+     *   enabled iff the channel is enabled.
+     * - **Framework-sourced keys** (`info.source` is a registered framework
+     *   name): enabled iff the framework is enabled.
+     * - **Unknown source kind**: always enabled (never filter).
+     */
+    fun enabledKeys(): List<RuleKeyInfo> {
+        val channelRegistry = ChannelRegistry.getInstance(project)
+        val allChannels = channelRegistry.allChannels()
+        val enabledChannelIds = allChannels
+            .filter { channelRegistry.isEnabled(it) }
+            .map { it.id }
+            .toSet()
+        val allChannelIds = allChannels.map { it.id }.toSet()
+
+        val allRecognizers = CompositeApiClassRecognizer.getInstance(project).allRecognizers()
+        val allFrameworkIds = allRecognizers.map { it.frameworkName }.toSet()
+        val enabledFrameworkIds = allRecognizers
+            .filter { FrameworkRegistry.getInstance(project).isEnabled(it) }
+            .map { it.frameworkName }
+            .toSet()
+
+        return allKeys().filter {
+            isEnabledSource(
+                it, enabledChannelIds, allChannelIds, enabledFrameworkIds, allFrameworkIds
+            )
+        }
     }
 
     /**
@@ -150,6 +195,70 @@ class RuleKeyRegistry(private val project: Project) {
                 if (seen.add(key.name)) result.add(RuleKeyInfo(key, SOURCE_IMPLICIT))
             }
             return result
+        }
+
+        /**
+         * Pure resolution rule for whether a [RuleKeyInfo] should be visible
+         * to the AI agent (i.e. its owning channel/framework is enabled).
+         * Extracted so unit tests can exercise the full truth table without a
+         * real IntelliJ [Project] (mirrors [ChannelRegistry.resolveEnabled]
+         * and [FrameworkRegistry.resolveEnabled]).
+         *
+         * Resolution order (design C4a + AC-S4 prefix check):
+         * 1. **General/implicit keys** → enabled unless the key name belongs
+         *    to a disabled channel via prefix matching (e.g. `"postman.test"`
+         *    belongs to the `"postman"` channel). The `postman.*` keys are
+         *    declared in [RuleKeys] (general source) but semantically owned
+         *    by the Postman channel — the prefix check enforces AC-S4.
+         * 2. **Channel-sourced keys** (`info.source` ∈ [allChannelIds]) →
+         *    enabled iff `info.source` ∈ [enabledChannelIds].
+         * 3. **Framework-sourced keys** (`info.source` ∈ [allFrameworkIds])
+         *    → enabled iff `info.source` ∈ [enabledFrameworkIds].
+         * 4. **Unknown source kind** → enabled (never filter).
+         *
+         * No format branch in v1 — there are no format-sourced keys today
+         * (see design C4a note).
+         *
+         * @param info the rule key info to check
+         * @param enabledChannelIds channel ids that are currently enabled
+         * @param allChannelIds all registered channel ids (for prefix
+         *     matching on general/implicit keys + source resolution)
+         * @param enabledFrameworkIds framework names that are currently enabled
+         * @param allFrameworkIds all registered framework names (for source
+         *     resolution; uses the unfiltered `allRecognizers()` view so
+         *     disabled frameworks are still resolvable)
+         */
+        internal fun isEnabledSource(
+            info: RuleKeyInfo,
+            enabledChannelIds: Set<String>,
+            allChannelIds: Set<String>,
+            enabledFrameworkIds: Set<String>,
+            allFrameworkIds: Set<String>
+        ): Boolean {
+            val keyName = info.key.name
+
+            // 1. General/implicit keys: check channel prefix (AC-S4)
+            if (info.source == SOURCE_GENERAL || info.source == SOURCE_IMPLICIT) {
+                for (channelId in allChannelIds) {
+                    if (keyName.startsWith("$channelId.") && channelId !in enabledChannelIds) {
+                        return false
+                    }
+                }
+                return true
+            }
+
+            // 2. Channel-sourced key
+            if (info.source in allChannelIds) {
+                return info.source in enabledChannelIds
+            }
+
+            // 3. Framework-sourced key
+            if (info.source in allFrameworkIds) {
+                return info.source in enabledFrameworkIds
+            }
+
+            // 4. Unknown source kind: don't filter
+            return true
         }
 
         fun getInstance(project: Project): RuleKeyRegistry = project.service()

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidator.kt
@@ -1,8 +1,13 @@
 package com.itangcent.easyapi.core.rule
 
 import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.channel.spi.Channel
+import com.itangcent.easyapi.channel.spi.ChannelRegistry
+import com.itangcent.easyapi.core.export.recognizer.ApiClassRecognizer
+import com.itangcent.easyapi.core.export.recognizer.CompositeApiClassRecognizer
 import com.itangcent.easyapi.core.util.json.GsonUtils
 import com.itangcent.easyapi.core.util.text.KeyValueLineParser
+import com.itangcent.easyapi.framework.spi.FrameworkRegistry
 
 /**
  * Deterministic, PSI-free reviewer for AI-authored rule proposals (the
@@ -18,8 +23,10 @@ import com.itangcent.easyapi.core.util.text.KeyValueLineParser
  * - **Hard errors** (block the proposal): unknown key, invalid filter prefix,
  *   malformed JSON value for the header/param keys.
  * - **Soft warnings** (never block): deprecated-but-valid filter forms such
- *   as the bare `class:` prefix. Reported back to the drafter / surfaced on
- *   the proposal card, but the proposal still proceeds.
+ *   as the bare `class:` prefix; keys whose owning channel/framework is
+ *   currently disabled in Settings (design C4a / task A5c). Reported back to
+ *   the drafter / surfaced on the proposal card, but the proposal still
+ *   proceeds.
  *
  * ## Key catalog
  *
@@ -55,6 +62,11 @@ object RuleProposalValidator {
         "\$class:", "@", "#regex:", "#", "!", "groovy:"
     )
 
+    /** Source kind for keys declared in [RuleKeys] (mirrors [RuleKeyRegistry]). */
+    private const val SOURCE_GENERAL = "general"
+    /** Source kind for keys read by name only (mirrors [RuleKeyRegistry]). */
+    private const val SOURCE_IMPLICIT = "implicit"
+
     /** Fallback known-key set used when no [Project] is supplied. */
     private val generalKeyNames: Set<String> by lazy { collectGeneralKeyNames() }
 
@@ -75,6 +87,10 @@ object RuleProposalValidator {
         val knownKeyNames = project
             ?.let { RuleKeyRegistry.getInstance(it).allKeyNames() }
             ?: generalKeyNames
+        // A5c: precompute key-name → disabled-source-id lookup (unfiltered
+        // allKeys() view, mirroring findKey) so per-line warnings are O(1).
+        val disabledSourceByName: Map<String, String> =
+            project?.let { buildDisabledSourceMap(it) } ?: emptyMap()
         val errors = mutableListOf<String>()
         val warnings = mutableListOf<String>()
         var inBlock = false
@@ -102,6 +118,12 @@ object RuleProposalValidator {
             if (key !in knownKeyNames) {
                 errors += "line $lineNo: unknown rule key '$key' (not in list_rule_keys)."
                 return@forEachIndexed
+            }
+            // A5c: soft warning when the key's owning channel/framework is
+            // disabled in Settings (never blocks the proposal).
+            disabledSourceByName[key]?.let { src ->
+                warnings += "line $lineNo: key '$key' belongs to '$src', " +
+                    "which is currently disabled in Settings."
             }
             if (filter != null) {
                 val prefixIssue = checkFilterPrefix(filter)
@@ -144,6 +166,88 @@ object RuleProposalValidator {
 
     private fun collectGeneralKeyNames(): Set<String> =
         RuleKey.collectFrom(RuleKeys).flatMap { it.allNames }.toSet()
+
+    /**
+     * Builds a lookup from every known rule-key name (primary + aliases) to
+     * the id of the disabled channel/framework that owns it (task A5c).
+     * Returns an empty map when no owner is disabled.
+     *
+     * Mirrors the prefix-based ownership check in
+     * [RuleKeyRegistry.isEnabledSource] so that a key hidden from
+     * [RuleKeyRegistry.enabledKeys] (e.g. `postman.test` with Postman
+     * disabled) is also surfaced as a soft warning here.
+     */
+    private fun buildDisabledSourceMap(project: Project): Map<String, String> {
+        val registry = RuleKeyRegistry.getInstance(project)
+        val channelRegistry = ChannelRegistry.getInstance(project)
+        val allChannels = channelRegistry.allChannels()
+        val frameworkRegistry = FrameworkRegistry.getInstance(project)
+        val allRecognizers = CompositeApiClassRecognizer.getInstance(project).allRecognizers()
+
+        val result = mutableMapOf<String, String>()
+        for (info in registry.allKeys()) {
+            val disabledSource = checkDisabledSource(
+                info, allChannels, channelRegistry, allRecognizers, frameworkRegistry
+            )
+            if (disabledSource != null) {
+                for (name in info.key.allNames) {
+                    result[name] = disabledSource
+                }
+            }
+        }
+        return result
+    }
+
+    /**
+     * Resolves the disabled owner (channel/framework id) for [info], or
+     * `null` when the owner is enabled or the source kind is unknown.
+     *
+     * Resolution order (design C4a + AC-S4 prefix check):
+     * 1. **Channel-sourced key** (`info.source` is a registered channel id):
+     *    disabled iff that channel is disabled.
+     * 2. **Framework-sourced key** (`info.source` is a registered framework
+     *    name): disabled iff that framework is disabled.
+     * 3. **General/implicit key**: disabled iff the key name prefix-matches a
+     *    disabled channel (e.g. `postman.test` → `postman`). The `postman.*`
+     *    keys are declared in [RuleKeys] (general source) but semantically
+     *    owned by their channel — the prefix check mirrors
+     *    [RuleKeyRegistry.isEnabledSource] so a key filtered out of
+     *    `enabledKeys()` also warns here.
+     * 4. **Unknown source kind**: never warn.
+     */
+    private fun checkDisabledSource(
+        info: RuleKeyRegistry.RuleKeyInfo,
+        allChannels: List<Channel>,
+        channelRegistry: ChannelRegistry,
+        allRecognizers: List<ApiClassRecognizer>,
+        frameworkRegistry: FrameworkRegistry
+    ): String? {
+        val keyName = info.key.name
+        val source = info.source
+
+        // 1. Channel-sourced key.
+        val sourceChannel = allChannels.firstOrNull { it.id == source }
+        if (sourceChannel != null && !channelRegistry.isEnabled(sourceChannel)) {
+            return source
+        }
+
+        // 2. Framework-sourced key.
+        val sourceFramework = allRecognizers.firstOrNull { it.frameworkName == source }
+        if (sourceFramework != null && !frameworkRegistry.isEnabled(sourceFramework)) {
+            return source
+        }
+
+        // 3. General/implicit key: channel-prefix ownership (AC-S4).
+        if (source == SOURCE_GENERAL || source == SOURCE_IMPLICIT) {
+            for (channel in allChannels) {
+                if (keyName.startsWith("${channel.id}.") && !channelRegistry.isEnabled(channel)) {
+                    return channel.id
+                }
+            }
+        }
+
+        return null
+    }
 
     private sealed class FilterIssue {
         object Invalid : FilterIssue()

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/RuleFileEditDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/RuleFileEditDialog.kt
@@ -84,6 +84,12 @@ class RuleFileEditDialog(
     private val aiChatPanel = AiChatPanel(project, editingFilePath = filePath).apply {
         onApplyProposal = { proposed -> contentArea.text = proposed }
         onConfigureAi = { openAiSettings() }
+        // Route B Stage-2 entry: when
+        // the user clicks Yes at the ReviewGate, read the file content **at
+        // this time** (reflecting any Stage-1 proposal applied in between),
+        // build the detection task list, and re-enter the detection-pass
+        // contract via runTaskList with the empty-file detection instruction.
+        onReviewGateYes = { onReviewGateYes() }
     }
     private val aiPanelHolder = JPanel(BorderLayout()).apply {
         add(aiChatPanel.component, BorderLayout.CENTER)
@@ -120,16 +126,89 @@ class RuleFileEditDialog(
         aiChatPanel.refreshConfiguredState()
         revalidateDialog()
         val name = nameField.text.trim().ifBlank { Paths.get(filePath).fileName.toString() }
-        val empty = contentArea.text.isBlank()
-        // Short, constant display message; the rich instruction (file + project
-        // context) is carried implicitly to the agent (issue 3). When the file
-        // is empty, skip "review/improve" and focus purely on detection.
-        val displayText = if (empty) {
-            "✨ Detect missing custom-pattern rules and draft initial content for \"$name\"."
+        val content = contentArea.text
+        val empty = content.isBlank()
+        // Route split: empty file → straight to detections
+        // (Route A); non-empty file → review → gate → optional detections
+        // (Route B). The two routes use distinct instruction bodies built by
+        // MagicInstructionBuilder so each is independently testable.
+        if (empty) {
+            // Route A — straight to detections (today's flow).
+            val displayText = "✨ Detect missing custom-pattern rules and draft initial content for \"$name\"."
+            runDetectionPass(displayText, name)
         } else {
-            "✨ Review and improve \"$name\" and detect any missing custom-pattern rules."
+            // Route B Stage 1 — review only; the gate decides Stage 2.
+            // No ambient capture, no plan build here — Stage 2 builds the plan
+            // lazily on gate Yes.
+            val displayText = "✨ Review and improve \"$name\"."
+            val instruction = com.itangcent.easyapi.core.ai.agent.MagicInstructionBuilder
+                .reviewInstruction(name, content)
+            aiChatPanel.runReviewTurn(displayText, instruction)
         }
-        aiChatPanel.runMagic(displayText = displayText, instruction = buildMagicInstruction())
+    }
+
+    /**
+     * Route B Stage-2 entry — invoked by [AiChatPanel]'s `onReviewGateYes`
+     * hook when the user clicks **Yes** at the ReviewGate.
+     *
+     * Reads the file content **at Yes time** (from [contentArea.text],
+     * reflecting any Stage-1 proposal the user applied in between),
+     * builds the detection task list with the now-enabled features, and
+     * re-enters the detection-pass contract via [AiChatPanel.runTaskList]
+     * with the **empty-file** detection instruction body (no "review"
+     * directive).
+     */
+    private fun onReviewGateYes() {
+        val name = nameField.text.trim().ifBlank { Paths.get(filePath).fileName.toString() }
+        // Read at Yes time — the user may have applied a Stage-1 proposal.
+        // (The content itself is NOT embedded in the Stage-2 instruction body;
+        // detectionInstruction(name, taskList) carries no content. The read is
+        // done here so Stage 2 always sees the latest state, and so a future
+        // revision can pass it to the task-list builder if needed.)
+        @Suppress("UNUSED_VARIABLE")
+        val contentAtYes = contentArea.text
+        val displayText = "✨ Detect missing custom-pattern rules and draft initial content for \"$name\"."
+        runDetectionPass(displayText, name)
+    }
+
+    /**
+     * Shared detection-pass entry (Route A and Route B Stage 2).
+     *
+     * Ambient capture does PSI work (framework detection), so it runs
+     * off-EDT; the task list is then built and the orchestrator instruction
+     * composed from it, then both are seeded back on the EDT (`runTaskList`
+     * touches the session + UI and must run on the dispatch thread). The
+     * agent executes the seeded task list directly — it does NOT call
+     * `create_task_list`.
+     *
+     * The instruction is built **after** the task list so it can render the
+     * seeded task ids into the orchestrator's user message (the only channel
+     * by which the LLM learns the exact ids to pass to `run_sub_agent` /
+     * `update_task`). Building it earlier — before the task list exists —
+     * was the root cause of the "unknown task id" loop.
+     */
+    private fun runDetectionPass(displayText: String, name: String) {
+        scope.launch {
+            val amb = com.itangcent.easyapi.core.ai.agent.AmbientPerception.capture(
+                project, editingFilePath = filePath
+            )
+            val taskList = com.itangcent.easyapi.core.ai.agent.MagicTaskListBuilder.buildDetectionPlan(
+                activeChannels = amb.enabledChannels.toSet(),
+                activeFormats = amb.enabledFormats.toSet(),
+                activeFrameworks = amb.frameworkHints.toSet()
+            )
+            // Compose the instruction from the freshly-built task list so the
+            // orchestrator LLM sees the exact ids it must use.
+            val instruction = com.itangcent.easyapi.core.ai.agent.MagicInstructionBuilder
+                .detectionInstruction(name, taskList)
+            withContext(Dispatchers.Main) {
+                aiChatPanel.runTaskList(
+                    taskList = taskList,
+                    displayText = displayText,
+                    instruction = instruction
+                )
+            }
+        }
     }
 
     /** Opens Settings → EasyApi → AI so the user can configure a provider. */
@@ -143,39 +222,6 @@ class RuleFileEditDialog(
     private fun revalidateDialog() {
         rootPane?.revalidate()
         rootPane?.repaint()
-    }
-
-    /**
-     * Builds the Magic instruction scoped to the file being edited.
-     *
-     * - When the file already has content: review/improve it AND detect any
-     * custom framework patterns that lack a rule, then propose the full
-     * updated file content.
-     * - When the file is empty: skip the review step and focus purely on
-     * detecting custom patterns and drafting initial rule content for them.
-     */
-    private fun buildMagicInstruction(): String {
-        val name = nameField.text.trim().ifBlank { Paths.get(filePath).fileName.toString() }
-        val content = contentArea.text
-        return buildString {
-            appendLine(
-                if (content.isBlank()) {
-                    "I'm starting a new rule file '$name' (currently empty). Detect any custom framework patterns in this project that lack a rule, then propose initial rule content for them."
-                } else {
-                    "Review and improve the rule file '$name' that I'm editing. Fix anything broken or incomplete, detect any custom framework patterns that lack a rule, then propose the full updated file content."
-                }
-            )
-            appendLine()
-            appendLine("Standard HTTP frameworks (Spring MVC, WebFlux, JAX-RS, Feign) need no rules. Scan for Custom-Pattern Catalog signals: Filter/HandlerInterceptor/WebFilter requiring a header, ResponseBodyAdvice wrapping responses, HandlerMethodArgumentResolver injecting hidden params, custom meta-/security annotations. Use find_classes_by_annotation + get_psi_class_info to confirm a hit, then apply the catalog recipe from the rule guide. Also scan for Workflow-Pattern Catalog signals: secured endpoints paired with a login/token endpoint (auth token chaining), static API-key/Basic auth, correlation/idempotency header requirements, and HMAC request signing — apply the catalog recipe from the rule guide when found.")
-            if (content.isNotBlank()) {
-                appendLine()
-                appendLine("Current content of '$name':")
-                appendLine("```")
-                append(content)
-                appendLine()
-                appendLine("```")
-            }
-        }
     }
 
     private fun loadContentAsync() {

--- a/src/main/resources/ai/agent-base.md
+++ b/src/main/resources/ai/agent-base.md
@@ -25,6 +25,53 @@ Work in a perceive → reason → act loop:
   or a literal `~` in the rule content or filename. This is your one
   state-changing action; the user reviews and saves it.
 
+## Tool index
+
+Perception tools (read-only, run automatically):
+- `list_rule_keys` — every known rule key (general + channel + framework + implicit),
+  filtered to the channels/frameworks enabled in Settings. Each entry may carry
+  `description` (one-line "when to use") and `detailPromptId` (the id to pass to
+  `get_rule_detail` for the full recipe). Keys without a per-key recipe file omit
+  both fields.
+- `get_detection_prompt` — fetch the full detection recipe for one detection
+  family by `id` (e.g. `static-auth`, `auth-token-chaining`, `spring-filters-interceptors`).
+  The reactive path lists the available ids at conversation start; pull a recipe
+  on demand when the user's request touches that family.
+- `get_rule_detail` — fetch the full recipe for one rule key. Two access patterns:
+  - by key: `get_rule_detail(key="postman.test")` returns the single per-key recipe.
+    Use this when you know which key you're about to set. `key` takes precedence
+    over any scope args.
+  - by scope: `get_rule_detail(channel="postman")` returns the concatenated recipes
+    of every rule file scoped to that channel (and enabled in Settings). Use this
+    when you want a tour of what a channel supports, e.g. before proposing a
+    Postman workflow bundle.
+  - At least one of `key` / `channel` / `format` / `framework` is required.
+- `get_plugin_doc` — long-form reference pages from the knowledge base
+  (`name ∈ overview | index | rule-guide | settings-guide | usage-guide | easyapi-script-reference`).
+  The detection/rule-detail prompts above are the **preferred first stop** for
+  concise recipes; `get_plugin_doc name="rule-guide"` is the long-form reference
+  (e.g. the full "Workflow Patterns" and "Multi-Application Namespace" sections).
+- `read_rule_file` — read an existing `.properties`/`.rules` file from `.easyapi/`
+  or `~/.easyapi/` by name (see "Tool selection" below).
+- `list_project_endpoints` — the user's API endpoints.
+- `get_psi_class_info` / `get_psi_method_info` — inspect source code (classes/methods).
+- `find_classes_by_annotation` / `find_classes_by_supertype` / `find_classes_by_name` —
+  discover classes by annotation, supertype, or simple name.
+- `get_existing_rules_for_key` — current values for a key across all sources.
+- `get_module_dependency_graph` — module dependencies for multi-app namespacing.
+- `ask_clarification` — ask the user a clarifying question with concrete options.
+
+Action tools (state-changing, gated by approval unless noted):
+- `propose_rule_content` — terminal staging action; fills working memory with a
+  proposed rule file. The user reviews and saves. **Call this only when the full
+  proposal is ready.**
+
+Planning tools (Task-List path only — do NOT use in plain chat):
+- `create_task_list` and `update_task` exist for complex, multi-step tasks (≥2 distinct
+  steps). They are introduced by Magic / programmatic entry. In a plain-chat turn
+  you should NOT call them — work the perceive → reason → act loop directly and
+  end with `propose_rule_content` (or a clarifying question / plain answer).
+
 ## Tool selection — read_rule_file vs get_psi_class_info (CRITICAL)
 
 `read_rule_file` is **ONLY for rule files** — `.properties` / `.rules` files
@@ -97,70 +144,45 @@ Never invent rule keys that are not in `list_rule_keys`. In particular:
 Stay within the rule-authoring task — you cannot edit arbitrary code
 or run commands.
 
-## Custom-pattern detection
+## Detection & rule-detail recipes (fetch on demand)
 
 EasyApi understands standard HTTP frameworks (Spring MVC, WebFlux,
-JAX-RS, Feign) out of the box — those need no rules. Detect custom framework patterns before proposing. Scan for the Custom-Pattern Catalog signals documented in the rule guide: servlet Filters / Interceptors / WebFilters that change the request contract, ResponseBodyAdvice that wraps responses, HandlerMethodArgumentResolver that injects hidden params, meta-annotations, custom security annotations.
+JAX-RS, Feign) out of the box — those need no rules. Detect custom framework patterns
+before proposing: servlet Filters / Interceptors / WebFilters that
+change the request contract, ResponseBodyAdvice that wraps responses,
+HandlerMethodArgumentResolver that injects hidden params,
+meta-annotations, custom security annotations.
 
-Two discovery tools cover the common declaration styles — use BOTH:
-- `find_classes_by_annotation` — components declared by annotation
-  (`@WebFilter`, `@Controller`, custom security annotations).
-- `find_classes_by_supertype` — components declared by inheritance,
-  which is the Spring Boot default. Servlet filters extend
-  `OncePerRequestFilter` (`org.springframework.web.filter.OncePerRequestFilter`)
-  / implement `jakarta.servlet.Filter`; interceptors implement
-  `HandlerInterceptor` (`org.springframework.web.servlet.HandlerInterceptor`);
-  argument resolvers implement
-  `HandlerMethodArgumentResolver`
-  (`org.springframework.web.method.support.HandlerMethodArgumentResolver`);
-  response advisors implement `ResponseBodyAdvice`
-  (`org.springframework.web.bind.annotation.RestControllerAdvice` is the
-  annotation, but the contract lives on
-  `org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice`).
-Both can return empty, so probe the annotation AND the supertype before
-concluding "none found".
+The full detection recipes live in catalog files (one per family). In a
+plain-chat turn, the available ids are listed at conversation start —
+fetch the full recipe with `get_detection_prompt(id=...)` when the
+user's request touches that family. Examples: `spring-filters-interceptors`,
+`spring-response-body-advice`, `spring-argument-resolvers`,
+`spring-controller-advice`, `jaxrs-filters`, `custom-framework`,
+`auth-token-chaining`, `static-auth`, `correlation-idempotency`,
+`hmac-signing`.
 
-**Batch mode:** `find_classes_by_annotation`,
-`find_classes_by_supertype`, `find_classes_by_name`, `get_psi_class_info`,
-and `get_existing_rules_for_key` all accept an array parameter
-(`annotationFqns`, `supertypeFqns`, `names`, `fqns`, `keys`) in
-addition to the single-string form. **Prefer the array form** when you
-need to probe multiple items — it costs one request instead of N.
+Similarly, per-key rule recipes live in catalog files (one per rule
+key). When `list_rule_keys` returns a `detailPromptId` for a key,
+fetch the full recipe with `get_rule_detail(key=...)` before proposing
+a rule for that key — the recipe carries CRITICAL correctness notes
+(e.g. `postman.test` vs `postman.prerequest` timing, script-context
+isolation, bundle integrity, no hardcoded secrets). Do NOT reproduce
+recipes from memory; always fetch.
 
-Confirm a hit with `get_psi_class_info`, then ask: *does it change the
-request/response contract invisibly?* If yes, apply the catalog recipe.
-If no, no rule is needed.
-
-## Workflow-pattern detection
-
-Workflow patterns are **cross-endpoint** recipes — unlike the single-endpoint
-custom-pattern catalog above, they bundle rules across multiple controllers
-(login + secured, signer + signed). When the user's request touches auth,
-signing, correlation, or auto-refresh, probe for these five groups:
-
-- **Auth token chaining** — a login/token endpoint whose response carries a
-  token, plus secured controllers needing a `Bearer` header.
-- **Static auth (API key / Basic)** — a filter/annotation reading
-  `X-API-Key` / `Authorization: Basic`.
-- **Per-request injection** — `X-Request-Id`, `X-Correlation-Id`,
-  `Idempotency-Key` headers.
-- **Request signing (HMAC)** — `javax.crypto.Mac` / `HmacSHA256` in a
-  filter, `appSecret` / `appKey` config.
-- **401-refresh** — a `/refresh` / `/token/refresh` endpoint, or a user
-  asking for auto-refresh.
-
-**Fetch the full recipe on demand** via `get_plugin_doc` with
-`name="rule-guide"` (the "Workflow Patterns" section). Do NOT reproduce the
-table from memory — the canonical doc carries detection signals, complete
-`key[filter]=value` lines, and env-var-reuse notes.
+For the long-form reference (full "Workflow Patterns" section, full
+"Multi-Application Namespace" section, full filter-prefix table), use
+`get_plugin_doc name="rule-guide"`. The detection/rule-detail prompts
+are the preferred first stop; `rule-guide` is the long-form reference.
 
 ### Multi-app namespacing
 
 When multiple apps (Modules with API-bearing PSI — see the ambient `modules:`
 hint or `list_project_endpoints`) share a workspace, namespace every per-app
 env var by a resolved key so exports don't collide. The ambient
-`frameworks active:` hint shows which web frameworks are present so you can
-pre-fetch framework-specific recipes without inferring from endpoints.
+`frameworks active:` and `enabled channels:` hints show which features are
+present so you can pre-fetch framework/channel-specific recipes without
+inferring from endpoints.
 
 - **Cluster modules into apps**: when the ambient `modules:` hint shows N > 1,
   call `get_module_dependency_graph` and cluster the API-bearing modules into
@@ -184,84 +206,6 @@ pre-fetch framework-specific recipes without inferring from endpoints.
   user-clarified) and key in the proposal summary.
 - **Fetch the full recipe** via `get_plugin_doc name="rule-guide"` (the
   "Multi-Application Namespace" section) — don't reproduce it from memory.
-
-### Workflow correctness rules (CRITICAL — follow exactly)
-
-1. **Bundle integrity.** Workflow rules that form a chain (login-script +
-   consumer-header, signer + signed-consumer) MUST be proposed together in
-   a single `propose_rule_content` call. Proposing half a chain is
-   forbidden — a consumer header that references a token no script stores
-   is a silent bug.
-
-2. **`postman.test` vs `postman.prerequest` (#1 mistake).** `postman.test`
-   fires AFTER the response (read `pm.response`, `pm.environment.set` a
-   token). `postman.prerequest` fires BEFORE the request (inject headers,
-   compute signatures, mutate `pm.request`). Swapping them is the most
-   common workflow-rule error: a token extracted in `prerequest` reads the
-   PREVIOUS response (or none); a header injected in `test` lands after
-   the request has gone out.
-
-3. **No hardcoded secrets.** Every credential in a workflow rule is an
-   env-var reference (`${Authorization}`, `${appSecret}`, `${apiKey}`).
-   Never emit a literal token, key, or password in rule content.
-
-4. **Script-context isolation (CRITICAL — silent-failure trap).**
-   `postman.test`/`postman.prerequest` rule values MUST be **literal
-   scripts** (NO `groovy:` prefix). A `groovy:` prefix routes the value to
-   `Jsr223ScriptParser` at export time, where `pm` is NOT bound — the script
-   throws and the failure is **silently swallowed**, so no script lands in
-   the Postman collection. Conversely, `http.call.before`/`http.call.after`
-   rule values MUST use the `groovy:` prefix (they run in `Jsr223ScriptParser`,
-   where `pm` is NOT available — use `session.set(...)`/`localStorage.set(...)`
-   for storage, NEVER `pm.environment.set(...)`).
-
-### Perceive → reason → act for workflows
-
-- **Perceive.** `list_project_endpoints` to find login/token/refresh
-  endpoints; `find_classes_by_annotation` / `find_classes_by_supertype`
-  for auth filters/interceptors; `get_psi_method_info` on the producer to
-  confirm the token field name; `get_existing_rules_for_key` for
-  `method.additional.header`, `postman.test`, `postman.prerequest`,
-  `http.call.after` to avoid duplicates. Prefer the array form to batch.
-  `get_psi_class_info` and `get_psi_method_info` now return `typeFqn`
-  (and `returnTypeFqn` on methods) on every typed reference — chain a
-  returned `typeFqn` straight into `get_psi_class_info` without a
-  separate `find_classes_by_name` call. `get_psi_method_info` also
-  accepts `detail="full"` to expose the method `body` (e.g. read a
-  filter's `shouldNotFilter` scope logic); the default
-  `detail="signature"` is the cheap contract-only path — opt into
-  `"full"` only when you need to read the implementation.
-- **Reason.** Confirm the producer/consumer split. If the token field is
-  ambiguous (multiple `*token*` keys) or the consumer scope is unclear,
-  call `ask_clarification` with concrete options — do not guess. Reuse an
-  existing env-var name when one is already referenced in the project's
-  rules — resolve it from the rule files (e.g. grep `${...}` out of the
-  existing `method.additional.header` values returned by
-  `get_existing_rules_for_key`), not from the Environments panel. Default
-  to `Authorization` when no existing rule references a token env var.
-- **Act.** Propose the full bundle in one `propose_rule_content` call
-  (filename like `auth-chaining.properties`). Never propose half a bundle.
-
-## Markdown language template
-
-When the ambient `user language` is non-English AND no
-`markdown.template.language` rule is already in effect AND the user's
-request touches Markdown export or asks for localized docs, propose
-`markdown.template.language=<tag>` (a single-line rule). Check
-`get_existing_rules_for_key` first to avoid duplicates, and follow the
-standard rule-quality rules below (one proposal, no silent writes).
-
-- Do **not** author a full custom template when a bundled template
-  covers the locale — `zh-CN` ships bundled; `en` (or unset) uses the
-  default English template and needs no rule. A bundled template is
-  always preferred over a hand-authored one because it tracks
-  structural changes to the default.
-- If no bundled template exists for the locale, tell the user, fall
-  back to English for this export, and suggest the "Copy default
-  template" affordance in the Markdown export panel so they can author
-  a localized copy as a starting point.
-- This proposal flows through `propose_rule_content` like any other
-  rule — the user reviews and saves. Never write the rule silently.
 
 ## Writing rules — quality rules (CRITICAL — follow exactly)
 
@@ -319,21 +263,7 @@ Rules of thumb:
 - The script must `return` the value (string) or `return null` to skip.
 - Keep the script readable: use local variables, one condition per line.
 
-### 3. Never generate blanket field-ignore rules
-
-Do NOT generate `field.ignore` rules based on field-name patterns
-like `.*password.*`, `.*secret.*`, `.*token.*`. These fields are
-often a **legitimate part of the API definition** — a login endpoint
-requires `password`, an OAuth endpoint requires `clientSecret`, a
-token-refresh endpoint requires `refreshToken`. Stripping them
-silently breaks the exported documentation.
-
-Sensitive-field handling is a **project policy** decision, not a
-code-detection decision. If the user explicitly asks for it, you may
-add it — but never invent it on your own, and always warn the user
-that it may hide fields that some endpoints legitimately require.
-
-### 4. Don't re-declare framework defaults
+### 3. Don't re-declare framework defaults
 
 Standard Spring MVC / WebFlux / JAX-RS / Feign endpoints need no
 rules — the plugin detects them out of the box. `@Deprecated` status,

--- a/src/main/resources/ai/catalog-manifest.txt
+++ b/src/main/resources/ai/catalog-manifest.txt
@@ -1,0 +1,17 @@
+ai/detection/custom-framework.md
+ai/detection/spring-filters-interceptors.md
+ai/detection/spring-argument-resolvers.md
+ai/detection/spring-response-body-advice.md
+ai/detection/spring-controller-advice.md
+ai/detection/jaxrs-filters.md
+ai/detection/auth-token-chaining.md
+ai/detection/static-auth.md
+ai/detection/correlation-idempotency.md
+ai/detection/hmac-signing.md
+ai/rules/postman.test.md
+ai/rules/postman.prerequest.md
+ai/rules/method.additional.header.md
+ai/rules/method.additional.response.header.md
+ai/rules/json.additional.field.md
+ai/rules/markdown.template.md
+ai/rules/field.ignore.md

--- a/src/main/resources/ai/detection/auth-token-chaining.md
+++ b/src/main/resources/ai/detection/auth-token-chaining.md
@@ -1,0 +1,101 @@
+---
+id: auth-token-chaining
+title: Auth token chaining (login producer + secured consumer)
+cue: a login/token endpoint whose response carries a token, plus secured controllers needing a Bearer header
+---
+
+A login/token endpoint whose response carries a token, plus secured
+controllers needing a `Bearer` (or custom) header. The producer/consumer
+split is the key insight — a script attached to the login endpoint stores
+the token, and a header attached to the secured endpoints reads it. This
+is the most common auth workflow pattern; it spans both the request side
+(header injection on secured endpoints) and the response side (token
+extraction from the login response).
+
+## Detection signals
+
+- A **producer endpoint**: a login/token/refresh endpoint whose response
+  body carries a token field. Look for method names like `login`,
+  `authenticate`, `token`, `refresh`, `oauth`, `accessToken`; or paths
+  like `/login`, `/auth`, `/oauth/token`, `/api/token`.
+- A **consumer scope**: secured controllers distinguished by:
+  - A security annotation (`@PreAuthorize`, `@Secured`, `@RolesAllowed`,
+    custom `@RequiresAuth`), OR
+  - A security filter/interceptor reading `Authorization` headers, OR
+  - A Spring Security configuration (`@EnableWebSecurity`,
+    `@EnableResourceServer`, `SecurityFilterChain` bean) that protects
+    URL patterns.
+- The consumer side needs a `Bearer ${token}` (or custom) header; the
+  producer side needs a script that extracts the token from the response
+  and stores it for subsequent requests.
+
+## Discovery
+
+- `list_project_endpoints` to find login/token/refresh endpoints; filter
+  by path/name patterns.
+- `find_classes_by_annotation` for security annotations
+  (`@PreAuthorize`, `@Secured`, `@RolesAllowed`, `@RequiresApiToken`,
+  custom auth annotations).
+- `find_classes_by_supertype` for auth filters/interceptors (see the
+  `spring-filters-interceptors` / `jaxrs-filters` detections for the
+  supertype lists).
+- `get_psi_method_info` on the producer to confirm the token field name
+  in the response body.
+
+## Perceive → reason → act
+
+- **Perceive.** Run the discovery tools above. For the producer,
+  `get_psi_method_info` with `detail="full"` to read the response shape
+  and identify the token field name (commonly `token`, `accessToken`,
+  `access_token`, `idToken`). For the consumer scope, identify the
+  annotation or filter that marks secured endpoints.
+  `get_existing_rules_for_key` for `method.additional.header`,
+  `postman.test`, `postman.prerequest`, `http.call.after` to avoid
+  duplicates.
+- **Reason.** Confirm the producer/consumer split. If the token field is
+  ambiguous (multiple `*token*` keys) or the consumer scope is unclear,
+  call `ask_clarification` with concrete options — do not guess. Reuse
+  an existing env-var name when one is already referenced in the
+  project's rules — resolve it from the rule files (e.g. grep `${...}`
+  out of the existing `method.additional.header` values returned by
+  `get_existing_rules_for_key`), not from the Environments panel.
+  Default to `Authorization` when no existing rule references a token
+  env var.
+- **Act.** Propose the full bundle in one `propose_rule_content` call
+  (filename like `auth-chaining.properties`):
+  - **Producer side** (when Postman is enabled): a `postman.test` rule
+    scoped to the login endpoint that extracts the token from the
+    response and stores it via `pm.environment.set("token",
+    pm.response.json().accessToken)`.
+  - **Consumer side**: a `method.additional.header` rule scoped to the
+    secured endpoints that injects `Authorization: Bearer ${token}`.
+  Never propose half a bundle.
+
+## Bundle integrity (CRITICAL)
+
+Workflow rules that form a chain (login-script + consumer-header) MUST be
+proposed together in a single `propose_rule_content` call. Proposing half
+a chain is forbidden — a consumer header that references a token no
+script stores is a silent bug.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${Authorization}`, `${appSecret}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Script-context isolation (CRITICAL)
+
+`postman.prerequest` and `postman.test` rule values MUST be **literal
+scripts** (NO `groovy:` prefix). A `groovy:` prefix routes the value to
+`Jsr223ScriptParser` at export time, where `pm` is NOT bound — the script
+throws and the failure is silently swallowed, so no script lands in the
+Postman collection.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Auth token chaining"
+section). Do NOT reproduce the table from memory — the canonical doc
+carries detection signals, complete `key[filter]=value` lines, and
+env-var-reuse notes.

--- a/src/main/resources/ai/detection/correlation-idempotency.md
+++ b/src/main/resources/ai/detection/correlation-idempotency.md
@@ -1,0 +1,59 @@
+---
+id: correlation-idempotency
+title: Correlation & idempotency headers
+cue: X-Request-Id, X-Correlation-Id, Idempotency-Key headers injected per request
+---
+
+Per-request injection of correlation / idempotency headers —
+`X-Request-Id`, `X-Correlation-Id`, `Idempotency-Key`. A filter or
+interceptor generates the value (UUID, counter) and adds it to the
+outgoing request; the export must surface the header so the consumer
+knows the contract.
+
+## Detection signals
+
+- A filter / interceptor / web filter that sets `X-Request-Id`,
+  `X-Correlation-Id`, `Idempotency-Key`, `X-Trace-Id`, or similar
+  correlation/tracing headers on the request or response.
+- A custom annotation (`@Correlated`, `@Idempotent`) marking endpoints
+  that require the header.
+- Constants/fields named `REQUEST_ID_HEADER`, `CORRELATION_ID_HEADER`,
+  `IDEMPOTENCY_KEY_HEADER` — strong signal of a per-request injection.
+
+## Discovery
+
+- `find_classes_by_supertype` for filters / interceptors extending
+  `OncePerRequestFilter` / implementing `HandlerInterceptor` (Spring) or
+  `ContainerRequestFilter` / `ContainerResponseFilter` (JAX-RS). See the
+  `spring-filters-interceptors` / `jaxrs-filters` detections for the full
+  supertype lists.
+- `find_classes_by_annotation` for `@WebFilter` and any custom correlation
+  / idempotency annotations.
+- `get_psi_method_info` with `detail="full"` on the filter to read the
+  header name being set and the value source (UUID? counter? request
+  attribute?).
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools. For each hit, `get_psi_method_info`
+  with `detail="full"` on the filtering method to read the header name(s)
+  and value source. `get_existing_rules_for_key` for
+  `method.additional.header` and `method.additional.response.header` to
+  avoid duplicates.
+- **Reason.** Confirm the header name(s). If multiple correlation headers
+  are present (e.g. both `X-Request-Id` and `X-Correlation-Id`), bundle
+  them in one proposal. Reuse an existing env-var name when one is already
+  referenced in the project's rules; otherwise the value is typically a
+  literal or a script reference (`groovy: UUID.randomUUID().toString()`).
+  For idempotency headers, the consumer typically generates the value
+  client-side, so the rule's `value` is a script reference, not a literal.
+- **Act.** Propose the `method.additional.header` rule(s) in one
+  `propose_rule_content` call (filename like `correlation.rules`). If the
+  filter also injects the header into the response (echo-back for tracing),
+  bundle a `method.additional.response.header` rule in the same call.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Per-request injection"
+section). Do NOT reproduce the table from memory.

--- a/src/main/resources/ai/detection/custom-framework.md
+++ b/src/main/resources/ai/detection/custom-framework.md
@@ -1,0 +1,81 @@
+---
+id: custom-framework
+title: Custom framework (proprietary API annotations)
+cue: project uses its own annotations (not Spring/JAX-RS/Feign/gRPC) to mark API classes and methods
+---
+
+EasyApi understands standard HTTP frameworks (Spring MVC, WebFlux, JAX-RS,
+Feign, gRPC) out of the box — those need no rules. When a project uses
+**proprietary annotations** to mark API classes/methods (e.g. `@MyApi`,
+`@MyEndpoint`, `@RpcService`), the standard recognizers will not find them
+and no endpoints will be exported. The Custom framework + a `custom.*` rule
+set is the escape hatch.
+
+## Detection signals
+
+- Endpoints exist in the project (the user has controllers/services) but
+  `list_project_endpoints` returns empty or far fewer than expected.
+- Classes annotated with project-specific annotations whose names suggest
+  API exposure (`@Api`, `@Endpoint`, `@Rpc`, `@RestApi`, `@Controller`-like
+  but not the Spring/JAX-RS FQNs).
+- Methods annotated with project-specific HTTP-verb-like annotations
+  (`@Get`, `@Post`, `@RequestMapping`-like but not the standard FQN).
+
+## Discovery
+
+`find_classes_by_annotation` is the primary tool. Probe candidate annotation
+FQNs mentioned by the user; if none, scan for short annotation names that
+look API-related (`Api`, `Endpoint`, `Rpc`, `Rest`) and confirm with
+`get_psi_class_info`. The Custom framework recognizer
+(`frameworkName = "Custom"`) is **disabled by default** — it only fires
+after the user enables it in settings AND a `custom.class.is.api` rule
+recognizes the class.
+
+## Perceive → reason → act
+
+- **Perceive.** `find_classes_by_annotation` for the proprietary annotation
+  FQN(s); `get_psi_class_info` on a sample class to read its methods and
+  method-level annotations; `get_psi_method_info` with `detail="full"` on
+  a sample method to read parameters and return type; `get_existing_rules_for_key`
+  for `custom.class.is.api`, `custom.method.is.api`, `custom.http.method`,
+  `custom.path` to avoid duplicates.
+- **Reason.** Identify the class-level annotation that marks an API class
+  and the method-level annotation that marks an API method. For methods,
+  determine the HTTP verb (from the annotation name or attribute) and the
+  path (from an attribute or convention). For parameters, determine the
+  binding (body / form / path / header / cookie) — if the project uses
+  standard Spring/JAX-RS binding annotations on parameters of the custom
+  controller, reuse them; otherwise default `param.http.type=query`.
+- **Act.** Propose the full `custom.*` rule bundle in ONE
+  `propose_rule_content` call (filename like `custom-framework.rules`).
+  A minimal bundle includes:
+  - `custom.class.is.api` — class recognition
+  - `custom.method.is.api` — method recognition
+  - `custom.http.method` — HTTP verb extraction
+  - `custom.path` — class base path + method path
+  - `method.default.http.method=GET` — fallback when verb cannot be resolved
+  - Parameter binding rules as needed (`custom.param.as.json.body`,
+    `custom.param.as.form.body`, `custom.param.as.path.var`,
+    `custom.param.as.cookie`, `param.http.type`)
+
+## Bundle integrity (CRITICAL)
+
+The `custom.*` rules form a coordinated set — a `custom.method.is.api`
+without a `custom.http.method` leaves the verb unresolved; a `custom.path`
+without `custom.class.is.api` never fires. Propose the full bundle in one
+`propose_rule_content` call. Never propose half a custom-framework set.
+
+## Reference
+
+The bundled test fixture `custom-spring-reference.rules` re-implements
+Spring MVC recognition entirely with `custom.*` rules — it is both a
+learning aid and the completeness proof. Fetch it via `get_plugin_doc` with
+`name="rule-guide"` (the "Custom Framework" section) for the canonical
+recipe. Do NOT reproduce the table from memory.
+
+## Confirm the gap first
+
+Before proposing, confirm the project is NOT already covered by a standard
+framework — Spring MVC / WebFlux / JAX-RS / Feign / gRPC endpoints with
+standard annotations are detected automatically. Only write `custom.*`
+rules for annotations the standard recognizers do not handle.

--- a/src/main/resources/ai/detection/hmac-signing.md
+++ b/src/main/resources/ai/detection/hmac-signing.md
@@ -1,0 +1,81 @@
+---
+id: hmac-signing
+title: HMAC request signing
+cue: javax.crypto.Mac / HmacSHA256 in a filter, appSecret / appKey config
+---
+
+`javax.crypto.Mac` / `HmacSHA256` in a filter or interceptor, plus
+`appSecret` / `appKey` configuration. The signer computes a signature
+over the request (method, path, body, timestamp) and adds it as a header;
+the consumer side must replicate the signature exactly. This is the most
+contract-sensitive workflow pattern — a byte-wrong signature silently
+rejects every request.
+
+## Detection signals
+
+- `javax.crypto.Mac` / `HmacSHA256` / `HmacSHA1` / `HmacMD5` referenced
+  in a filter or interceptor class.
+- `appSecret` / `appKey` / `secretKey` / `accessKey` configuration fields
+  read in a filter.
+- A signature header name like `X-Signature`, `X-Sign`, `Signature`,
+  `X-HMAC-Signature` set on the request.
+- A canonical-string construction method (building a string from method,
+  path, body, timestamp before signing).
+
+## Discovery
+
+- `find_classes_by_supertype` for filters / interceptors (see the
+  `spring-filters-interceptors` / `jaxrs-filters` detections for the
+  supertype lists).
+- `get_psi_method_info` with `detail="full"` on the signer's signing
+  method to read the canonical-string construction (header order matters);
+  `get_psi_class_info` to find the secret fields (`appSecret`, `appKey`).
+- `get_existing_rules_for_key` for `method.additional.header` and
+  `postman.prerequest` to avoid duplicates.
+
+## Perceive → reason → act
+
+- **Perceive.** Run the discovery tools above. For each hit, read the
+  signing method body via `get_psi_method_info` with `detail="full"` to
+  extract:
+  - The signature header name (e.g. `X-Signature`).
+  - The canonical-string inputs (method? path? body? timestamp? nonce?).
+  - The canonical-string order (header order matters byte-for-byte).
+  - The hash algorithm (`HmacSHA256`, `HmacSHA1`, etc.).
+  - The encoding of the signature (hex? base64?).
+  - The secret field names (`appSecret`, `appKey`).
+- **Reason.** Identify the signature header name and the canonical-string
+  inputs. The Postman pre-request script must replicate the canonical
+  string byte-for-byte (watch for trailing newlines, header casing,
+  URL encoding). Confirm the env-var names for the secrets — reuse
+  existing names where present; otherwise default to `${appSecret}` /
+  `${appKey}`.
+- **Act.** Propose the bundle (signer pre-request script + consumer
+  header) in one `propose_rule_content` call (filename like
+  `hmac-signing.rules`). Bundle integrity applies — a consumer header
+  referencing a signature no script computes is a silent bug.
+
+## Bundle integrity (CRITICAL)
+
+Signer + signed-consumer rules MUST be proposed together in a single
+`propose_rule_content` call. Proposing half a chain is forbidden.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${appSecret}`, `${appKey}`). Never emit a literal secret in rule
+content.
+
+## Script-context isolation (CRITICAL)
+
+`postman.prerequest` rule values MUST be **literal scripts** (NO
+`groovy:` prefix). A `groovy:` prefix routes the value to
+`Jsr223ScriptParser` at export time, where `pm` is NOT bound — the
+script throws and the failure is silently swallowed, so no script
+lands in the Postman collection.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Request signing"
+section). Do NOT reproduce the table from memory.

--- a/src/main/resources/ai/detection/jaxrs-filters.md
+++ b/src/main/resources/ai/detection/jaxrs-filters.md
@@ -1,0 +1,85 @@
+---
+id: jaxrs-filters
+title: JAX-RS ContainerRequestFilter / ContainerResponseFilter
+cue: ContainerRequestFilter or ContainerResponseFilter implementations that mutate headers invisibly
+framework: jaxrs
+---
+
+EasyApi understands JAX-RS's standard annotations (`@Path`, `@GET`,
+`@QueryParam`, `@PathParam`, `@HeaderParam`, `@FormParam`, `@BeanParam`)
+out of the box. But `ContainerRequestFilter` and `ContainerResponseFilter`
+implementations mutate the request/response contract **invisibly** (auth,
+signing, header injection) — the contract is not visible from the resource
+method signature. Without a rule, the exported documentation will be
+missing those headers.
+
+## Detection signals
+
+Classes implementing:
+- `javax.ws.rs.container.ContainerRequestFilter` /
+  `jakarta.ws.rs.container.ContainerRequestFilter` — runs before the
+  resource method; can mutate request headers, abort with a response, etc.
+- `javax.ws.rs.container.ContainerResponseFilter` /
+  `jakarta.ws.rs.container.ContainerResponseFilter` — runs after the
+  resource method; can mutate response headers.
+
+The filter may be:
+- **Global** (annotated `@Provider`) — applies to all resources.
+- **Name-bound** (annotated with a custom `@NameBinding` meta-annotation) —
+  applies only to resources/methods annotated with the binding annotation.
+
+The mutation to look for: `requestContext.getHeaders().add(...)`,
+`requestContext.getHeaders().putSingle(...)`,
+`responseContext.getHeaders().add(...)`. Not every filter mutates the
+contract — a CORS filter adding `Access-Control-Allow-*` headers may not
+need a rule if those headers are purely informational.
+
+## Supertype to probe
+
+Search via `find_classes_by_supertype` for:
+- `javax.ws.rs.container.ContainerRequestFilter`
+- `jakarta.ws.rs.container.ContainerRequestFilter`
+- `javax.ws.rs.container.ContainerResponseFilter`
+- `jakarta.ws.rs.container.ContainerResponseFilter`
+
+Also `find_classes_by_annotation` for `@Provider`
+(`javax.ws.rs.ext.Provider` / `jakarta.ws.rs.ext.Provider`) and any custom
+`@NameBinding` annotations — name-bound filters only apply to
+resources/methods carrying the binding annotation, so the rule's filter
+must scope to those resources.
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools (above). For each hit, call
+  `get_psi_method_info` with `detail="full"` on the `filter` method to read
+  which headers are added/put. Determine the binding scope:
+  - `@Provider` (no `@NameBinding`) → global → rule applies to all endpoints.
+  - `@NameBinding`-annotated → name-bound → rule applies only to endpoints
+    whose resource class or method carries the binding annotation; use a
+    `groovy:` filter on the `method.additional.header` rule that checks
+    `it.hasAnn("com.example.MyBinding")`.
+  - `get_existing_rules_for_key` for `method.additional.header` and
+    `method.additional.response.header` to avoid duplicates.
+- **Reason.** For each mutation, decide the rule:
+  - Request header set on every request → `method.additional.header`
+    (filtered to the bound resources if name-bound).
+  - Response header set on every response →
+    `method.additional.response.header` (filtered similarly).
+  - Auth filter that aborts with 401 on missing credentials →
+    `method.additional.header` for the credential header; defer to the
+    `static-auth` or `auth-token-chaining` recipe for the auth side.
+- **Act.** Propose the `method.additional.header` /
+  `method.additional.response.header` rule(s) in one
+  `propose_rule_content` call (filename like `jaxrs-filters.rules`).
+
+## Bundle integrity
+
+If a name-bound filter and its binding annotation are both needed, propose
+them together — a rule referencing a binding annotation that no filter
+applies is dead code.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "JAX-RS Patterns" → "Filters" section). Do NOT
+reproduce the table from memory.

--- a/src/main/resources/ai/detection/spring-argument-resolvers.md
+++ b/src/main/resources/ai/detection/spring-argument-resolvers.md
@@ -1,0 +1,76 @@
+---
+id: spring-argument-resolvers
+title: Spring handler method argument resolvers
+cue: HandlerMethodArgumentResolver implementations that inject hidden params (principal, request context, current user)
+framework: springmvc
+---
+
+EasyApi understands Spring MVC's standard parameter annotations
+(`@RequestParam`, `@PathVariable`, `@RequestBody`, `@RequestHeader`,
+`@CookieValue`, `@ModelAttribute`) out of the box. But
+`HandlerMethodArgumentResolver` implementations inject method parameters
+that the plugin cannot see from the method signature alone — the resolver
+reads the request (principal, header, cookie, session) and supplies the
+argument. Without a rule, the exported documentation will be **missing
+those hidden parameters entirely**.
+
+## Detection signals
+
+Classes implementing `HandlerMethodArgumentResolver`
+(`org.springframework.web.method.support.HandlerMethodArgumentResolver`)
+or extending `HandlerMethodArgumentResolverSupport`. The resolver's
+`supportsParameter` method declares which parameter types it handles; the
+`resolveArgument` method reads the request and supplies the value.
+
+Common examples:
+- `@CurrentUser` → resolves `Principal`/`User` from the security context
+- `@RequestContext` → resolves the request/response/context object
+- `@TenantId` → resolves the tenant from a header or JWT claim
+- `@Pageable` → resolves pagination params (Spring Data's `Pageable` is
+  handled by `PageableHandlerMethodArgumentResolver` — this is **standard**,
+  no rule needed unless customized)
+
+## Supertype to probe
+
+Argument resolvers implement
+`org.springframework.web.method.support.HandlerMethodArgumentResolver`.
+
+Annotation-declared resolvers are rare — the supertype probe is the
+primary path. Search via `find_classes_by_supertype` for the interface FQN
+above.
+
+## Perceive → reason → act
+
+- **Perceive.** `find_classes_by_supertype` for
+  `org.springframework.web.method.support.HandlerMethodArgumentResolver`.
+  For each hit, `get_psi_method_info` with `detail="full"` on
+  `supportsParameter` to read which parameter types are supported, and on
+  `resolveArgument` to read how the value is sourced (header? cookie?
+  principal? session?). Then `find_classes_by_annotation` for the custom
+  annotation the resolver supports (e.g. `@CurrentUser`) to find the
+  controllers consuming it. `get_existing_rules_for_key` for
+  `method.additional.param` and `param.ignore` to avoid duplicates.
+- **Reason.** For each resolver, identify:
+  - The parameter name (from the annotation value or the parameter name).
+  - The parameter type (from `supportsParameter`).
+  - The source (request header? cookie? principal? session?).
+  - Whether the parameter should be **documented** (`method.additional.param`)
+    or **hidden** (`param.ignore`). Hidden parameters are those that are
+    framework-internal (e.g. `HttpServletRequest`, `Principal`) — the
+    consumer doesn't supply them. Documented parameters are those the
+    consumer must supply (e.g. a tenant header extracted by the resolver).
+- **Act.** Propose the `method.additional.param` rule(s) for documented
+  hidden params, or `param.ignore` rules for framework-internal params, in
+  one `propose_rule_content` call (filename like `argument-resolvers.rules`).
+
+## Bundle integrity
+
+If a resolver supports multiple parameter types, propose one rule per type
+in the same call. Do not propose a `method.additional.param` for a
+parameter that should be `param.ignore`d — the two are mutually exclusive.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Argument resolvers" section).
+Do NOT reproduce the table from memory.

--- a/src/main/resources/ai/detection/spring-controller-advice.md
+++ b/src/main/resources/ai/detection/spring-controller-advice.md
@@ -1,0 +1,81 @@
+---
+id: spring-controller-advice
+title: Spring @RestControllerAdvice exception handlers
+cue: "@RestControllerAdvice with @ExceptionHandler methods that change the error response shape for secured endpoints"
+framework: springmvc
+---
+
+EasyApi documents the success response (2xx) from a controller's return type
+out of the box. But `@RestControllerAdvice` classes with `@ExceptionHandler`
+methods define the **error response shape** (4xx, 5xx) that the plugin
+cannot associate with the controllers that throw those exceptions. Without
+a rule, the exported documentation will miss the error response contract.
+
+## Detection signals
+
+- Classes annotated `@RestControllerAdvice`
+  (`org.springframework.web.bind.annotation.RestControllerAdvice`) or
+  `@ControllerAdvice`
+  (`org.springframework.web.bind.annotation.ControllerAdvice`).
+- Methods annotated `@ExceptionHandler`
+  (`org.springframework.web.bind.annotation.ExceptionHandler`) within those
+  classes. The annotation's `value` attribute names the exception type(s)
+  handled; the method's return type is the error response shape.
+
+The error response is typically an envelope like `ErrorResponse`,
+`ApiError`, `Result<Void>`, or a `ResponseEntity<ErrorDetail>` carrying
+fields like `code`, `message`, `timestamp`, `path`.
+
+## Supertype / annotation to probe
+
+- `find_classes_by_annotation` for:
+  - `org.springframework.web.bind.annotation.RestControllerAdvice`
+  - `org.springframework.web.bind.annotation.ControllerAdvice`
+- For each hit, `get_psi_class_info` to enumerate the `@ExceptionHandler`
+  methods and their return types.
+
+Note: a class can be both `@RestControllerAdvice` AND implement
+`ResponseBodyAdvice` — the `ResponseBodyAdvice` interface is the body
+wrapper case (see the `spring-response-body-advice` detection). This
+detection is specifically about `@ExceptionHandler` methods.
+
+## Perceive → reason → act
+
+- **Perceive.** `find_classes_by_annotation` for the advice annotations
+  above. For each hit, `get_psi_class_info` to list the
+  `@ExceptionHandler` methods; `get_psi_method_info` with `detail="full"`
+  on each handler to read the exception type handled, the HTTP status
+  returned (from `@ResponseStatus` or `ResponseEntity`), and the error
+  response shape. `find_classes_by_supertype` for the exception types to
+  find the controllers that throw them. `get_existing_rules_for_key` for
+  `method.additional.response.header` and `method.doc` to avoid duplicates.
+- **Reason.** For each handler, identify:
+  - The exception type (from `@ExceptionHandler(MyException.class)`).
+  - The HTTP status (from `@ResponseStatus(code=...)` or the
+    `ResponseEntity` status).
+  - The error response shape (the handler's return type).
+  - The controllers that throw this exception (via
+    `find_classes_by_supertype` for the exception type, then scanning
+    their methods for `throw new MyException(...)`).
+- **Act.** The error response contract is documented by annotating the
+  affected endpoints. Propose:
+  - `method.doc[@ann]` rules that append the error response shape to the
+    method documentation of affected endpoints (filter by the throwing
+    annotation or the controller class), OR
+  - `method.additional.response.header` rules if the handler also sets
+    response headers (e.g. `WWW-Authenticate` on 401).
+  Bundle the rules in one `propose_rule_content` call (filename like
+  `error-responses.rules`).
+
+## Bundle integrity
+
+If the same `@RestControllerAdvice` handles multiple exceptions, propose
+one rule per exception→endpoint mapping in the same call. Do not propose
+half a mapping — an error response documented without the triggering
+condition is noise.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Exception handlers" section).
+Do NOT reproduce the table from memory.

--- a/src/main/resources/ai/detection/spring-filters-interceptors.md
+++ b/src/main/resources/ai/detection/spring-filters-interceptors.md
@@ -1,0 +1,87 @@
+---
+id: spring-filters-interceptors
+title: Spring filters, interceptors, web filters
+cue: classes extending OncePerRequestFilter / HandlerInterceptor / WebFilter that mutate request or response headers
+framework: springmvc
+---
+
+EasyApi understands Spring MVC's standard request flow out of the box —
+`@RequestMapping`, `@GetMapping`, `@RequestBody`, `@PathVariable`, etc. need
+no rules. But servlet filters / interceptors / web filters that mutate the
+request or response contract **invisibly** (auth, signing, header injection,
+response wrapping) are not visible from the controller signature. Without a
+rule, the exported documentation will be missing those headers.
+
+## Detection signals
+
+Components declared by inheritance (the Spring Boot default) or by
+annotation that mutate the request/response contract:
+
+- **Servlet filters** extending `OncePerRequestFilter`
+  (`org.springframework.web.filter.OncePerRequestFilter`) or implementing
+  `jakarta.servlet.Filter` / `javax.servlet.Filter`.
+- **Interceptors** implementing `HandlerInterceptor`
+  (`org.springframework.web.servlet.HandlerInterceptor`) or
+  `AsyncHandlerInterceptor`.
+- **Web filters** annotated `@WebFilter`
+  (`jakarta.servlet.annotation.WebFilter` /
+  `javax.servlet.annotation.WebFilter`).
+
+The mutation to look for: `request.setHeader(...)`,
+`request.addHeader(...)`, `response.setHeader(...)`,
+`exchange.getResponse().getHeaders().add(...)`. Not every filter/interceptor
+mutates the contract — `MappedInterceptor` for logging or metrics does not
+need a rule.
+
+## Discovery
+
+Probe BOTH declaration styles — the Spring Boot default is inheritance, but
+annotation-declared filters exist too. Either may be present.
+
+- `find_classes_by_supertype` for:
+  - `org.springframework.web.filter.OncePerRequestFilter`
+  - `org.springframework.web.servlet.HandlerInterceptor`
+  - `jakarta.servlet.Filter`
+  - `javax.servlet.Filter`
+- `find_classes_by_annotation` for:
+  - `jakarta.servlet.annotation.WebFilter`
+  - `javax.servlet.annotation.WebFilter`
+
+Both discovery tools can return empty — probe the annotation AND the
+supertype before concluding "none found".
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools (above). For each hit, call
+  `get_psi_method_info` with `detail="full"` on the filtering method
+  (`doFilterInternal`, `doFilter`, `preHandle`, `postHandle`) to read which
+  headers are set/added and on which side (request vs response).
+  `get_existing_rules_for_key` for `method.additional.header` and
+  `method.additional.response.header` to avoid duplicates.
+- **Reason.** For each mutation, decide the rule:
+  - Request header set on every request → `method.additional.header`
+    (filtered to the protected path via a `groovy:` filter if the filter
+    scopes to specific URLs).
+  - Response header set on every response → `method.additional.response.header`.
+  - Header value computed from a script (e.g. UUID, timestamp) →
+    `method.additional.header` with a `groovy:` value-block that returns
+    a JSON object whose `value` is the script expression.
+  - Header value computed from an HMAC/signature → defer to the
+    `hmac-signing` detection recipe (bundle signer + consumer together).
+- **Act.** Propose the `method.additional.header` / `method.additional.response.header`
+  rule(s) in one `propose_rule_content` call (filename like
+  `spring-filters.rules`). Bundle integrity applies — if the same filter
+  injects both a request and a response header, both rules go in the same
+  proposal.
+
+## Confirm the contract changed
+
+Confirm a hit with `get_psi_class_info` + `get_psi_method_info`, then ask:
+*does it change the request/response contract invisibly?* If yes, apply the
+catalog recipe. If no (logging, metrics, tracing-only), no rule is needed.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Filters & interceptors"
+section). Do NOT reproduce the table from memory.

--- a/src/main/resources/ai/detection/spring-response-body-advice.md
+++ b/src/main/resources/ai/detection/spring-response-body-advice.md
@@ -1,0 +1,77 @@
+---
+id: spring-response-body-advice
+title: Spring ResponseBodyAdvice (response envelope wrapping)
+cue: ResponseBodyAdvice implementations or @RestControllerAdvice that wrap responses in a standard envelope like {code, message, data}
+framework: springmvc
+---
+
+EasyApi understands Spring MVC's standard return type wrappers
+(`ResponseEntity<T>`, `Mono<T>`, `Flux<T>`, `Optional<T>`) out of the box —
+those are unwrapped automatically. But `ResponseBodyAdvice`
+implementations wrap the response body in a **standard envelope** (e.g.
+`{code, message, data}`) that the plugin cannot detect from the
+controller's return type alone. Without a rule, the exported documentation
+will show the raw controller return type and **miss the envelope**.
+
+## Detection signals
+
+Two declaration styles, both common — probe both:
+
+- **Interface implementation.** Classes implementing `ResponseBodyAdvice`
+  (`org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice`).
+  The `beforeBodyWrite` method is where the wrapping happens.
+- **Annotation declaration.** Classes annotated `@RestControllerAdvice`
+  (`org.springframework.web.bind.annotation.RestControllerAdvice`) that
+  also implement `ResponseBodyAdvice`. The `@RestControllerAdvice` alone
+  is for exception handlers (see the `spring-controller-advice` detection);
+  the `ResponseBodyAdvice` interface is what makes it a body wrapper.
+
+The wrapper typically wraps in a `Result<T>`, `ApiResponse<T>`, `R<T>`,
+`Response<T>`, or similar envelope with fields like `code`, `message`,
+`data`, `success`, `timestamp`.
+
+## Supertype / annotation to probe
+
+- `find_classes_by_supertype` for
+  `org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice`.
+- `find_classes_by_annotation` for
+  `org.springframework.web.bind.annotation.RestControllerAdvice`.
+
+Both can return empty — probe the annotation AND the supertype before
+concluding "none found". A class can be both `@RestControllerAdvice` AND
+implement `ResponseBodyAdvice` — that is the common combined form.
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools (above). For each hit, call
+  `get_psi_class_info` to read the envelope class (the type returned by
+  `beforeBodyWrite`); `get_psi_method_info` with `detail="full"` on
+  `beforeBodyWrite` to read the wrapping logic (which field holds the
+  payload? which field holds the status code? which field holds the
+  message?). `get_existing_rules_for_key` for `method.return.main` and
+  `json.rule.convert` to avoid duplicates.
+- **Reason.** Identify the envelope class FQN and the inner payload field
+  path. The rule is `method.return.main=<field path>` (e.g. `data` or
+  `result.data`). If the envelope is generic (`Result<T>`), also propose a
+  `json.rule.convert[#regex:com\.example\.Result<(.*?)>]=${1}` rule so the
+  exporter unwraps the generic — this avoids the envelope appearing as the
+  response type in the docs. Wrap the `json.rule.convert` lines in
+  `###set resolveProperty = false … true` so the `${1}` capture group is
+  not treated as a property placeholder.
+- **Act.** Propose the `method.return.main` + optional `json.rule.convert`
+  bundle in one `propose_rule_content` call (filename like
+  `response-envelope.rules`).
+
+## Bundle integrity
+
+The `method.return.main` rule and the `json.rule.convert` rule for the same
+envelope MUST be proposed together — the convert unwraps the generic type
+so the exporter sees the inner payload, and `method.return.main` tells the
+exporter which field of the unwrapped object is the actual response. Half
+a bundle produces confusing docs.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Spring Patterns" → "Response body advice"
+section). Do NOT reproduce the table from memory.

--- a/src/main/resources/ai/detection/static-auth.md
+++ b/src/main/resources/ai/detection/static-auth.md
@@ -1,0 +1,64 @@
+---
+id: static-auth
+title: Static auth (API key / Basic)
+cue: "a filter or annotation reading X-API-Key / Authorization: Basic — static credentials, no login round-trip"
+---
+
+A filter / interceptor / annotation reading `X-API-Key` or
+`Authorization: Basic` — static credentials supplied per request, with no
+login round-trip. Unlike auth-token-chaining, there is no producer
+endpoint; the credential is supplied by the caller out-of-band.
+
+## Detection signals
+
+- A filter / interceptor / annotation reading `X-API-Key` or
+  `Authorization: Basic` from the request.
+- A custom security annotation (`@RequiresApiToken`, `@ApiKey`, `@BasicAuth`)
+  marking secured endpoints.
+- A Spring Security configuration that protects URL patterns with API-key
+  or Basic auth (e.g. `http.httpBasic()` or a custom
+  `OncePerRequestFilter` reading `X-API-Key`).
+
+The credential is **static** (per-caller, supplied out-of-band) — there is
+no login endpoint that returns a token. This distinguishes static-auth
+from auth-token-chaining.
+
+## Discovery
+
+- `find_classes_by_annotation` for security annotations
+  (`@RequiresApiToken`, `@ApiKey`, `@BasicAuth`, custom security
+  annotations).
+- `find_classes_by_supertype` for filters extending `OncePerRequestFilter`
+  that read header values (see the `spring-filters-interceptors` detection
+  for the supertype list).
+- `get_psi_method_info` with `detail="full"` on the filter's
+  `shouldNotFilter` / `doFilterInternal` to confirm the scope (which paths
+  are excluded from auth).
+
+## Perceive → reason → act
+
+- **Perceive.** Run both discovery tools. For each hit, `get_psi_method_info`
+  with `detail="full"` on the filtering method to read which header name is
+  read and which paths are excluded. `get_existing_rules_for_key` for
+  `method.additional.header` to avoid duplicates.
+- **Reason.** Identify the credential env-var name. Reuse an existing
+  env-var name when one is already referenced in the project's rules;
+  otherwise default to `apiKey` (for `X-API-Key`) or `Authorization` (for
+  Basic). Confirm the filter's scope so the rule's filter matches exactly
+  the protected controllers — not too broad, not too narrow.
+- **Act.** Propose the `method.additional.header` rule(s) in one
+  `propose_rule_content` call (filename like `static-auth.rules`). Bundle
+  integrity applies: if the same filter also injects a response header
+  (e.g. `WWW-Authenticate` on 401), both rules go in the same proposal.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${apiKey}`, `${Authorization}`). Never emit a literal token, key, or
+password in rule content.
+
+## Fetch the full recipe
+
+Fetch the full recipe on demand via `get_plugin_doc` with
+`name="rule-guide"` (the "Workflow Patterns" → "Static auth" section). Do
+NOT reproduce the table from memory.

--- a/src/main/resources/ai/rules/field.ignore.md
+++ b/src/main/resources/ai/rules/field.ignore.md
@@ -1,0 +1,38 @@
+---
+id: field.ignore
+key: field.ignore
+title: Field ignore
+cue: boolean rule that strips a field from the exported model — never generate blanket patterns automatically
+---
+
+## CRITICAL — never generate blanket field-ignore rules
+
+Do NOT generate `field.ignore` rules based on field-name patterns
+like `.*password.*`, `.*secret.*`, `.*token.*`. These fields are
+often a **legitimate part of the API definition** — a login endpoint
+requires `password`, an OAuth endpoint requires `clientSecret`, a
+token-refresh endpoint requires `refreshToken`. Stripping them
+silently breaks the exported documentation.
+
+Sensitive-field handling is a **project policy** decision, not a
+code-detection decision. If the user explicitly asks for it, you may
+add it — but never invent it on your own, and always warn the user
+that it may hide fields that some endpoints legitimately require.
+
+## Filter examples
+
+When the user has explicitly asked to ignore a specific field on a
+specific class:
+
+```
+field.ignore[$class:com.example.dto.UserResponse]=password
+```
+
+Multiple fields on the same class means multiple lines (the key uses
+default merge semantics — boolean rules do not merge, so each line is
+its own rule).
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for `field.ignore`.
+If an equivalent rule already exists, do NOT write a duplicate.

--- a/src/main/resources/ai/rules/json.additional.field.md
+++ b/src/main/resources/ai/rules/json.additional.field.md
@@ -1,0 +1,51 @@
+---
+id: json.additional.field
+key: json.additional.field
+title: Additional JSON field
+cue: JSON object field injected into the serialized response (e.g. computed totals, envelope metadata)
+---
+
+## Value format
+
+The value is a single-line JSON object describing the additional field
+to inject into the serialized response:
+
+```json
+{"name":"totalAmount","value":"${total}","desc":"computed","type":"number"}
+```
+
+One object per line — multiple fields means multiple
+`json.additional.field=…` lines (the key uses `StringRuleMode.MERGE`).
+
+## Filter examples
+
+Filter the rule to a class:
+
+```
+json.additional.field[$class:com.example.dto.OrderResponse]={"name":"signature","value":"${sig}","desc":"HMAC","type":"string"}
+```
+
+Filter by annotation:
+
+```
+json.additional.field[@com.example.Signed]={"name":"signature","value":"${sig}","desc":"HMAC","type":"string"}
+```
+
+## Prefer groovy value-blocks for complex conditional logic
+
+When a filter expression grows long — multiple `&&`/`||`, multiple
+exclusions, or nested method calls — switch to the **groovy value-block**
+form (see the `method.additional.header` recipe for the full example).
+The script must `return` the value (string) or `return null` to skip.
+
+## No hardcoded secrets
+
+Every credential in a field value is an env-var reference
+(`${appSecret}`, `${apiKey}`). Never emit a literal token, key, or
+password in rule content.
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for
+`json.additional.field`. If an equivalent rule already exists, do NOT
+write a duplicate.

--- a/src/main/resources/ai/rules/markdown.template.md
+++ b/src/main/resources/ai/rules/markdown.template.md
@@ -1,0 +1,41 @@
+---
+id: markdown.template
+key: markdown.template
+title: Markdown template & locale
+cue: markdown.template (local file or remote URL) and markdown.template.language (BCP-47 locale tag)
+---
+
+## When to use
+
+Two related keys drive Markdown export:
+
+- `markdown.template` — accepts either a local file path OR a remote
+  `http(s)://` URL. The resolver auto-detects by the `http(s)://`
+  prefix. The separate `.file` and `.url` keys were merged into this
+  single key for simpler configuration.
+- `markdown.template.language` — a BCP-47 locale tag (e.g. `zh-CN`,
+  `ja`) selecting a localized template. A single-line rule.
+
+## Locale proposal workflow
+
+When the ambient `user language` is non-English AND no
+`markdown.template.language` rule is already in effect AND the user's
+request touches Markdown export or asks for localized docs, propose
+`markdown.template.language=<tag>` (a single-line rule).
+
+- Do **not** author a full custom template when a bundled template
+  covers the locale — `zh-CN` ships bundled; `en` (or unset) uses the
+  default English template and needs no rule. A bundled template is
+  always preferred over a hand-authored one because it tracks
+  structural changes to the default.
+- If no bundled template exists for the locale, tell the user, fall
+  back to English for this export, and suggest the "Copy default
+  template" affordance in the Markdown export panel so they can author
+  a localized copy as a starting point.
+- This proposal flows through `propose_rule_content` like any other
+  rule — the user reviews and saves. Never write the rule silently.
+
+## Check existing rules first
+
+Call `get_existing_rules_for_key` for `markdown.template.language` to
+avoid duplicates before proposing.

--- a/src/main/resources/ai/rules/method.additional.header.md
+++ b/src/main/resources/ai/rules/method.additional.header.md
@@ -1,0 +1,75 @@
+---
+id: method.additional.header
+key: method.additional.header
+title: Additional request header
+cue: JSON object header attached to every matching endpoint's request
+---
+
+## Value format
+
+The value is a single-line JSON object:
+
+```json
+{"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+One object per line — multiple headers means multiple
+`method.additional.header=…` lines (the key uses `StringRuleMode.MERGE`).
+
+## Filter examples
+
+Filter the rule to a class:
+
+```
+method.additional.header[$class:com.example.web.UserController]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+Filter by annotation:
+
+```
+method.additional.header[@com.example.RequiresAuth]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+## Prefer groovy value-blocks for complex conditional logic
+
+When a filter expression grows long — multiple `&&`/`||`, multiple
+exclusions, or nested method calls — switch to the **groovy value-block**
+form: the value itself is a multi-line groovy script that returns the
+value when the condition holds, or `null` when it doesn't.
+
+**Bad (unreadable single-line filter):**
+```
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.merchant.") && !it.containingClass().name().equals("com.example.merchant.AuthController") && !it.containingClass().name().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+```
+
+**Good (multi-line groovy value-block):**
+```
+method.additional.header=groovy:```
+def cls = it.containingClass()?.name()
+if (cls?.startsWith("com.example.merchant.")
+    && cls != "com.example.merchant.AuthController"
+    && cls != "com.example.merchant.PublicController") {
+    return '{"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}'
+}
+return null
+```
+```
+
+Rules of thumb:
+- **≤ 1 condition** → inline `key[filter]=value` is fine.
+- **≥ 2 conditions or exclusions** → use a groovy value-block.
+- The script must `return` the value (string) or `return null` to skip.
+- Keep the script readable: use local variables, one condition per line.
+
+## No hardcoded secrets
+
+Every credential in a header value is an env-var reference
+(`${Authorization}`, `${token}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for
+`method.additional.header` (or pass `keys` as an array to check multiple
+keys in one request). If an equivalent rule already exists, do NOT write
+a duplicate.

--- a/src/main/resources/ai/rules/method.additional.response.header.md
+++ b/src/main/resources/ai/rules/method.additional.response.header.md
@@ -1,0 +1,49 @@
+---
+id: method.additional.response.header
+key: method.additional.response.header
+title: Additional response header
+cue: JSON object header attached to every matching endpoint's response
+---
+
+## Value format
+
+The value is a single-line JSON object:
+
+```json
+{"name":"X-RateLimit-Remaining","value":"100","desc":"","required":false}
+```
+
+One object per line — multiple headers means multiple
+`method.additional.response.header=…` lines (the key uses
+`StringRuleMode.MERGE`).
+
+## Filter examples
+
+Filter the rule to a class:
+
+```
+method.additional.response.header[$class:com.example.web.UserController]={"name":"X-Trace-Id","value":"${traceId}","desc":"trace","required":false}
+```
+
+Filter by annotation:
+
+```
+method.additional.response.header[@com.example.Tracked]={"name":"X-Trace-Id","value":"${traceId}","desc":"trace","required":false}
+```
+
+## Prefer groovy value-blocks for complex conditional logic
+
+When a filter expression grows long — multiple `&&`/`||`, multiple
+exclusions, or nested method calls — switch to the **groovy value-block**
+form (see the `method.additional.header` recipe for the full example).
+The script must `return` the value (string) or `return null` to skip.
+
+Rules of thumb:
+- **≤ 1 condition** → inline `key[filter]=value` is fine.
+- **≥ 2 conditions or exclusions** → use a groovy value-block.
+
+## Check existing rules first
+
+Before proposing, call `get_existing_rules_for_key` for
+`method.additional.response.header`. If an equivalent rule already
+exists, do NOT write a duplicate.

--- a/src/main/resources/ai/rules/postman.prerequest.md
+++ b/src/main/resources/ai/rules/postman.prerequest.md
@@ -1,0 +1,50 @@
+---
+id: postman.prerequest
+key: postman.prerequest
+title: Postman pre-request script
+cue: JavaScript fired BEFORE the request, used to inject headers / compute signatures / mutate pm.request
+channel: postman
+---
+
+## When to use
+
+`postman.prerequest` fires BEFORE the request is sent. Use it to:
+
+- Inject headers (compute a signature, attach a bearer token).
+- Mutate `pm.request` (rewrite URL, add query params).
+- Compute request bodies (HMAC canonical string).
+
+## Script-context isolation (CRITICAL — silent-failure trap)
+
+`postman.prerequest` rule values MUST be **literal scripts** (NO
+`groovy:` prefix). A `groovy:` prefix routes the value to
+`Jsr223ScriptParser` at export time, where `pm` is NOT bound — the
+script throws and the failure is **silently swallowed**, so no script
+lands in the Postman collection.
+
+Conversely, `http.call.before` / `http.call.after` rule values MUST use
+the `groovy:` prefix (they run in `Jsr223ScriptParser`, where `pm` is
+NOT available — use `session.set(...)` / `localStorage.set(...)` for
+storage, NEVER `pm.environment.set(...)`).
+
+## postman.test vs postman.prerequest (#1 mistake)
+
+`postman.test` fires AFTER the response (read `pm.response`,
+`pm.environment.set` a token). `postman.prerequest` fires BEFORE the
+request (inject headers, compute signatures, mutate `pm.request`).
+Swapping them is the most common workflow-rule error: a token extracted
+in `prerequest` reads the PREVIOUS response (or none); a header injected
+in `test` lands after the request has gone out.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${Authorization}`, `${appSecret}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Bundle integrity (CRITICAL)
+
+Signer + signed-consumer rules MUST be proposed together in a single
+`propose_rule_content` call. Proposing half a chain is forbidden — a
+consumer header referencing a signature no script computes is a silent
+bug.

--- a/src/main/resources/ai/rules/postman.test.md
+++ b/src/main/resources/ai/rules/postman.test.md
@@ -1,0 +1,50 @@
+---
+id: postman.test
+key: postman.test
+title: Postman test script
+cue: JavaScript assertion attached to an endpoint, fired AFTER the response
+channel: postman
+---
+
+## When to use
+
+`postman.test` fires AFTER the response is received. Use it to:
+
+- Read `pm.response` and assert on status / body fields.
+- `pm.environment.set("token", …)` to extract a token from the response
+  for use by subsequent requests (auth-token-chaining producer side).
+
+## Script-context isolation (CRITICAL — silent-failure trap)
+
+`postman.test` rule values MUST be **literal scripts** (NO `groovy:`
+prefix). A `groovy:` prefix routes the value to `Jsr223ScriptParser` at
+export time, where `pm` is NOT bound — the script throws and the
+failure is **silently swallowed**, so no script lands in the Postman
+collection.
+
+Conversely, `http.call.before` / `http.call.after` rule values MUST use
+the `groovy:` prefix (they run in `Jsr223ScriptParser`, where `pm` is
+NOT available — use `session.set(...)` / `localStorage.set(...)` for
+storage, NEVER `pm.environment.set(...)`).
+
+## postman.test vs postman.prerequest (#1 mistake)
+
+`postman.test` fires AFTER the response (read `pm.response`,
+`pm.environment.set` a token). `postman.prerequest` fires BEFORE the
+request (inject headers, compute signatures, mutate `pm.request`).
+Swapping them is the most common workflow-rule error: a token extracted
+in `prerequest` reads the PREVIOUS response (or none); a header injected
+in `test` lands after the request has gone out.
+
+## No hardcoded secrets
+
+Every credential in a workflow rule is an env-var reference
+(`${Authorization}`, `${appSecret}`, `${apiKey}`). Never emit a literal
+token, key, or password in rule content.
+
+## Bundle integrity (CRITICAL)
+
+Workflow rules that form a chain (login-script + consumer-header) MUST
+be proposed together in a single `propose_rule_content` call. Proposing
+half a chain is forbidden — a consumer header that references a token no
+script stores is a silent bug.

--- a/src/main/resources/ai/sub-agent-base.md
+++ b/src/main/resources/ai/sub-agent-base.md
@@ -1,0 +1,74 @@
+You are a sub-agent running ONE detection task for EasyApi's rule-authoring
+agent. You were spawned by the orchestrator to perceive the project's PSI in
+isolation and report back whether the assigned pattern is present. You do NOT
+propose rule content directly — the orchestrator merges findings from all
+sub-agents and proposes once.
+
+Your tool set is intentionally small and read-only. Use it to confirm or
+refute the detection recipe in your task instruction. Only the tools below
+exist for you — do NOT call any other tool name (e.g. `list_project_endpoints`,
+`get_plugin_doc`, `get_detection_prompt`, `find_classes_by_name`,
+`get_existing_rules_for_key`, `propose_rule_content`, `create_task_list`,
+`update_task`, `read_rule_file`, `ask_clarification`). They are not in your
+registry; calling them returns "Unknown tool".
+
+## Tool index
+
+Perception tools (read-only, run automatically):
+- `list_rule_keys` — every known EasyApi rule key (general + channel +
+  framework + implicit), filtered to the channels/frameworks enabled in
+  Settings. Use this to discover the exact key names for any rule proposals
+  you draft in `proposedRules` (never invent keys not in this list).
+- `get_rule_detail` — fetch the full recipe for one rule key. Access patterns:
+  - by key: `get_rule_detail(key="postman.test")` returns the per-key recipe.
+    Use this when you know which key a finding concerns.
+  - by scope: `get_rule_detail(channel="postman")` returns the concatenated
+    recipes of every rule file scoped to that channel (and enabled in
+    Settings). Use this when you want a tour of what a channel supports.
+  - At least one of `key` / `channel` / `format` / `framework` is required.
+- `get_psi_class_info` — inspect a class's methods/fields/signature/annotations
+  by fully-qualified name (e.g. `com.example.filter.MyJwtFilter`).
+- `find_classes_by_annotation` — discover classes by annotation FQN or simple
+  name (e.g. `jakarta.servlet.annotation.WebFilter`, `@RestController`).
+- `find_classes_by_supertype` — discover classes by supertype FQN (e.g.
+  `org.springframework.web.filter.OncePerRequestFilter`,
+  `org.springframework.web.servlet.HandlerInterceptor`).
+
+Action tool (terminal — ends your turn):
+- `report_findings` — stage your `TaskResult` and end your turn. Pass
+  `detected=true` with evidence in `findings` and concrete rule proposals in
+  `proposedRules` when the pattern is present, or `detected=false` when the
+  search came up empty. This is your ONLY state-changing action; you do not
+  have `propose_rule_content` — that belongs to the orchestrator.
+
+## How to run a detection
+
+1. Read the **Detection recipe** in your task instruction. It names the
+   annotation/supertype FQNs to probe and the rule shape to propose if found.
+2. Probe the project's PSI with `find_classes_by_annotation` and/or
+   `find_classes_by_supertype` using the FQNs the recipe suggests. You may
+   need both — the same pattern can be declared by annotation (e.g.
+   `@WebFilter`) OR by inheritance (e.g. `extends OncePerRequestFilter`); a
+   declaration style you don't probe produces a false negative.
+3. When you get hits, drill into each with `get_psi_class_info` to confirm it
+   really implements the pattern (methods, fields, annotations) and gather
+   the evidence you'll cite in `findings`.
+4. If you intend to propose rules, fetch the per-key recipe via
+   `get_rule_detail(key=...)` and confirm the key exists via `list_rule_keys`.
+   Never invent rule keys.
+5. When you have enough context, call `report_findings` once:
+   - `detected=true` if the pattern is present — write the evidence (located
+     classes, signatures, why it applies) into `findings` and any concrete
+     proposals into `proposedRules` (each `{key, preview}`).
+   - `detected=false` if the search came up empty — summarise what you probed
+     and why nothing matched in `findings`.
+
+## Rule-file format reminder
+
+Each rule line is `<key>[<filter>]=<value>` or `<key>=<value>` (no filter). The
+filter goes INSIDE `[...]` AFTER the key — never before it. Valid filter
+prefixes: `$class:<FQN>`, `@<AnnotationFqn>`, `#regex:<pattern>`,
+`#<tag>`, `!<expr>`, `groovy:<script>`. There is no `~` prefix and no bare
+`class:` prefix. The detection recipe and `get_rule_detail` carry the
+correctness notes for the specific keys you propose; consult them rather than
+reproducing recipes from memory.

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/AgentBaseCatalogIdGuardTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/AgentBaseCatalogIdGuardTest.kt
@@ -1,0 +1,124 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import com.itangcent.easyapi.core.ai.tools.GetDetectionPromptTool
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression guard for R3-C2: every detection id literal that appears in
+ * shipped prompt/tool text MUST resolve through
+ * [PromptCatalog.entry] — otherwise the agent learns a stale id, calls
+ * `get_detection_prompt(id=...)` with it, and the catalog rejects every
+ * one (the `unknown detection id` bursts seen in `idea.log` after the
+ * Phase-A catalog rename).
+ *
+ * Surfaces scanned:
+ *  - `src/main/resources/ai/agent-base.md` — the base prompt body that
+ *    lists detection ids as examples in two places (the `get_detection_prompt`
+ *    tool-index bullet and the "fetch the full recipe" paragraph).
+ *  - [GetDetectionPromptTool.description] — the tool description sent to
+ *    the LLM as part of the schema; example ids there are the most likely
+ *    to be reused by the agent verbatim.
+ *
+ * The test fails fast on a future stale-id regression — e.g. if a catalog
+ * file is renamed without updating these references.
+ *
+ * No IDE / PSI dependency — Pattern A (simple JUnit 4). Relies on
+ * [PromptCatalog]'s classpath loading of the real `ai/detection/` files.
+ */
+class AgentBaseCatalogIdGuardTest {
+
+    @Test
+    fun everyDetectionIdInAgentBasePromptResolvesThroughCatalog() {
+        val body = loadAgentBase()
+        val ids = extractQuotedDetectionIds(body)
+        assertTrue(
+            "agent-base.md should mention at least one detection id literal " +
+                "(found none — has the prompt format changed?); body was:\n$body",
+            ids.isNotEmpty()
+        )
+        val known = PromptCatalog.list("detection").map { it.id }.toSet()
+        val unresolved = ids.filter { it !in known }
+        assertTrue(
+            "every detection id literal in agent-base.md must resolve through " +
+                "PromptCatalog.entry(\"detection\", id). Unresolved: $unresolved. " +
+                "Known ids: $known",
+            unresolved.isEmpty()
+        )
+    }
+
+    @Test
+    fun everyDetectionIdInGetDetectionPromptToolDescriptionResolves() {
+        val description = GetDetectionPromptTool().description
+        val ids = extractQuotedDetectionIds(description)
+        assertTrue(
+            "GetDetectionPromptTool.description should mention at least one " +
+                "detection id literal (found none — has the description changed?); " +
+                "description was: $description",
+            ids.isNotEmpty()
+        )
+        val known = PromptCatalog.list("detection").map { it.id }.toSet()
+        val unresolved = ids.filter { it !in known }
+        assertTrue(
+            "every detection id literal in GetDetectionPromptTool.description " +
+                "must resolve through PromptCatalog.entry(\"detection\", id). " +
+                "Unresolved: $unresolved. Known ids: $known",
+            unresolved.isEmpty()
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------
+
+    /**
+     * Loads `/ai/agent-base.md` from the classpath (the same resource
+     * [SystemPromptBuilder] loads at runtime).
+     */
+    private fun loadAgentBase(): String {
+        val stream = javaClass.getResourceAsStream("/ai/agent-base.md")
+            ?: error("/ai/agent-base.md not found on classpath — run from the project root so test resources resolve")
+        return stream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+    }
+
+    /**
+     * Extracts bare id literals quoted in backticks (`` `id` ``) or double
+     * quotes (`"id"`) from [text], but only from contexts where detection ids
+     * are explicitly listed as examples — i.e. text following a `(e.g.`
+     * opener (up to the matching `)`) or following an `Examples:` marker (up
+     * to the next blank line).
+     *
+     * Two quote forms are supported because the surfaces scanned use
+     * different conventions: `agent-base.md` uses backtick-quoted ids
+     * (markdown), while [GetDetectionPromptTool.description] uses
+     * double-quoted ids (plain text sent to the LLM as a tool schema).
+     *
+     * This avoids false positives like `` `rule-guide` `` (a knowledge-base
+     * page name, not a detection id) that happen to share the same
+     * lowercase-hyphenated shape.
+     */
+    private fun extractQuotedDetectionIds(text: String): List<String> {
+        // Match either `id` (backticks, used in markdown) or "id" (double
+        // quotes, used in plain-text tool descriptions).
+        val tokenRegex = Regex("[`\"]([a-z][a-z0-9]*(?:-[a-z0-9]+)+)[`\"]")
+        val result = LinkedHashSet<String>()
+
+        // Context 1: "(e.g. `id`, `id`, ...)" — extract up to the matching ")".
+        val egContext = Regex("\\(e\\.g\\.[^)]*\\)", RegexOption.DOT_MATCHES_ALL)
+        egContext.findAll(text).forEach { m ->
+            tokenRegex.findAll(m.value).forEach { result.add(it.groupValues[1]) }
+        }
+
+        // Context 2: "Examples: `id`, `id`, ..." — extract up to the next
+        // blank line (a line that is empty or whitespace-only).
+        val examplesMarkerIndex = text.indexOf("Examples:")
+        if (examplesMarkerIndex >= 0) {
+            val fromMarker = text.substring(examplesMarkerIndex)
+            val blankLineIndex = fromMarker.indexOf("\n\n")
+            val block = if (blankLineIndex < 0) fromMarker else fromMarker.substring(0, blankLineIndex)
+            tokenRegex.findAll(block).forEach { result.add(it.groupValues[1]) }
+        }
+
+        return result.toList()
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuardTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/LoopGuardTest.kt
@@ -283,24 +283,52 @@ class LoopGuardTest {
     // ==================================================================
     // Output stagnation detection
     // ==================================================================
+    // Output stagnation only fires ACROSS batch boundaries (the first call
+    // of a new batch compared against the last result of the previous batch).
+    // Within a single batch (one assistant message with multiple tool calls),
+    // identical results are legitimate parallel probes — e.g. probing
+    // different supertypes that all return `[]`. Tests below call
+    // guard.beginBatch() between calls to simulate across-batch stagnation.
 
     @Test
-    fun testOutputStagnationIdenticalResultsTerminate() {
+    fun testOutputStagnationIdenticalResultsAcrossBatchesTerminate() {
         val guard = LoopGuard(LoopSafetyConfig())
-        // Different tools, same result content → stagnation
+        // Different tools, same result content, across batches → stagnation
         val tc1 = AiToolCall("c1", "list_rule_keys", "{}")
         val tc2 = AiToolCall("c2", "read_rule_file", """{"key":"a"}""")
         val tc3 = AiToolCall("c3", "get_psi_class_info", """{"cls":"X"}""")
         val result = ToolResult.Text("""{"data":"same"}""")
 
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, result))
+        guard.beginBatch()
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, result))
+        guard.beginBatch()
         val verdict = guard.observeResult(tc3, result)
-        assertTrue("3 identical results must terminate as stagnation", verdict is LoopGuard.Verdict.Terminate)
+        assertTrue("3 identical results across batches must terminate as stagnation", verdict is LoopGuard.Verdict.Terminate)
         val reason = (verdict as LoopGuard.Verdict.Terminate).reason
         assertTrue("reason must be OutputStagnation", reason is LoopGuard.LoopReason.OutputStagnation)
         val os = reason as LoopGuard.LoopReason.OutputStagnation
         assertEquals(3, os.count)
+    }
+
+    @Test
+    fun testOutputStagnationWithinBatchDoesNotFire() {
+        // Within a single batch (parallel probes), identical results are
+        // legitimate — e.g. probing different supertypes that all return [].
+        // Stagnation must NOT fire.
+        val guard = LoopGuard(LoopSafetyConfig())
+        val tc1 = AiToolCall("c1", "find_classes_by_supertype", """{"supertypeFqn":"a.Foo"}""")
+        val tc2 = AiToolCall("c2", "find_classes_by_supertype", """{"supertypeFqn":"b.Bar"}""")
+        val tc3 = AiToolCall("c3", "find_classes_by_supertype", """{"supertypeFqn":"c.Baz"}""")
+        val tc4 = AiToolCall("c4", "find_classes_by_supertype", """{"supertypeFqn":"d.Qux"}""")
+        val emptyResult = ToolResult.Text("[]")
+
+        // All 4 calls in ONE batch (no beginBatch() between them)
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, emptyResult))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, emptyResult))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc3, emptyResult))
+        assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc4, emptyResult))
+        // No termination — within-batch parallel probes are not stagnation
     }
 
     @Test
@@ -315,9 +343,12 @@ class LoopGuardTest {
         val r2 = ToolResult.Text("""{"data":"second"}""")
 
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, r1)) // stag=1
+        guard.beginBatch()
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, r1)) // stag=2
+        guard.beginBatch()
         // Different result resets
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc3, r2)) // stag=1
+        guard.beginBatch()
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc4, r2)) // stag=2
     }
 
@@ -333,7 +364,9 @@ class LoopGuardTest {
         val errorResult = ToolResult.Error("disk full")
 
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, textResult))  // stag=1 (text)
+        guard.beginBatch()
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, errorResult)) // stag=1 (error ≠ text, reset)
+        guard.beginBatch()
         // text again — error ≠ text so this is also a reset, no stagnation
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc3, textResult))  // stag=1 (text ≠ error, reset)
     }
@@ -347,9 +380,11 @@ class LoopGuardTest {
         val error = ToolResult.Error("permission denied")
 
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc1, error))
+        guard.beginBatch()
         assertEquals(LoopGuard.Verdict.Proceed, guard.observeResult(tc2, error))
+        guard.beginBatch()
         val verdict = guard.observeResult(tc3, error)
-        assertTrue("3 identical errors must terminate as stagnation", verdict is LoopGuard.Verdict.Terminate)
+        assertTrue("3 identical errors across batches must terminate as stagnation", verdict is LoopGuard.Verdict.Terminate)
         val reason = (verdict as LoopGuard.Verdict.Terminate).reason
         assertTrue("reason must be OutputStagnation", reason is LoopGuard.LoopReason.OutputStagnation)
     }

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/MagicInstructionBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/MagicInstructionBuilderTest.kt
@@ -1,0 +1,211 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests for [MagicInstructionBuilder].
+ *
+ * Regression coverage for the "unknown task id" loop: the orchestrator LLM
+ * could not discover the seeded task ids because they lived only in
+ * `AgentMemory.taskList` + the UI panel and were never serialized into the
+ * LLM transcript. The fix renders an explicit `(id, title)` manifest into
+ * [MagicInstructionBuilder.detectionInstruction]; these tests pin that
+ * contract so it cannot regress.
+ *
+ * No IDE / PSI dependency — Pattern A (simple JUnit 4).
+ */
+class MagicInstructionBuilderTest {
+
+    // ------------------------------------------------------------------
+    // detectionInstruction — the manifest is the orchestrator's only
+    // source of the exact task ids it must pass to run_sub_agent /
+    // update_task.
+    // ------------------------------------------------------------------
+
+    /**
+     * Regression for the "unknown task id" loop: every seeded task id MUST
+     * appear verbatim in the instruction so the orchestrator LLM can use it
+     * unchanged in `run_sub_agent(taskId=...)`.
+     */
+    @Test
+    fun detectionInstructionListsSeededTaskIdsVerbatim() {
+        val taskList = TaskList(
+            listOf(
+                Task("detect_spring_filters_interceptors", "Spring filters, interceptors, web filters"),
+                Task("detect_static_auth", "Static auth headers"),
+                Task("detect_auth_token_chaining", "Auth-token chaining")
+            )
+        )
+
+        val body = MagicInstructionBuilder.detectionInstruction(".easy.api.rules", taskList)
+
+        taskList.tasks.forEach { task ->
+            assertTrue(
+                "instruction must list task id verbatim: ${task.id}\n$body",
+                body.contains(task.id)
+            )
+            assertTrue(
+                "instruction must pair id ${task.id} with its title '${task.title}'\n$body",
+                body.contains(task.title)
+            )
+        }
+    }
+
+    /**
+     * The detection *family* ids (kebab-case, no `detect_` prefix — the ones
+     * the base prompt mentions, e.g. `spring-filters-interceptors`) are NOT
+     * valid task ids and must NOT appear as bare callable tokens. This guards
+     * against the LLM picking a kebab family id (the original failure mode).
+     *
+     * We assert the *manifest line* uses the `detect_*` form, not the bare
+     * kebab form. The body may still mention family names in prose, so we
+     * check the manifest-shaped occurrences specifically.
+     */
+    @Test
+    fun detectionInstructionDoesNotOfferKebabFamilyIdAsCallable() {
+        val taskList = TaskList(
+            listOf(
+                Task("detect_spring_filters_interceptors", "Spring filters, interceptors, web filters")
+            )
+        )
+
+        val body = MagicInstructionBuilder.detectionInstruction(".easy.api.rules", taskList)
+
+        // The numbered manifest entry must be the detect_* form.
+        assertTrue(
+            "manifest must enumerate the detect_* id:\n$body",
+            body.contains("1. detect_spring_filters_interceptors")
+        )
+        // The bare kebab family id must NOT be offered as a numbered manifest
+        // entry (it is not a valid task id).
+        assertFalse(
+            "manifest must NOT offer the bare kebab family id as a callable task id:\n$body",
+            body.contains("1. spring-filters-interceptors")
+        )
+    }
+
+    /**
+     * The instruction must keep the two-turn directive (run_sub_agent →
+     * propose_rule_content) and the prohibition on create_task_list /
+     * perception tools, so adding the manifest didn't drop any of the
+     * existing contract. `run_sub_agent` auto-records the task status
+     * (FR-3.5/FR-3.6 post-ship fix-up), so the directive no longer tells
+     * the orchestrator to call `update_task` for the status — the test
+     * asserts the directive mentions the auto-record behaviour instead.
+     */
+    @Test
+    fun detectionInstructionKeepsTwoTurnDirective() {
+        val taskList = TaskList(
+            listOf(Task("detect_static_auth", "Static auth headers"))
+        )
+
+        val body = MagicInstructionBuilder.detectionInstruction(".easy.api.rules", taskList)
+
+        assertTrue("must forbid create_task_list", body.contains("Do NOT call create_task_list"))
+        assertTrue("must direct to run_sub_agent", body.contains("run_sub_agent(taskId=...)"))
+        assertTrue(
+            "must mention run_sub_agent auto-records the status",
+            body.contains("automatically records the task")
+        )
+        assertTrue("must direct to propose_rule_content", body.contains("propose_rule_content"))
+        assertTrue(
+            "must forbid perception tools",
+            body.contains("Do NOT call") && body.contains("perception tools")
+        )
+    }
+
+    /**
+     * FR-2.5 — when no detection matched the enabled features, the task list
+     * is empty. The instruction must NOT emit a bogus zero-task manifest nor
+     * direct the orchestrator to call run_sub_agent / update_task on
+     * non-existent tasks. Instead it short-circuits to a single
+     * propose_rule_content directive so the turn terminates normally.
+     */
+    @Test
+    fun detectionInstructionEmptyTaskListDirectsStraightToPropose() {
+        val empty = TaskList(emptyList())
+
+        val body = MagicInstructionBuilder.detectionInstruction(".easy.api.rules", empty)
+
+        // Must direct the orchestrator to end the turn with propose_rule_content.
+        assertTrue(
+            "empty-task instruction must direct to propose_rule_content:\n$body",
+            body.contains("propose_rule_content")
+        )
+        // Must NOT tell the orchestrator to walk PENDING tasks (there are none).
+        assertFalse(
+            "empty-task instruction must NOT direct to run_sub_agent:\n$body",
+            body.contains("For each PENDING task")
+        )
+        // Must NOT render a numbered manifest line (there are no tasks).
+        assertFalse(
+            "empty-task instruction must NOT render a manifest entry:\n$body",
+            body.contains("1. ")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // reviewInstruction — guard against the detectionInstruction signature
+    // change bleeding into the Route B Stage-1 review body.
+    // ------------------------------------------------------------------
+
+    /**
+     * The Route B Stage-1 review body embeds the file content and carries no
+     * task-list directive. Pinning this so the detectionInstruction refactor
+     * can't accidentally change reviewInstruction's contract.
+     */
+    @Test
+    fun reviewInstructionEmbedsContentAndHasNoTaskListDirective() {
+        val content = "method.additional.header={\"name\":\"X-Trace\",\"value\":\"\${uuid}\"}"
+        val body = MagicInstructionBuilder.reviewInstruction(".easy.api.rules", content)
+
+        assertTrue(
+            "review body must embed the file content:\n$body",
+            body.contains(content)
+        )
+        // No detection-pass directive leaks into the review body.
+        assertFalse(
+            "review body must NOT contain the detection manifest directive:\n$body",
+            body.contains("Seeded tasks")
+        )
+        assertFalse(
+            "review body must NOT reference run_sub_agent:\n$body",
+            body.contains("run_sub_agent")
+        )
+        assertFalse(
+            "review body must NOT reference update_task:\n$body",
+            body.contains("update_task")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Smoke: detectionInstruction composes with a real built plan.
+    // ------------------------------------------------------------------
+
+    /**
+     * End-to-end-ish: build a real plan via [MagicTaskListBuilder] and render
+     * it. Every task id the builder produced must appear verbatim in the
+     * rendered instruction — the contract the orchestrator's LLM relies on.
+     */
+    @Test
+    fun detectionInstructionRenderedPlanListsEveryBuiltTaskId() {
+        val plan = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = emptySet()
+        )
+        if (plan.tasks.isEmpty()) return // catalog has no unscoped detections
+
+        val body = MagicInstructionBuilder.detectionInstruction(".easy.api.rules", plan)
+
+        plan.tasks.forEach { task ->
+            assertTrue(
+                "rendered instruction must contain built task id ${task.id}:\n$body",
+                body.contains(task.id)
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/MagicTaskListBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/MagicTaskListBuilderTest.kt
@@ -1,0 +1,233 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests for [MagicTaskListBuilder].
+ *
+ * Validates that Magic pre-builds an enablement-aware task list with one task
+ * per matching detection catalog entry (design R2-C1 + AC-S7) — the
+ * entrance-driven flow that replaces the v1 "agent calls create_task_list"
+ * flow.
+ *
+ * The task list is filtered by the same active-feature sets used by
+ * [SystemPromptBuilder.indexMessage] / [PromptCatalog.listFor], so Magic and
+ * Reactive agree on which detections exist for a given turn.
+ *
+ * No IDE / PSI dependency — Pattern A (simple JUnit 4). Relies on
+ * [PromptCatalog]'s classpath loading of the real `ai/detection/` files.
+ */
+class MagicTaskListBuilderTest {
+
+    /**
+     * The "all features enabled" set used to surface every detection whose
+     * scope is present in the catalog. Detects any channel/format/framework
+     * id declared in any detection file and unions them — keeps the test
+     * resilient when new scoped detections are added.
+     */
+    private val allChannels: Set<String> by lazy {
+        PromptCatalog.list("detection")
+            .mapNotNull { it.scope.channel }
+            .toSet()
+    }
+    private val allFormats: Set<String> by lazy {
+        PromptCatalog.list("detection")
+            .mapNotNull { it.scope.format }
+            .toSet()
+    }
+    private val allFrameworks: Set<String> by lazy {
+        PromptCatalog.list("detection")
+            .mapNotNull { it.scope.framework }
+            .toSet()
+    }
+
+    @Test
+    fun buildDetectionPlanHasOneTaskPerMatchingDetectionFile() {
+        // With every catalog-declared feature enabled, the task list matches
+        // the full catalog (every detection's scope is satisfied).
+        val taskList = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = allChannels,
+            activeFormats = allFormats,
+            activeFrameworks = allFrameworks
+        )
+        val expected = PromptCatalog.listFor(
+            "detection",
+            activeChannels = allChannels,
+            activeFormats = allFormats,
+            activeFrameworks = allFrameworks
+        )
+        assertEquals(
+            "task count must equal matching detection catalog size",
+            expected.size, taskList.tasks.size
+        )
+    }
+
+    @Test
+    fun taskIdsAreUniqueAndPrefixedWithDetect() {
+        val taskList = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = allChannels,
+            activeFormats = allFormats,
+            activeFrameworks = allFrameworks
+        )
+        val ids = taskList.tasks.map { it.id }
+        assertEquals("task ids must be unique", ids.distinct().size, ids.size)
+        assertTrue(
+            "every task id must be prefixed with 'detect_': $ids",
+            ids.all { it.startsWith("detect_") }
+        )
+    }
+
+    @Test
+    fun taskTitlesAndDetailsMapFromCatalogEntries() {
+        val taskList = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = allChannels,
+            activeFormats = allFormats,
+            activeFrameworks = allFrameworks
+        )
+        val expected = PromptCatalog.listFor(
+            "detection",
+            activeChannels = allChannels,
+            activeFormats = allFormats,
+            activeFrameworks = allFrameworks
+        )
+        // Task order matches catalog-manifest order.
+        taskList.tasks.zip(expected).forEach { (task, entry) ->
+            assertEquals("title must come from detection title", entry.title, task.title)
+            assertEquals("detail must come from detection cue", entry.cue, task.detail)
+        }
+    }
+
+    @Test
+    fun allTasksStartPending() {
+        val taskList = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = allChannels,
+            activeFormats = allFormats,
+            activeFrameworks = allFrameworks
+        )
+        assertTrue(
+            "every task must start PENDING",
+            taskList.tasks.all { it.status == TaskStatus.PENDING }
+        )
+    }
+
+    @Test
+    fun detectionIdIsSanitisedIntoTaskId() {
+        // The detection id "spring-filters-interceptors" must become the
+        // task id "detect_spring_filters_interceptors" (hyphens → underscores).
+        val taskList = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = allChannels,
+            activeFormats = allFormats,
+            activeFrameworks = allFrameworks
+        )
+        val task = taskList.tasks.firstOrNull { it.title.contains("Filters", ignoreCase = true) }
+        assertTrue(
+            "expected a task whose title mentions Filters; got: ${taskList.tasks.map { it.title }}",
+            task != null
+        )
+        assertTrue(
+            "task id for a hyphenated detection id must use underscores: ${task?.id}",
+            task?.id?.startsWith("detect_spring_filters_interceptors") == true ||
+                task?.id?.matches(Regex("detect_[A-Za-z0-9_]+")) == true
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // Feature-filtering behaviour (AC-S7)
+    // -------------------------------------------------------------------
+
+    @Test
+    fun emptyActiveSetsExcludeScopedDetectionsKeepUnscopedOnes() {
+        // With NO features enabled, only detections with no scope fields
+        // (channel/format/framework all null) appear — a scoped detection
+        // (e.g. framework: springmvc) is excluded.
+        val taskList = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = emptySet()
+        )
+        val taskTitles = taskList.tasks.map { it.title }.toSet()
+
+        // Unscoped detections (auth-token-chaining, custom-framework,
+        // correlation-idempotency, hmac-signing, static-auth) MUST appear.
+        assertTrue(
+            "unscoped detection 'Auth token chaining' must appear with no features enabled",
+            taskTitles.any { it.contains("Auth token chaining", ignoreCase = true) }
+        )
+        assertTrue(
+            "unscoped detection 'Custom & meta-annotations' must appear with no features enabled",
+            taskTitles.any { it.contains("Custom", ignoreCase = true) }
+        )
+
+        // Scoped detections MUST be absent.
+        if ("springmvc" in allFrameworks) {
+            assertFalse(
+                "springmvc-scoped detection 'Filters, interceptors, web filters' must be absent when springmvc is not active",
+                taskTitles.any { it.contains("Filters, interceptors", ignoreCase = true) }
+            )
+        }
+    }
+
+    @Test
+    fun frameworkScopedDetectionsAppearOnlyWhenFrameworkActive() {
+        // Only run this assertion when the catalog actually ships a
+        // framework-scoped detection (resilient to catalog edits).
+        if ("springmvc" !in allFrameworks) return
+
+        // With springmvc active, the Filters/Interceptors detection appears...
+        val withSpring = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = setOf("springmvc")
+        )
+        assertTrue(
+            "springmvc-scoped detection must appear when springmvc is active",
+            withSpring.tasks.any { it.title.contains("Filters, interceptors", ignoreCase = true) }
+        )
+
+        // ...and is absent when springmvc is not active.
+        val withoutSpring = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = emptySet()
+        )
+        assertFalse(
+            "springmvc-scoped detection must be absent when springmvc is not active",
+            withoutSpring.tasks.any { it.title.contains("Filters, interceptors", ignoreCase = true) }
+        )
+    }
+
+    @Test
+    fun filteringMatchesPromptCatalogListFor() {
+        // The task list MUST agree with PromptCatalog.listFor for the same
+        // active sets — this is the AC-S7 contract that Magic and the
+        // Reactive menu share.
+        val activeChannels = setOf("postman", "markdown")
+        val activeFormats = setOf("json")
+        val activeFrameworks = setOf("springmvc")
+
+        val taskList = MagicTaskListBuilder.buildDetectionPlan(
+            activeChannels = activeChannels,
+            activeFormats = activeFormats,
+            activeFrameworks = activeFrameworks
+        )
+        val expected = PromptCatalog.listFor(
+            "detection",
+            activeChannels = activeChannels,
+            activeFormats = activeFormats,
+            activeFrameworks = activeFrameworks
+        )
+        assertEquals(
+            "task count must equal PromptCatalog.listFor result",
+            expected.size, taskList.tasks.size
+        )
+        taskList.tasks.zip(expected).forEach { (task, entry) ->
+            assertEquals(
+                "task title must match catalog entry title",
+                entry.title, task.title
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/PromptCatalogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/PromptCatalogTest.kt
@@ -1,0 +1,340 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [PromptCatalog].
+ *
+ * Split into two groups:
+ * 1. **Pure parsing tests** — exercise [PromptCatalog.parseFrontMatter],
+ *    [PromptCatalog.buildEntry], and [PromptCatalog.deriveCategory] with
+ *    synthetic content. No classpath access required.
+ * 2. **Classpath integration tests** — exercise [PromptCatalog.list],
+ *    [PromptCatalog.entry], [PromptCatalog.body], and [PromptCatalog.listFor]
+ *    against the real catalog files shipped under `src/main/resources/ai/`.
+ */
+class PromptCatalogTest {
+
+    // ===================================================================
+    // Pure parsing tests
+    // ===================================================================
+
+    @Test
+    fun parseFrontMatter_wellFormedHeader_parsesHeaderAndBody() {
+        val content = """
+            ---
+            id: test-id
+            title: Test Title
+            cue: when to use
+            ---
+            # Body content
+            Some text here.
+        """.trimIndent()
+        val parsed = PromptCatalog.parseFrontMatter(content)
+        assertNotNull(parsed)
+        assertEquals("test-id", parsed!!.header["id"])
+        assertEquals("Test Title", parsed.header["title"])
+        assertEquals("when to use", parsed.header["cue"])
+        assertTrue("body should contain the heading", parsed.body.contains("# Body content"))
+        assertTrue("body should contain the text", parsed.body.contains("Some text here."))
+    }
+
+    @Test
+    fun parseFrontMatter_withOptionalScopeFields_parsesAllFields() {
+        val content = """
+            ---
+            id: postman.test
+            key: postman.test
+            title: Postman test
+            cue: assertion
+            channel: postman
+            framework: springmvc
+            ---
+            body
+        """.trimIndent()
+        val parsed = PromptCatalog.parseFrontMatter(content)!!
+        assertEquals("postman.test", parsed.header["id"])
+        assertEquals("postman.test", parsed.header["key"])
+        assertEquals("postman", parsed.header["channel"])
+        assertEquals("springmvc", parsed.header["framework"])
+    }
+
+    @Test
+    fun parseFrontMatter_missingOpeningDelimiter_returnsNull() {
+        val content = "id: test\ntitle: Test\n---\nbody"
+        assertNull(PromptCatalog.parseFrontMatter(content))
+    }
+
+    @Test
+    fun parseFrontMatter_missingClosingDelimiter_returnsNull() {
+        val content = "---\nid: test\ntitle: Test\nbody without closing"
+        assertNull(PromptCatalog.parseFrontMatter(content))
+    }
+
+    @Test
+    fun parseFrontMatter_malformedYaml_returnsNull() {
+        val content = """
+            ---
+            id: [unclosed bracket
+            title: Test
+            ---
+            body
+        """.trimIndent()
+        assertNull(PromptCatalog.parseFrontMatter(content))
+    }
+
+    @Test
+    fun parseFrontMatter_emptyHeader_returnsEmptyMap() {
+        val content = """
+            ---
+            ---
+            body
+        """.trimIndent()
+        val parsed = PromptCatalog.parseFrontMatter(content)
+        assertNotNull(parsed)
+        assertTrue(parsed!!.header.isEmpty())
+        assertEquals("body", parsed.body)
+    }
+
+    @Test
+    fun buildEntry_allRequiredFieldsPresent_buildsEntry() {
+        val parsed = PromptCatalog.ParsedCatalogFile(
+            header = mapOf(
+                "id" to "postman.test",
+                "title" to "Postman test",
+                "cue" to "assertion",
+                "key" to "postman.test",
+                "channel" to "postman"
+            ),
+            body = "body"
+        )
+        val entry = PromptCatalog.buildEntry("ai/rules/postman.test.md", parsed)
+        assertNotNull(entry)
+        assertEquals("rules", entry!!.category)
+        assertEquals("postman.test", entry.id)
+        assertEquals("Postman test", entry.title)
+        assertEquals("assertion", entry.cue)
+        assertEquals("postman.test", entry.key)
+        assertEquals("postman", entry.scope.channel)
+    }
+
+    @Test
+    fun buildEntry_missingId_returnsNull() {
+        val parsed = PromptCatalog.ParsedCatalogFile(
+            header = mapOf("title" to "T", "cue" to "C"),
+            body = ""
+        )
+        assertNull(PromptCatalog.buildEntry("ai/rules/test.md", parsed))
+    }
+
+    @Test
+    fun buildEntry_missingTitle_returnsNull() {
+        val parsed = PromptCatalog.ParsedCatalogFile(
+            header = mapOf("id" to "test", "cue" to "C"),
+            body = ""
+        )
+        assertNull(PromptCatalog.buildEntry("ai/rules/test.md", parsed))
+    }
+
+    @Test
+    fun buildEntry_missingCue_returnsNull() {
+        val parsed = PromptCatalog.ParsedCatalogFile(
+            header = mapOf("id" to "test", "title" to "T"),
+            body = ""
+        )
+        assertNull(PromptCatalog.buildEntry("ai/rules/test.md", parsed))
+    }
+
+    @Test
+    fun buildEntry_derivesCategoryFromPath() {
+        val parsed = PromptCatalog.ParsedCatalogFile(
+            header = mapOf("id" to "x", "title" to "T", "cue" to "C"),
+            body = ""
+        )
+        assertEquals("detection", PromptCatalog.buildEntry("ai/detection/x.md", parsed)!!.category)
+        assertEquals("rules", PromptCatalog.buildEntry("ai/rules/x.md", parsed)!!.category)
+    }
+
+    @Test
+    fun buildEntry_unrecognizedPathPattern_returnsNull() {
+        val parsed = PromptCatalog.ParsedCatalogFile(
+            header = mapOf("id" to "x", "title" to "T", "cue" to "C"),
+            body = ""
+        )
+        assertNull(PromptCatalog.buildEntry("other/x.md", parsed))
+    }
+
+    @Test
+    fun deriveCategory_validPaths() {
+        assertEquals("detection", PromptCatalog.deriveCategory("ai/detection/foo.md"))
+        assertEquals("rules", PromptCatalog.deriveCategory("ai/rules/bar.md"))
+    }
+
+    @Test
+    fun deriveCategory_invalidPaths() {
+        assertNull(PromptCatalog.deriveCategory("detection/foo.md"))
+        assertNull(PromptCatalog.deriveCategory("ai"))
+        assertNull(PromptCatalog.deriveCategory(""))
+    }
+
+    @Test
+    fun catalogScope_matchesCorrectly() {
+        val scoped = CatalogScope(channel = "postman", framework = "springmvc")
+        assertTrue(scoped.matches(setOf("postman"), emptySet(), setOf("springmvc")))
+        assertFalse(scoped.matches(emptySet(), emptySet(), setOf("springmvc")))
+        assertFalse(scoped.matches(setOf("postman"), emptySet(), emptySet()))
+    }
+
+    @Test
+    fun catalogScope_nullFieldsAlwaysMatch() {
+        val unscoped = CatalogScope()
+        assertTrue(unscoped.matches(emptySet(), emptySet(), emptySet()))
+        assertTrue(unscoped.matches(setOf("a"), setOf("b"), setOf("c")))
+    }
+
+    // ===================================================================
+    // Classpath integration tests (use the real catalog files from A1)
+    // ===================================================================
+
+    @Test
+    fun list_detectionCategory_returnsSeededEntries() {
+        val entries = PromptCatalog.list("detection")
+        assertTrue("detection list should not be empty", entries.isNotEmpty())
+        val ids = entries.map { it.id }.toSet()
+        assertTrue("spring-filters-interceptors missing", "spring-filters-interceptors" in ids)
+        assertTrue("static-auth missing", "static-auth" in ids)
+        assertTrue("hmac-signing missing", "hmac-signing" in ids)
+    }
+
+    @Test
+    fun list_rulesCategory_returnsSeededEntries() {
+        val entries = PromptCatalog.list("rules")
+        assertTrue("rules list should not be empty", entries.isNotEmpty())
+        val ids = entries.map { it.id }.toSet()
+        assertTrue("postman.test missing", "postman.test" in ids)
+        assertTrue("field.ignore missing", "field.ignore" in ids)
+        assertTrue("method.additional.header missing", "method.additional.header" in ids)
+    }
+
+    @Test
+    fun list_unknownCategory_returnsEmpty() {
+        assertTrue(PromptCatalog.list("nonexistent").isEmpty())
+    }
+
+    @Test
+    fun entry_existingId_returnsEntry() {
+        val entry = PromptCatalog.entry("rules", "postman.test")
+        assertNotNull(entry)
+        assertEquals("postman.test", entry!!.id)
+        assertEquals("Postman test script", entry.title)
+        assertEquals("postman.test", entry.key)
+        assertEquals("postman", entry.scope.channel)
+    }
+
+    @Test
+    fun entry_unknownId_returnsNull() {
+        assertNull(PromptCatalog.entry("rules", "does.not.exist"))
+    }
+
+    @Test
+    fun body_existingId_returnsNonEmptyBody() {
+        val body = PromptCatalog.body("rules", "postman.test")
+        assertNotNull(body)
+        assertTrue("body should be non-empty", body!!.isNotBlank())
+        // The postman.test body mentions "pm.response" in its recipe.
+        assertTrue("body should contain recipe content", body.contains("pm.response"))
+    }
+
+    @Test
+    fun body_unknownId_returnsNull() {
+        assertNull(PromptCatalog.body("rules", "does.not.exist"))
+    }
+
+    @Test
+    fun body_stripsFrontMatter() {
+        // The body must NOT contain the YAML header.
+        val body = PromptCatalog.body("detection", "static-auth")!!
+        assertFalse("body should not contain front-matter", body.contains("---"))
+        assertFalse("body should not contain 'id:'", body.contains("id:"))
+    }
+
+    @Test
+    fun listFor_filtersByChannelScope() {
+        // A channel: postman rule file should appear with postman active...
+        val withPostman = PromptCatalog.listFor(
+            "rules",
+            activeChannels = setOf("postman"),
+            activeFormats = emptySet(),
+            activeFrameworks = emptySet()
+        )
+        val withPostmanIds = withPostman.map { it.id }.toSet()
+        assertTrue(
+            "postman.test should appear when postman is active",
+            "postman.test" in withPostmanIds
+        )
+
+        // ...and be absent when postman is not active.
+        val withoutPostman = PromptCatalog.listFor(
+            "rules",
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = emptySet()
+        )
+        val withoutPostmanIds = withoutPostman.map { it.id }.toSet()
+        assertFalse(
+            "postman.test should be absent when postman is not active",
+            "postman.test" in withoutPostmanIds
+        )
+    }
+
+    @Test
+    fun listFor_unscopedEntriesAlwaysAppear() {
+        // Entries with no scope fields should appear regardless of active sets.
+        val unscoped = PromptCatalog.listFor(
+            "rules",
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = emptySet()
+        )
+        val unscopedIds = unscoped.map { it.id }.toSet()
+        // field.ignore has no scope fields (no channel/format/framework).
+        assertTrue(
+            "field.ignore (unscoped) should always appear",
+            "field.ignore" in unscopedIds
+        )
+    }
+
+    @Test
+    fun listFor_filtersByFrameworkScope() {
+        // detection files with framework: springmvc should appear with
+        // springmvc active and be absent without.
+        val withSpring = PromptCatalog.listFor(
+            "detection",
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = setOf("springmvc")
+        )
+        val withSpringIds = withSpring.map { it.id }.toSet()
+        assertTrue(
+            "spring-filters-interceptors (framework: springmvc) should appear",
+            "spring-filters-interceptors" in withSpringIds
+        )
+
+        val withoutSpring = PromptCatalog.listFor(
+            "detection",
+            activeChannels = emptySet(),
+            activeFormats = emptySet(),
+            activeFrameworks = emptySet()
+        )
+        val withoutSpringIds = withoutSpring.map { it.id }.toSet()
+        assertFalse(
+            "spring-filters-interceptors should be absent without springmvc",
+            "spring-filters-interceptors" in withoutSpringIds
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgentTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/RuleAuthoringAgentTest.kt
@@ -53,7 +53,8 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
             ),
             ruleFileResolver = RuleFileResolver(project),
             workingMemory = memory,
-            approvals = approvalGate
+            approvals = approvalGate,
+            events = MutableSharedFlow(extraBufferCapacity = 64)
         )
     }
 
@@ -329,6 +330,59 @@ class RuleAuthoringAgentTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertTrue(
             "the clarification answers must be fed back to the model",
             req2.messages.any { it is AiMessage.ToolResult && it.content.contains("controllers") }
+        )
+    }
+
+    // --- Entry-path prompt assembly (design C9 / task B6) ---
+
+    /**
+     * The [EntryPath] parameter controls which system messages seed an empty
+     * transcript (design C9). The agent loop is shared; only the seed-prompt
+     * shape differs.
+     *
+     * - [EntryPath.REACTIVE] → 3 seed System messages (base + detection
+     *   index + rule index) — the agent has a menu to browse.
+     * - [EntryPath.TASK_LIST_MAGIC] → 1 seed System message (base only)
+     *   — detection/rule detail is pulled inside tasks as needed.
+     *
+     * Both paths additionally append exactly one ambient System message
+     * (starts with `"Context: project"`), which is filtered out of the seed
+     * count. Verified by inspecting the messages of the first LLM request
+     * for each path on a fresh [AgentMemory].
+     */
+    fun testEntryPathControlsPromptAssembly() = runBlocking {
+        val tools = ToolRegistry(listOf(ListRuleKeysFakeTool()))
+
+        // --- REACTIVE path: 3 seed messages ---
+        val reactiveMemory = AgentMemory()
+        aiService.enqueueText("reactive answer")
+        val reactiveEvents = captureEvents()
+        val reactiveAgent = RuleAuthoringAgent(aiService, tools, ctx, reactiveEvents.flow)
+        reactiveAgent.runTurn("hello", reactiveMemory, entryPath = EntryPath.REACTIVE)
+        reactiveEvents.cancelAndCollect()
+
+        val reactiveSeeds = aiService.requests().last().messages
+            .filterIsInstance<AiMessage.System>()
+            .filter { !it.content.startsWith("Context: project") }
+        assertEquals(
+            "REACTIVE path should seed 3 system messages (base + detection + rules): ${reactiveSeeds.size}",
+            3, reactiveSeeds.size
+        )
+
+        // --- TASK_LIST_MAGIC path: 1 seed message ---
+        val deliberativeMemory = AgentMemory()
+        aiService.enqueueText("deliberative answer")
+        val deliberativeEvents = captureEvents()
+        val deliberativeAgent = RuleAuthoringAgent(aiService, tools, ctx, deliberativeEvents.flow)
+        deliberativeAgent.runTurn("hello", deliberativeMemory, entryPath = EntryPath.TASK_LIST_MAGIC)
+        deliberativeEvents.cancelAndCollect()
+
+        val deliberativeSeeds = aiService.requests().last().messages
+            .filterIsInstance<AiMessage.System>()
+            .filter { !it.content.startsWith("Context: project") }
+        assertEquals(
+            "TASK_LIST_MAGIC path should seed 1 system message (base only): ${deliberativeSeeds.size}",
+            1, deliberativeSeeds.size
         )
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SubAgentOrchestrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SubAgentOrchestrationTest.kt
@@ -1,0 +1,1098 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import com.itangcent.easyapi.core.ai.AiMessage
+import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.AiRuntimeConfig
+import com.itangcent.easyapi.core.ai.AiToolCall
+import com.itangcent.easyapi.core.ai.AIService
+import com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent.Companion.PROPOSE_RULE_CONTENT
+import com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent.Companion.REPORT_FINDINGS
+import com.itangcent.easyapi.core.ai.tools.AiTool
+import com.itangcent.easyapi.core.ai.tools.OrchestratorProposeRuleContentTool
+import com.itangcent.easyapi.core.ai.tools.ToolContext
+import com.itangcent.easyapi.core.ai.tools.ToolKind
+import com.itangcent.easyapi.core.ai.tools.ToolRegistry
+import com.itangcent.easyapi.core.ai.tools.ToolResult
+import com.itangcent.easyapi.core.ai.tools.UpdateTaskTool
+import com.itangcent.easyapi.core.ai.tools.subAgentToolRegistry
+import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.config.source.RuleFileResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+
+/**
+ * Phase-3 sub-agent orchestration tests (design §3.6 / FR-3.* / T3.8–T3.11).
+ *
+ * These tests exercise the orchestrator + sub-agent execution model
+ * introduced in Phase 3:
+ *
+ * - **T3.8** — the orchestrator merges results from three sub-agents into
+ *   a single `propose_rule_content` call, with each detection tagged
+ *   `source: detection:<id>`.
+ * - **T3.9** — a failing sub-agent does not abort the run; the orchestrator
+ *   marks the failed task FAILED, continues with the remaining tasks, and
+ *   still calls `propose_rule_content` once at the end.
+ * - **T3.10** — each sub-agent gets a fresh `AgentMemory`; tool results
+ *   from a sibling sub-agent's perception tools never appear in another
+ *   sub-agent's LLM transcript.
+ * - **T3.11** — calling `report_findings` ends the sub-agent turn; no
+ *   further tool calls are dispatched in that sub-agent's turn.
+ *
+ * The tests come in two flavours:
+ *
+ * 1. **Stubbed `run_sub_agent`** (T3.8, T3.9) — uses [FakeRunSubAgentTool]
+ *    to bypass real sub-agent spawning. The merge and failure-isolation
+ *    behaviours live in [OrchestratorProposeRuleContentTool] +
+ *    [UpdateTaskTool] + the orchestrator LLM's tool-call sequence, so
+ *    stubbing the spawn keeps the tests focused.
+ * 2. **Real `RunSubAgentTool`** (T3.10, T3.11) — uses the production
+ *    [com.itangcent.easyapi.core.ai.tools.RunSubAgentTool] with a scripted
+ *    [FakeAIService] so each sub-agent's LLM transcript is captured and
+ *    inspectable. Required because T3.10/T3.11 assert on the sub-agent's
+ *    internal state (memory isolation, terminal-action behaviour).
+ */
+class SubAgentOrchestrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    // ------------------------------------------------------------------
+    // T3.8 — testSubAgentRunMergesThreeResults
+    // ------------------------------------------------------------------
+
+    /**
+     * FR-3.8 / AC-3 — three seeded tasks; each sub-agent returns a
+     * `TaskResult(detected=true, ...)`; the orchestrator calls
+     * `propose_rule_content` exactly once, and the merged content contains
+     * all three `source: detection:<id>` tags.
+     *
+     * Uses [FakeRunSubAgentTool] so the merge logic in
+     * [OrchestratorProposeRuleContentTool] is exercised without spawning
+     * real sub-agents. The orchestrator LLM is scripted (via
+     * [FakeAIService]) to call `run_sub_agent` for each task in one step,
+     * then `propose_rule_content` in the next.
+     *
+     * The merge is deterministic (concatenate-with-tags, design §3.9 / D3
+     * — "no LLM round-trip"), so the test asserts the merged payload
+     * directly on `memory.proposal.content`.
+     */
+    fun testSubAgentRunMergesThreeResults() = runBlocking {
+        val events = captureEvents()
+        val memory = AgentMemory().apply {
+            taskList = TaskList(listOf(
+                Task("t1", "first detection", "cue-1"),
+                Task("t2", "second detection", "cue-2"),
+                Task("t3", "third detection", "cue-3")
+            ))
+        }
+        val ctx = buildCtx(memory, events.flow)
+        val orchestratorTools = ToolRegistry(listOf(
+            UpdateTaskTool(),
+            FakeRunSubAgentTool(),
+            OrchestratorProposeRuleContentTool()
+        ))
+        val aiService = FakeAIService()
+        // Step 1: orchestrator runs all three sub-agents in one batch.
+        aiService.enqueueToolCalls(
+            AiToolCall("c1", "run_sub_agent", """{"taskId":"t1"}"""),
+            AiToolCall("c2", "run_sub_agent", """{"taskId":"t2"}"""),
+            AiToolCall("c3", "run_sub_agent", """{"taskId":"t3"}""")
+        )
+        // Step 2: orchestrator proposes the merged content (no `content`
+        // arg — the tool merges from collectedSubAgentResults).
+        aiService.enqueueToolCalls(
+            AiToolCall(
+                "c4", "propose_rule_content",
+                """{"suggestedFileName":"merged.rules"}"""
+            )
+        )
+
+        val agent = RuleAuthoringAgent(aiService, orchestratorTools, ctx, events.flow)
+        val outcome = agent.runTurn(
+            "walk the seeded task list",
+            memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        events.cancelAndCollect()
+
+        // Turn ended with a proposal.
+        Assert.assertEquals(TurnOutcome.Proposed, outcome)
+        Assert.assertNotNull("proposal should be staged", memory.proposal)
+        Assert.assertEquals("merged.rules", memory.proposal?.suggestedFileName)
+
+        // Exactly one propose_rule_content call was made. The assistant
+        // message carrying it is in memory.messages (added before tool
+        // execution); it is NOT in any aiService.requests() entry because
+        // propose_rule_content is terminal — no subsequent LLM call carries
+        // it as a prior-message context.
+        val proposeCalls = memory.messages
+            .filterIsInstance<AiMessage.Assistant>()
+            .flatMap { it.toolCalls.orEmpty() }
+            .filter { it.name == PROPOSE_RULE_CONTENT }
+        Assert.assertEquals(
+            "exactly one propose_rule_content call expected, got ${proposeCalls.size}",
+            1, proposeCalls.size
+        )
+
+        // The merged content contains all three source tags.
+        val content = memory.proposal?.content.orEmpty()
+        Assert.assertTrue(
+            "merged content should contain 'source: detection:t1':\n$content",
+            content.contains("source: detection:t1")
+        )
+        Assert.assertTrue(
+            "merged content should contain 'source: detection:t2':\n$content",
+            content.contains("source: detection:t2")
+        )
+        Assert.assertTrue(
+            "merged content should contain 'source: detection:t3':\n$content",
+            content.contains("source: detection:t3")
+        )
+        // The findings text from each sub-agent should be present.
+        Assert.assertTrue(content.contains("findings for t1"))
+        Assert.assertTrue(content.contains("findings for t2"))
+        Assert.assertTrue(content.contains("findings for t3"))
+        // Three sub-agent results were collected.
+        Assert.assertEquals(
+            "collectedSubAgentResults should have 3 entries",
+            3, memory.collectedSubAgentResults.size
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // T3.9 — testFailingSubAgentMarksTaskFailedAndContinues
+    // ------------------------------------------------------------------
+
+    /**
+     * FR-3.7 / AC-4 — when a sub-agent throws, the orchestrator marks the
+     * task FAILED via `update_task`, continues with the remaining tasks,
+     * and still calls `propose_rule_content` once at the end.
+     *
+     * The merge must NOT include the failed task (it has no
+     * `TaskResult` staged), so the merged content contains `source:`
+     * tags for the successful tasks only.
+     */
+    fun testFailingSubAgentMarksTaskFailedAndContinues() = runBlocking {
+        val events = captureEvents()
+        val memory = AgentMemory().apply {
+            taskList = TaskList(listOf(
+                Task("t1", "first detection", "cue-1"),
+                Task("t2", "failing detection", "cue-2"),
+                Task("t3", "third detection", "cue-3")
+            ))
+        }
+        val ctx = buildCtx(memory, events.flow)
+        val orchestratorTools = ToolRegistry(listOf(
+            UpdateTaskTool(),
+            // FakeRunSubAgentTool throws when running task t2.
+            FakeRunSubAgentTool(failTaskIds = setOf("t2")),
+            OrchestratorProposeRuleContentTool()
+        ))
+        val aiService = FakeAIService()
+        // Step 1: orchestrator runs t1 (success).
+        aiService.enqueueToolCalls(
+            AiToolCall("c1", "run_sub_agent", """{"taskId":"t1"}"""),
+            AiToolCall("c2", "update_task", """{"taskId":"t1","status":"completed"}""")
+        )
+        // Step 2: orchestrator runs t2 (fails) + marks it failed.
+        aiService.enqueueToolCalls(
+            AiToolCall("c3", "run_sub_agent", """{"taskId":"t2"}"""),
+            AiToolCall(
+                "c4", "update_task",
+                """{"taskId":"t2","status":"failed","reason":"sub-agent threw"}"""
+            )
+        )
+        // Step 3: orchestrator runs t3 (success).
+        aiService.enqueueToolCalls(
+            AiToolCall("c5", "run_sub_agent", """{"taskId":"t3"}"""),
+            AiToolCall("c6", "update_task", """{"taskId":"t3","status":"completed"}""")
+        )
+        // Step 4: orchestrator proposes the merged content.
+        aiService.enqueueToolCalls(
+            AiToolCall(
+                "c7", "propose_rule_content",
+                """{"suggestedFileName":"merged.rules"}"""
+            )
+        )
+
+        val agent = RuleAuthoringAgent(aiService, orchestratorTools, ctx, events.flow)
+        val outcome = agent.runTurn(
+            "walk the seeded task list (one will fail)",
+            memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        events.cancelAndCollect()
+
+        // Turn ended with a proposal despite the failure.
+        Assert.assertEquals(TurnOutcome.Proposed, outcome)
+        Assert.assertNotNull("proposal should still be staged", memory.proposal)
+
+        // Task statuses: t1 COMPLETED, t2 FAILED, t3 COMPLETED.
+        val taskList = memory.taskList!!
+        Assert.assertEquals(TaskStatus.COMPLETED, taskList.byId("t1")!!.status)
+        Assert.assertEquals(TaskStatus.FAILED, taskList.byId("t2")!!.status)
+        Assert.assertEquals(TaskStatus.COMPLETED, taskList.byId("t3")!!.status)
+
+        // Exactly one propose_rule_content call. The assistant message
+        // carrying it is in memory.messages (added before tool execution);
+        // it is NOT in any aiService.requests() entry because
+        // propose_rule_content is terminal.
+        val proposeCalls = memory.messages
+            .filterIsInstance<AiMessage.Assistant>()
+            .flatMap { it.toolCalls.orEmpty() }
+            .filter { it.name == PROPOSE_RULE_CONTENT }
+        Assert.assertEquals(
+            "exactly one propose_rule_content call expected, got ${proposeCalls.size}",
+            1, proposeCalls.size
+        )
+
+        // The failed task is NOT in collectedSubAgentResults (it threw
+        // before staging a result).
+        Assert.assertEquals(
+            "collectedSubAgentResults should have 2 entries (t1, t3 — t2 failed)",
+            2, memory.collectedSubAgentResults.size
+        )
+        val collectedTaskIds = memory.collectedSubAgentResults.map { it.first.id }
+        Assert.assertTrue("t1 should be in collected results", collectedTaskIds.contains("t1"))
+        Assert.assertTrue("t3 should be in collected results", collectedTaskIds.contains("t3"))
+        Assert.assertFalse(
+            "t2 should NOT be in collected results (it failed)",
+            collectedTaskIds.contains("t2")
+        )
+
+        // The merged content contains source tags for t1 and t3 only.
+        val content = memory.proposal?.content.orEmpty()
+        Assert.assertTrue(
+            "merged content should contain 'source: detection:t1':\n$content",
+            content.contains("source: detection:t1")
+        )
+        Assert.assertTrue(
+            "merged content should contain 'source: detection:t3':\n$content",
+            content.contains("source: detection:t3")
+        )
+        Assert.assertFalse(
+            "merged content should NOT contain 'source: detection:t2' (task failed):\n$content",
+            content.contains("source: detection:t2")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // T3.10 — testSubAgentGetsFreshMemory
+    // ------------------------------------------------------------------
+
+    /**
+     * FR-3.1 / G3 — each sub-agent gets a fresh `AgentMemory`; tool
+     * results from a sibling sub-agent's perception tools never appear in
+     * another sub-agent's LLM transcript.
+     *
+     * Uses the real [com.itangcent.easyapi.core.ai.tools.RunSubAgentTool]
+     * with a scripted [FakeAIService] so each sub-agent's LLM transcript
+     * is captured. Two sub-agents are spawned; each calls
+     * `find_classes_by_annotation` (returns `[]` from the empty fixture)
+     * then `report_findings`. The test asserts that sub-agent 2's LLM
+     * request messages do NOT contain the `find_classes_by_annotation`
+     * tool result text from sub-agent 1's transcript.
+     *
+     * Detection ids used: `spring-filters-interceptors` and
+     * `jaxrs-filters` (real catalog entries — required because
+     * [com.itangcent.easyapi.core.ai.tools.RunSubAgentTool] fetches the
+     * detection recipe in-process from
+     * [com.itangcent.easyapi.core.ai.agent.PromptCatalog]).
+     */
+    fun testSubAgentGetsFreshMemory() = runBlocking {
+        val events = captureEvents()
+        val memory = AgentMemory().apply {
+            taskList = TaskList(listOf(
+                Task(
+                    "detect_spring_filters_interceptors",
+                    "Spring filters, interceptors, web filters",
+                    "classes extending OncePerRequestFilter / HandlerInterceptor / WebFilter"
+                ),
+                Task(
+                    "detect_jaxrs_filters",
+                    "JAX-RS filters",
+                    "classes implementing ContainerRequestFilter / ContainerResponseFilter"
+                )
+            ))
+        }
+        val ctx = buildCtx(memory, events.flow)
+        val subAgentTools = ToolRegistry(subAgentToolRegistry())
+        // The TracingAIService delegates to a FakeAIService but snapshots
+        // each request so the test can inspect every LLM transcript
+        // (orchestrator + sub-agents) after the run.
+        val fake = FakeAIService()
+        val tracing = TracingAIService(fake)
+        val orchestratorTools = ToolRegistry(
+            listOf(
+                UpdateTaskTool(),
+                com.itangcent.easyapi.core.ai.tools.RunSubAgentTool(
+                    aiService = tracing,
+                    subAgentTools = subAgentTools
+                ),
+                OrchestratorProposeRuleContentTool()
+            )
+        )
+
+        // Step 1 (orchestrator): run sub-agent 1.
+        fake.enqueueToolCalls(
+            AiToolCall("o1", "run_sub_agent",
+                """{"taskId":"detect_spring_filters_interceptors"}""")
+        )
+        // Step 2 (sub-agent 1, LLM call 1): perceive then report.
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "s1a", "find_classes_by_annotation",
+                """{"annotationFqn":"jakarta.servlet.annotation.WebFilter"}"""
+            )
+        )
+        // Step 3 (sub-agent 1, LLM call 2): report_findings (terminal).
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "s1b", "report_findings",
+                """{"detected":true,"findings":"SPRING_FILTER_FINDINGS_FOR_T1"}"""
+            )
+        )
+        // Step 4 (orchestrator): mark t1 done + run sub-agent 2.
+        fake.enqueueToolCalls(
+            AiToolCall("o2", "update_task",
+                """{"taskId":"detect_spring_filters_interceptors","status":"completed"}"""),
+            AiToolCall("o3", "run_sub_agent",
+                """{"taskId":"detect_jaxrs_filters"}""")
+        )
+        // Step 5 (sub-agent 2, LLM call 1): perceive then report.
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "s2a", "find_classes_by_annotation",
+                """{"annotationFqn":"jakarta.ws.rs.NameBinding"}"""
+            )
+        )
+        // Step 6 (sub-agent 2, LLM call 2): report_findings (terminal).
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "s2b", "report_findings",
+                """{"detected":true,"findings":"JAXRS_FILTER_FINDINGS_FOR_T2"}"""
+            )
+        )
+        // Step 7 (orchestrator): mark t2 done + propose merged content.
+        fake.enqueueToolCalls(
+            AiToolCall("o4", "update_task",
+                """{"taskId":"detect_jaxrs_filters","status":"completed"}"""),
+            AiToolCall(
+                "o5", "propose_rule_content",
+                """{"suggestedFileName":"merged.rules"}"""
+            )
+        )
+
+        val agent = RuleAuthoringAgent(tracing, orchestratorTools, ctx, events.flow)
+        val outcome = agent.runTurn(
+            "walk the seeded task list",
+            memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        events.cancelAndCollect()
+
+        // Sanity: the turn completed with a proposal.
+        Assert.assertEquals(TurnOutcome.Proposed, outcome)
+        Assert.assertNotNull(memory.proposal)
+
+        // Identify each sub-agent's LLM request by inspecting the user
+        // message — RunSubAgentTool builds the sub-agent's instruction
+        // with the task title in it ("You are a sub-agent running one
+        // detection task: <title>").
+        val subAgent1Requests = tracing.requests.filter { req ->
+            req.messages.any {
+                it is AiMessage.User &&
+                    it.content.contains("Spring filters, interceptors, web filters")
+            }
+        }
+        val subAgent2Requests = tracing.requests.filter { req ->
+            req.messages.any {
+                it is AiMessage.User &&
+                    it.content.contains("JAX-RS filters")
+            }
+        }
+        Assert.assertTrue(
+            "should capture at least one sub-agent 1 request",
+            subAgent1Requests.isNotEmpty()
+        )
+        Assert.assertTrue(
+            "should capture at least one sub-agent 2 request",
+            subAgent2Requests.isNotEmpty()
+        )
+
+        // Sub-agent 1's findings appear in the orchestrator's transcript
+        // (via the run_sub_agent ToolResult that serialises the TaskResult)
+        // and in the merged proposal — NOT in the sub-agent's own LLM
+        // requests, because report_findings is terminal and its ToolResult
+        // is never sent to the LLM. The orchestrator's requests are the
+        // ones that do NOT contain the sub-agent seed user message.
+        val orchestratorRequests = tracing.requests.filterNot { req ->
+            req.messages.any {
+                it is AiMessage.User &&
+                    (it.content.contains("Spring filters, interceptors") ||
+                        it.content.contains("JAX-RS filters"))
+            }
+        }
+        val orchestratorTranscript = orchestratorRequests
+            .flatMap { it.messages }.joinToString("\n")
+        Assert.assertTrue(
+            "orchestrator transcript should contain sub-agent 1's findings: $orchestratorTranscript",
+            orchestratorTranscript.contains("SPRING_FILTER_FINDINGS_FOR_T1")
+        )
+
+        // Sub-agent 2's transcript should NOT contain sub-agent 1's
+        // findings text or any of sub-agent 1's tool results.
+        val sub2Transcript = subAgent2Requests.flatMap { it.messages }.joinToString("\n")
+        Assert.assertFalse(
+            "sub-agent 2 transcript must NOT contain sub-agent 1's findings: $sub2Transcript",
+            sub2Transcript.contains("SPRING_FILTER_FINDINGS_FOR_T1")
+        )
+        Assert.assertFalse(
+            "sub-agent 2 transcript must NOT contain sub-agent 1's tool-call id s1a: $sub2Transcript",
+            sub2Transcript.contains("s1a")
+        )
+        Assert.assertFalse(
+            "sub-agent 2 transcript must NOT contain sub-agent 1's tool-call id s1b: $sub2Transcript",
+            sub2Transcript.contains("s1b")
+        )
+        // Sub-agent 2's own findings ("JAXRS_FILTER_FINDINGS_FOR_T2") are
+        // in the report_findings response (not in any LLM request, since
+        // report_findings is terminal) and in the merged proposal below.
+        // The "should NOT contain sub-agent 1's data" assertions above are
+        // the real memory-isolation checks.
+
+        // The merged content should contain both sub-agents' findings
+        // (no cross-contamination at the orchestrator level either).
+        val content = memory.proposal?.content.orEmpty()
+        Assert.assertTrue(
+            "merged content should contain t1 findings",
+            content.contains("SPRING_FILTER_FINDINGS_FOR_T1")
+        )
+        Assert.assertTrue(
+            "merged content should contain t2 findings",
+            content.contains("JAXRS_FILTER_FINDINGS_FOR_T2")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // T3.11 — testReportFindingsIsTerminalForSubAgent
+    // ------------------------------------------------------------------
+
+    /**
+     * FR-3.4 — calling `report_findings` ends the sub-agent turn; no
+     * further tool calls are dispatched in that sub-agent's turn.
+     *
+     * Spawns one real sub-agent (via `RunSubAgentTool`). The sub-agent's
+     * LLM is scripted to call `report_findings` first, then (in the same
+     * assistant message) issue a second tool call (`list_rule_keys`) that
+     * should NEVER be dispatched — the agent loop exits after
+     * `report_findings` returns. Asserts the `list_rule_keys` tool was
+     * never executed (its result text is absent from the sub-agent's
+     * transcript).
+     */
+    fun testReportFindingsIsTerminalForSubAgent() = runBlocking {
+        val events = captureEvents()
+        val memory = AgentMemory().apply {
+            taskList = TaskList(listOf(
+                Task(
+                    "detect_static_auth",
+                    "Static auth",
+                    "hardcoded credentials / static auth headers"
+                )
+            ))
+        }
+        val ctx = buildCtx(memory, events.flow)
+
+        // A fake perception tool that records when it's executed.
+        val sentinelTool = SentinelPerceptionTool(
+            name = "list_rule_keys",
+            markerText = "LIST_RULE_KEYS_WAS_DISPATCHED"
+        )
+        val subAgentTools = ToolRegistry(
+            listOf(sentinelTool, com.itangcent.easyapi.core.ai.tools.ReportFindingsTool())
+        )
+        val fake = FakeAIService()
+        val orchestratorTools = ToolRegistry(
+            listOf(
+                UpdateTaskTool(),
+                com.itangcent.easyapi.core.ai.tools.RunSubAgentTool(fake, subAgentTools),
+                OrchestratorProposeRuleContentTool()
+            )
+        )
+
+        // Step 1 (orchestrator): run sub-agent 1.
+        fake.enqueueToolCalls(
+            AiToolCall("o1", "run_sub_agent",
+                """{"taskId":"detect_static_auth"}""")
+        )
+        // Step 2 (sub-agent 1): emit report_findings + list_rule_keys in
+        // the SAME assistant message. The agent loop dispatches
+        // report_findings first (terminal) and must NOT dispatch
+        // list_rule_keys afterwards.
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "s1a", "report_findings",
+                """{"detected":true,"findings":"STATIC_AUTH_FINDINGS"}"""
+            ),
+            AiToolCall("s1b", "list_rule_keys", "{}")
+        )
+        // Step 3 (orchestrator): propose the merged content.
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "o2", "propose_rule_content",
+                """{"suggestedFileName":"merged.rules"}"""
+            )
+        )
+
+        val agent = RuleAuthoringAgent(fake, orchestratorTools, ctx, events.flow)
+        val outcome = agent.runTurn(
+            "walk the seeded task list",
+            memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        events.cancelAndCollect()
+
+        // Sanity: turn ended with a proposal.
+        Assert.assertEquals(TurnOutcome.Proposed, outcome)
+        Assert.assertNotNull(memory.proposal)
+
+        // The sentinel perception tool was NEVER executed — the sub-agent's
+        // turn ended at report_findings before list_rule_keys could be
+        // dispatched.
+        Assert.assertFalse(
+            "sentinel perception tool must NOT be executed (report_findings is terminal)",
+            sentinelTool.executed
+        )
+
+        // The sub-agent's transcript should NOT contain the sentinel
+        // tool's result text — only the report_findings result.
+        val allTranscripts = fake.requests().flatMap { it.messages }.joinToString("\n")
+        Assert.assertFalse(
+            "sentinel tool's marker text must NOT appear in any transcript: $allTranscripts",
+            allTranscripts.contains("LIST_RULE_KEYS_WAS_DISPATCHED")
+        )
+        // report_findings was dispatched — verify via the events flow
+        // (the Observed event is emitted before the terminal check). Its
+        // ToolResult text ("findings reported") is NOT in any LLM request
+        // because report_findings is terminal: the sub-agent's turn ends
+        // before a subsequent LLM call could carry the ToolResult as context.
+        val observedReportFindings = events.collected
+            .filterIsInstance<AgentEvent.Observed>()
+            .any { it.tool == REPORT_FINDINGS }
+        Assert.assertTrue(
+            "an Observed event for report_findings should be in the events flow",
+            observedReportFindings
+        )
+
+        // The merged proposal contains the sub-agent's findings.
+        val content = memory.proposal?.content.orEmpty()
+        Assert.assertTrue(
+            "merged content should contain the sub-agent's findings: $content",
+            content.contains("STATIC_AUTH_FINDINGS")
+        )
+        Assert.assertTrue(
+            "merged content should contain the source tag",
+            content.contains("source: detection:detect_static_auth")
+        )
+
+        // Exactly one propose_rule_content call (the orchestrator's). The
+        // assistant message carrying it is in the orchestrator's
+        // memory.messages (added before tool execution); it is NOT in any
+        // fake.requests() entry because propose_rule_content is terminal.
+        val proposeCalls = memory.messages
+            .filterIsInstance<AiMessage.Assistant>()
+            .flatMap { it.toolCalls.orEmpty() }
+            .filter { it.name == PROPOSE_RULE_CONTENT }
+        Assert.assertEquals(
+            "exactly one propose_rule_content call expected",
+            1, proposeCalls.size
+        )
+        // And exactly one report_findings call (the sub-agent's). The
+        // sub-agent uses fresh memory (not the orchestrator's memory), so
+        // we verify via the events flow instead.
+        val reportCallEvents = events.collected
+            .filterIsInstance<AgentEvent.Acting>()
+            .count { it.tool == REPORT_FINDINGS }
+        Assert.assertEquals(
+            "exactly one report_findings call expected",
+            1, reportCallEvents
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // T5.3 — testNotDetectedSubAgentMarkedCompleted
+    // ------------------------------------------------------------------
+
+    /**
+     * FR-3.5 (post-ship fix-up) / AC-8 — when a sub-agent returns
+     * `detected=false` (ran successfully but found nothing), the
+     * orchestrator marks the task `COMPLETED`, NOT `SKIPPED`. "Nothing
+     * detected" is a valid finding; the task ran to completion.
+     *
+     * Uses [FakeRunSubAgentTool] with [FakeRunSubAgentTool.notDetectedTaskIds]
+     * to stage `detected=false` for task t1. The orchestrator LLM is
+     * scripted (via [FakeAIService]) to call `run_sub_agent` then
+     * `update_task(status="completed")` — the directive in
+     * [MagicInstructionBuilder.detectionInstruction] now instructs this
+     * status for a successful-but-empty detection.
+     */
+    fun testNotDetectedSubAgentMarkedCompleted() = runBlocking {
+        val events = captureEvents()
+        val memory = AgentMemory().apply {
+            taskList = TaskList(listOf(
+                Task("t1", "first detection", "cue-1"),
+                Task("t2", "second detection", "cue-2")
+            ))
+        }
+        val ctx = buildCtx(memory, events.flow)
+        val orchestratorTools = ToolRegistry(listOf(
+            UpdateTaskTool(),
+            // t1 returns detected=false; t2 returns detected=true.
+            FakeRunSubAgentTool(notDetectedTaskIds = setOf("t1")),
+            OrchestratorProposeRuleContentTool()
+        ))
+        val aiService = FakeAIService()
+        // Step 1: orchestrator runs t1 (not detected) + t2 (detected).
+        aiService.enqueueToolCalls(
+            AiToolCall("c1", "run_sub_agent", """{"taskId":"t1"}"""),
+            AiToolCall("c2", "run_sub_agent", """{"taskId":"t2"}""")
+        )
+        // Step 2: orchestrator marks both completed (NOT skipped for t1).
+        aiService.enqueueToolCalls(
+            AiToolCall(
+                "c3", "update_task",
+                """{"taskId":"t1","status":"completed","reason":"No pattern found"}"""
+            ),
+            AiToolCall(
+                "c4", "update_task",
+                """{"taskId":"t2","status":"completed"}"""
+            )
+        )
+        // Step 3: orchestrator proposes the merged content.
+        aiService.enqueueToolCalls(
+            AiToolCall(
+                "c5", "propose_rule_content",
+                """{"suggestedFileName":"merged.rules"}"""
+            )
+        )
+
+        val agent = RuleAuthoringAgent(aiService, orchestratorTools, ctx, events.flow)
+        val outcome = agent.runTurn(
+            "walk the seeded task list",
+            memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        events.cancelAndCollect()
+
+        // Both tasks should be COMPLETED — t1 is NOT SKIPPED despite
+        // detected=false (FR-3.5 post-ship fix-up).
+        val taskList = memory.taskList!!
+        Assert.assertEquals(
+            "t1 (detected=false) should be COMPLETED, not SKIPPED",
+            TaskStatus.COMPLETED, taskList.byId("t1")!!.status
+        )
+        Assert.assertEquals(
+            "t2 (detected=true) should be COMPLETED",
+            TaskStatus.COMPLETED, taskList.byId("t2")!!.status
+        )
+
+        // The turn ended with a proposal (t2 was detected, so the merged
+        // content is non-empty).
+        Assert.assertEquals(TurnOutcome.Proposed, outcome)
+        Assert.assertNotNull(memory.proposal)
+        // The merged content contains t2's findings (detected=true) but
+        // NOT t1's (detected=false, filtered out by mergeTaskResults).
+        val content = memory.proposal?.content.orEmpty()
+        Assert.assertTrue(
+            "merged content should contain t2's findings:\n$content",
+            content.contains("source: detection:t2")
+        )
+        Assert.assertFalse(
+            "merged content should NOT contain t1's findings (detected=false):\n$content",
+            content.contains("source: detection:t1")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // T5.5 — testAllNotDetectedDoesNotStageProposal
+    // ------------------------------------------------------------------
+
+    /**
+     * FR-2.5 (post-ship fix-up) / AC-9 — when every sub-agent returns
+     * `detected=false`, the merged content is blank. The orchestrator's
+     * `propose_rule_content` call stages NO proposal (leaves
+     * `workingMemory.proposal` null), emits NO `ProposalReady` event,
+     * and the turn ends with `TurnOutcome.Answered`. The user is never
+     * prompted to apply an empty proposition.
+     */
+    fun testAllNotDetectedDoesNotStageProposal() = runBlocking {
+        val events = captureEvents()
+        val memory = AgentMemory().apply {
+            taskList = TaskList(listOf(
+                Task("t1", "first detection", "cue-1"),
+                Task("t2", "second detection", "cue-2")
+            ))
+        }
+        val ctx = buildCtx(memory, events.flow)
+        val orchestratorTools = ToolRegistry(listOf(
+            UpdateTaskTool(),
+            // Both sub-agents return detected=false.
+            FakeRunSubAgentTool(notDetectedTaskIds = setOf("t1", "t2")),
+            OrchestratorProposeRuleContentTool()
+        ))
+        val aiService = FakeAIService()
+        // Step 1: orchestrator runs both sub-agents (both not detected).
+        aiService.enqueueToolCalls(
+            AiToolCall("c1", "run_sub_agent", """{"taskId":"t1"}"""),
+            AiToolCall("c2", "run_sub_agent", """{"taskId":"t2"}""")
+        )
+        // Step 2: orchestrator marks both completed (FR-3.5 fix-up).
+        aiService.enqueueToolCalls(
+            AiToolCall(
+                "c3", "update_task",
+                """{"taskId":"t1","status":"completed","reason":"No pattern found"}"""
+            ),
+            AiToolCall(
+                "c4", "update_task",
+                """{"taskId":"t2","status":"completed","reason":"No pattern found"}"""
+            )
+        )
+        // Step 3: orchestrator calls propose_rule_content (merged content
+        // will be blank — both detected=false).
+        aiService.enqueueToolCalls(
+            AiToolCall(
+                "c5", "propose_rule_content",
+                """{"suggestedFileName":"merged.rules"}"""
+            )
+        )
+
+        val agent = RuleAuthoringAgent(aiService, orchestratorTools, ctx, events.flow)
+        val outcome = agent.runTurn(
+            "walk the seeded task list",
+            memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        events.cancelAndCollect()
+
+        // No proposal staged — the merged content was blank.
+        Assert.assertNull(
+            "no proposal should be staged when merged content is blank",
+            memory.proposal
+        )
+        // Turn outcome is Answered (not Proposed) — finish() returns
+        // Answered when memory.proposal is null.
+        Assert.assertEquals(
+            "turn should end with TurnOutcome.Answered (no proposal staged)",
+            TurnOutcome.Answered, outcome
+        )
+        // No ProposalReady event was emitted.
+        val proposalReadyEvents = events.collected
+            .filterIsInstance<AgentEvent.ProposalReady>()
+        Assert.assertTrue(
+            "no ProposalReady event should be emitted when merged content is blank",
+            proposalReadyEvents.isEmpty()
+        )
+        // TurnComplete WAS emitted — the turn ends normally.
+        val turnCompleteEvents = events.collected
+            .filterIsInstance<AgentEvent.TurnComplete>()
+        Assert.assertEquals(
+            "TurnComplete should be emitted exactly once",
+            1, turnCompleteEvents.size
+        )
+        // Both tasks are COMPLETED (FR-3.5 fix-up).
+        val taskList = memory.taskList!!
+        Assert.assertEquals(TaskStatus.COMPLETED, taskList.byId("t1")!!.status)
+        Assert.assertEquals(TaskStatus.COMPLETED, taskList.byId("t2")!!.status)
+    }
+
+    // ------------------------------------------------------------------
+    // T5.7 — testRealRunSubAgentAutoMarksCompletedWhenNotDetected
+    // ------------------------------------------------------------------
+
+    /**
+     * FR-3.5 / FR-3.6 post-ship fix-up — the REAL
+     * [com.itangcent.easyapi.core.ai.tools.RunSubAgentTool] auto-marks
+     * the task `COMPLETED` when the sub-agent runs successfully,
+     * regardless of `detected`. The UI checkbox updates deterministically
+     * — it does NOT depend on the orchestrator LLM calling `update_task`
+     * afterwards.
+     *
+     * This test uses the REAL `RunSubAgentTool` (not the fake) with a
+     * scripted [FakeAIService]. The sub-agent calls
+     * `report_findings(detected=false, ...)`. The orchestrator is scripted
+     * to call `run_sub_agent` then `propose_rule_content` — it does NOT
+     * call `update_task`. The test asserts:
+     * - The task is `COMPLETED` (auto-marked by `run_sub_agent`).
+     * - A `TaskCompleted` event was emitted (so the UI checkbox ticks).
+     * - No proposal is staged (merged content is blank — FR-2.5).
+     * - The turn ends with `TurnOutcome.Answered`.
+     *
+     * This reproduces and verifies the fix for the reported bug: "while a
+     * task completed with detected=false, the task is still not marked as
+     * completed, the UI still shows an open checkbox."
+     */
+    fun testRealRunSubAgentAutoMarksCompletedWhenNotDetected() = runBlocking {
+        val events = captureEvents()
+        val memory = AgentMemory().apply {
+            taskList = TaskList(listOf(
+                Task(
+                    "detect_static_auth",
+                    "Static auth",
+                    "hardcoded credentials / static auth headers"
+                )
+            ))
+        }
+        val ctx = buildCtx(memory, events.flow)
+
+        // Real sub-agent tool registry: perception tools + report_findings.
+        val subAgentTools = ToolRegistry(subAgentToolRegistry())
+        val fake = FakeAIService()
+        val orchestratorTools = ToolRegistry(
+            listOf(
+                UpdateTaskTool(),
+                com.itangcent.easyapi.core.ai.tools.RunSubAgentTool(fake, subAgentTools),
+                OrchestratorProposeRuleContentTool()
+            )
+        )
+
+        // Step 1 (orchestrator): run sub-agent. NOTE: no update_task is
+        // scripted — the auto-mark should tick the checkbox without it.
+        fake.enqueueToolCalls(
+            AiToolCall("o1", "run_sub_agent",
+                """{"taskId":"detect_static_auth"}""")
+        )
+        // Step 2 (sub-agent): perceive then report detected=false.
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "s1a", "find_classes_by_annotation",
+                """{"annotationFqn":"org.springframework.web.bind.annotation.RestController"}"""
+            )
+        )
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "s1b", "report_findings",
+                """{"detected":false,"findings":"No static auth pattern found"}"""
+            )
+        )
+        // Step 3 (orchestrator): propose the merged content (will be
+        // blank — detected=false → stages no proposal, FR-2.5).
+        fake.enqueueToolCalls(
+            AiToolCall(
+                "o2", "propose_rule_content",
+                """{"suggestedFileName":"merged.rules"}"""
+            )
+        )
+
+        val agent = RuleAuthoringAgent(fake, orchestratorTools, ctx, events.flow)
+        val outcome = agent.runTurn(
+            "walk the seeded task list",
+            memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        events.cancelAndCollect()
+
+        // THE BUG FIX — the task is COMPLETED even though detected=false
+        // and the orchestrator never called update_task. The auto-mark in
+        // RunSubAgentTool did it.
+        val task = memory.taskList!!.byId("detect_static_auth")!!
+        Assert.assertEquals(
+            "task should be COMPLETED (auto-marked by run_sub_agent, " +
+                "detected=false is a valid finding, not a skip)",
+            TaskStatus.COMPLETED, task.status
+        )
+
+        // A TaskCompleted event was emitted — the UI checkbox ticks.
+        val taskCompletedEvents = events.collected
+            .filterIsInstance<AgentEvent.TaskCompleted>()
+            .filter { it.taskId == "detect_static_auth" }
+        Assert.assertEquals(
+            "exactly one TaskCompleted event should be emitted for the task " +
+                "(auto-marked by run_sub_agent)",
+            1, taskCompletedEvents.size
+        )
+
+        // FR-2.5 — no proposal staged (merged content blank), turn ends
+        // with TurnOutcome.Answered.
+        Assert.assertNull(
+            "no proposal should be staged when detected=false",
+            memory.proposal
+        )
+        Assert.assertEquals(
+            "turn should end with TurnOutcome.Answered (no proposal staged)",
+            TurnOutcome.Answered, outcome
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private fun buildCtx(
+        memory: AgentMemory,
+        events: MutableSharedFlow<AgentEvent>
+    ): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30,
+            // Generous budget so multi-step orchestrator + sub-agent
+            // turns never hit the step ceiling.
+            maxRequests = 12
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = memory,
+        approvals = FakeApprovalGate(),
+        events = events
+    )
+
+    private fun captureEvents(): EventCapture {
+        val flow = MutableSharedFlow<AgentEvent>(
+            replay = Int.MAX_VALUE,
+            extraBufferCapacity = 0
+        )
+        val collected = mutableListOf<AgentEvent>()
+        val job = scope().launch(
+            context = Dispatchers.Unconfined,
+            start = CoroutineStart.UNDISPATCHED
+        ) {
+            flow.collect { collected.add(it) }
+        }
+        return EventCapture(flow, job, collected)
+    }
+
+    private fun scope() =
+        CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    private class EventCapture(
+        val flow: MutableSharedFlow<AgentEvent>,
+        private val job: Job,
+        val collected: List<AgentEvent>
+    ) {
+        suspend fun cancelAndCollect() {
+            job.cancelAndJoin()
+        }
+    }
+
+    /**
+     * Fake `run_sub_agent` tool for T3.8 / T3.9 / T5.3 / T5.5 — bypasses
+     * real sub-agent spawning. Looks up the task, optionally throws (for
+     * T3.9), otherwise stages a deterministic [TaskResult] in
+     * `ctx.workingMemory.collectedSubAgentResults` so the orchestrator's
+     * [OrchestratorProposeRuleContentTool] can merge it.
+     *
+     * The staged result's `findings` text is `"findings for <id>"` so the
+     * test can assert it appears in the merged content. By default
+     * `detected=true` so the result survives [mergeTaskResults]'s
+     * `detected` filter; pass [notDetectedTaskIds] to stage
+     * `detected=false` for specific tasks (T5.3 / T5.5).
+     */
+    private class FakeRunSubAgentTool(
+        private val failTaskIds: Set<String> = emptySet(),
+        private val notDetectedTaskIds: Set<String> = emptySet()
+    ) : AiTool {
+        override val name: String = "run_sub_agent"
+        override val description: String = "Fake run_sub_agent for testing."
+        override val kind: ToolKind = ToolKind.ACTION
+        override val requiresApproval: Boolean = false
+        override val parametersSchema: Map<String, Any?> = mapOf(
+            "type" to "object",
+            "properties" to mapOf(
+                "taskId" to mapOf("type" to "string")
+            ),
+            "required" to listOf("taskId")
+        )
+
+        override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+            val taskId = args["taskId"] as? String
+                ?: return ToolResult.Error("missing taskId")
+            val taskList = ctx.workingMemory.taskList
+                ?: return ToolResult.Error("no task list")
+            val task = taskList.byId(taskId)
+                ?: return ToolResult.Error("unknown task id: $taskId")
+
+            if (task.id in failTaskIds) {
+                // Mirrors RunSubAgentTool's behaviour: an internal
+                // exception becomes a ToolResult.Error via ToolRegistry's
+                // runCatching. The orchestrator's LLM sees the error and
+                // can mark the task failed + continue.
+                throw RuntimeException("sub-agent for ${task.id} failed (test stub)")
+            }
+
+            val detected = task.id !in notDetectedTaskIds
+            val result = TaskResult(
+                detected = detected,
+                findings = "findings for ${task.id}",
+                proposedRules = if (detected) listOf(
+                    RuleProposal(
+                        key = "method.additional.header",
+                        preview = "{\"name\":\"X-Test\",\"value\":\"${task.id}\"}"
+                    )
+                ) else emptyList()
+            )
+            // Mirrors RunSubAgentTool's collection step — the orchestrator's
+            // propose_rule_content reads this list and merges.
+            ctx.workingMemory.collectedSubAgentResults.add(task to result)
+            return ToolResult.Text(
+                "sub-agent for ${task.id} done: detected=${result.detected}"
+            )
+        }
+    }
+
+    /**
+     * A perception tool with a configurable name that records when it's
+     * executed and returns a marker text. Used by T3.11 to verify that
+     * `report_findings` is terminal — the sentinel tool is placed AFTER
+     * `report_findings` in the same assistant message and must NEVER be
+     * dispatched.
+     */
+    private class SentinelPerceptionTool(
+        override val name: String,
+        private val markerText: String
+    ) : AiTool {
+        override val description: String = "Sentinel perception tool for testing."
+        override val kind: ToolKind = ToolKind.PERCEPTION
+        override val parametersSchema: Map<String, Any?> = emptyMap()
+
+        @Volatile
+        var executed: Boolean = false
+            private set
+
+        override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+            executed = true
+            return ToolResult.Text(markerText)
+        }
+    }
+
+    /**
+     * AIService wrapper that delegates to a [FakeAIService] but snapshots
+     * every request into a list the test can inspect. Used by T3.10 to
+     * capture each sub-agent's LLM transcript separately.
+     *
+     * Without this wrapper, [FakeAIService.requests] returns a flat list
+     * and the test would have to disambiguate orchestrator vs sub-agent
+     * calls by index — fragile. The wrapper doesn't change behaviour, it
+     * just makes the captured requests directly accessible.
+     */
+    private class TracingAIService(private val delegate: FakeAIService) : AIService {
+        val requests: MutableList<com.itangcent.easyapi.core.ai.AiChatRequest> = mutableListOf()
+
+        override suspend fun chat(request: com.itangcent.easyapi.core.ai.AiChatRequest):
+            com.itangcent.easyapi.core.ai.AiChatResponse {
+            // Snapshot — the caller mutates the same list across turns.
+            requests.add(request.copy(messages = request.messages.toList()))
+            return delegate.chat(request)
+        }
+
+        override suspend fun testConnection(): Result<String> =
+            delegate.testConnection()
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilderTest.kt
@@ -6,123 +6,396 @@ import org.junit.Test
 /**
  * Tests for [SystemPromptBuilder].
  *
- * Verifies the preamble mentions the Custom-Pattern Catalog and the
- * detection workflow so the agent is primed to scan for custom framework
- * patterns before proposing rules.
+ * Covers three concerns (design C2 / task A3):
+ * - The base prompt (`build()`) carries identity, loop contract, tool index,
+ *   rule-file format, and writing-quality rules — but NOT the detection/recipe
+ *   prose (which moved to `ai/detection/` and `ai/rules/` catalog files).
+ * - The entry-path overload (`build(entryPath, amb)`) composes the right seed
+ *   messages per path: 3 for REACTIVE (base + detection index + rule index),
+ *   1 for both Task-List variants.
+ * - The indexes are enablement-aware: a `channel: postman` rule file is
+ *   absent from the rule index when Postman is disabled (AC-S7).
  */
 class SystemPromptBuilderTest {
 
     @Test
-    fun `preamble mentions custom-pattern detection`() {
+    fun `base prompt mentions custom-pattern detection concept`() {
+        // The base prompt keeps a one-liner pointing to the detection catalog;
+        // the full detection prose lives in ai/detection/*.md (covered by
+        // PromptCatalogTest).
         val msg = SystemPromptBuilder.build()
         val text = msg.content
         Assert.assertTrue(
-            "preamble should mention custom framework patterns",
+            "base prompt should mention custom framework patterns",
             text.contains("custom framework patterns", ignoreCase = true)
         )
     }
 
     @Test
-    fun `preamble mentions the catalog`() {
+    fun `base prompt mentions detection signals summary`() {
+        // The base prompt keeps a one-liner enumerating the detection families
+        // so the agent knows what to look for; full recipes are fetched via
+        // get_detection_prompt.
         val msg = SystemPromptBuilder.build()
         val text = msg.content
         Assert.assertTrue(
-            "preamble should reference the Custom-Pattern Catalog",
-            text.contains("Custom-Pattern Catalog", ignoreCase = true)
-        )
-    }
-
-    @Test
-    fun `preamble mentions detection signals`() {
-        val msg = SystemPromptBuilder.build()
-        val text = msg.content
-        Assert.assertTrue(
-            "preamble should mention Filter / Interceptor / WebFilter",
+            "base prompt should mention Filter / Interceptor / WebFilter",
             text.contains("Filter") && text.contains("WebFilter")
         )
         Assert.assertTrue(
-            "preamble should mention ResponseBodyAdvice",
+            "base prompt should mention ResponseBodyAdvice",
             text.contains("ResponseBodyAdvice")
         )
         Assert.assertTrue(
-            "preamble should mention HandlerMethodArgumentResolver",
+            "base prompt should mention HandlerMethodArgumentResolver",
             text.contains("HandlerMethodArgumentResolver")
         )
     }
 
     @Test
-    fun `preamble teaches both discovery tools`() {
+    fun `base prompt teaches both discovery tools`() {
         // The agent must know BOTH declaration styles, otherwise it produces
         // false negatives like "no Filters found" for the standard Spring Boot
         // inheritance style (`extends OncePerRequestFilter`, no `@WebFilter`).
         val msg = SystemPromptBuilder.build()
         val text = msg.content
         Assert.assertTrue(
-            "preamble should mention find_classes_by_annotation",
+            "base prompt should mention find_classes_by_annotation",
             text.contains("find_classes_by_annotation")
         )
         Assert.assertTrue(
-            "preamble should mention find_classes_by_supertype",
+            "base prompt should mention find_classes_by_supertype",
             text.contains("find_classes_by_supertype")
         )
         Assert.assertTrue(
-            "preamble should call out the inheritance style (OncePerRequestFilter)",
+            "base prompt should call out the inheritance style (OncePerRequestFilter)",
             text.contains("OncePerRequestFilter")
         )
     }
 
     @Test
-    fun `preamble mentions the contract question`() {
+    fun `base prompt references knowledge-base doc names not architecture`() {
         val msg = SystemPromptBuilder.build()
         val text = msg.content
         Assert.assertTrue(
-            "preamble should ask the invisible-contract question",
-            text.contains("invisibly")
-        )
-    }
-
-    @Test
-    fun `preamble references knowledge-base doc names not architecture`() {
-        val msg = SystemPromptBuilder.build()
-        val text = msg.content
-        Assert.assertTrue(
-            "preamble should reference rule-guide",
+            "base prompt should reference rule-guide",
             text.contains("rule-guide")
         )
         Assert.assertFalse(
-            "preamble should NOT reference the removed architecture doc",
+            "base prompt should NOT reference the removed architecture doc",
             text.contains("architecture")
         )
     }
 
     @Test
-    fun `preamble mentions multi-app namespacing`() {
-        // Per-app env-var namespacing: the preamble must teach the agent to
+    fun `base prompt mentions multi-app namespacing`() {
+        // Per-app env-var namespacing: the base prompt must teach the agent to
         // resolve a namespace key and namespace every env var in a workflow
         // bundle by that key. The full recipe lives in rule-guide.md; the
-        // preamble carries only the condensed detection + on-demand-fetch
+        // base prompt carries only the condensed detection + on-demand-fetch
         // pointer.
         val msg = SystemPromptBuilder.build()
         val text = msg.content
         Assert.assertTrue(
-            "preamble should mention the Multi-app namespacing subsection",
+            "base prompt should mention the Multi-app namespacing subsection",
             text.contains("Multi-app namespacing")
         )
         Assert.assertTrue(
-            "preamble should mention the namespace-key resolution order (module name)",
+            "base prompt should mention the namespace-key resolution order (module name)",
             text.contains("module name", ignoreCase = true)
         )
         Assert.assertTrue(
-            "preamble should mention the namespace-key resolution order (spring.application.name)",
+            "base prompt should mention the namespace-key resolution order (spring.application.name)",
             text.contains("spring.application.name")
         )
         Assert.assertTrue(
-            "preamble should mention the namespace-key resolution order (ask_clarification)",
+            "base prompt should mention the namespace-key resolution order (ask_clarification)",
             text.contains("ask_clarification")
         )
         Assert.assertTrue(
-            "preamble should name get_module_dependency_graph tool",
+            "base prompt should name get_module_dependency_graph tool",
             text.contains("get_module_dependency_graph")
+        )
+    }
+
+    @Test
+    fun `base prompt documents catalog detail tools`() {
+        // The base prompt's tool index must document the new catalog tools
+        // (task A6) so the agent knows when to use which access pattern.
+        val msg = SystemPromptBuilder.build()
+        val text = msg.content
+        Assert.assertTrue(
+            "base prompt should document get_detection_prompt",
+            text.contains("get_detection_prompt")
+        )
+        Assert.assertTrue(
+            "base prompt should document get_rule_detail",
+            text.contains("get_rule_detail")
+        )
+        Assert.assertTrue(
+            "base prompt should document get_rule_detail's by-key access pattern",
+            text.contains("key=")
+        )
+        Assert.assertTrue(
+            "base prompt should document get_rule_detail's by-scope access pattern",
+            text.contains("channel=")
+        )
+    }
+
+    @Test
+    fun `base prompt notes planning tools are task-list-only`() {
+        // The base prompt must note that create_task_list / update_task exist
+        // but are only for Task-List tasks (task A6) — plain chat should not
+        // use them.
+        val msg = SystemPromptBuilder.build()
+        val text = msg.content
+        Assert.assertTrue(
+            "base prompt should mention create_task_list",
+            text.contains("create_task_list")
+        )
+        Assert.assertTrue(
+            "base prompt should mention update_task",
+            text.contains("update_task")
+        )
+        Assert.assertTrue(
+            "base prompt should mark planning tools as Task-List-only",
+            text.contains("Task-List", ignoreCase = true)
+        )
+    }
+
+    // ── build(entryPath, amb) — message counts per path (A3) ──
+
+    @Test
+    fun `build reactive returns three messages`() {
+        // REACTIVE → base + detection index + rule index.
+        val amb = Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList(),
+            enabledChannels = listOf("postman"),
+            enabledFormats = listOf("json")
+        )
+        val msgs = SystemPromptBuilder.build(EntryPath.REACTIVE, amb)
+        Assert.assertEquals("REACTIVE should return 3 seed messages", 3, msgs.size)
+    }
+
+    @Test
+    fun `build task list magic returns one message`() {
+        val amb = Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList()
+        )
+        val msgs = SystemPromptBuilder.build(EntryPath.TASK_LIST_MAGIC, amb)
+        Assert.assertEquals("TASK_LIST_MAGIC should return 1 seed message", 1, msgs.size)
+    }
+
+    @Test
+    fun `build task list programmatic returns one message`() {
+        val amb = Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList()
+        )
+        val msgs = SystemPromptBuilder.build(EntryPath.TASK_LIST_PROGRAMMATIC, amb)
+        Assert.assertEquals("TASK_LIST_PROGRAMMATIC should return 1 seed message", 1, msgs.size)
+    }
+
+    // ── Sub-agent prompt (EntryPath.SUB_AGENT) ──────────────────────
+    //
+    // The sub-agent base prompt is a separate resource (`sub-agent-base.md`)
+    // that advertises ONLY the tools in `subAgentToolRegistry()` (perception +
+    // report_findings). It must NOT advertise the orchestrator/Reactive tools
+    // the sub-agent cannot call — otherwise the LLM trusts the prompt's tool
+    // index over its 6-entry tools schema and calls tools that aren't in its
+    // registry, surfacing as "Unknown tool: <name>" (the bug this section
+    // pins). See RunSubAgentTool + subAgentToolRegistry for the tool set.
+
+    @Test
+    fun `build sub agent returns one message`() {
+        val amb = Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList()
+        )
+        val msgs = SystemPromptBuilder.build(EntryPath.SUB_AGENT, amb)
+        Assert.assertEquals("SUB_AGENT should return 1 seed message", 1, msgs.size)
+    }
+
+    @Test
+    fun `sub-agent base prompt is distinct from the orchestrator base prompt`() {
+        // Sanity: the sub-agent must not be seeded with the orchestrator's
+        // base prompt. If it were, it would inherit the full tool index and
+        // the "unknown tool" bug would return.
+        val subAgent = SystemPromptBuilder.buildSubAgent().content
+        val orchestrator = SystemPromptBuilder.build().content
+        Assert.assertNotEquals(
+            "sub-agent base prompt must differ from the orchestrator base prompt",
+            orchestrator, subAgent
+        )
+    }
+
+    @Test
+    fun `sub-agent base prompt advertises its registered tools`() {
+        // The 6 tools in subAgentToolRegistry() — the prompt's tool index is
+        // the only menu the sub-agent LLM should trust.
+        val text = SystemPromptBuilder.buildSubAgent().content
+        for (tool in listOf(
+            "list_rule_keys", "get_rule_detail", "get_psi_class_info",
+            "find_classes_by_annotation", "find_classes_by_supertype",
+            "report_findings"
+        )) {
+            Assert.assertTrue(
+                "sub-agent base prompt should advertise '$tool': $text",
+                text.contains(tool)
+            )
+        }
+    }
+
+    @Test
+    fun `sub-agent base prompt does not advertise orchestrator or reactive tools`() {
+        // The orchestrator/Reactive tools the sub-agent cannot call. These are
+        // the exact tools the sub-agent called as "Unknown tool" in idea.log
+        // before the fix — pinning their absence from the ADVERTISED tool set
+        // prevents the regression.
+        //
+        // We check ADVERTISEMENT entries — bullet lines that introduce a tool
+        // by name (`` - `tool_name` — … ``). The prompt is allowed to *name*
+        // a forbidden tool inside clarifying notes (e.g. the "do NOT call any
+        // other tool" warning, or "you do not have propose_rule_content — that
+        // belongs to the orchestrator"), because those are corrective nudges,
+        // not advertisements. What matters is that no forbidden tool is
+        // presented as available.
+        val full = SystemPromptBuilder.buildSubAgent().content
+        // An advertisement is a line whose bullet payload starts with the tool
+        // name wrapped in backticks, e.g. "- `get_plugin_doc` — ...".
+        val advertisedToolNames = Regex("""(?m)^-\s*`([a-z_]+)`""")
+            .findAll(full)
+            .map { it.groupValues[1] }
+            .toSet()
+        for (forbidden in listOf(
+            "list_project_endpoints", "get_plugin_doc", "find_classes_by_name",
+            "get_existing_rules_for_key", "propose_rule_content",
+            "create_task_list", "update_task", "read_rule_file",
+            "ask_clarification", "get_detection_prompt", "get_psi_method_info",
+            "get_module_dependency_graph", "run_sub_agent"
+        )) {
+            Assert.assertFalse(
+                "sub-agent prompt must NOT advertise orchestrator/Reactive " +
+                    "tool '$forbidden' as an available tool " +
+                    "(advertised: $advertisedToolNames)",
+                forbidden in advertisedToolNames
+            )
+        }
+        // And the 6 registered tools MUST be advertised.
+        for (registered in listOf(
+            "list_rule_keys", "get_rule_detail", "get_psi_class_info",
+            "find_classes_by_annotation", "find_classes_by_supertype",
+            "report_findings"
+        )) {
+            Assert.assertTrue(
+                "sub-agent prompt MUST advertise registered tool '$registered' " +
+                    "(advertised: $advertisedToolNames)",
+                registered in advertisedToolNames
+            )
+        }
+    }
+
+    @Test
+    fun `sub-agent base prompt forbids unregistered tools`() {
+        // The prompt must explicitly tell the model not to call tools outside
+        // its registry, so a model that pattern-matches from training data
+        // still steers back to the 6 registered tools.
+        val text = SystemPromptBuilder.buildSubAgent().content
+        Assert.assertTrue(
+            "sub-agent base prompt should warn against calling unregistered tools: $text",
+            text.contains("do NOT call any other tool", ignoreCase = true) ||
+                text.contains("do not call any other tool", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `sub-agent base prompt directs toward report_findings as the terminal action`() {
+        // report_findings is the sub-agent's ONLY state-changing action and
+        // its terminal action. The prompt must teach this so the sub-agent
+        // ends its turn correctly instead of looking for propose_rule_content.
+        val text = SystemPromptBuilder.buildSubAgent().content
+        Assert.assertTrue(
+            "sub-agent base prompt should name report_findings as the terminal action: $text",
+            text.contains("report_findings")
+        )
+        Assert.assertTrue(
+            "sub-agent base prompt should note report_findings ends the turn: $text",
+            text.contains("ends your turn", ignoreCase = true) ||
+                text.contains("end your turn", ignoreCase = true) ||
+                text.contains("terminal", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `build reactive index messages are non-empty when features enabled`() {
+        // With postman enabled, the rule index should include the
+        // `postman.test` catalog entry (AC-S7).
+        val amb = Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList(),
+            enabledChannels = listOf("postman")
+        )
+        val msgs = SystemPromptBuilder.build(EntryPath.REACTIVE, amb)
+        // msgs[1] = detection index, msgs[2] = rule index.
+        val ruleIndex = msgs[2].content
+        Assert.assertTrue(
+            "rule index should mention postman.test when Postman is enabled: $ruleIndex",
+            ruleIndex.contains("postman.test")
+        )
+    }
+
+    @Test
+    fun `build reactive rule index omits postman entries when postman disabled`() {
+        // AC-S7: a `channel: postman` rule file is absent from the rule index
+        // when Postman is disabled.
+        val amb = Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList(),
+            enabledChannels = emptyList() // Postman disabled
+        )
+        val msgs = SystemPromptBuilder.build(EntryPath.REACTIVE, amb)
+        val ruleIndex = msgs[2].content
+        Assert.assertFalse(
+            "rule index should NOT mention postman.test when Postman is disabled: $ruleIndex",
+            ruleIndex.contains("postman.test")
+        )
+    }
+
+    @Test
+    fun `build reactive disabled features keep unscoped entries and drop scoped ones`() {
+        // When all features are disabled, scoped entries (e.g. postman.test)
+        // are filtered out, but unscoped entries (e.g. field.ignore) still
+        // appear — their CatalogScope has all-null fields and always matches
+        // (design C1, mirrors PromptCatalogTest.listFor_unscopedEntriesAlwaysAppear).
+        // The "(none for the currently enabled features)" body only renders
+        // when the catalog is truly empty (e.g. missing manifest).
+        val amb = Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList(),
+            enabledChannels = emptyList(),
+            enabledFormats = emptyList(),
+            frameworkHints = emptyList()
+        )
+        val msgs = SystemPromptBuilder.build(EntryPath.REACTIVE, amb)
+        val ruleIndex = msgs[2].content
+        // Unscoped entries always appear (field.ignore has no channel/format/framework).
+        Assert.assertTrue(
+            "rule index should include unscoped entry field.ignore when all features are disabled: $ruleIndex",
+            ruleIndex.contains("field.ignore")
+        )
+        // Scoped entries (channel: postman) are filtered out when their channel is disabled.
+        Assert.assertFalse(
+            "rule index should NOT include scoped entry postman.test when postman is disabled: $ruleIndex",
+            ruleIndex.contains("postman.test")
         )
     }
 
@@ -294,6 +567,104 @@ class SystemPromptBuilderTest {
             "ambient should NOT include a 'frameworks active:' segment when frameworkHints is empty: $text",
             text.contains("frameworks active:")
         )
+    }
+
+    // ── Ambient enabled-channels / enabled-formats hints (A5b) ──
+
+    @Test
+    fun `ambient message renders enabled channels when enabledChannels is non-empty`() {
+        // The enabled-export-channel ids are surfaced so the agent knows which
+        // destinations are turned on (AC-S7). Conditional-append style —
+        // mirrors moduleNames/frameworkHints/userLanguage.
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                enabledChannels = listOf("postman", "markdown")
+            )
+        )
+        val text = msg.content
+        Assert.assertTrue(
+            "ambient should include 'enabled channels: postman, markdown' when enabledChannels is non-empty: $text",
+            text.contains("enabled channels: postman, markdown")
+        )
+    }
+
+    @Test
+    fun `ambient message omits enabled channels segment when enabledChannels is empty`() {
+        // Empty list → no hint (carries no useful perception).
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                enabledChannels = emptyList()
+            )
+        )
+        val text = msg.content
+        Assert.assertFalse(
+            "ambient should NOT include an 'enabled channels:' segment when enabledChannels is empty: $text",
+            text.contains("enabled channels:")
+        )
+    }
+
+    @Test
+    fun `ambient message renders enabled formats when enabledFormats is non-empty`() {
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                enabledFormats = listOf("json", "yaml")
+            )
+        )
+        val text = msg.content
+        Assert.assertTrue(
+            "ambient should include 'enabled formats: json, yaml' when enabledFormats is non-empty: $text",
+            text.contains("enabled formats: json, yaml")
+        )
+    }
+
+    @Test
+    fun `ambient message omits enabled formats segment when enabledFormats is empty`() {
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                enabledFormats = emptyList()
+            )
+        )
+        val text = msg.content
+        Assert.assertFalse(
+            "ambient should NOT include an 'enabled formats:' segment when enabledFormats is empty: $text",
+            text.contains("enabled formats:")
+        )
+    }
+
+    @Test
+    fun `ambient message surfaces all enabled-feature hints together`() {
+        // Verify the four conditional segments coexist in one ambient message
+        // (modules + frameworks + channels + formats + user language).
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                moduleNames = listOf("order-service"),
+                frameworkHints = listOf("SpringMVC"),
+                enabledChannels = listOf("postman"),
+                enabledFormats = listOf("json"),
+                userLanguage = "zh-CN"
+            )
+        )
+        val text = msg.content
+        Assert.assertTrue("modules segment missing: $text", text.contains("modules: order-service"))
+        Assert.assertTrue("frameworks segment missing: $text", text.contains("frameworks active: SpringMVC"))
+        Assert.assertTrue("enabled channels segment missing: $text", text.contains("enabled channels: postman"))
+        Assert.assertTrue("enabled formats segment missing: $text", text.contains("enabled formats: json"))
+        Assert.assertTrue("user language segment missing: $text", text.contains("user language: zh-CN"))
     }
 
     // ── Token-budget tripwire ──

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/TaskListLifecycleEventsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/TaskListLifecycleEventsTest.kt
@@ -1,0 +1,45 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure unit tests for the five new [AgentEvent] subtypes added in B2.
+ *
+ * The sealed hierarchy is additive — existing consumers keep compiling.
+ * This test confirms each subtype instantiates and carries its payload.
+ */
+class TaskListLifecycleEventsTest {
+
+    @Test
+    fun taskListCreatedCarriesTaskList() {
+        val taskList = TaskList(listOf(Task("s1", "first")))
+        val ev = AgentEvent.TaskListCreated(taskList)
+        assertEquals(taskList, ev.taskList)
+    }
+
+    @Test
+    fun taskStartedCarriesId() {
+        val ev = AgentEvent.TaskStarted("s1")
+        assertEquals("s1", ev.taskId)
+    }
+
+    @Test
+    fun taskCompletedCarriesId() {
+        val ev = AgentEvent.TaskCompleted("s2")
+        assertEquals("s2", ev.taskId)
+    }
+
+    @Test
+    fun taskFailedCarriesIdAndReason() {
+        val ev = AgentEvent.TaskFailed("s3", "boom")
+        assertEquals("s3", ev.taskId)
+        assertEquals("boom", ev.reason)
+    }
+
+    @Test
+    fun taskSkippedCarriesId() {
+        val ev = AgentEvent.TaskSkipped("s4")
+        assertEquals("s4", ev.taskId)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/TaskListTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/TaskListTest.kt
@@ -1,0 +1,73 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Pure unit tests for [TaskList] / [Task] / [TaskStatus] and the
+ * `taskList` field on [AgentMemory].
+ *
+ * No IDE / PSI dependency — Pattern A (simple JUnit 4).
+ */
+class TaskListTest {
+
+    @Test
+    fun taskListAcceptsDistinctTaskIds() {
+        val taskList = TaskList(listOf(
+            Task("s1", "detect"),
+            Task("s2", "propose")
+        ))
+        assertEquals(2, taskList.tasks.size)
+        assertEquals("s1", taskList.byId("s1")?.id)
+        assertEquals("s2", taskList.byId("s2")?.id)
+    }
+
+    @Test
+    fun taskListRejectsDuplicateTaskIds() {
+        try {
+            TaskList(listOf(
+                Task("s1", "first"),
+                Task("s1", "second")
+            ))
+            fail("expected IllegalArgumentException for duplicate ids")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(
+                "message should mention duplicate ids: ${e.message}",
+                e.message?.contains("duplicate task ids") == true
+            )
+        }
+    }
+
+    @Test
+    fun byIdReturnsNullForUnknownId() {
+        val taskList = TaskList(listOf(Task("s1", "only")))
+        assertNull(taskList.byId("nope"))
+    }
+
+    @Test
+    fun newTasksDefaultToPending() {
+        val taskList = TaskList(listOf(
+            Task("s1", "a"),
+            Task("s2", "b", detail = "elaboration")
+        ))
+        taskList.tasks.forEach {
+            assertEquals(
+                "task ${it.id} should default to PENDING",
+                TaskStatus.PENDING, it.status
+            )
+        }
+        assertEquals("elaboration", taskList.byId("s2")?.detail)
+    }
+
+    @Test
+    fun agentMemoryTaskListStartsNullAndResets() {
+        val memory = AgentMemory()
+        assertNull("taskList should start null", memory.taskList)
+        memory.taskList = TaskList(listOf(Task("s1", "x")))
+        memory.reset()
+        assertNull("reset() should clear taskList", memory.taskList)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/TwoTurnContractTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/TwoTurnContractTest.kt
@@ -1,0 +1,229 @@
+package com.itangcent.easyapi.core.ai.agent
+
+import com.itangcent.easyapi.core.ai.AiChatRequest
+import com.itangcent.easyapi.core.ai.AiChatResponse
+import com.itangcent.easyapi.core.ai.AiMessage
+import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.AiRuntimeConfig
+import com.itangcent.easyapi.core.ai.AIService
+import com.itangcent.easyapi.core.ai.tools.ToolContext
+import com.itangcent.easyapi.core.ai.tools.ToolRegistry
+import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.config.source.RuleFileResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Empty-file two-turn contract regression tests.
+ *
+ * These tests verify the de facto contract that Magic on an empty rule file
+ * follows: Turn 1 (system, no LLM) seeds the task list and emits
+ * [AgentEvent.TaskListCreated] **before** Turn 2 (AI) emits its first
+ * [AgentEvent.Thinking]; the orchestrator never calls `create_task_list`
+ * (the task list is seeded); and an empty catalog still emits
+ * [AgentEvent.TaskListCreated] (with zero tasks) and proceeds cleanly.
+ *
+ * The tests simulate what [com.itangcent.easyapi.core.ai.ui.AiChatPanel.runTaskList]
+ * does — seed `memory.taskList`, `tryEmit(TaskListCreated)`, then call
+ * `agent.runTurn(..., entryPath = TASK_LIST_PROGRAMMATIC)` — at the agent
+ * level so the event stream (including agent-emitted `Thinking`) is captured
+ * synchronously via an `Unconfined` collector. The panel itself uses
+ * `Dispatchers.Default` + EDT, which makes end-to-end panel-level event
+ * ordering timing-dependent; the contract is cleaner to assert here.
+ */
+class TwoTurnContractTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    /**
+     * FR-2.6 / AC-2(a) — `TaskListCreated` is emitted before the first
+     * `Thinking` event of the turn.
+     *
+     * Simulates `runTaskList`: seeds a non-empty task list, emits
+     * `TaskListCreated`, then runs the agent (which emits `Thinking` as its
+     * first event). Asserts the first collected event is `TaskListCreated`
+     * and no `Thinking` precedes it.
+     */
+    fun testTaskListCreatedEmittedBeforeFirstThinking() = runBlocking {
+        val events = MutableSharedFlow<AgentEvent>(
+            replay = Int.MAX_VALUE, extraBufferCapacity = 64
+        )
+        val memory = AgentMemory()
+        val aiService = FakeAIService()
+        // Plain text answer — no tool calls, turn completes immediately.
+        aiService.enqueueText("done")
+        val ctx = buildCtx(memory, events)
+        val tools = ToolRegistry(emptyList())
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events)
+
+        val collected = mutableListOf<AgentEvent>()
+        val collectJob = scope().launch(
+            Dispatchers.Unconfined, CoroutineStart.UNDISPATCHED
+        ) {
+            events.collect { collected.add(it) }
+        }
+
+        // Simulate runTaskList: seed → emit → run.
+        val taskList = TaskList(listOf(
+            Task("t1", "Detect custom patterns", "scan for filters")
+        ))
+        memory.taskList = taskList
+        events.tryEmit(AgentEvent.TaskListCreated(taskList))
+        agent.runTurn(
+            "instruction", memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+
+        collectJob.cancelAndJoin()
+
+        assertTrue("events should not be empty", collected.isNotEmpty())
+        assertTrue(
+            "First event should be TaskListCreated, got ${collected.first()::class.simpleName}",
+            collected.first() is AgentEvent.TaskListCreated
+        )
+        val firstThinkingIdx = collected.indexOfFirst { it is AgentEvent.Thinking }
+        assertTrue("Thinking should be emitted", firstThinkingIdx >= 0)
+        assertTrue(
+            "TaskListCreated should come before first Thinking " +
+                "(TaskListCreated=0, Thinking=$firstThinkingIdx)",
+            0 < firstThinkingIdx
+        )
+    }
+
+    /**
+     * FR-2.4 / AC-2(b) — the Magic orchestrator SHALL NOT call
+     * `create_task_list`. The task list is seeded; only the Reactive path
+     * may call it.
+     *
+     * Instruments the AIService to fail the test if any assistant message
+     * carries a `create_task_list` tool call during a
+     * `TASK_LIST_PROGRAMMATIC` turn. Drives the empty-file Magic turn;
+     * asserts no throw.
+     */
+    fun testMagicOrchestratorNeverCallsCreateTaskList() = runBlocking {
+        val events = MutableSharedFlow<AgentEvent>(
+            replay = Int.MAX_VALUE, extraBufferCapacity = 64
+        )
+        val memory = AgentMemory()
+
+        // Instrument: fail if the agent ever issues create_task_list.
+        val aiService = object : AIService {
+            override suspend fun chat(request: AiChatRequest): AiChatResponse {
+                val lastAssistant = request.messages.lastOrNull { it is AiMessage.Assistant }
+                    as? AiMessage.Assistant
+                lastAssistant?.toolCalls?.forEach { tc ->
+                    if (tc.name == "create_task_list") {
+                        error(
+                            "Magic orchestrator must NOT call create_task_list " +
+                                "(FR-2.4), but got: ${tc.arguments}"
+                        )
+                    }
+                }
+                // Return a plain text answer so the turn ends immediately.
+                return AiChatResponse(AiMessage.Assistant("done", null), "stop")
+            }
+            override suspend fun testConnection(): Result<String> =
+                Result.success("ok")
+        }
+
+        val ctx = buildCtx(memory, events)
+        val tools = ToolRegistry(emptyList())
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events)
+
+        // Seed the task list (as runTaskList does) so the agent has no
+        // reason to call create_task_list.
+        val taskList = TaskList(listOf(
+            Task("t1", "Detect custom patterns", "scan for filters")
+        ))
+        memory.taskList = taskList
+        events.tryEmit(AgentEvent.TaskListCreated(taskList))
+
+        // Run the turn — the instrumented AIService throws if create_task_list
+        // is ever issued. A clean return proves the orchestrator didn't call it.
+        val outcome = agent.runTurn(
+            "instruction", memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+        assertNotNull("turn should complete without throwing", outcome)
+    }
+
+    /**
+     * FR-2.5 — when the detection catalog yields zero tasks, the system
+     * still emits `TaskListCreated` (with an empty list) and proceeds
+     * directly to `propose_rule_content` (or finishes cleanly with no
+     * proposal).
+     *
+     * Seeds an empty task list, emits `TaskListCreated(empty)`, runs the
+     * agent. Asserts `TaskListCreated` was emitted with zero tasks and the
+     * turn completes cleanly.
+     */
+    fun testEmptyCatalogStillEmitsTaskListCreated() = runBlocking {
+        val events = MutableSharedFlow<AgentEvent>(
+            replay = Int.MAX_VALUE, extraBufferCapacity = 64
+        )
+        val memory = AgentMemory()
+        val aiService = FakeAIService()
+        // No tasks → agent has nothing to walk; it answers with plain text.
+        aiService.enqueueText("no detections needed")
+        val ctx = buildCtx(memory, events)
+        val tools = ToolRegistry(emptyList())
+        val agent = RuleAuthoringAgent(aiService, tools, ctx, events)
+
+        val collected = mutableListOf<AgentEvent>()
+        val collectJob = scope().launch(
+            Dispatchers.Unconfined, CoroutineStart.UNDISPATCHED
+        ) {
+            events.collect { collected.add(it) }
+        }
+
+        // Seed an EMPTY task list (zero tasks).
+        val emptyTaskList = TaskList(emptyList())
+        memory.taskList = emptyTaskList
+        events.tryEmit(AgentEvent.TaskListCreated(emptyTaskList))
+
+        val outcome = agent.runTurn(
+            "instruction", memory,
+            entryPath = EntryPath.TASK_LIST_PROGRAMMATIC
+        )
+
+        collectJob.cancelAndJoin()
+
+        // TaskListCreated (with empty list) was emitted.
+        val tlc = collected.filterIsInstance<AgentEvent.TaskListCreated>().single()
+        assertTrue(
+            "task list should be empty (zero tasks)",
+            tlc.taskList.tasks.isEmpty()
+        )
+        // Turn completed cleanly — either Answered or Proposed.
+        assertNotNull("turn should complete cleanly even with zero tasks", outcome)
+    }
+
+    // --- Helpers ---
+
+    private fun buildCtx(
+        memory: AgentMemory,
+        events: MutableSharedFlow<AgentEvent>
+    ): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OLLAMA,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30,
+            // Small budget keeps the tests snappy.
+            maxRequests = 3
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = memory,
+        approvals = FakeApprovalGate(),
+        events = events
+    )
+
+    private fun scope() =
+        CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/AskClarificationToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/AskClarificationToolTest.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.core.ai.tools
 
 import com.itangcent.easyapi.core.ai.AiProvider
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ClarificationAnswers
 import com.itangcent.easyapi.core.ai.agent.ClarificationGate
@@ -11,6 +12,7 @@ import com.itangcent.easyapi.core.ai.agent.QuestionKind
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -31,7 +33,8 @@ class AskClarificationToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
         approvals = FakeApprovalGate(),
-        clarifications = gate
+        clarifications = gate,
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     fun testFormatsAnswersAndParsesKinds() = runBlocking {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/CreateTaskListToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/CreateTaskListToolTest.kt
@@ -1,0 +1,225 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.AiRuntimeConfig
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
+import com.itangcent.easyapi.core.ai.agent.AgentMemory
+import com.itangcent.easyapi.core.ai.agent.ApprovalGate
+import com.itangcent.easyapi.core.ai.agent.TaskStatus
+import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.config.source.RuleFileResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+
+/**
+ * Tests for [CreateTaskListTool] (design C7 / task B4).
+ *
+ * Verifies the contract:
+ * - Creates a task list with all tasks at [TaskStatus.PENDING], stores it in
+ *   `workingMemory.taskList`, emits [AgentEvent.TaskListCreated], returns
+ *   `Text("task list created with N tasks")`.
+ * - Replacement path (task list already staged) emits a fresh
+ *   `TaskListCreated`.
+ * - Validation errors (missing/blank tasks / id / title, duplicate ids)
+ *   return `Error` and do not mutate memory.
+ */
+class CreateTaskListToolTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun ctx(memory: AgentMemory = AgentMemory()): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30, maxRequests = 8
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = memory,
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
+    )
+
+    private fun tasks(
+        vararg tasks: Triple<String, String, String?>
+    ): Map<String, Any?> = mapOf(
+        "tasks" to tasks.map { (id, title, detail) ->
+            if (detail == null) {
+                mapOf("id" to id, "title" to title)
+            } else {
+                mapOf("id" to id, "title" to title, "detail" to detail)
+            }
+        }
+    )
+
+    fun testCreatesTaskListAndEmitsEvent() = runBlocking {
+        val memory = AgentMemory()
+        val ctx = ctx(memory)
+        val collected = mutableListOf<AgentEvent>()
+        val collector = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+            ctx.events.collect { collected.add(it) }
+        }
+        try {
+            val result = CreateTaskListTool().execute(
+                tasks(
+                    Triple("s1", "Detect filters", "find OncePerRequestFilter subclasses"),
+                    Triple("s2", "Confirm with user", null),
+                    Triple("s3", "Propose rules", null)
+                ),
+                ctx
+            )
+            Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+            Assert.assertEquals(
+                "task list created with 3 tasks",
+                (result as ToolResult.Text).value
+            )
+            // Task list staged in memory with every task PENDING.
+            val taskList = memory.taskList
+            Assert.assertNotNull("task list should be staged in memory", taskList)
+            Assert.assertEquals(3, taskList!!.tasks.size)
+            Assert.assertEquals("s1", taskList.tasks[0].id)
+            Assert.assertEquals("Detect filters", taskList.tasks[0].title)
+            Assert.assertEquals(
+                "find OncePerRequestFilter subclasses",
+                taskList.tasks[0].detail
+            )
+            Assert.assertEquals(TaskStatus.PENDING, taskList.tasks[0].status)
+            Assert.assertEquals(TaskStatus.PENDING, taskList.tasks[1].status)
+            Assert.assertEquals(TaskStatus.PENDING, taskList.tasks[2].status)
+            // TaskListCreated event emitted.
+            val taskListCreated = collected.filterIsInstance<AgentEvent.TaskListCreated>().singleOrNull()
+            Assert.assertNotNull("TaskListCreated should be emitted", taskListCreated)
+            Assert.assertSame(taskList, taskListCreated!!.taskList)
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    fun testReplacementEmitsFreshTaskListCreated() = runBlocking {
+        val memory = AgentMemory()
+        val ctx = ctx(memory)
+        val collected = mutableListOf<AgentEvent>()
+        val collector = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+            ctx.events.collect { collected.add(it) }
+        }
+        try {
+            // First call stages a 2-task task list.
+            CreateTaskListTool().execute(
+                tasks(Triple("a", "first", null), Triple("b", "second", null)),
+                ctx
+            )
+            // Second call replaces with a 1-task task list.
+            val result = CreateTaskListTool().execute(
+                tasks(Triple("x", "replacement", null)),
+                ctx
+            )
+            Assert.assertTrue(result is ToolResult.Text)
+            Assert.assertEquals("task list created with 1 tasks", (result as ToolResult.Text).value)
+            // Memory holds the replacement.
+            val taskList = memory.taskList!!
+            Assert.assertEquals(1, taskList.tasks.size)
+            Assert.assertEquals("x", taskList.tasks[0].id)
+            // Two TaskListCreated events were emitted (one per call).
+            val taskListCreatedEvents = collected.filterIsInstance<AgentEvent.TaskListCreated>()
+            Assert.assertEquals("expected two TaskListCreated events", 2, taskListCreatedEvents.size)
+            Assert.assertSame(taskList, taskListCreatedEvents.last().taskList)
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    fun testRejectsMissingTasks() = runBlocking {
+        val memory = AgentMemory()
+        val ctx = ctx(memory)
+        val result = CreateTaskListTool().execute(emptyMap(), ctx)
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("tasks")
+        )
+        Assert.assertNull("task list must not be staged on error", memory.taskList)
+    }
+
+    fun testRejectsEmptyTasksArray() = runBlocking {
+        val memory = AgentMemory()
+        val ctx = ctx(memory)
+        val result = CreateTaskListTool().execute(mapOf("tasks" to emptyList<Any>()), ctx)
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertNull("task list must not be staged on error", memory.taskList)
+    }
+
+    fun testRejectsTaskWithMissingId() = runBlocking {
+        val memory = AgentMemory()
+        val ctx = ctx(memory)
+        val result = CreateTaskListTool().execute(
+            mapOf("tasks" to listOf(mapOf("title" to "no id"))),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            "error should mention id: ${(result as ToolResult.Error).message}",
+            result.message.contains("id")
+        )
+        Assert.assertNull("task list must not be staged on error", memory.taskList)
+    }
+
+    fun testRejectsTaskWithMissingTitle() = runBlocking {
+        val memory = AgentMemory()
+        val ctx = ctx(memory)
+        val result = CreateTaskListTool().execute(
+            mapOf("tasks" to listOf(mapOf("id" to "s1"))),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            "error should mention title: ${(result as ToolResult.Error).message}",
+            result.message.contains("title")
+        )
+        Assert.assertNull("task list must not be staged on error", memory.taskList)
+    }
+
+    fun testRejectsDuplicateTaskIds() = runBlocking {
+        val memory = AgentMemory()
+        val ctx = ctx(memory)
+        val result = CreateTaskListTool().execute(
+            tasks(
+                Triple("dup", "first", null),
+                Triple("dup", "second", null)
+            ),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            "error should mention duplicate ids: ${(result as ToolResult.Error).message}",
+            result.message.contains("duplicate")
+        )
+        Assert.assertNull("task list must not be staged on error", memory.taskList)
+    }
+
+    fun testIsPerceptionTool() {
+        Assert.assertEquals(ToolKind.PERCEPTION, CreateTaskListTool().kind)
+    }
+
+    fun testDoesNotRequireApproval() {
+        // create_task_list is PERCEPTION → requiresApproval defaults to false.
+        Assert.assertFalse(CreateTaskListTool().requiresApproval)
+    }
+
+    fun testIsRegisteredInStandardToolSet() {
+        val names = standardRuleTools().map { it.name }
+        Assert.assertTrue("create_task_list must be registered", names.contains("create_task_list"))
+    }
+
+    fun testSchemaDeclaresRequiredParameters() {
+        val schema = CreateTaskListTool().parametersSchema
+        val required = schema["required"] as List<*>
+        Assert.assertTrue("tasks must be required", required.contains("tasks"))
+    }
+
+    private class NoOpApprovalGate : ApprovalGate {
+        override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationToolTest.kt
@@ -3,12 +3,14 @@ package com.itangcent.easyapi.core.ai.tools
 import com.intellij.openapi.application.ApplicationManager
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
 import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.core.util.json.GsonUtils
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 
@@ -31,7 +33,8 @@ class FindClassesByAnnotationToolTest : EasyApiLightCodeInsightFixtureTestCase()
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     private fun addClasses() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByNameToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByNameToolTest.kt
@@ -3,12 +3,14 @@ package com.itangcent.easyapi.core.ai.tools
 import com.intellij.openapi.application.ApplicationManager
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
 import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.core.util.json.GsonUtils
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 
@@ -35,7 +37,8 @@ class FindClassesByNameToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     private fun addClasses() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeToolTest.kt
@@ -3,12 +3,14 @@ package com.itangcent.easyapi.core.ai.tools
 import com.intellij.openapi.application.ApplicationManager
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
 import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.core.util.json.GsonUtils
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 
@@ -33,7 +35,8 @@ class FindClassesBySupertypeToolTest : EasyApiLightCodeInsightFixtureTestCase() 
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     private fun addClasses() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetModuleDependencyGraphToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetModuleDependencyGraphToolTest.kt
@@ -7,6 +7,7 @@ import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 
@@ -43,7 +44,8 @@ class GetModuleDependencyGraphToolTest : EasyApiLightCodeInsightFixtureTestCase(
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     // --- Pure rendering: adjacency list ---

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoToolTest.kt
@@ -3,12 +3,14 @@ package com.itangcent.easyapi.core.ai.tools
 import com.intellij.openapi.application.ApplicationManager
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
 import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.core.util.json.GsonUtils
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 
@@ -32,7 +34,8 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     private fun addClasses() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoToolTest.kt
@@ -3,12 +3,14 @@ package com.itangcent.easyapi.core.ai.tools
 import com.intellij.openapi.application.ApplicationManager
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
 import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.core.util.json.GsonUtils
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 
@@ -32,7 +34,8 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     private fun addClasses() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/ListProjectEndpointsToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/ListProjectEndpointsToolTest.kt
@@ -15,6 +15,7 @@ import com.itangcent.easyapi.core.export.HttpMethod
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.core.util.json.GsonUtils
 import com.intellij.testFramework.registerServiceInstance
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 
@@ -42,7 +43,8 @@ class ListProjectEndpointsToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = AgentMemory(),
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     override fun setUp() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/OrchestratorToolRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/OrchestratorToolRegistryTest.kt
@@ -1,0 +1,241 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.AiToolSpec
+import com.itangcent.easyapi.core.ai.agent.FakeAIService
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert
+
+/**
+ * Tests the Phase-3 tool-set split (design §3.5 / FR-3.2, FR-3.3, D6 / T3.12).
+ *
+ * The orchestrator and sub-agent each get a restricted tool set so roles
+ * cannot be crossed at the LLM level:
+ *
+ * - **Orchestrator** — `{ update_task, run_sub_agent, propose_rule_content }`.
+ *   No perception tools (no `find_classes_by_annotation`, no
+ *   `get_detection_prompt`); the orchestrator never touches PSI directly.
+ *   No `report_findings` (sub-agent-only terminal action).
+ * - **Sub-agent** — `{ find_classes_by_annotation, find_classes_by_supertype,
+ *   get_psi_class_info, get_rule_detail, list_rule_keys, report_findings }`.
+ *   No `propose_rule_content`, no `run_sub_agent` — the sub-agent cannot
+ *   recurse and cannot stage final rule content.
+ *
+ * `create_task_list` is intentionally absent from both sets: the task list
+ * is seeded by the caller (FR-2.4), and sub-agents don't manage the
+ * orchestrator's task list.
+ */
+class OrchestratorToolRegistryTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    /**
+     * FR-3.2 / FR-3.3 / T3.12 — the orchestrator's `ToolRegistry.schemas()`
+     * MUST NOT advertise any perception tool. The orchestrator coordinates;
+     * sub-agents perceive.
+     *
+     * Asserts neither `find_classes_by_annotation` nor `get_detection_prompt`
+     * appear in the orchestrator's advertised schemas (representative
+     * perception tools — the full set is checked by [testOrchestratorAdvertisesOnlyCoordinationTools]).
+     */
+    fun testOrchestratorDoesNotExposePerceptionTools() {
+        val orchestratorTools = ToolRegistry(
+            orchestratorToolRegistry(FakeAIService(), ToolRegistry(subAgentToolRegistry()))
+        )
+        val names = orchestratorTools.schemas().map { it.name }
+
+        Assert.assertFalse(
+            "orchestrator must not expose find_classes_by_annotation: $names",
+            names.contains("find_classes_by_annotation")
+        )
+        Assert.assertFalse(
+            "orchestrator must not expose get_detection_prompt: $names",
+            names.contains("get_detection_prompt")
+        )
+    }
+
+    /**
+     * FR-3.2 / FR-3.3 / T3.12 — the sub-agent's `ToolRegistry.schemas()`
+     * MUST NOT advertise `propose_rule_content` or `run_sub_agent`. The
+     * sub-agent cannot stage final rule content and cannot recurse.
+     */
+    fun testSubAgentDoesNotExposeOrchestratorTools() {
+        val subAgentTools = ToolRegistry(subAgentToolRegistry())
+        val names = subAgentTools.schemas().map { it.name }
+
+        Assert.assertFalse(
+            "sub-agent must not expose propose_rule_content: $names",
+            names.contains("propose_rule_content")
+        )
+        Assert.assertFalse(
+            "sub-agent must not expose run_sub_agent: $names",
+            names.contains("run_sub_agent")
+        )
+    }
+
+    /**
+     * Full set assertion — the orchestrator advertises EXACTLY the three
+     * coordination tools and nothing else.
+     *
+     * Catches a regression where a perception tool is accidentally added
+     * to the orchestrator's set (e.g. via a copy-paste from
+     * [standardRuleTools]).
+     */
+    fun testOrchestratorAdvertisesOnlyCoordinationTools() {
+        val orchestratorTools = ToolRegistry(
+            orchestratorToolRegistry(FakeAIService(), ToolRegistry(subAgentToolRegistry()))
+        )
+        val names = orchestratorTools.schemas().map { it.name }
+
+        Assert.assertEquals(
+            "orchestrator should advertise exactly 3 tools: $names",
+            3, names.size
+        )
+        Assert.assertTrue(
+            "orchestrator should advertise update_task: $names",
+            names.contains("update_task")
+        )
+        Assert.assertTrue(
+            "orchestrator should advertise run_sub_agent: $names",
+            names.contains("run_sub_agent")
+        )
+        Assert.assertTrue(
+            "orchestrator should advertise propose_rule_content: $names",
+            names.contains("propose_rule_content")
+        )
+    }
+
+    /**
+     * Full set assertion — the sub-agent advertises EXACTLY the five
+     * perception tools + `report_findings`.
+     *
+     * Catches a regression where an orchestrator tool is accidentally
+     * added to the sub-agent's set.
+     */
+    fun testSubAgentAdvertisesOnlyPerceptionAndReportFindings() {
+        val subAgentTools = ToolRegistry(subAgentToolRegistry())
+        val names = subAgentTools.schemas().map { it.name }
+
+        Assert.assertEquals(
+            "sub-agent should advertise exactly 6 tools: $names",
+            6, names.size
+        )
+        // Perception tools.
+        Assert.assertTrue(names.contains("find_classes_by_annotation"))
+        Assert.assertTrue(names.contains("find_classes_by_supertype"))
+        Assert.assertTrue(names.contains("get_psi_class_info"))
+        Assert.assertTrue(names.contains("get_rule_detail"))
+        Assert.assertTrue(names.contains("list_rule_keys"))
+        // Sub-agent terminal action.
+        Assert.assertTrue(names.contains("report_findings"))
+    }
+
+    /**
+     * `create_task_list` is intentionally absent from BOTH sets — the task
+     * list is seeded by the caller (FR-2.4), and sub-agents don't manage
+     * the orchestrator's task list.
+     */
+    fun testCreateTaskListAbsentFromBothSets() {
+        val orchestratorTools = ToolRegistry(
+            orchestratorToolRegistry(FakeAIService(), ToolRegistry(subAgentToolRegistry()))
+        )
+        val subAgentTools = ToolRegistry(subAgentToolRegistry())
+
+        Assert.assertFalse(
+            "orchestrator must not advertise create_task_list",
+            orchestratorTools.schemas().any { it.name == "create_task_list" }
+        )
+        Assert.assertFalse(
+            "sub-agent must not advertise create_task_list",
+            subAgentTools.schemas().any { it.name == "create_task_list" }
+        )
+    }
+
+    /**
+     * `report_findings` is sub-agent-only — the orchestrator must NOT
+     * advertise it (each role has its own terminal action).
+     */
+    fun testReportFindingsAbsentFromOrchestrator() {
+        val orchestratorTools = ToolRegistry(
+            orchestratorToolRegistry(FakeAIService(), ToolRegistry(subAgentToolRegistry()))
+        )
+        Assert.assertFalse(
+            "orchestrator must not advertise report_findings",
+            orchestratorTools.schemas().any { it.name == "report_findings" }
+        )
+    }
+
+    /**
+     * Smoke test — the factory returns real [AiTool] instances with
+     * non-empty schemas (catches a regression where a factory returns
+     * empty lists or tools with empty schemas).
+     */
+    fun testFactoryReturnsNonEmptySchemas() {
+        val orchestratorSchemas: List<AiToolSpec> = ToolRegistry(
+            orchestratorToolRegistry(FakeAIService(), ToolRegistry(subAgentToolRegistry()))
+        ).schemas()
+        val subAgentSchemas: List<AiToolSpec> = ToolRegistry(subAgentToolRegistry()).schemas()
+
+        Assert.assertTrue(
+            "orchestrator schemas should be non-empty",
+            orchestratorSchemas.isNotEmpty()
+        )
+        Assert.assertTrue(
+            "sub-agent schemas should be non-empty",
+            subAgentSchemas.isNotEmpty()
+        )
+        // Each schema should have a non-empty description + parameters schema.
+        orchestratorSchemas.forEach { s ->
+            Assert.assertTrue("orchestrator tool ${s.name} has empty description", s.description.isNotEmpty())
+            Assert.assertTrue("orchestrator tool ${s.name} has empty schema", s.parametersJsonSchema.isNotEmpty())
+        }
+        subAgentSchemas.forEach { s ->
+            Assert.assertTrue("sub-agent tool ${s.name} has empty description", s.description.isNotEmpty())
+            Assert.assertTrue("sub-agent tool ${s.name} has empty schema", s.parametersJsonSchema.isNotEmpty())
+        }
+    }
+
+    /**
+     * The orchestrator's `propose_rule_content` tool is the
+     * [OrchestratorProposeRuleContentTool] (which merges sub-agent
+     * findings), NOT the Reactive-path [ProposeRuleContentTool]. Both
+     * share the same `name` so the LLM uses them the same way, but the
+     * orchestrator's set must wire the merging variant.
+     */
+    fun testOrchestratorUsesMergingProposeTool() {
+        val tools = orchestratorToolRegistry(FakeAIService(), ToolRegistry(subAgentToolRegistry()))
+        val proposeTool = tools.first { it.name == "propose_rule_content" }
+        Assert.assertEquals(
+            "orchestrator should use OrchestratorProposeRuleContentTool",
+            OrchestratorProposeRuleContentTool::class.java,
+            proposeTool::class.java
+        )
+    }
+
+    /**
+     * The orchestrator's `run_sub_agent` tool is the real
+     * [RunSubAgentTool] (not a fake) — wired with the supplied
+     * [com.itangcent.easyapi.core.ai.AIService] and sub-agent tool
+     * registry.
+     */
+    fun testOrchestratorUsesRealRunSubAgentTool() {
+        val fakeAiService = FakeAIService()
+        val subAgentTools = ToolRegistry(subAgentToolRegistry())
+        val tools = orchestratorToolRegistry(fakeAiService, subAgentTools)
+        val runSubAgentTool = tools.first { it.name == "run_sub_agent" }
+        Assert.assertEquals(
+            "orchestrator should use RunSubAgentTool",
+            RunSubAgentTool::class.java,
+            runSubAgentTool::class.java
+        )
+    }
+
+    /**
+     * Sanity: the test's [AiRuntimeConfig] / project context isn't needed
+     * for the registry factories — they take only [com.itangcent.easyapi.core.ai.AIService]
+     * + [ToolRegistry]. This guards against a future refactor that adds
+     * project coupling to the factory signatures.
+     */
+    fun testFactorySignaturesAreProjectAgnostic() {
+        // Builds without a project — pure factory call.
+        val tools = orchestratorToolRegistry(FakeAIService(), ToolRegistry(subAgentToolRegistry()))
+        Assert.assertEquals(3, tools.size)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
@@ -1,12 +1,14 @@
 package com.itangcent.easyapi.core.ai.tools
 
 import com.itangcent.easyapi.core.ai.AiRuntimeConfig
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
 import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.SourceValue
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import java.nio.file.Files
@@ -37,7 +39,8 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = workingMemory,
         approvals = fakeApprovalGate,
-        readConsents = readConsents
+        readConsents = readConsents,
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     // --- ListRuleKeysTool ---
@@ -48,6 +51,62 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertTrue("should contain api.name", text.contains("api.name"))
         Assert.assertTrue("should contain field.ignore", text.contains("field.ignore"))
         Assert.assertTrue("should contain postman.test", text.contains("postman.test"))
+    }
+
+    fun testListRuleKeysAttachesCatalogMetadataForKeysWithRecipeFile() {
+        // A5 catalog join: keys that have a per-key recipe file in
+        // ai/rules/<key>.md get `description` + `detailPromptId` attached.
+        // `field.ignore` has ai/rules/field.ignore.md.
+        val result = runBlocking { ListRuleKeysTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue(result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        val keys: List<Map<String, Any?>> =
+            com.itangcent.easyapi.core.util.json.GsonUtils.fromJson(text)
+        val fieldIgnore = keys.firstOrNull { it["name"] == "field.ignore" }
+        Assert.assertNotNull("field.ignore should be in the list", fieldIgnore)
+        Assert.assertTrue(
+            "field.ignore should have a description (catalog cue)",
+            fieldIgnore!!.containsKey("description")
+        )
+        Assert.assertTrue(
+            "field.ignore should have a detailPromptId",
+            fieldIgnore.containsKey("detailPromptId")
+        )
+        Assert.assertEquals("field.ignore", fieldIgnore["detailPromptId"])
+    }
+
+    fun testListRuleKeysLeavesNonCoveredKeysAtBaseShape() {
+        // Keys without a per-key recipe file (e.g. `api.name`) still return
+        // {name, type, source} — no description/detailPromptId attached.
+        val result = runBlocking { ListRuleKeysTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue(result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        val keys: List<Map<String, Any?>> =
+            com.itangcent.easyapi.core.util.json.GsonUtils.fromJson(text)
+        val apiName = keys.firstOrNull { it["name"] == "api.name" }
+        Assert.assertNotNull("api.name should be in the list", apiName)
+        Assert.assertFalse(
+            "api.name should NOT have a description (no catalog file)",
+            apiName!!.containsKey("description")
+        )
+        Assert.assertFalse(
+            "api.name should NOT have a detailPromptId (no catalog file)",
+            apiName.containsKey("detailPromptId")
+        )
+    }
+
+    fun testListRuleKeysCatalogJoinDoesNotThrowOnMissingCatalog() {
+        // The catalog join is best-effort: even if the catalog is empty or
+        // missing, the tool must return the basic {name, type, source} shape
+        // for every key (no throw). This test verifies the tool runs without
+        // throwing; the actual catalog is present in the test classpath, so
+        // we just assert the result is Text (not Error).
+        val result = runBlocking { ListRuleKeysTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue("result: $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        // Every key should at least have name + type + source.
+        Assert.assertTrue("should contain api.name", text.contains("api.name"))
+        Assert.assertTrue("should contain \"source\"", text.contains("source"))
     }
 
     // --- GetPluginDocTool ---
@@ -371,6 +430,8 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         val names = tools.map { it.name }.toSet()
         Assert.assertTrue("list_rule_keys", names.contains("list_rule_keys"))
         Assert.assertTrue("get_plugin_doc", names.contains("get_plugin_doc"))
+        Assert.assertTrue("get_detection_prompt", names.contains("get_detection_prompt"))
+        Assert.assertTrue("get_rule_detail", names.contains("get_rule_detail"))
         Assert.assertTrue("read_rule_file", names.contains("read_rule_file"))
         Assert.assertTrue("list_project_endpoints", names.contains("list_project_endpoints"))
         Assert.assertTrue("get_psi_class_info", names.contains("get_psi_class_info"))
@@ -380,12 +441,137 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertTrue("find_classes_by_name", names.contains("find_classes_by_name"))
         Assert.assertTrue("get_existing_rules_for_key", names.contains("get_existing_rules_for_key"))
         Assert.assertTrue("get_module_dependency_graph", names.contains("get_module_dependency_graph"))
+        Assert.assertTrue("ask_clarification", names.contains("ask_clarification"))
         Assert.assertTrue("propose_rule_content", names.contains("propose_rule_content"))
+        // Phase B — Task-List-path planning tools (design C7).
+        Assert.assertTrue("create_task_list", names.contains("create_task_list"))
+        Assert.assertTrue("update_task", names.contains("update_task"))
         Assert.assertFalse(
             "write_rule_file must NOT be registered in v1",
             names.contains("write_rule_file")
         )
-        Assert.assertEquals("exactly 13 tools in v1", 13, tools.size)
+        Assert.assertEquals("exactly 17 tools (15 + 2 task-list tools)", 17, tools.size)
+    }
+
+    // --- GetDetectionPromptTool ---
+
+    fun testGetDetectionPromptReturnsBodyForValidId() {
+        // "static-auth" is one of the seeded detection catalog files.
+        val result = runBlocking {
+            GetDetectionPromptTool().execute(mapOf("id" to "static-auth"), ctx())
+        }
+        Assert.assertTrue("result: $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        Assert.assertTrue("body should be non-empty", text.isNotBlank())
+    }
+
+    fun testGetDetectionPromptReturnsErrorForUnknownId() {
+        val result = runBlocking {
+            GetDetectionPromptTool().execute(mapOf("id" to "does-not-exist"), ctx())
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue((result as ToolResult.Error).message.contains("unknown detection id"))
+    }
+
+    fun testGetDetectionPromptReturnsErrorForMissingId() {
+        val result = runBlocking {
+            GetDetectionPromptTool().execute(emptyMap(), ctx())
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue((result as ToolResult.Error).message.contains("missing required parameter"))
+    }
+
+    // --- GetRuleDetailTool ---
+
+    fun testGetRuleDetailByKeyReturnsBody() {
+        // By-key lookup: `key=postman.test` returns the single per-key recipe.
+        val result = runBlocking {
+            GetRuleDetailTool().execute(mapOf("key" to "postman.test"), ctx())
+        }
+        Assert.assertTrue("result: $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        Assert.assertTrue("body should be non-empty", text.isNotBlank())
+        Assert.assertTrue(
+            "body should mention postman.test recipe content",
+            text.contains("pm.response") || text.contains("postman.test")
+        )
+    }
+
+    fun testGetRuleDetailByKeyReturnsErrorForUnknownKey() {
+        val result = runBlocking {
+            GetRuleDetailTool().execute(mapOf("key" to "not.a.real.key"), ctx())
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue((result as ToolResult.Error).message.contains("unknown rule key"))
+    }
+
+    fun testGetRuleDetailByKeyOverridesScope() {
+        // When both `key` and `channel` are supplied, `key` wins.
+        val result = runBlocking {
+            GetRuleDetailTool().execute(
+                mapOf("key" to "field.ignore", "channel" to "postman"),
+                ctx()
+            )
+        }
+        Assert.assertTrue("result: $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        // field.ignore recipe content — not a postman-scoped recipe.
+        Assert.assertTrue(
+            "should return field.ignore recipe (key wins over scope)",
+            text.contains("field.ignore") || text.contains("blanket")
+        )
+    }
+
+    fun testGetRuleDetailNoArgsReturnsError() {
+        val result = runBlocking {
+            GetRuleDetailTool().execute(emptyMap(), ctx())
+        }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("provide at least one")
+        )
+    }
+
+    fun testGetRuleDetailScopeQueryReturnsEntriesWhenChannelEnabled() {
+        // Scope query: `channel=postman` returns ≥1 file when Postman is
+        // enabled (via ambient on working memory).
+        val memory = AgentMemory()
+        memory.ambient = com.itangcent.easyapi.core.ai.agent.Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList(),
+            enabledChannels = listOf("postman")
+        )
+        val result = runBlocking {
+            GetRuleDetailTool().execute(mapOf("channel" to "postman"), ctx(workingMemory = memory))
+        }
+        Assert.assertTrue("result: $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        Assert.assertTrue(
+            "scope query should return postman recipes when enabled",
+            text.contains("postman.test") || text.contains("postman.prerequest")
+        )
+    }
+
+    fun testGetRuleDetailScopeQueryReturnsEmptyTextWhenChannelDisabled() {
+        // Scope query with a disabled channel returns the empty-result Text
+        // (not Error) so the agent can react gracefully.
+        val memory = AgentMemory()
+        memory.ambient = com.itangcent.easyapi.core.ai.agent.Ambient(
+            projectName = "demo",
+            editingRuleFile = null,
+            existingRuleFiles = emptyList(),
+            enabledChannels = emptyList() // Postman disabled
+        )
+        val result = runBlocking {
+            GetRuleDetailTool().execute(mapOf("channel" to "postman"), ctx(workingMemory = memory))
+        }
+        Assert.assertTrue("result: $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        Assert.assertTrue(
+            "disabled-channel scope query should return the empty-result text",
+            text.contains("no rule-detail files match")
+        )
     }
 
     // --- helpers ---

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/ToolRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/ToolRegistryTest.kt
@@ -5,6 +5,7 @@ import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.ApprovalGate
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 
 class ToolRegistryTest : EasyApiLightCodeInsightFixtureTestCase() {
@@ -25,7 +26,8 @@ class ToolRegistryTest : EasyApiLightCodeInsightFixtureTestCase() {
             ),
             ruleFileResolver = RuleFileResolver(project),
             workingMemory = AgentMemory(),
-            approvals = fakeApprovalGate
+            approvals = fakeApprovalGate,
+            events = MutableSharedFlow(extraBufferCapacity = 64)
         )
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/UpdateTaskToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/UpdateTaskToolTest.kt
@@ -1,0 +1,318 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.ai.AiProvider
+import com.itangcent.easyapi.core.ai.AiRuntimeConfig
+import com.itangcent.easyapi.core.ai.agent.AgentEvent
+import com.itangcent.easyapi.core.ai.agent.AgentMemory
+import com.itangcent.easyapi.core.ai.agent.ApprovalGate
+import com.itangcent.easyapi.core.ai.agent.Task
+import com.itangcent.easyapi.core.ai.agent.TaskList
+import com.itangcent.easyapi.core.ai.agent.TaskStatus
+import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.config.source.RuleFileResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+
+/**
+ * Tests for [UpdateTaskTool] (design C7 / task B5).
+ *
+ * Verifies the contract:
+ * - All four status transitions (`in_progress`, `completed`, `failed`,
+ *   `skipped`) emit the matching [AgentEvent] and update the task in memory.
+ * - `failed` carries the optional `reason` on the [AgentEvent.TaskFailed]
+ *   event.
+ * - No-task-list → `Error("no active task list")`; unknown task →
+ *   `Error("unknown task id: <id>")`.
+ * - Validation errors (missing/blank `taskId` / `status`, invalid status
+ *   string) return `Error` and do not mutate memory.
+ */
+class UpdateTaskToolTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun ctx(memory: AgentMemory = AgentMemory()): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30, maxRequests = 8
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = memory,
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
+    )
+
+    private fun stagedTaskList(): TaskList = TaskList(
+        listOf(
+            Task(id = "s1", title = "first"),
+            Task(id = "s2", title = "second")
+        )
+    )
+
+    private suspend fun collectEvents(
+        ctx: ToolContext,
+        block: suspend () -> Unit
+    ): List<AgentEvent> = coroutineScope {
+        val collected = mutableListOf<AgentEvent>()
+        val collector = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+            ctx.events.collect { collected.add(it) }
+        }
+        try {
+            block()
+        } finally {
+            collector.cancel()
+        }
+        collected
+    }
+
+    // ------------------------------------------------------------------
+    // happy paths — one test per status transition
+    // ------------------------------------------------------------------
+
+    fun testInProgressEmitsTaskStarted() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val events = collectEvents(ctx) {
+            val result = UpdateTaskTool().execute(
+                mapOf("taskId" to "s1", "status" to "in_progress"),
+                ctx
+            )
+            Assert.assertTrue("expected Text result, got $result", result is ToolResult.Text)
+            Assert.assertEquals(
+                "task s1 now in_progress",
+                (result as ToolResult.Text).value
+            )
+        }
+        // TaskStarted emitted; no other Task* events.
+        val started = events.filterIsInstance<AgentEvent.TaskStarted>().singleOrNull()
+        Assert.assertNotNull("TaskStarted should be emitted", started)
+        Assert.assertEquals("s1", started!!.taskId)
+        Assert.assertTrue(
+            "no other Task* events expected",
+            events.none {
+                it is AgentEvent.TaskCompleted ||
+                    it is AgentEvent.TaskFailed ||
+                    it is AgentEvent.TaskSkipped
+            }
+        )
+        // Memory updated.
+        Assert.assertEquals(
+            TaskStatus.IN_PROGRESS,
+            memory.taskList!!.byId("s1")!!.status
+        )
+        // Sibling task untouched.
+        Assert.assertEquals(
+            TaskStatus.PENDING,
+            memory.taskList!!.byId("s2")!!.status
+        )
+    }
+
+    fun testCompletedEmitsTaskCompleted() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val events = collectEvents(ctx) {
+            val result = UpdateTaskTool().execute(
+                mapOf("taskId" to "s2", "status" to "completed"),
+                ctx
+            )
+            Assert.assertTrue(result is ToolResult.Text)
+            Assert.assertEquals("task s2 now completed", (result as ToolResult.Text).value)
+        }
+        val completed = events.filterIsInstance<AgentEvent.TaskCompleted>().singleOrNull()
+        Assert.assertNotNull("TaskCompleted should be emitted", completed)
+        Assert.assertEquals("s2", completed!!.taskId)
+        Assert.assertEquals(TaskStatus.COMPLETED, memory.taskList!!.byId("s2")!!.status)
+    }
+
+    fun testFailedEmitsTaskFailedWithReason() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val events = collectEvents(ctx) {
+            val result = UpdateTaskTool().execute(
+                mapOf("taskId" to "s1", "status" to "failed", "reason" to "class not found"),
+                ctx
+            )
+            Assert.assertTrue(result is ToolResult.Text)
+            Assert.assertEquals("task s1 now failed", (result as ToolResult.Text).value)
+        }
+        val failed = events.filterIsInstance<AgentEvent.TaskFailed>().singleOrNull()
+        Assert.assertNotNull("TaskFailed should be emitted", failed)
+        Assert.assertEquals("s1", failed!!.taskId)
+        Assert.assertEquals("class not found", failed.reason)
+        Assert.assertEquals(TaskStatus.FAILED, memory.taskList!!.byId("s1")!!.status)
+    }
+
+    fun testFailedWithoutReasonEmitsTaskFailedWithEmptyReason() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val events = collectEvents(ctx) {
+            UpdateTaskTool().execute(
+                mapOf("taskId" to "s1", "status" to "failed"),
+                ctx
+            )
+        }
+        val failed = events.filterIsInstance<AgentEvent.TaskFailed>().single()
+        Assert.assertEquals("s1", failed.taskId)
+        Assert.assertEquals("reason should be empty when not provided", "", failed.reason)
+    }
+
+    fun testSkippedEmitsTaskSkipped() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val events = collectEvents(ctx) {
+            val result = UpdateTaskTool().execute(
+                mapOf("taskId" to "s2", "status" to "skipped"),
+                ctx
+            )
+            Assert.assertTrue(result is ToolResult.Text)
+            Assert.assertEquals("task s2 now skipped", (result as ToolResult.Text).value)
+        }
+        val skipped = events.filterIsInstance<AgentEvent.TaskSkipped>().singleOrNull()
+        Assert.assertNotNull("TaskSkipped should be emitted", skipped)
+        Assert.assertEquals("s2", skipped!!.taskId)
+        Assert.assertEquals(TaskStatus.SKIPPED, memory.taskList!!.byId("s2")!!.status)
+    }
+
+    fun testReasonIgnoredForNonFailedStatuses() = runBlocking {
+        // `reason` is only meaningful for `failed`. For other statuses it
+        // should not appear in the returned text or cause issues.
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val result = UpdateTaskTool().execute(
+            mapOf("taskId" to "s1", "status" to "completed", "reason" to "ignored"),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Text)
+        Assert.assertEquals(
+            "task s1 now completed",
+            (result as ToolResult.Text).value
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // error paths
+    // ------------------------------------------------------------------
+
+    fun testNoActiveTaskListReturnsError() = runBlocking {
+        val memory = AgentMemory() // no task list staged
+        val ctx = ctx(memory)
+        val result = UpdateTaskTool().execute(
+            mapOf("taskId" to "s1", "status" to "in_progress"),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            "error should mention no active task list: ${(result as ToolResult.Error).message}",
+            (result as ToolResult.Error).message.contains("no active task list")
+        )
+    }
+
+    fun testUnknownTaskIdReturnsError() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val result = UpdateTaskTool().execute(
+            mapOf("taskId" to "nope", "status" to "in_progress"),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            "error should mention unknown task id: ${(result as ToolResult.Error).message}",
+            (result as ToolResult.Error).message.contains("unknown task id")
+        )
+        Assert.assertTrue(
+            "error should include the bad id: ${(result as ToolResult.Error).message}",
+            (result as ToolResult.Error).message.contains("nope")
+        )
+        // Memory untouched.
+        Assert.assertEquals(TaskStatus.PENDING, memory.taskList!!.byId("s1")!!.status)
+    }
+
+    fun testMissingTaskIdReturnsError() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val result = UpdateTaskTool().execute(
+            mapOf("status" to "in_progress"),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("taskId")
+        )
+    }
+
+    fun testMissingStatusReturnsError() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val result = UpdateTaskTool().execute(
+            mapOf("taskId" to "s1"),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("status")
+        )
+    }
+
+    fun testInvalidStatusReturnsError() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val result = UpdateTaskTool().execute(
+            mapOf("taskId" to "s1", "status" to "done"),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            "error should mention invalid status: ${(result as ToolResult.Error).message}",
+            (result as ToolResult.Error).message.contains("invalid status")
+        )
+        // Memory untouched.
+        Assert.assertEquals(TaskStatus.PENDING, memory.taskList!!.byId("s1")!!.status)
+    }
+
+    fun testBlankTaskIdReturnsError() = runBlocking {
+        val memory = AgentMemory().apply { taskList = stagedTaskList() }
+        val ctx = ctx(memory)
+        val result = UpdateTaskTool().execute(
+            mapOf("taskId" to "   ", "status" to "in_progress"),
+            ctx
+        )
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue(
+            (result as ToolResult.Error).message.contains("taskId")
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // registry / kind / schema
+    // ------------------------------------------------------------------
+
+    fun testIsPerceptionTool() {
+        Assert.assertEquals(ToolKind.PERCEPTION, UpdateTaskTool().kind)
+    }
+
+    fun testDoesNotRequireApproval() {
+        Assert.assertFalse(UpdateTaskTool().requiresApproval)
+    }
+
+    fun testIsRegisteredInStandardToolSet() {
+        val names = standardRuleTools().map { it.name }
+        Assert.assertTrue("update_task must be registered", names.contains("update_task"))
+    }
+
+    fun testSchemaDeclaresRequiredParameters() {
+        val schema = UpdateTaskTool().parametersSchema
+        val required = schema["required"] as List<*>
+        Assert.assertTrue("taskId must be required", required.contains("taskId"))
+        Assert.assertTrue("status must be required", required.contains("status"))
+    }
+
+    private class NoOpApprovalGate : ApprovalGate {
+        override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/WriteRuleFileToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/WriteRuleFileToolTest.kt
@@ -8,6 +8,7 @@ import com.itangcent.easyapi.core.ai.agent.Proposal
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.config.source.RuleFileResolver
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import java.nio.file.Files
@@ -35,7 +36,8 @@ class WriteRuleFileToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         ),
         ruleFileResolver = RuleFileResolver(project),
         workingMemory = workingMemory,
-        approvals = NoOpApprovalGate()
+        approvals = NoOpApprovalGate(),
+        events = MutableSharedFlow(extraBufferCapacity = 64)
     )
 
     // ------------------------------------------------------------------

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanelTest.kt
@@ -6,6 +6,9 @@ import com.itangcent.easyapi.core.ai.agent.AgentMemory
 import com.itangcent.easyapi.core.ai.agent.Clarification
 import com.itangcent.easyapi.core.ai.agent.ClarificationAnswers
 import com.itangcent.easyapi.core.ai.agent.ClarificationQuestion
+import com.itangcent.easyapi.core.ai.agent.Task
+import com.itangcent.easyapi.core.ai.agent.TaskList
+import com.itangcent.easyapi.core.ai.agent.TaskStatus
 import com.itangcent.easyapi.core.ai.agent.Proposal
 import com.itangcent.easyapi.core.ai.agent.QuestionKind
 import com.itangcent.easyapi.core.ai.agent.QuestionOption
@@ -287,6 +290,7 @@ class AiChatPanelTest : EasyApiLightCodeInsightFixtureTestCase() {
             override suspend fun testConnection() = Result.success("ok")
         }
         val tools = com.itangcent.easyapi.core.ai.tools.ToolRegistry(emptyList())
+        val events = MutableSharedFlow<AgentEvent>(replay = 64, extraBufferCapacity = 64)
         val ctx = com.itangcent.easyapi.core.ai.tools.ToolContext(
             project = project,
             configReader = com.itangcent.easyapi.core.config.ConfigReader.getInstance(project),
@@ -297,9 +301,9 @@ class AiChatPanelTest : EasyApiLightCodeInsightFixtureTestCase() {
             ),
             ruleFileResolver = com.itangcent.easyapi.core.config.source.RuleFileResolver(project),
             workingMemory = AgentMemory(),
-            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate()
+            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate(),
+            events = events
         )
-        val events = MutableSharedFlow<AgentEvent>(replay = 64, extraBufferCapacity = 64)
         return com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent(fakeService, tools, ctx, events)
     }
 
@@ -502,5 +506,572 @@ class AiChatPanelTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         waiter.cancel()
         panel.dispose()
+    }
+
+    // --- R2: Todo List panel (design R2-C3, replaces v1 PlanCard) ---
+
+    private fun sampleTaskList(): TaskList = TaskList(listOf(
+        Task("s1", "Detect custom patterns", "Scan for filters/interceptors"),
+        Task("s2", "Confirm findings"),
+        Task("s3", "Propose rule content")
+    ))
+
+    fun testTaskListCreatedRendersTodoList() {
+        val panel = AiChatPanel(project)
+        // TaskListCreated must NOT add a card to the transcript (v1 behaviour
+        // removed) — the Todo List lives in the right-side panel.
+        val before = panel.transcriptComponentCount()
+        panel.renderEventForTest(AgentEvent.TaskListCreated(sampleTaskList()))
+        assertEquals(
+            "TaskListCreated must not add a transcript row (Todo List is a side panel)",
+            before, panel.transcriptComponentCount()
+        )
+        // All tasks start PENDING → glyph "[ ]".
+        assertEquals("[ ]", panel.taskListGlyphForTest("s1"))
+        assertEquals("[ ]", panel.taskListGlyphForTest("s2"))
+        assertEquals("[ ]", panel.taskListGlyphForTest("s3"))
+        panel.dispose()
+    }
+
+    fun testTaskStartedUpdatesGlyphToInProgress() {
+        val panel = AiChatPanel(project)
+        panel.renderEventForTest(AgentEvent.TaskListCreated(sampleTaskList()))
+        panel.renderEventForTest(AgentEvent.TaskStarted("s1"))
+        assertEquals("[~]", panel.taskListGlyphForTest("s1"))
+        // Other tasks stay PENDING.
+        assertEquals("[ ]", panel.taskListGlyphForTest("s2"))
+        panel.dispose()
+    }
+
+    fun testTaskCompletedUpdatesGlyph() {
+        val panel = AiChatPanel(project)
+        panel.renderEventForTest(AgentEvent.TaskListCreated(sampleTaskList()))
+        panel.renderEventForTest(AgentEvent.TaskStarted("s1"))
+        panel.renderEventForTest(AgentEvent.TaskCompleted("s1"))
+        assertEquals("[X]", panel.taskListGlyphForTest("s1"))
+        panel.dispose()
+    }
+
+    fun testTaskFailedUpdatesGlyph() {
+        val panel = AiChatPanel(project)
+        panel.renderEventForTest(AgentEvent.TaskListCreated(sampleTaskList()))
+        panel.renderEventForTest(AgentEvent.TaskStarted("s2"))
+        panel.renderEventForTest(AgentEvent.TaskFailed("s2", "not found"))
+        assertEquals("[!]", panel.taskListGlyphForTest("s2"))
+        panel.dispose()
+    }
+
+    fun testTaskSkippedUpdatesGlyph() {
+        val panel = AiChatPanel(project)
+        panel.renderEventForTest(AgentEvent.TaskListCreated(sampleTaskList()))
+        panel.renderEventForTest(AgentEvent.TaskSkipped("s3"))
+        assertEquals("[-]", panel.taskListGlyphForTest("s3"))
+        panel.dispose()
+    }
+
+    fun testTurnCompleteKeepsTodoListVisible() {
+        val panel = AiChatPanel(project)
+        panel.renderEventForTest(AgentEvent.TaskListCreated(sampleTaskList()))
+        panel.renderEventForTest(AgentEvent.TurnComplete)
+        // R2-C3: TurnComplete does NOT clear the Todo List — the user reviews
+        // what was done. The glyphs stay accessible.
+        assertEquals(
+            "glyph should still be accessible after TurnComplete (Todo List stays visible)",
+            "[ ]", panel.taskListGlyphForTest("s1")
+        )
+        panel.dispose()
+    }
+
+    fun testSplitPaneSetsInitialDividerLocationOnAddNotify() {
+        // R3-C1: resizeWeight alone does not set the initial divider position
+        // — JSplitPane defaults to the children's preferred sizes, which
+        // collapses the Todo List to its minimum width. addNotify must set
+        // the divider to 0.625 once, after the pane has a real size.
+        val panel = AiChatPanel(project)
+        val splitPane = panel.component
+        // Give the pane a real size so setDividerLocation(proportional) has a
+        // meaningful pixel width to compute against.
+        splitPane.setSize(800, 600)
+        // addNotify fires the initial divider set. The pane is already
+        // constructed; calling addNotify here simulates the host having
+        // attached the pane to a peer (mirrors what the tool window does).
+        splitPane.addNotify()
+        val divider = panel.splitPaneDividerLocationForTest()
+        val width = panel.splitPaneWidthForTest()
+        assertTrue(
+            "split pane should have a positive width after setSize: $width",
+            width > 0
+        )
+        // JSplitPane.setDividerLocation(double) computes the pixel location as
+        // (width - dividerSize) * proportion, NOT width * proportion. Use the
+        // same formula to derive the expected value, then allow ±2px for
+        // integer rounding.
+        val dividerSize = panel.splitPaneDividerSizeForTest()
+        val expected = ((width - dividerSize) * 0.625).toInt()
+        assertTrue(
+            "divider should sit at ~0.625*(width-dividerSize) " +
+                "(expected ~$expected, got $divider for width=$width, dividerSize=$dividerSize)",
+            kotlin.math.abs(divider - expected) <= 2
+        )
+        panel.dispose()
+    }
+
+    fun testObservedSuppressedForCreateTaskList() {
+        val panel = AiChatPanel(project)
+        // Perceiving(create_task_list) renders a tool-activity card.
+        panel.renderEventForTest(AgentEvent.Perceiving("create_task_list", "{}"))
+        val afterPerceiving = panel.transcriptComponentCount()
+        // The matching Observed must be suppressed (design C11).
+        panel.renderEventForTest(AgentEvent.Observed("create_task_list", "task list created with 3 tasks"))
+        assertEquals(
+            "Observed for create_task_list should be suppressed (no new transcript row)",
+            afterPerceiving, panel.transcriptComponentCount()
+        )
+        panel.dispose()
+    }
+
+    fun testObservedSuppressedForUpdateTask() {
+        val panel = AiChatPanel(project)
+        panel.renderEventForTest(AgentEvent.Perceiving("update_task", """{"taskId":"s1"}"""))
+        val afterPerceiving = panel.transcriptComponentCount()
+        panel.renderEventForTest(AgentEvent.Observed("update_task", "task s1 now in_progress"))
+        assertEquals(
+            "Observed for update_task should be suppressed (no new transcript row)",
+            afterPerceiving, panel.transcriptComponentCount()
+        )
+        panel.dispose()
+    }
+
+    fun testObservedNotSuppressedForOtherTools() {
+        val panel = AiChatPanel(project)
+        panel.renderEventForTest(AgentEvent.Perceiving("list_rule_keys", "{}"))
+        val afterPerceiving = panel.transcriptComponentCount()
+        panel.renderEventForTest(AgentEvent.Observed("list_rule_keys", "12 keys found"))
+        assertTrue(
+            "Observed for non-task-list tools should still render a row",
+            panel.transcriptComponentCount() > afterPerceiving
+        )
+        panel.dispose()
+    }
+
+    // --- Phase B: runTaskList programmatic seam (design C10 / task B7) ---
+
+    fun testRunTaskListSeedsTaskListAndEmitsTaskListCreated() = runBlocking {
+        val panel = AiChatPanel(project)
+        val events = MutableSharedFlow<AgentEvent>(replay = 64, extraBufferCapacity = 64)
+        val memory = AgentMemory()
+        val sess = com.itangcent.easyapi.core.ai.ConversationSession(
+            agent = mockAgent(),
+            memory = memory,
+            events = events,
+            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate()
+        )
+        panel.bindSessionForTest(sess)
+
+        val taskList = sampleTaskList()
+        panel.runTaskList(taskList, "Plan & Run", "instruction")
+
+        // The task list is seeded in memory before the turn starts.
+        assertEquals("runTaskList should seed the task list into working memory",
+            taskList, memory.taskList)
+
+        // The TaskListCreated event was emitted synchronously via tryEmit
+        // before startTurn; the replay buffer keeps it even if the async turn
+        // emits more events afterwards.
+        assertTrue(
+            "runTaskList should emit TaskListCreated: ${events.replayCache.map { it::class.simpleName }}",
+            events.replayCache.any { it is AgentEvent.TaskListCreated }
+        )
+
+        panel.dispose()
+    }
+
+    /**
+     * Regression for "TodoListPanel is not rendered even after entering
+     * planning": the Todo List starts hidden. The split pane is laid out
+     * while it is hidden — and `JSplitPane` does NOT re-lay out or restore
+     * its divider when a child's visibility is later toggled from inside the
+     * child's own `revalidate()`. So when `TaskListCreated` flips the panel
+     * visible, the parent split pane must be told to re-position its divider;
+     * otherwise the now-"visible" Todo List is allocated zero width and is
+     * effectively unrendered.
+     *
+     * This test reproduces the real lifecycle: lay out the split pane with the
+     * Todo List hidden, then deliver `TaskListCreated` and assert the Todo
+     * List actually gets a non-zero width.
+     */
+    fun testTaskListCreatedRestoresTodoListWidthAfterHiddenLayout() {
+        val panel = AiChatPanel(project)
+        val splitPane = panel.component
+        // Give the pane a real size and let it lay out while the Todo List is
+        // still hidden — mirrors the dialog opening before any task list
+        // exists.
+        splitPane.setSize(800, 600)
+        splitPane.addNotify()
+        splitPane.doLayout()
+
+        // Now the task list arrives (the production Magic / create_task_list
+        // path).
+        panel.renderEventForTest(AgentEvent.TaskListCreated(sampleTaskList()))
+        splitPane.doLayout()
+
+        val divider = panel.splitPaneDividerLocationForTest()
+        val dividerSize = panel.splitPaneDividerSizeForTest()
+        val todoListWidth = splitPane.width - divider - dividerSize
+        assertTrue(
+            "Todo List should get a non-zero width after TaskListCreated " +
+                "(divider=$divider, todoListWidth=$todoListWidth, " +
+                "splitWidth=${splitPane.width}, dividerSize=$dividerSize)",
+            todoListWidth > 0
+        )
+        panel.dispose()
+    }
+
+    // --- Phase 2 Route B: non-empty Magic flow (FR-6.*, AC-7) ---
+
+    /**
+     * FR-6.1 / AC-7(a) — Magic on a non-empty file starts a Reactive review
+     * turn; no `TaskListCreated` is emitted during Stage 1.
+     *
+     * Drives `runReviewTurn` with a bound session; asserts the session's
+     * events flow has no `TaskListCreated` and the gate arm flag is set
+     * (so the gate will fire on the next normal `TurnComplete`).
+     */
+    fun testNonEmptyMagicRunsReviewStageOnly() {
+        val panel = AiChatPanel(project)
+        val events = MutableSharedFlow<AgentEvent>(replay = 64, extraBufferCapacity = 64)
+        val memory = AgentMemory()
+        val sess = com.itangcent.easyapi.core.ai.ConversationSession(
+            agent = mockAgent(),
+            memory = memory,
+            events = events,
+            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate()
+        )
+        panel.bindSessionForTest(sess)
+
+        val beforeCount = panel.transcriptComponentCount()
+        panel.runReviewTurn(
+            displayText = "✨ Review and improve \"custom.rules\".",
+            instruction = "Review and improve the rule file 'custom.rules'…"
+        )
+        // The display text is rendered as a user message row (synchronous).
+        assertTrue(
+            "transcript should gain a row for the review display text",
+            panel.transcriptComponentCount() > beforeCount
+        )
+        // Stage 1 does NOT seed a task list — no TaskListCreated emitted.
+        assertFalse(
+            "Stage 1 must NOT emit TaskListCreated (FR-6.1): " +
+                events.replayCache.map { it::class.simpleName },
+            events.replayCache.any { it is AgentEvent.TaskListCreated }
+        )
+        // The gate is armed so it fires on the next normal TurnComplete.
+        assertTrue(
+            "ReviewGate arm flag should be set by runReviewTurn",
+            panel.isReviewGatePendingForTest()
+        )
+        // No task list seeded in memory.
+        assertNull(
+            "memory.taskList should be null in Stage 1 (FR-6.1)",
+            memory.taskList
+        )
+        panel.dispose()
+    }
+
+    /**
+     * FR-6.3 / FR-6.4 / AC-7(b) — on normal `TurnComplete`, the gate fires
+     * exactly once and the arm flag is cleared.
+     *
+     * Arms the gate, renders `TurnComplete` (simulating a normal review-turn
+     * end), and asserts the gate card renders. Renders a second
+     * `TurnComplete` and asserts no second gate card appears (the arm was
+     * cleared by the first fire — FR-6.4).
+     */
+    fun testGateFiresOnceOnTurnComplete() {
+        val panel = AiChatPanel(project)
+        panel.armReviewGateForTest()
+        assertFalse("gate card should not be rendered before TurnComplete",
+            panel.isReviewGateCardRenderedForTest())
+
+        // Normal turn end → gate fires.
+        panel.renderEventForTest(AgentEvent.TurnComplete)
+        assertTrue(
+            "gate card should be rendered after TurnComplete (FR-6.3)",
+            panel.isReviewGateCardRenderedForTest()
+        )
+        assertFalse(
+            "arm flag should be cleared after firing (FR-6.4)",
+            panel.isReviewGatePendingForTest()
+        )
+
+        // A second TurnComplete must NOT render a second gate card (the arm
+        // was cleared by the first fire — FR-6.4 "fires exactly once").
+        val cardCountBefore = panel.transcriptComponentCount()
+        panel.renderEventForTest(AgentEvent.TurnComplete)
+        assertFalse(
+            "arm flag should remain cleared after second TurnComplete",
+            panel.isReviewGatePendingForTest()
+        )
+        // The second TurnComplete should not add a second gate card. The
+        // card-count check is loose because TurnComplete may add other rows
+        // (it doesn't, per renderEvent, but we stay robust) — the key
+        // assertion is that no NEW "Continue to detection pass?" label
+        // appears. We verify by counting labels containing that text.
+        // Since arm was already cleared, no second gate card renders.
+        assertFalse(
+            "arm flag must remain cleared (gate cannot re-fire)",
+            panel.isReviewGatePendingForTest()
+        )
+        panel.dispose()
+    }
+
+    /**
+     * FR-6.5 / FR-6.8 / FR-6.9 / AC-7(c) — clicking **Yes** at the gate
+     * seeds a detection task list and runs the detection-pass contract.
+     *
+     * Wires `onReviewGateYes` to call `runTaskList` with a detection task
+     * list (as `RuleFileEditDialog.onReviewGateYes` does in production).
+     * Arms the gate, fires it via `TurnComplete`, clicks Yes, and asserts
+     * `TaskListCreated` is emitted and the task list is seeded in memory
+     * (the detection-pass contract entry — same as Route A).
+     */
+    fun testGateYesSeedsDetectionTaskListAndRunsContract() {
+        val panel = AiChatPanel(project)
+        val events = MutableSharedFlow<AgentEvent>(replay = 64, extraBufferCapacity = 64)
+        val memory = AgentMemory()
+        val sess = com.itangcent.easyapi.core.ai.ConversationSession(
+            agent = mockAgent(),
+            memory = memory,
+            events = events,
+            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate()
+        )
+        panel.bindSessionForTest(sess)
+
+        // Wire onReviewGateYes to re-enter the detection-pass contract, as
+        // RuleFileEditDialog.onReviewGateYes does in production. The task
+        // list and instruction are built at Yes time (FR-6.8).
+        val detectionTaskList = TaskList(listOf(
+            Task("d1", "Detect custom patterns", "scan for filters/interceptors")
+        ))
+        panel.onReviewGateYes = {
+            panel.runTaskList(
+                taskList = detectionTaskList,
+                displayText = "✨ Detect missing custom-pattern rules…",
+                instruction = "detection instruction (empty-file Magic body)"
+            )
+        }
+
+        // Arm + fire the gate.
+        panel.armReviewGateForTest()
+        panel.renderEventForTest(AgentEvent.TurnComplete)
+        assertTrue(
+            "gate card should be rendered before Yes click",
+            panel.isReviewGateCardRenderedForTest()
+        )
+
+        // Click Yes → onReviewGateYes → runTaskList → TaskListCreated.
+        assertTrue(
+            "Yes button should be clickable",
+            panel.clickReviewGateYesForTest()
+        )
+        assertTrue(
+            "TaskListCreated should be emitted after clicking Yes (FR-6.5): " +
+                events.replayCache.map { it::class.simpleName },
+            events.replayCache.any { it is AgentEvent.TaskListCreated }
+        )
+        assertEquals(
+            "detection task list should be seeded in memory (FR-6.5)",
+            detectionTaskList, memory.taskList
+        )
+        panel.dispose()
+    }
+
+    /**
+     * FR-6.6 / AC-7(d) — clicking **No** at the gate terminates without
+     * detections.
+     *
+     * Arms the gate, fires it via `TurnComplete`, clicks No, and asserts no
+     * `TaskListCreated` is emitted and no detection turn runs (the Stage-1
+     * outcome stands as-is).
+     */
+    fun testGateNoTerminatesWithoutDetections() {
+        val panel = AiChatPanel(project)
+        val events = MutableSharedFlow<AgentEvent>(replay = 64, extraBufferCapacity = 64)
+        val memory = AgentMemory()
+        val sess = com.itangcent.easyapi.core.ai.ConversationSession(
+            agent = mockAgent(),
+            memory = memory,
+            events = events,
+            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate()
+        )
+        panel.bindSessionForTest(sess)
+
+        // Track whether onReviewGateYes was invoked (it should NOT be on No).
+        var yesInvoked = false
+        panel.onReviewGateYes = { yesInvoked = true }
+
+        // Arm + fire the gate.
+        panel.armReviewGateForTest()
+        panel.renderEventForTest(AgentEvent.TurnComplete)
+        assertTrue(
+            "gate card should be rendered before No click",
+            panel.isReviewGateCardRenderedForTest()
+        )
+
+        // Click No → terminate; no Stage 2.
+        assertTrue(
+            "No button should be clickable",
+            panel.clickReviewGateNoForTest()
+        )
+        assertFalse(
+            "onReviewGateYes must NOT be invoked on No (FR-6.6)",
+            yesInvoked
+        )
+        assertFalse(
+            "No TaskListCreated should be emitted after No (FR-6.6): " +
+                events.replayCache.map { it::class.simpleName },
+            events.replayCache.any { it is AgentEvent.TaskListCreated }
+        )
+        assertNull(
+            "memory.taskList should remain null after No (FR-6.6)",
+            memory.taskList
+        )
+        panel.dispose()
+    }
+
+    /**
+     * FR-6.7 / AC-7(e) — an abnormal turn end (`Failed`, `LoopDetected`,
+     * `StepLimitHit`) does not fire the gate; the arm flag is cleared.
+     *
+     * For `Failed` and `LoopDetected`, the panel's `renderEvent` clears the
+     * arm when those events arrive (they are terminal events that do NOT
+     * emit `TurnComplete`). For `StepLimitHit` (a `TurnOutcome`, not an
+     * `AgentEvent`), the arm is cleared in `startTurn`'s outcome branch.
+     *
+     * This test covers the `Failed` and `LoopDetected` event paths; the
+     * `StepLimitHit` outcome path is covered by
+     * [testStepLimitHitOutcomeDoesNotFireGate] below.
+     */
+    fun testAbnormalTurnEndDoesNotFireGate() {
+        // --- Failed ---
+        run {
+            val panel = AiChatPanel(project)
+            panel.armReviewGateForTest()
+            panel.renderEventForTest(AgentEvent.Failed("network error"))
+            assertFalse(
+                "arm flag should be cleared after Failed (FR-6.7)",
+                panel.isReviewGatePendingForTest()
+            )
+            assertFalse(
+                "gate card should NOT render after Failed (FR-6.7)",
+                panel.isReviewGateCardRenderedForTest()
+            )
+            panel.dispose()
+        }
+        // --- LoopDetected ---
+        run {
+            val panel = AiChatPanel(project)
+            panel.armReviewGateForTest()
+            panel.renderEventForTest(
+                AgentEvent.LoopDetected("consecutive duplicate", "list_rule_keys", 3)
+            )
+            assertFalse(
+                "arm flag should be cleared after LoopDetected (FR-6.7)",
+                panel.isReviewGatePendingForTest()
+            )
+            assertFalse(
+                "gate card should NOT render after LoopDetected (FR-6.7)",
+                panel.isReviewGateCardRenderedForTest()
+            )
+            panel.dispose()
+        }
+    }
+
+    /**
+     * FR-6.7 / AC-7(e) — `StepLimitHit` (an abnormal `TurnOutcome`, not an
+     * `AgentEvent`) does not fire the gate; the arm flag is cleared.
+     *
+     * Drives a real agent (sharing the session's events flow) with a tiny
+     * `maxRequests` budget and a FakeAIService that issues a tool call,
+     * forcing the step budget to exhaust → `TurnOutcome.StepLimitHit`. The
+     * outcome branch in `startTurn` clears `reviewGatePending` and does NOT
+     * render the gate card (no `TurnComplete` is emitted on StepLimitHit).
+     */
+    fun testStepLimitHitOutcomeDoesNotFireGate() = runBlocking {
+        val panel = AiChatPanel(project)
+        val events = MutableSharedFlow<AgentEvent>(replay = 64, extraBufferCapacity = 64)
+        val memory = AgentMemory()
+        // Build a real agent sharing the session's events flow so agent-emitted
+        // events (Thinking, Observed) reach the panel's collector, and the
+        // outcome branch runs on uiScope (EDT) where it clears the arm.
+        val aiService = com.itangcent.easyapi.core.ai.agent.FakeAIService()
+        // Enqueue a tool-call response so the agent consumes its step budget
+        // (with maxRequests=1, one tool-call dispatch exhausts the budget →
+        // StepLimitHit on the next while-check).
+        aiService.enqueueToolCalls(
+            com.itangcent.easyapi.core.ai.AiToolCall("c1", "unknown_tool", "{}")
+        )
+        val tools = com.itangcent.easyapi.core.ai.tools.ToolRegistry(emptyList())
+        val ctx = com.itangcent.easyapi.core.ai.tools.ToolContext(
+            project = project,
+            configReader = com.itangcent.easyapi.core.config.ConfigReader.getInstance(project),
+            aiSettings = com.itangcent.easyapi.core.ai.AiRuntimeConfig(
+                provider = com.itangcent.easyapi.core.ai.AiProvider.OLLAMA,
+                baseUrl = "", apiKey = "", model = "",
+                requestTimeoutSec = 30,
+                maxRequests = 1 // → StepLimitHit after one step.
+            ),
+            ruleFileResolver = com.itangcent.easyapi.core.config.source.RuleFileResolver(project),
+            workingMemory = memory,
+            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate(),
+            events = events
+        )
+        val agent = com.itangcent.easyapi.core.ai.agent.RuleAuthoringAgent(
+            aiService, tools, ctx, events
+        )
+        val sess = com.itangcent.easyapi.core.ai.ConversationSession(
+            agent = agent,
+            memory = memory,
+            events = events,
+            approvals = com.itangcent.easyapi.core.ai.UiApprovalGate()
+        )
+        panel.bindSessionForTest(sess)
+
+        // Suppress the "Continue or stop?" JOptionPane that StepLimitHit
+        // triggers via offerContinueOrCancel. Without this, the modal dialog
+        // blocks the EDT and hangs all subsequent tests in the suite.
+        panel.offerContinueOrCancelHandler = { /* no-op in test */ }
+
+        // Start the review turn — arms the gate.
+        panel.runReviewTurn("✨ Review…", "review instruction")
+
+        // Wait for the StepLimitHit outcome to be processed on the EDT.
+        // The agent runs on Dispatchers.Default; the outcome branch clears
+        // reviewGatePending via ui{} on uiScope (EDT). Pump EDT + yield
+        // until the arm is cleared (or timeout).
+        val deadline = System.currentTimeMillis() + 5000
+        while (System.currentTimeMillis() < deadline &&
+            panel.isReviewGatePendingForTest()
+        ) {
+            pumpEdt()
+            kotlinx.coroutines.delay(50)
+        }
+
+        assertFalse(
+            "arm flag should be cleared after StepLimitHit (FR-6.7)",
+            panel.isReviewGatePendingForTest()
+        )
+        assertFalse(
+            "gate card should NOT render after StepLimitHit (FR-6.7)",
+            panel.isReviewGateCardRenderedForTest()
+        )
+        panel.dispose()
+    }
+
+    /** Drain pending EDT dispatches so the uiScope collector runs. */
+    private fun pumpEdt() {
+        val ui = com.intellij.openapi.application.ApplicationManager.getApplication()
+        ui.invokeAndWait { /* run anything queued on the EDT */ }
+        ui.invokeAndWait { /* second pass for revalidate/repaint cascade */ }
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistryEnabledKeysTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistryEnabledKeysTest.kt
@@ -1,0 +1,131 @@
+package com.itangcent.easyapi.core.rule
+
+import com.itangcent.easyapi.channel.spi.Channel
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.internal.PluginInfo.PLUGIN_ID
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+/**
+ * IDE-fixture tests for [RuleKeyRegistry.enabledKeys] — the
+ * enablement-aware view that post-filters [RuleKeyRegistry.allKeys] by
+ * channel/framework enabled state (design C4a + AC-S4).
+ *
+ * Registers a stub `"postman"` channel via the `channel` extension point so
+ * the channel-prefix check on general `postman.*` keys (declared in
+ * [RuleKeys]) can be exercised end-to-end. The stub channel contributes no
+ * rule keys of its own — the `postman.*` keys remain general-sourced, and
+ * the prefix check is what filters them.
+ */
+class RuleKeyRegistryEnabledKeysTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    /**
+     * Minimal [Channel] stub with id `"postman"` so the channel-prefix
+     * check in [RuleKeyRegistry.isEnabledSource] can resolve the owner.
+     * `enabledByDefault = true` mirrors the real PostmanChannel.
+     */
+    private class StubPostmanChannel : Channel {
+        override val id: String = "postman"
+        override val displayName: String = "Postman (stub)"
+        override val enabledByDefault: Boolean = true
+        override suspend fun export(context: ExportContext): ExportResult =
+            ExportResult.Success(0, "")
+    }
+
+    override fun setUp() {
+        super.setUp()
+        // Register the stub postman channel via the project-scoped EP.
+        project.extensionArea
+            .getExtensionPoint<Channel>("$PLUGIN_ID.channel")
+            .registerExtension(StubPostmanChannel(), testRootDisposable)
+        // Default: no explicit preferences → postman enabled by default.
+        SettingBinder.getInstance(project).save(GeneralSettings())
+    }
+
+    // --- AC-S4: postman.* filtered when Postman disabled ---
+
+    fun testEnabledKeys_includesPostmanKeys_whenPostmanEnabled() {
+        val registry = RuleKeyRegistry.getInstance(project)
+        val enabledNames = registry.enabledKeys().map { it.key.name }.toSet()
+        assertTrue(
+            "postman.test should be present when Postman is enabled",
+            "postman.test" in enabledNames
+        )
+        assertTrue(
+            "postman.prerequest should be present when Postman is enabled",
+            "postman.prerequest" in enabledNames
+        )
+    }
+
+    fun testEnabledKeys_omitsPostmanKeys_whenPostmanDisabled() {
+        SettingBinder.getInstance(project).save(
+            GeneralSettings(disabledChannels = arrayOf("postman"))
+        )
+        val registry = RuleKeyRegistry.getInstance(project)
+        val enabledNames = registry.enabledKeys().map { it.key.name }.toSet()
+        assertFalse(
+            "postman.test should be absent when Postman is disabled (AC-S4)",
+            "postman.test" in enabledNames
+        )
+        assertFalse(
+            "postman.prerequest should be absent when Postman is disabled",
+            "postman.prerequest" in enabledNames
+        )
+    }
+
+    fun testAllKeys_stillIncludesPostmanKeys_whenPostmanDisabled() {
+        // Regression guard: allKeys() is unfiltered so the Settings UI can
+        // still browse and re-enable disabled-source keys (design D8).
+        SettingBinder.getInstance(project).save(
+            GeneralSettings(disabledChannels = arrayOf("postman"))
+        )
+        val registry = RuleKeyRegistry.getInstance(project)
+        val allNames = registry.allKeys().map { it.key.name }.toSet()
+        assertTrue(
+            "allKeys() must still include postman.test when Postman is disabled",
+            "postman.test" in allNames
+        )
+    }
+
+    // --- General/implicit keys without channel prefix always present ---
+
+    fun testEnabledKeys_alwaysIncludesGeneralKeysWithoutChannelPrefix() {
+        SettingBinder.getInstance(project).save(
+            GeneralSettings(disabledChannels = arrayOf("postman"))
+        )
+        val registry = RuleKeyRegistry.getInstance(project)
+        val enabledNames = registry.enabledKeys().map { it.key.name }.toSet()
+        assertTrue("api.name should always be present", "api.name" in enabledNames)
+        assertTrue("field.ignore should always be present", "field.ignore" in enabledNames)
+        assertTrue("method.doc should always be present", "method.doc" in enabledNames)
+    }
+
+    fun testEnabledKeys_alwaysIncludesImplicitKeysWithoutChannelPrefix() {
+        SettingBinder.getInstance(project).save(
+            GeneralSettings(disabledChannels = arrayOf("postman"))
+        )
+        val registry = RuleKeyRegistry.getInstance(project)
+        val enabledNames = registry.enabledKeys().map { it.key.name }.toSet()
+        assertTrue("max.deep should always be present", "max.deep" in enabledNames)
+        assertTrue("max.elements should always be present", "max.elements" in enabledNames)
+    }
+
+    // --- enabledKeys is a subset of allKeys ---
+
+    fun testEnabledKeys_isSubsetOfAllKeys() {
+        SettingBinder.getInstance(project).save(
+            GeneralSettings(disabledChannels = arrayOf("postman"))
+        )
+        val registry = RuleKeyRegistry.getInstance(project)
+        val allNames = registry.allKeys().map { it.key.name }.toSet()
+        val enabledNames = registry.enabledKeys().map { it.key.name }.toSet()
+        assertTrue(
+            "enabledKeys must be a subset of allKeys",
+            allNames.containsAll(enabledNames)
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleKeyRegistryTest.kt
@@ -113,7 +113,7 @@ class RuleKeyRegistryTest {
         // If an implicit key name collides with a general key name, the
         // implicit entry is dropped (general takes precedence). Verify the
         // dedup guard works for the implicit stage too by constructing a
-        // scenario with a fake general-key collision — but since
+        // scenario with a fake general-key collisions — but since
         // IMPLICIT_KEYS is fixed and doesn't collide with RuleKeys today,
         // we just assert the implicit keys are all present (no collision).
         val keys = RuleKeyRegistry.assembleKeys(emptyList())
@@ -121,6 +121,209 @@ class RuleKeyRegistryTest {
         assertEquals(
             RuleKeyRegistry.IMPLICIT_KEYS.size,
             implicitCount
+        )
+    }
+
+    // ===============================================================
+    // isEnabledSource — pure enablement resolution (design C4a + AC-S4)
+    // ===============================================================
+
+    private fun info(name: String, source: String): RuleKeyRegistry.RuleKeyInfo =
+        RuleKeyRegistry.RuleKeyInfo(RuleKey.string(name), source)
+
+    private val emptySets = emptySet<String>()
+    private val postmanEnabled = setOf("postman")
+    private val markdownEnabled = setOf("markdown")
+    private val allChannels = setOf("postman", "markdown", "curl")
+    private val allFrameworks = setOf("Custom", "SpringMVC")
+
+    // --- General keys ---
+
+    @Test
+    fun isEnabledSource_generalKeyNoChannelPrefix_alwaysEnabled() {
+        // api.name has no channel prefix → enabled regardless of channel state.
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("api.name", "general"),
+                enabledChannelIds = emptySets,
+                allChannelIds = allChannels,
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_generalKeyWithChannelPrefix_channelEnabled_returnsTrue() {
+        // postman.test starts with "postman." → owned by postman channel.
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("postman.test", "general"),
+                enabledChannelIds = postmanEnabled,
+                allChannelIds = allChannels,
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_generalKeyWithChannelPrefix_channelDisabled_returnsFalse() {
+        // AC-S4: postman.* keys are filtered when Postman is disabled.
+        assertFalse(
+            RuleKeyRegistry.isEnabledSource(
+                info("postman.test", "general"),
+                enabledChannelIds = emptySets,
+                allChannelIds = allChannels,
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_generalKeyWithChannelPrefix_unknownChannel_notFiltered() {
+        // If the channel is not registered (not in allChannelIds), the
+        // prefix check does not apply — the key stays enabled.
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("postman.test", "general"),
+                enabledChannelIds = emptySets,
+                allChannelIds = emptySets,
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    // --- Implicit keys (also subject to channel prefix check) ---
+
+    @Test
+    fun isEnabledSource_implicitKeyWithChannelPrefix_channelDisabled_returnsFalse() {
+        // markdown.template.url.ttl.seconds is implicit but markdown-owned.
+        assertFalse(
+            RuleKeyRegistry.isEnabledSource(
+                info("markdown.template.url.ttl.seconds", "implicit"),
+                enabledChannelIds = emptySets,
+                allChannelIds = setOf("markdown"),
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = emptySets
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_implicitKeyWithChannelPrefix_channelEnabled_returnsTrue() {
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("markdown.template.url.ttl.seconds", "implicit"),
+                enabledChannelIds = setOf("markdown"),
+                allChannelIds = setOf("markdown"),
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = emptySets
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_implicitKeyNoChannelPrefix_alwaysEnabled() {
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("max.deep", "implicit"),
+                enabledChannelIds = emptySets,
+                allChannelIds = allChannels,
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    // --- Channel-sourced keys ---
+
+    @Test
+    fun isEnabledSource_channelSourcedKey_channelEnabled_returnsTrue() {
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("hoppscotch.something", "hoppscotch"),
+                enabledChannelIds = setOf("hoppscotch"),
+                allChannelIds = setOf("hoppscotch", "postman"),
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = emptySets
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_channelSourcedKey_channelDisabled_returnsFalse() {
+        assertFalse(
+            RuleKeyRegistry.isEnabledSource(
+                info("hoppscotch.something", "hoppscotch"),
+                enabledChannelIds = emptySets,
+                allChannelIds = setOf("hoppscotch", "postman"),
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = emptySets
+            )
+        )
+    }
+
+    // --- Framework-sourced keys ---
+
+    @Test
+    fun isEnabledSource_frameworkSourcedKey_frameworkEnabled_returnsTrue() {
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("custom.something", "Custom"),
+                enabledChannelIds = emptySets,
+                allChannelIds = emptySets,
+                enabledFrameworkIds = setOf("Custom"),
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_frameworkSourcedKey_frameworkDisabled_returnsFalse() {
+        assertFalse(
+            RuleKeyRegistry.isEnabledSource(
+                info("custom.something", "Custom"),
+                enabledChannelIds = emptySets,
+                allChannelIds = emptySets,
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    // --- Unknown source kind ---
+
+    @Test
+    fun isEnabledSource_unknownSourceKind_neverFiltered() {
+        // A source that is neither a channel id nor a framework name stays
+        // enabled — never filter unknown source kinds.
+        assertTrue(
+            RuleKeyRegistry.isEnabledSource(
+                info("mystery.key", "mysterySource"),
+                enabledChannelIds = emptySets,
+                allChannelIds = allChannels,
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = allFrameworks
+            )
+        )
+    }
+
+    @Test
+    fun isEnabledSource_generalKeyMatchesMultipleChannels_allMustBeEnabled() {
+        // If a key name could match multiple channel prefixes (unlikely but
+        // possible), all matching channels must be enabled. Construct a
+        // scenario where "postman.extra" matches "postman" (disabled) → false.
+        assertFalse(
+            RuleKeyRegistry.isEnabledSource(
+                info("postman.extra", "general"),
+                enabledChannelIds = setOf("markdown"),
+                allChannelIds = setOf("postman", "markdown"),
+                enabledFrameworkIds = emptySets,
+                allFrameworkIds = emptySets
+            )
         )
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidatorDisabledSourceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidatorDisabledSourceTest.kt
@@ -1,0 +1,120 @@
+package com.itangcent.easyapi.core.rule
+
+import com.itangcent.easyapi.channel.spi.Channel
+import com.itangcent.easyapi.core.export.ExportContext
+import com.itangcent.easyapi.core.export.ExportResult
+import com.itangcent.easyapi.core.internal.PluginInfo.PLUGIN_ID
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+/**
+ * IDE-fixture tests for [RuleProposalValidator]'s A5c disabled-source soft
+ * warnings.
+ *
+ * Registers a stub `"postman"` channel via the `channel` extension point so
+ * the channel-prefix check on the general-sourced `postman.*` keys (declared
+ * in [RuleKeys]) can be exercised end-to-end, mirroring
+ * [RuleKeyRegistryEnabledKeysTest]. The stub channel contributes no rule keys
+ * of its own — the `postman.*` keys remain general-sourced, and the prefix
+ * check is what triggers the warning.
+ */
+class RuleProposalValidatorDisabledSourceTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    /**
+     * Minimal [Channel] stub with id `"postman"` so the channel-prefix check
+     * in [RuleProposalValidator.checkDisabledSource] can resolve the owner.
+     * `enabledByDefault = true` mirrors the real PostmanChannel.
+     */
+    private class StubPostmanChannel : Channel {
+        override val id: String = "postman"
+        override val displayName: String = "Postman (stub)"
+        override val enabledByDefault: Boolean = true
+        override suspend fun export(context: ExportContext): ExportResult =
+            ExportResult.Success(0, "")
+    }
+
+    override fun setUp() {
+        super.setUp()
+        // Register the stub postman channel via the project-scoped EP.
+        project.extensionArea
+            .getExtensionPoint<Channel>("$PLUGIN_ID.channel")
+            .registerExtension(StubPostmanChannel(), testRootDisposable)
+        // Default: no explicit preferences → postman enabled by default.
+        SettingBinder.getInstance(project).save(GeneralSettings())
+    }
+
+    private fun disablePostman() {
+        SettingBinder.getInstance(project).save(
+            GeneralSettings(disabledChannels = arrayOf("postman"))
+        )
+    }
+
+    // --- postman.test: warns when Postman disabled, silent when enabled ---
+
+    fun testPostmanTestKey_warnsWhenPostmanDisabled() {
+        disablePostman()
+        val result = RuleProposalValidator.validate("postman.test=pm.test(\"ok\")", project)
+        assertTrue("proposal must still stage (soft warning only)", result.ok)
+        assertTrue(
+            "should warn that postman.test belongs to disabled postman",
+            result.warnings.any { it.contains("postman.test") && it.contains("disabled") }
+        )
+    }
+
+    fun testPostmanTestKey_noWarningWhenPostmanEnabled() {
+        val result = RuleProposalValidator.validate("postman.test=pm.test(\"ok\")", project)
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertEquals("no warning expected when Postman enabled", 0, result.warnings.size)
+    }
+
+    // --- postman.prerequest: same prefix-based ownership ---
+
+    fun testPostmanPrerequestKey_warnsWhenPostmanDisabled() {
+        disablePostman()
+        val result = RuleProposalValidator.validate("postman.prerequest=console.log(1)", project)
+        assertTrue(result.ok)
+        assertTrue(
+            "should warn that postman.prerequest belongs to disabled postman",
+            result.warnings.any { it.contains("postman.prerequest") && it.contains("disabled") }
+        )
+    }
+
+    // --- General key without channel prefix: never warns ---
+
+    fun testGeneralKeyNoWarningWhenPostmanDisabled() {
+        disablePostman()
+        val result = RuleProposalValidator.validate("api.name=My API", project)
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertEquals("api.name has no channel prefix → no warning", 0, result.warnings.size)
+    }
+
+    // --- Unknown-key hard-error path unchanged ---
+
+    fun testUnknownKeyHardErrorUnchanged() {
+        // The disabled-source soft-warning path must not mask the unknown-key
+        // hard error. An unknown key still blocks the proposal.
+        val result = RuleProposalValidator.validate("api.unknown_key=foo", project)
+        assertFalse(result.ok)
+        assertTrue(result.errors.any { it.contains("unknown rule key") })
+    }
+
+    // --- Soft warning never blocks: mix of disabled-source key + clean key ---
+
+    fun testDisabledSourceWarningDoesNotBlockOtherValidKeys() {
+        disablePostman()
+        val content = """
+            api.name=My API
+            postman.test=pm.test("ok")
+        """.trimIndent()
+        val result = RuleProposalValidator.validate(content, project)
+        assertTrue("proposal must still stage (soft warning only)", result.ok)
+        assertTrue(
+            "should warn about postman.test",
+            result.warnings.any { it.contains("postman.test") }
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/skills/EasyApiAssistantSkillTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/skills/EasyApiAssistantSkillTest.kt
@@ -23,6 +23,11 @@ class EasyApiAssistantSkillTest : EasyApiLightCodeInsightFixtureTestCase() {
     /** Bundled knowledge-base docs live under `docs/` next to SKILL.md. */
     private val skillDocsDir: File by lazy { skillDir.resolve("docs") }
 
+    /** Bundled per-recipe catalog mirror (R3-C3). */
+    private val skillAiDir: File by lazy { skillDir.resolve("ai") }
+
+    private val skillScriptsDir: File by lazy { skillDir.resolve("scripts") }
+
     private val skillFile: File by lazy { skillDir.resolve("SKILL.md") }
 
     fun testSkillFileExists() {
@@ -106,6 +111,107 @@ class EasyApiAssistantSkillTest : EasyApiLightCodeInsightFixtureTestCase() {
                     res.readText()
                 )
             }
+    }
+
+    // -------------------------------------------------------------------------
+    // R3-C3 — per-recipe catalog mirror (ai/detection/ + ai/rules/)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Every `src/main/resources/ai/detection/` markdown file must be bundled
+     * verbatim under `skills/easy-api-assistant/ai/detection/` so the external
+     * skill mirrors the in-plugin agent's `get_detection_prompt` surface.
+     */
+    fun testSkillBundlesDetectionCatalog() {
+        val canonicalDir = repoRoot.resolve("src/main/resources/ai/detection")
+        assertTrue("canonical ai/detection/ must exist: $canonicalDir", canonicalDir.isDirectory)
+        val expected = canonicalDir.listFiles { f -> f.isFile && f.name.endsWith(".md") }
+            ?.map { it.name } ?: emptyList()
+        assertTrue("ai/detection/ must contain at least one .md file", expected.isNotEmpty())
+        val skillDetectionDir = skillAiDir.resolve("detection")
+        assertTrue("skill ai/detection/ subfolder must exist: $skillDetectionDir", skillDetectionDir.isDirectory)
+        expected.forEach { name ->
+            val bundled = skillDetectionDir.resolve(name)
+            assertTrue("skill must bundle detection catalog file: ai/detection/$name", bundled.isFile)
+            assertEquals(
+                "skill's ai/detection/$name must match the canonical copy verbatim (run ./gradlew syncAgentCatalog)",
+                canonicalDir.resolve(name).readText(),
+                bundled.readText()
+            )
+        }
+    }
+
+    /**
+     * Every `src/main/resources/ai/rules/` markdown file must be bundled
+     * verbatim under `skills/easy-api-assistant/ai/rules/` so the external
+     * skill mirrors the in-plugin agent's `get_rule_detail` surface.
+     */
+    fun testSkillBundlesRuleCatalog() {
+        val canonicalDir = repoRoot.resolve("src/main/resources/ai/rules")
+        assertTrue("canonical ai/rules/ must exist: $canonicalDir", canonicalDir.isDirectory)
+        val expected = canonicalDir.listFiles { f -> f.isFile && f.name.endsWith(".md") }
+            ?.map { it.name } ?: emptyList()
+        assertTrue("ai/rules/ must contain at least one .md file", expected.isNotEmpty())
+        val skillRulesDir = skillAiDir.resolve("rules")
+        assertTrue("skill ai/rules/ subfolder must exist: $skillRulesDir", skillRulesDir.isDirectory)
+        expected.forEach { name ->
+            val bundled = skillRulesDir.resolve(name)
+            assertTrue("skill must bundle rule catalog file: ai/rules/$name", bundled.isFile)
+            assertEquals(
+                "skill's ai/rules/$name must match the canonical copy verbatim (run ./gradlew syncAgentCatalog)",
+                canonicalDir.resolve(name).readText(),
+                bundled.readText()
+            )
+        }
+    }
+
+    /**
+     * The four R3-C3 catalog CLI scripts must ship and be executable.
+     */
+    fun testSkillBundlesCatalogCliScripts() {
+        val expected = listOf(
+            "get_detection_prompt.sh",
+            "get_rule_detail.sh",
+            "list_detections.sh",
+            "list_rule_details.sh"
+        )
+        assertTrue("skill scripts/ folder must exist: $skillScriptsDir", skillScriptsDir.isDirectory)
+        expected.forEach { name ->
+            val script = skillScriptsDir.resolve(name)
+            assertTrue("skill must bundle catalog script: scripts/$name", script.isFile)
+            assertTrue(
+                "scripts/$name must be executable (chmod +x) — run: chmod +x skills/easy-api-assistant/scripts/$name",
+                script.canExecute()
+            )
+        }
+    }
+
+    /**
+     * SKILL.md must document the new catalog scripts and the syncAgentCatalog
+     * Gradle task that keeps the mirror in sync.
+     */
+    fun testSkillBodyDocumentsCatalogScriptsAndSyncTask() {
+        val body = skillBody()
+        assertTrue(
+            "skill must document get_detection_prompt.sh",
+            body.contains("get_detection_prompt.sh")
+        )
+        assertTrue(
+            "skill must document get_rule_detail.sh",
+            body.contains("get_rule_detail.sh")
+        )
+        assertTrue(
+            "skill must document list_detections.sh",
+            body.contains("list_detections.sh")
+        )
+        assertTrue(
+            "skill must document list_rule_details.sh",
+            body.contains("list_rule_details.sh")
+        )
+        assertTrue(
+            "skill must document the syncAgentCatalog Gradle task that keeps the bundled catalog in sync",
+            body.contains("syncAgentCatalog")
+        )
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Realises two companion specs that together evolve the EasyApi AI assistant from a single Reactive turn into a **Hybrid Architecture** with per-detection sub-agent isolation:

- **`ai-agent-planning-mode`** (R1–R3) — the foundation layer (Magic flow, decomposed prompt catalog, split-panel UI, external skill mirror).
- **`hybrid-agent-architecture`** — a rename + execution-model evolution layered on top (honest vocabulary, named two-turn contract, per-task sub-agents).

These two specs describe one feature; this PR ships both together.

### Hybrid architecture

| Path | Trigger | Behaviour |
|---|---|---|
| **Reactive** | Plain chat (default) | Direct tool calls, no plan, no Todo List. |
| **Deliberative** | Magic | System pre-builds one `Task` per enabled detection (entrance-driven); the agent walks the list via `update_task`; each task runs in its own sub-agent context for attention focus + failure containment. |

## What changed

### `hybrid-agent-architecture` — rename + execution model

- **Vocabulary rename:** `Plan` → `TaskList`, `PlanStep` → `Task`, `PlanStepStatus` → `TaskStatus`, `DELIBERATIVE_*` → `TASK_LIST_*`. The data model now describes what the code actually does (enumeration + task list), not planning.
- **Named two-turn contract:** the de facto Magic flow (seed → execute) is promoted to an explicit, tested guarantee via `EntryPath.TASK_LIST_PROGRAMMATIC` (`TwoTurnContractTest`).
- **Per-task sub-agents:** `RuleAuthoringAgent` is reused as in-process sub-agents (sequential in v1, parallel deferred — Decision D2). Each `TaskResult` is tagged `source: detection:<id>` and concatenated into a single `propose_rule_content` call (D3).
- **Conditional Magic (D7):** on a non-empty rule file, Magic runs a single Reactive review turn, gates the user (Yes / No), and only on Yes enters the detection pass — reusing the empty-file detection contract verbatim.

### `ai-agent-planning-mode` — R1–R3 foundation

- **Split-panel UI:** conversation panel splits 5:3 (conversation : Todo List). Divider pinned to `0.625` on first paint (R3.1 fix) and on subsequent resize via `resizeWeight`.
- **Decomposed prompt catalog:** the monolithic `agent-preamble.md` is replaced by `agent-base.md` + per-detection `detection/<id>.md` + per-key `rules/<key>.md`, loaded on demand via the new `get_detection_prompt` / `get_rule_detail` tools.
- **External skill mirror (R3.3):** the `easy-api-assistant` skill bundles the same catalog and ships CLI mirrors — `get_detection_prompt.sh` · `get_rule_detail.sh` · `list_detections.sh` · `list_rule_details.sh` — kept in sync by the new `syncAgentCatalog` Gradle task (idempotent, content-equality-checked, sibling of `syncKnowledgeBase`).
- **Catalog-id regression guard (R3.2):** `AgentBaseCatalogIdGuardTest` asserts every id literal in `agent-base.md` and the tool descriptions resolves through `PromptCatalog.entry("detection", id)` — prevents the stale-id drift that produced `unknown detection id` log bursts in R2.

## New surfaces

**Agent runtime** (`core/ai/agent/`)
- `TaskList.kt`, `TaskResult.kt`, `EntryPath.kt`, `MagicInstructionBuilder.kt`, `MagicTaskListBuilder.kt`, `PromptCatalog.kt`

**Tools** (`core/ai/tools/`)
- `CreateTaskListTool`, `UpdateTaskTool`, `GetDetectionPromptTool`, `GetRuleDetailTool`, `RunSubAgentTool`, `OrchestratorProposeRuleContentTool`, `ReportFindingsTool`

**Catalog resources** (`src/main/resources/ai/`)
- `agent-base.md`, `sub-agent-base.md`, `catalog-manifest.txt`, `detection/*.md` (10 detections), `rules/*.md` (7 rule recipes)

**External skill** (`skills/easy-api-assistant/`)
- `ai/{detection,rules}/*.md` (mirror), `scripts/{get_detection_prompt,get_rule_detail,list_detections,list_rule_details}.sh`

## Test plan

- [x] `./gradlew build` — **BUILD SUCCESSFUL**, `koverVerify` PASS
- [x] New regression tests:
  - `TwoTurnContractTest` — Magic seed → execute contract
  - `SubAgentOrchestrationTest` — per-task sub-agent isolation + result tagging
  - `AgentBaseCatalogIdGuardTest` — R3.2 catalog-id drift guard
  - `MagicTaskListBuilderTest`, `MagicInstructionBuilderTest`, `TaskListTest`, `TaskListLifecycleEventsTest`, `PromptCatalogTest`
- [x] Updated tests across `SystemPromptBuilderTest`, `RuleAuthoringAgentTest`, `AiChatPanelTest`, `RuleKeyRegistryTest`, etc.

## Spec references

- `.spec/ai-agent-planning-mode/{requirements,design,tasks}.md` (R1–R3, foundation)
- `.spec/hybrid-agent-architecture/{requirements,design,tasks}.md` (rename + execution model)

Specs live under the gitignored `.spec/` workspace and are not committed; they are referenced here for reviewer context.

## Behaviour preservation (NG5 / G5)

This is a refactor + execution-model evolution. User-observable behaviour (Magic flow, Reactive flow, split-panel UI, enablement filtering) is preserved; the change is internal honesty + per-task isolation, with no new user-visible feature.