### PR TITLE
refactor(markdown): move template settings from export dialog to settings panel

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownChannel.kt
@@ -1,31 +1,22 @@
 package com.itangcent.easyapi.channel.markdown
 
-import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.fileChooser.FileSaverDescriptor
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileWrapper
-import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
 import com.itangcent.easyapi.core.config.ConfigReader
 import com.itangcent.easyapi.core.internal.threading.IdeDispatchers
 import com.itangcent.easyapi.core.internal.threading.background
-import com.itangcent.easyapi.core.internal.threading.backgroundAsync
 import com.itangcent.easyapi.core.internal.threading.swing
 import com.itangcent.easyapi.channel.spi.Channel
 import com.itangcent.easyapi.channel.spi.ChannelConfig
 import com.itangcent.easyapi.channel.spi.ChannelOptionsPanel
 import com.itangcent.easyapi.channel.markdown.MarkdownExportMetadata
 import com.itangcent.easyapi.channel.curl.CurlSettings
-import com.itangcent.easyapi.channel.markdown.template.BundledLanguageTemplates
-import com.itangcent.easyapi.channel.markdown.template.DefaultMarkdownTemplate
-import com.itangcent.easyapi.channel.markdown.template.FetchResult
 import com.itangcent.easyapi.channel.markdown.template.MarkdownTemplateRenderer
 import com.itangcent.easyapi.channel.markdown.template.MarkdownTemplateResolver
 import com.itangcent.easyapi.channel.markdown.template.RemoteTemplateFetcher
@@ -37,8 +28,11 @@ import com.itangcent.easyapi.core.export.ExportContext
 import com.itangcent.easyapi.core.export.ExportResult
 import com.itangcent.easyapi.core.ide.support.NotificationUtils
 import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.settings.Settings
 import com.itangcent.easyapi.core.settings.settings
+import com.itangcent.easyapi.core.settings.ui.SettingsPanel
 import kotlinx.coroutines.CancellationException
+import kotlin.reflect.KClass
 import java.awt.BorderLayout
 import java.awt.CardLayout
 import java.io.File
@@ -62,22 +56,28 @@ class MarkdownChannel : Channel, IdeaLog {
     override val exposeAsAction: Boolean = true
     override val actionText: String = "Export to Markdown"
 
+    override val settingsType: KClass<out Settings> = MarkdownSettings::class
+    override val settingsTabOrder: Int = 120
+
     override fun createOptionsPanel(project: Project): ChannelOptionsPanel {
         return MarkdownOptionsPanel(project)
     }
+
+    override fun createSettingsPanel(project: Project): SettingsPanel<*>? =
+        MarkdownSettingsPanel(project)
 
     override suspend fun export(context: ExportContext): ExportResult {
         LOG.info("MarkdownChannel.export: endpoints=${context.endpointsToExport.size}")
         val project = context.project
         val markdownConfig = context.channelConfig as? MarkdownConfig
-        val templateConfig = markdownConfig?.let {
-            TemplateConfig(
-                templateInline = it.templateInline,
-                templatePath = it.templatePath,
-                templateUrl = it.templateUrl,
-                templateLanguage = it.templateLanguage,
-            )
-        }
+        val templateLanguage = markdownConfig?.templateLanguage
+            ?: project.settings<MarkdownSettings>().templateLanguage.takeIf { it != "en" }
+        val templateConfig = TemplateConfig(
+            templateInline = markdownConfig?.templateInline,
+            templatePath = markdownConfig?.templatePath,
+            templateUrl = markdownConfig?.templateUrl,
+            templateLanguage = templateLanguage,
+        )
         val configReader = ConfigReader.getInstance(project)
         val httpClient = HttpClientProvider.getInstance(project).getClient(httpTimeOut = 10)
 
@@ -236,86 +236,6 @@ private class MarkdownOptionsPanel(private val project: Project) : ChannelOption
         columns = 30
     }
 
-    private val templateFileField = TextFieldWithBrowseButton().apply {
-        addBrowseFolderListener(
-            project,
-            FileChooserDescriptor(true, false, false, false, false, false)
-                .withTitle("Select Template File")
-                .withDescription("Choose a Markdown template file (.tpl or .md.tpl)")
-        )
-    }
-
-    private val templateUrlField = JBTextField().apply {
-        columns = 40
-        toolTipText = "<html>http(s) URL to a remote Markdown template. " +
-            "Fetched over the network on each export (cached for 10 min).<br>" +
-            "Only http/https are allowed; redirects are not followed.</html>"
-    }
-
-    private val languageCombo = JComboBox(BundledLanguageTemplates.availableLocales().toTypedArray()).apply {
-        selectedItem = "en"
-        toolTipText = "Select a bundled language template (en uses the default template)"
-    }
-
-    private val inlineToggle = JToggleButton("Show inline template").apply {
-        toolTipText = "Toggle the inline template editor (overrides file template when non-blank)"
-    }
-
-    private val copyDefaultButton = JButton("Copy default template").apply {
-        toolTipText = "Save the bundled default template to a file and open it for editing"
-        addActionListener {
-            val descriptor = FileSaverDescriptor(
-                "Save Default Template",
-                "Choose where to save the bundled default Markdown template"
-            )
-            val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
-            val wrapper = saver.save(null as VirtualFile?, "default.md.tpl") ?: return@addActionListener
-            val targetFile = wrapper.file
-            backgroundAsync {
-                try {
-                    targetFile.writeText(DefaultMarkdownTemplate.get())
-                    swing {
-                        val vFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(targetFile)
-                        if (vFile != null) {
-                            FileEditorManager.getInstance(project).openFile(vFile)
-                        }
-                        // Pre-fill the template file field so the user can iterate on it directly.
-                        templateFileField.text = targetFile.absolutePath
-                    }
-                } catch (t: Throwable) {
-                    LOG.warn("Failed to save default template to ${targetFile.absolutePath}", t)
-                    swing {
-                        com.intellij.openapi.ui.Messages.showErrorDialog(
-                            project,
-                            "Failed to save default template: ${t.message}",
-                            "Save Error"
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private val inlineArea = JBTextArea().apply {
-        rows = 12
-        columns = 60
-        lineWrap = true
-        wrapStyleWord = true
-    }
-
-    private val inlineScroll = JBScrollPane(inlineArea).apply {
-        isVisible = false
-    }
-
-    init {
-        inlineToggle.addActionListener {
-            inlineToggle.text = if (inlineToggle.isSelected) "Hide inline template" else "Show inline template"
-            inlineScroll.isVisible = inlineToggle.isSelected
-            component.revalidate()
-            component.repaint()
-        }
-    }
-
     override val component: JComponent = JPanel().apply {
         layout = BoxLayout(this, BoxLayout.Y_AXIS)
         add(JPanel(BorderLayout()).apply {
@@ -327,39 +247,12 @@ private class MarkdownOptionsPanel(private val project: Project) : ChannelOption
             add(JLabel("File Name (without extension):"), BorderLayout.WEST)
             add(fileNameField, BorderLayout.CENTER)
         })
-        add(Box.createVerticalStrut(5))
-        add(JPanel(BorderLayout()).apply {
-            add(JLabel("Template File:"), BorderLayout.WEST)
-            add(templateFileField, BorderLayout.CENTER)
-        })
-        add(Box.createVerticalStrut(5))
-        add(JPanel(BorderLayout()).apply {
-            add(JLabel("Template URL:"), BorderLayout.WEST)
-            add(templateUrlField, BorderLayout.CENTER)
-        })
-        add(Box.createVerticalStrut(5))
-        add(JPanel(BorderLayout()).apply {
-            add(JLabel("Language:"), BorderLayout.WEST)
-            add(languageCombo, BorderLayout.CENTER)
-        })
-        add(Box.createVerticalStrut(5))
-        add(JPanel(BorderLayout()).apply {
-            add(inlineToggle, BorderLayout.WEST)
-            add(copyDefaultButton, BorderLayout.EAST)
-        })
-        add(inlineScroll)
     }
 
     override fun buildConfig(): MarkdownConfig {
-        val selectedLanguage = languageCombo.selectedItem as? String
         return MarkdownConfig(
             outputDir = outputDirField.text.takeIf { it.isNotBlank() },
             fileName = fileNameField.text.takeIf { it.isNotBlank() },
-            templatePath = templateFileField.text.takeIf { it.isNotBlank() },
-            templateInline = inlineArea.text.takeIf { it.isNotBlank() },
-            templateUrl = templateUrlField.text.takeIf { it.isNotBlank() },
-            // 'en' uses the default template — null means "no language override" .
-            templateLanguage = selectedLanguage?.takeIf { it != "en" },
         )
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownSettings.kt
@@ -1,0 +1,37 @@
+package com.itangcent.easyapi.channel.markdown
+
+import com.itangcent.easyapi.core.settings.Scope
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.StorageScope
+
+/**
+ * Persistent settings for the Markdown channel.
+ *
+ * Stores the template sources that are too complex for the per-export
+ * [MarkdownOptionsPanel]: a local template file path, a remote template URL,
+ * and an inline template content override. These are resolved by
+ * [com.itangcent.easyapi.channel.markdown.template.MarkdownTemplateResolver]
+ * at export time via config keys, falling through the same precedence chain.
+ *
+ * All fields are `var` with `@StorageScope(Scope.APPLICATION)` because the
+ * [com.itangcent.easyapi.core.settings.SettingBinder] mutates the instance
+ * in place when loading from persistent state. Fields without the annotation
+ * are silently skipped by the binder.
+ *
+ * @property templateFile Path to a local template file (e.g. `/path/to/template.md.tpl`).
+ *  Defaults to empty string (no file override).
+ * @property templateUrl http(s) URL to a remote template. Defaults to empty string.
+ * @property templateInlineContent Inline template content (overrides file/url when non-blank).
+ *  Defaults to empty string.
+ * @property templateLanguage BCP-47 locale tag for a bundled language template.
+ *  Defaults to "en" (the bundled default template).
+ *
+ * @see MarkdownSettingsPanel for the settings UI
+ * @see MarkdownConfig for the per-export counterpart
+ */
+data class MarkdownSettings(
+    @StorageScope(Scope.APPLICATION) var templateFile: String = "",
+    @StorageScope(Scope.APPLICATION) var templateUrl: String = "",
+    @StorageScope(Scope.APPLICATION) var templateInlineContent: String = "",
+    @StorageScope(Scope.APPLICATION) var templateLanguage: String = "en",
+) : Settings

--- a/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/channel/markdown/MarkdownSettingsPanel.kt
@@ -1,0 +1,196 @@
+package com.itangcent.easyapi.channel.markdown
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.FormBuilder
+import com.intellij.openapi.ui.ComboBox
+import com.itangcent.easyapi.channel.markdown.template.BundledLanguageTemplates
+import com.itangcent.easyapi.channel.markdown.template.DefaultMarkdownTemplate
+import com.itangcent.easyapi.core.internal.threading.backgroundAsync
+import com.itangcent.easyapi.core.internal.threading.swing
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.Settings
+import com.itangcent.easyapi.core.settings.settings
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.core.settings.ui.SettingsPanel
+import java.awt.BorderLayout
+import javax.swing.*
+
+/**
+ * Persistent settings panel for the Markdown channel.
+ *
+ * Hosts template-source fields that are too complex for the per-export
+ * [MarkdownOptionsPanel]: local template file path, remote template URL,
+ * copy-default-template button, and inline template editor.
+ *
+ * Typed as `SettingsPanel<Settings>` (not `SettingsPanel<MarkdownSettings>`)
+ * so the configurable's `ChannelPanelEntry.panel` unchecked cast at
+ * [com.itangcent.easyapi.core.settings.ui.EasyApiSettingsConfigurable]
+ * works for every channel without per-channel `Settings` subtype awareness.
+ * The panel still reads/writes its own [MarkdownSettings] module internally
+ * via [SettingBinder].
+ *
+ * @param project the IntelliJ project context
+ * @see MarkdownSettings for the persisted module
+ * @see MarkdownOptionsPanel for the per-export counterpart
+ */
+class MarkdownSettingsPanel(private val project: Project) : SettingsPanel<Settings>, IdeaLog {
+
+    private val templateFileField = TextFieldWithBrowseButton().apply {
+        addBrowseFolderListener(
+            project,
+            FileChooserDescriptor(true, false, false, false, false, false)
+                .withTitle("Select Template File")
+                .withDescription("Choose a Markdown template file (.tpl or .md.tpl)")
+        )
+    }
+
+    private val templateUrlField = JBTextField().apply {
+        columns = 40
+        toolTipText = "<html>http(s) URL to a remote Markdown template. " +
+            "Fetched over the network on each export (cached for 10 min).<br>" +
+            "Only http/https are allowed; redirects are not followed.</html>"
+    }
+
+    private val copyDefaultButton = JButton("Copy default template").apply {
+        toolTipText = "Save the bundled default template to a file and open it for editing"
+        addActionListener {
+            val descriptor = com.intellij.openapi.fileChooser.FileSaverDescriptor(
+                "Save Default Template",
+                "Choose where to save the bundled default Markdown template"
+            )
+            val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
+            val wrapper = saver.save(null as com.intellij.openapi.vfs.VirtualFile?, "default.md.tpl") ?: return@addActionListener
+            val targetFile = wrapper.file
+            backgroundAsync {
+                try {
+                    targetFile.writeText(DefaultMarkdownTemplate.get())
+                    swing {
+                        val vFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(targetFile)
+                        if (vFile != null) {
+                            FileEditorManager.getInstance(project).openFile(vFile)
+                        }
+                        templateFileField.text = targetFile.absolutePath
+                    }
+                } catch (t: Throwable) {
+                    LOG.warn("Failed to save default template to ${targetFile.absolutePath}", t)
+                    swing {
+                        com.intellij.openapi.ui.Messages.showErrorDialog(
+                            project,
+                            "Failed to save default template: ${t.message}",
+                            "Save Error"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private val inlineToggle = JToggleButton("Show inline template").apply {
+        toolTipText = "Toggle the inline template editor (overrides file template when non-blank)"
+    }
+
+    private val inlineArea = JBTextArea().apply {
+        rows = 12
+        columns = 60
+        lineWrap = true
+        wrapStyleWord = true
+    }
+
+    private val inlineScroll = JBScrollPane(inlineArea).apply {
+        isVisible = false
+    }
+
+    private val languageCombo = ComboBox(BundledLanguageTemplates.availableLocales().toTypedArray()).apply {
+        toolTipText = "Select a bundled language template (en uses the default template)"
+    }
+
+    init {
+        inlineToggle.addActionListener {
+            inlineToggle.text = if (inlineToggle.isSelected) "Hide inline template" else "Show inline template"
+            inlineScroll.isVisible = inlineToggle.isSelected
+            component.revalidate()
+            component.repaint()
+        }
+    }
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addLabeledComponent("Template File:", templateFileField)
+        .addLabeledComponent("Template URL:", templateUrlField)
+        .addLabeledComponent("Language:", languageCombo)
+        .addComponent(JPanel(BorderLayout()).apply {
+            add(inlineToggle, BorderLayout.WEST)
+            add(copyDefaultButton, BorderLayout.EAST)
+        })
+        .addComponent(inlineScroll)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    override fun resetFrom(settings: Settings?) {
+        val s = project.settings<MarkdownSettings>()
+        templateFileField.text = s.templateFile
+        templateUrlField.text = s.templateUrl
+        inlineArea.text = s.templateInlineContent
+        inlineToggle.isSelected = s.templateInlineContent.isNotBlank()
+        inlineToggle.text = if (inlineToggle.isSelected) "Hide inline template" else "Show inline template"
+        inlineScroll.isVisible = inlineToggle.isSelected
+        languageCombo.selectedItem = s.templateLanguage.ifBlank { "en" }
+    }
+
+    override fun applyTo(settings: Settings) {
+        SettingBinder.getInstance(project).update(MarkdownSettings::class) {
+            templateFile = templateFileField.text.trim()
+            templateUrl = templateUrlField.text.trim()
+            templateInlineContent = inlineArea.text
+            templateLanguage = (languageCombo.selectedItem as? String) ?: "en"
+        }
+    }
+
+    override fun isModified(settings: Settings?): Boolean {
+        val s = project.settings<MarkdownSettings>()
+        if (templateFileField.text.trim() != s.templateFile) return true
+        if (templateUrlField.text.trim() != s.templateUrl) return true
+        if (inlineArea.text != s.templateInlineContent) return true
+        if ((languageCombo.selectedItem as? String) != s.templateLanguage.ifBlank { "en" }) return true
+        return false
+    }
+
+    // --- Test-visible accessors (mirror the CurlSettingsPanel internal-accessor pattern) ---
+
+    internal fun templateFilePath(): String = templateFileField.text.trim()
+
+    internal fun setTemplateFile(path: String) {
+        templateFileField.text = path
+    }
+
+    internal fun templateUrlText(): String = templateUrlField.text.trim()
+
+    internal fun setTemplateUrl(url: String) {
+        templateUrlField.text = url
+    }
+
+    internal fun inlineContent(): String = inlineArea.text
+
+    internal fun setInlineContent(content: String) {
+        inlineArea.text = content
+        inlineToggle.isSelected = content.isNotBlank()
+        inlineToggle.text = if (inlineToggle.isSelected) "Hide inline template" else "Show inline template"
+        inlineScroll.isVisible = inlineToggle.isSelected
+    }
+
+    internal fun isInlineVisible(): Boolean = inlineScroll.isVisible
+
+    internal fun templateLanguage(): String = (languageCombo.selectedItem as? String) ?: "en"
+
+    internal fun setTemplateLanguage(locale: String) {
+        languageCombo.selectedItem = locale
+    }
+}


### PR DESCRIPTION
Move the template file, URL, inline editor, copy-default-template button, and language selector from the Markdown export dialog to the persistent Markdown settings tab. These are configuration preferences that users set once, not per-export choices, so they belong in Settings rather than cluttering the export action panel.

The export dialog now only shows Output Directory and File Name — the per-export essentials.