### PR TITLE
feat: enrich AI rule authoring context

### DIFF
--- a/docs/knowledge-base/easyapi-script-reference.md
+++ b/docs/knowledge-base/easyapi-script-reference.md
@@ -872,4 +872,27 @@ The existing EasyAPI rule script bindings remain available for advanced use case
 | `helper` / `H` | Class lookup |
 | `runtime` / `R` | Project/module metadata |
 
+### PSI class identity in rule scripts
+
+Rule scripts expose two different kinds of name APIs. Their semantics are
+intentionally different:
+
+| Context API | Result |
+|-------------|--------|
+| `name()` on a class context | simple class name, for example `TraceBean` |
+| `qualifiedName()` on a class context | Fully-qualified class name, for example `com.example.dto.TraceBean` |
+| `type().name()` | Fully-qualified type name, including type arguments when present |
+
+For inherited fields and methods:
+
+- `containingClass()` returns the class currently being exported.
+- `defineClass()` returns the class that originally declared the member.
+
+Always use `qualifiedName()` when comparing a class to an FQN or package
+prefix. For example, to ignore all fields declared by a shared base class:
+
+```groovy
+field.ignore=groovy:it.defineClass()?.qualifiedName() == "com.example.dto.TraceBean"
+```
+
 > **Recommendation:** For Pre-request and Post-response scripts in the API Dashboard, prefer the `pm.*` API for Postman compatibility. Use the legacy bindings only for IDE-specific operations (PSI inspection, file I/O, etc.).

--- a/docs/knowledge-base/rule-guide.md
+++ b/docs/knowledge-base/rule-guide.md
@@ -277,7 +277,7 @@ method.doc[@org.springframework.lang.Deprecated]=deprecated
 method.doc[#internal]=internal
 
 # Package-prefix match via groovy (wildcards are NOT supported by $class:)
-method.doc[groovy: it.containingClass().name().startsWith("com.example.web.")]=web
+method.doc[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]=web
 ```
 
 ---
@@ -342,11 +342,14 @@ When a rule value is prefixed with `groovy:`, it runs as a Groovy script via the
 `it` is the central object in every script. It wraps the current PSI element and exposes a script-friendly API:
 
 ```groovy
-// Name of the current element
+// Name of the current element; for a class context this is the simple name
 it.name()
 
-// Fully-qualified name of the containing class
-it.containingClass().name()
+// Fully-qualified name of the containing/current export class
+it.containingClass()?.qualifiedName()
+
+// Fully-qualified name of the class that originally declared an inherited member
+it.defineClass()?.qualifiedName()
 
 // Annotation access — returns the annotation wrapper or null
 it.ann("org.springframework.web.bind.annotation.RequestMapping")?.path()
@@ -358,6 +361,12 @@ it.doc()
 // Has annotation?
 it.hasAnn("java.lang.Deprecated")
 ```
+
+On class contexts, `name()` returns a simple name such as `TraceBean`;
+`qualifiedName()` returns an FQN such as `com.example.dto.TraceBean`. Always
+use `qualifiedName()` for package or FQN comparisons. For inherited members,
+`containingClass()` identifies the current export class and `defineClass()`
+identifies the original declaring class.
 
 ---
 
@@ -395,17 +404,17 @@ the same catalog when scanning your project.
 
 | Pattern | Detection signal (FQN / shape to search for) | Rule recipe |
 |---------|----------------------------------------------|-------------|
-| **Filter / Interceptor requiring a header** | `jakarta.servlet.Filter`, `jakarta.servlet.http.HttpFilter`, `javax.servlet.Filter`, `org.springframework.web.servlet.HandlerInterceptor` — implementations often call `request.getHeader("X-…")` in `doFilter` / `preHandle`. Search for `extends`/`implements` these types and confirm the FQN by resolving the import. | Add the header to every endpoint (no filter — applies globally): `method.additional.header={"name":"X-My-Header","value":"required-value","desc":"","required":true}`. Or scope it to a package via groovy: `method.additional.header[groovy: it.containingClass().name().startsWith("com.example.web.")]={"name":"X-My-Header","value":"\${value}","desc":"","required":true}`. |
+| **Filter / Interceptor requiring a header** | `jakarta.servlet.Filter`, `jakarta.servlet.http.HttpFilter`, `javax.servlet.Filter`, `org.springframework.web.servlet.HandlerInterceptor` — implementations often call `request.getHeader("X-…")` in `doFilter` / `preHandle`. Search for `extends`/`implements` these types and confirm the FQN by resolving the import. | Add the header to every endpoint (no filter — applies globally): `method.additional.header={"name":"X-My-Header","value":"required-value","desc":"","required":true}`. Or scope it to a package via groovy: `method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]={"name":"X-My-Header","value":"\${value}","desc":"","required":true}`. |
 | **WebFilter (Spring WebFlux)** | `org.springframework.web.server.WebFilter` — `filter()` that inspects `ServerHttpRequest`. | Same as above — `method.additional.header=…`. |
 | **Response wrapper (`@ControllerAdvice` + `ResponseBodyAdvice`)** | `org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice` — implementations wrap the body in `{ code, data, msg }`. Search for implementors; check the `beforeBodyWrite` return type. | Unwrap the response for documentation: `json.rule.convert[#regex:com\.example\.common\.ApiResult<(.*?)>]=${1}` (repeat for each wrapper type). |
-| **Custom argument resolver (injects hidden param)** | `org.springframework.web.method.support.HandlerMethodArgumentResolver` — `supportsParameter` checks for a custom annotation or type; `resolveArgument` returns the value. The parameter is **not** declared in the source signature. | Inject the param into the docs: `api.param.parse.before[groovy: it.containingClass().name().startsWith("com.example.web.")]=com.example.CurrentUser:current_user:the current user`. Or use `api.param.parse.before[@com.example.CurrentUser]=…` if annotated. |
+| **Custom argument resolver (injects hidden param)** | `org.springframework.web.method.support.HandlerMethodArgumentResolver` — `supportsParameter` checks for a custom annotation or type; `resolveArgument` returns the value. The parameter is **not** declared in the source signature. | Inject the param into the docs: `api.param.parse.before[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]=com.example.CurrentUser:current_user:the current user`. Or use `api.param.parse.before[@com.example.CurrentUser]=…` if annotated. |
 | **Meta-annotations (composed `@RequestMapping`)** | A custom annotation like `@GetRestApi` that is itself annotated `@GetMapping`. Search for annotations meta-annotated with `@org.springframework.web.bind.annotation.RequestMapping`. | Tell EasyApi to treat the custom annotation as a controller method marker: `class.is.spring.ctrl=groovy: it.hasAnn("com.example.GetRestApi")`. |
-| **Field naming convention (snake_case / camelCase mismatch)** | The DTO uses `camelCase`, but the API contract is `snake_case` (or vice-versa). Often visible in Jackson `@JsonNaming` or a `PropertyNamingStrategy`. | `field.name[groovy: it.containingClass().name().startsWith("com.example.dto.")]=groovy: it.name().replaceAll("([A-Z])") { "_" + it[1].toLowerCase() }` |
+| **Field naming convention (snake_case / camelCase mismatch)** | The DTO uses `camelCase`, but the API contract is `snake_case` (or vice-versa). Often visible in Jackson `@JsonNaming` or a `PropertyNamingStrategy`. | `field.name[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=groovy: it.name().replaceAll("([A-Z])") { "_" + it[1].toLowerCase() }` |
 | **Field ignores (sensitive fields)** | Fields named `password`, `secret`, `token`, `apiKey` that should never appear in exports. | `field.ignore[#regex:.*password.*]=true` · `field.ignore[#regex:.*(secret\|token\|apikey).*]=true` |
-| **Required / demo / default for a field** | A field is always required by the API but has no `@NotNull` in source, or needs a demo value for the exported example. | `field.required[groovy: it.containingClass().name().startsWith("com.example.dto.")]=name,email` · `field.demo[$class:com.example.dto.User]=18` |
-| **Path prefix per module / package** | Every controller in `com.example.admin` should be prefixed `/admin` in the docs, even if `@RequestMapping` doesn't declare it. | `class.prefix.path[groovy: it.name().startsWith("com.example.admin.")]=/admin` |
+| **Required / demo / default for a field** | A field is always required by the API but has no `@NotNull` in source, or needs a demo value for the exported example. | `field.required[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=name,email` · `field.demo[$class:com.example.dto.User]=18` |
+| **Path prefix per module / package** | Every controller in `com.example.admin` should be prefixed `/admin` in the docs, even if `@RequestMapping` doesn't declare it. | `class.prefix.path[groovy: it.qualifiedName()?.startsWith("com.example.admin.")]=/admin` |
 | **Enum representation** | The API exposes an enum as `{ "name": "ACTIVE", "value": 1 }` but EasyApi exports just the name. | `json.rule.convert[$class:com.example.Status]=groovy: '{"name":"' + it.name() + '","value":' + it.ann("com.example.Code")?.value() + '}'` |
-| **Status / version tag** | Every endpoint in `v2` package should carry a version label. | `method.doc[groovy: it.containingClass().name().startsWith("com.example.v2.")]=v2` |
+| **Status / version tag** | Every endpoint in `v2` package should carry a version label. | `method.doc[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.v2.")]=v2` |
 | **`@RequirePermission("admin")` → tag / header** | A custom security annotation that should become an `method.doc` or a Postman header. Search the codebase for `@com.example.RequirePermission` (resolve imports to confirm the FQN). | `method.doc[@com.example.RequirePermission]=admin` · `method.additional.header[@com.example.RequirePermission]={"name":"X-Permission","value":"\${it.ann('com.example.RequirePermission')?.value()}","desc":"","required":true}` |
 
 > **Detection tip for the AI assistant:** before proposing a rule, search the
@@ -478,10 +487,10 @@ the same catalog when scanning your project.
 
 | Pattern | Detection signal (PSI tools) | Rule recipe (full bundle) |
 |---------|------------------------------|---------------------------|
-| **Auth Token Chaining** (flagship) | **Producer:** endpoint path contains `/login`, `/signin`, `/auth`, `/token`, or `/oauth/token` (case-insensitive) OR method name contains `login`/`signin`/`authenticate`/`token`; return type carries a field named `token`/`accessToken`/`access_token`/`jwt`/`idToken`/`authToken`. **Consumer:** controllers in packages *other than* the auth controller. | **Producer** (post-response — extracts token, stores in env var):<br>`postman.test[groovy: it.containingClass().name() == "com.example.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("Authorization", token) }`<br>**Consumer** (attaches Bearer header to secured endpoints):<br>`method.additional.header[groovy: it.containingClass().name().startsWith("com.example.api.")]={"name":"Authorization","value":"Bearer ${Authorization}","desc":"bearer token from login","required":true}`<br>**Env var:** `Authorization` (reuse existing if present — resolve the name from any existing `method.additional.header=…${…}` rule via `get_existing_rules_for_key`, not from the Environments panel).<br>⚠ Uses `postman.test` (NOT `postman.prerequest`) — the token only exists after the login response.<br>⚠ If the token field is ambiguous (multiple candidates), call `ask_clarification` (single_choice) before writing the script. |
+| **Auth Token Chaining** (flagship) | **Producer:** endpoint path contains `/login`, `/signin`, `/auth`, `/token`, or `/oauth/token` (case-insensitive) OR method name contains `login`/`signin`/`authenticate`/`token`; return type carries a field named `token`/`accessToken`/`access_token`/`jwt`/`idToken`/`authToken`. **Consumer:** controllers in packages *other than* the auth controller. | **Producer** (post-response — extracts token, stores in env var):<br>`postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("Authorization", token) }`<br>**Consumer** (attaches Bearer header to secured endpoints):<br>`method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.api.")]={"name":"Authorization","value":"Bearer ${Authorization}","desc":"bearer token from login","required":true}`<br>**Env var:** `Authorization` (reuse existing if present — resolve the name from any existing `method.additional.header=…${…}` rule via `get_existing_rules_for_key`, not from the Environments panel).<br>⚠ Uses `postman.test` (NOT `postman.prerequest`) — the token only exists after the login response.<br>⚠ If the token field is ambiguous (multiple candidates), call `ask_clarification` (single_choice) before writing the script. |
 | **Static Auth (API Key / Basic)** | Security filter/interceptor calling `request.getHeader("X-API-Key")` / `"Authorization"` starting `Basic `; or custom `@ApiKeyAuth` annotation. Discover via `find_classes_by_annotation` + `get_psi_class_info` (read filter body for `getHeader(...)`). | **API-key-in-header:**<br>`method.additional.header={"name":"X-API-Key","value":"${apiKey}","desc":"api key","required":true}`<br>**API-key-in-query:**<br>`method.additional.param={"name":"key","type":"String","value":"${apiKey}","required":true,"desc":"api key"}`<br>**Basic auth:**<br>`method.additional.header={"name":"Authorization","value":"Basic ${basicAuth}","desc":"http basic credentials","required":true}`<br>**No script** — the user supplies the credential once in the Environments panel (base64-encode `user:pass` for Basic). |
 | **Per-Request Injection (Correlation / Idempotency)** | Filter/interceptor reading `request.getHeader("X-Request-Id")` / `"X-Correlation-Id"` / `"X-Trace-Id"`; or `Idempotency-Key` header on POST/PUT methods. | **Correlation ID** (global, pre-request):<br>`postman.prerequest=pm.request.headers.upsert("X-Request-Id", java.util.UUID.randomUUID().toString())`<br>**Idempotency key** (scoped to mutating methods — never unscoped):<br>`postman.prerequest[groovy: it.methodType().name() == "POST" || it.methodType().name() == "PUT"]=pm.request.headers.upsert("Idempotency-Key", java.util.UUID.randomUUID().toString())`<br>Uses `pm.request.headers.upsert(...)` (add-or-replace, case-insensitive), not `.add(...)` (which would duplicate). |
-| **Request Signing (HMAC)** | Filter/interceptor using `javax.crypto.Mac` / `HmacSHA256` / `Sha256.hmac`; reads `appSecret`/`appKey`/`accessKeyId`; or custom `@SignedRequest` annotation. | **Pre-request signing script** (computes HMAC, attaches signature header):<br>`postman.prerequest[groovy: it.containingClass().name().startsWith("com.example.api.")]=def mac = javax.crypto.Mac.getInstance("HmacSHA256"); mac.init(new javax.crypto.spec.SecretKeySpec("${appSecret}".getBytes("UTF-8"), "HmacSHA256")); def stringToSign = pm.request.url + "\n" + pm.request.body; def raw = mac.doFinal(stringToSign.getBytes("UTF-8")); def sig = raw.collect { String.format("%02x", it) }.join(); pm.request.headers.upsert("X-Signature", sig)`<br>**No hardcoded secret** — `${appSecret}` is always an env-var reference.<br>⚠ For non-trivial signing (AWS SigV4, etc.) treat as a scaffold + call `ask_clarification` for the canonical-string / algorithm variant. |
+| **Request Signing (HMAC)** | Filter/interceptor using `javax.crypto.Mac` / `HmacSHA256` / `Sha256.hmac`; reads `appSecret`/`appKey`/`accessKeyId`; or custom `@SignedRequest` annotation. | **Pre-request signing script** (computes HMAC, attaches signature header):<br>`postman.prerequest[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.api.")]=def mac = javax.crypto.Mac.getInstance("HmacSHA256"); mac.init(new javax.crypto.spec.SecretKeySpec("${appSecret}".getBytes("UTF-8"), "HmacSHA256")); def stringToSign = pm.request.url + "\n" + pm.request.body; def raw = mac.doFinal(stringToSign.getBytes("UTF-8")); def sig = raw.collect { String.format("%02x", it) }.join(); pm.request.headers.upsert("X-Signature", sig)`<br>**No hardcoded secret** — `${appSecret}` is always an env-var reference.<br>⚠ For non-trivial signing (AWS SigV4, etc.) treat as a scaffold + call `ask_clarification` for the canonical-string / algorithm variant. |
 | **401-Refresh** | Refresh endpoint at `/refresh`, `/token/refresh`; OR user explicitly asks for auto-refresh; OR documented "if 401, call /refresh" convention. | **Post-call rule** (detects 401, calls refresh, sets new header, forces retry):<br>`http.call.after=groovy: if (response.code() == 401) { def refreshReq = new com.itangcent.easyapi.core.http.HttpRequest("https://api.example.com/refresh", "POST", java.util.Collections.emptyList(), java.util.Collections.emptyList(), "grant_type=refresh_token", java.util.Collections.emptyList(), java.util.Collections.emptyList(), null); def resp = httpClient.executeSync(refreshReq); def newToken = new groovy.json.JsonSlurper().parseText(resp.body).access_token; if (newToken) { request.setHeader("Authorization", "Bearer " + newToken); response.discard() } }`<br>**Retry limit:** up to 3 (enforced by `HttpClientScriptInterceptor`). The retry re-sends the mutated request wrapper, so `request.setHeader(...)` + `response.discard()` is sufficient — `pm` is NOT available in `http.call.after` (use `session.set(...)` for cross-request persistence if needed).<br>⚠ Keep the refresh endpoint itself script-free (recursion guard limits sub-request hooks to depth < 2). Wrap in `try/catch`. |
 
 > **Detection tip for the AI assistant:** before proposing a workflow bundle,
@@ -652,10 +661,10 @@ clarification needed.
 postman.host={{order-service}}
 
 # Producer (post-response — extracts token, stores in namespaced env var)
-postman.test[groovy: it.containingClass().name() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
+postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
 
 # Consumer (attaches namespaced Bearer header to order-service secured endpoints)
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
 ```
 
 **Bundle 2 — `payment-service`** (a second `propose_rule_content`):
@@ -665,10 +674,10 @@ method.additional.header[groovy: it.containingClass().name().startsWith("com.exa
 postman.host={{payment-service}}
 
 # Producer (post-response — extracts token, stores in namespaced env var)
-postman.test[groovy: it.containingClass().name() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
+postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
 
 # Consumer (attaches namespaced Bearer header to payment-service secured endpoints)
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
 ```
 
 **Env vars** (user creates in the Environments panel): `order-service` (host),
@@ -701,7 +710,7 @@ consumer + host + env var, all carrying the same key).
 filter:
 
 ```
-api.name[groovy: it.containingClass().name() == "com.example.UserCtrl" && it.name() == "getUserName"]=Fetch User
+api.name[groovy: it.containingClass()?.qualifiedName() == "com.example.UserCtrl" && it.name() == "getUserName"]=Fetch User
 ```
 
 ### 2. Tag all endpoints in a controller
@@ -726,7 +735,7 @@ field.ignore[#regex:.*password.*]=true
 ### 5. Add a prefix to all fields in a DTO
 
 ```
-field.name.prefix[groovy: it.containingClass().name().startsWith("com.example.dto.")]=prop_
+field.name.prefix[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=prop_
 ```
 
 ### 6. Custom type conversion for Reactor types
@@ -778,7 +787,7 @@ Before EasyApi 3.0, rule editing happened in a dedicated "Built-in" tab inside t
   Note: `class:` (without `$`) is NOT a valid filter prefix in 3.0 — use `$class:`.
 - **`$class:` is exact-match only:** wildcards like `$class:com.example.*Controller`
   do NOT work. For package/pattern matching, use a `groovy:` filter
-  (e.g. `groovy: it.containingClass().name().startsWith("com.example.")`) or
+  (e.g. `groovy: it.containingClass()?.qualifiedName().startsWith("com.example.")`) or
   `#regex:`.
 - **No `~` regex prefix:** use `#regex:` instead.
 - **Header / param values are JSON:** `method.additional.header` takes a JSON

--- a/skills/easy-api-assistant/SKILL.md
+++ b/skills/easy-api-assistant/SKILL.md
@@ -354,13 +354,20 @@ Valid filter prefixes (and ONLY these):
 
 - `$class:<FQN>` — exact class-name match. **Wildcards are NOT supported.**
   For package/pattern matching use `groovy:` (e.g.
-  `groovy: it.containingClass()?.name()?.startsWith("com.example.web.")`).
+  `groovy: it.containingClass()?.qualifiedName()?.startsWith("com.example.web.")`).
 - `@<AnnotationFqn>` — annotation presence.
 - `#regex:<pattern>` — regex match; captured groups available as `${1}`,
   `${2}` in the value.
 - `#<tag>` — JavaDoc/KDoc tag.
 - `!<expr>` — negation.
 - `groovy:<script>` — truthy script result = match.
+
+Class identity in Groovy is context-sensitive:
+- `name()` on a class context returns only the simple name.
+- `qualifiedName()` returns the fully-qualified class name and is required for
+  FQN equality and package-prefix comparisons.
+- For inherited members, `containingClass()` is the class currently being
+  exported, while `defineClass()` is the original declaring class.
 
 There is **no `~` prefix** and **no bare `class:` prefix** — the older
 `class:com.example.Foo` and `~regex` forms are invalid; use `$class:` and
@@ -398,13 +405,13 @@ Binding Reference for the `it` object API.
 
 **Bad (unreadable single-line filter):**
 ```
-method.additional.header[groovy: it.containingClass()?.name()?.startsWith("com.example.merchant.") && it.containingClass()?.name() != "com.example.merchant.AuthController"]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName()?.startsWith("com.example.merchant.") && it.containingClass()?.qualifiedName() != "com.example.merchant.AuthController"]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
 ```
 
 **Good (multi-line groovy value-block):**
 ```
 method.additional.header=groovy:```
-def cls = it.containingClass()?.name()
+def cls = it.containingClass()?.qualifiedName()
 if (cls?.startsWith("com.example.merchant.")
     && cls != "com.example.merchant.AuthController") {
     return '{"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}'

--- a/skills/easy-api-assistant/ai/rules/field.ignore.md
+++ b/skills/easy-api-assistant/ai/rules/field.ignore.md
@@ -32,6 +32,18 @@ Multiple fields on the same class means multiple lines (the key uses
 default merge semantics — boolean rules do not merge, so each line is
 its own rule).
 
+When the user asks to ignore every field originally declared by a base
+class, compare the declaring class's **fully-qualified name**:
+
+```
+field.ignore=groovy:it.defineClass()?.qualifiedName() == "com.example.dto.TraceBean"
+```
+
+For inherited members, `containingClass()` is the class currently being
+exported, while `defineClass()` is the class that originally declared the
+field. Class-context `name()` returns only the simple name; always use
+`qualifiedName()` for FQN or package comparisons.
+
 ## Check existing rules first
 
 Before proposing, call `get_existing_rules_for_key` for `field.ignore`.

--- a/skills/easy-api-assistant/ai/rules/method.additional.header.md
+++ b/skills/easy-api-assistant/ai/rules/method.additional.header.md
@@ -39,13 +39,13 @@ value when the condition holds, or `null` when it doesn't.
 
 **Bad (unreadable single-line filter):**
 ```
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.merchant.") && !it.containingClass().name().equals("com.example.merchant.AuthController") && !it.containingClass().name().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.merchant.") && !it.containingClass()?.qualifiedName().equals("com.example.merchant.AuthController") && !it.containingClass()?.qualifiedName().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
 ```
 
 **Good (multi-line groovy value-block):**
 ```
 method.additional.header=groovy:```
-def cls = it.containingClass()?.name()
+def cls = it.containingClass()?.qualifiedName()
 if (cls?.startsWith("com.example.merchant.")
     && cls != "com.example.merchant.AuthController"
     && cls != "com.example.merchant.PublicController") {

--- a/skills/easy-api-assistant/docs/easyapi-script-reference.md
+++ b/skills/easy-api-assistant/docs/easyapi-script-reference.md
@@ -872,4 +872,27 @@ The existing EasyAPI rule script bindings remain available for advanced use case
 | `helper` / `H` | Class lookup |
 | `runtime` / `R` | Project/module metadata |
 
+### PSI class identity in rule scripts
+
+Rule scripts expose two different kinds of name APIs. Their semantics are
+intentionally different:
+
+| Context API | Result |
+|-------------|--------|
+| `name()` on a class context | simple class name, for example `TraceBean` |
+| `qualifiedName()` on a class context | Fully-qualified class name, for example `com.example.dto.TraceBean` |
+| `type().name()` | Fully-qualified type name, including type arguments when present |
+
+For inherited fields and methods:
+
+- `containingClass()` returns the class currently being exported.
+- `defineClass()` returns the class that originally declared the member.
+
+Always use `qualifiedName()` when comparing a class to an FQN or package
+prefix. For example, to ignore all fields declared by a shared base class:
+
+```groovy
+field.ignore=groovy:it.defineClass()?.qualifiedName() == "com.example.dto.TraceBean"
+```
+
 > **Recommendation:** For Pre-request and Post-response scripts in the API Dashboard, prefer the `pm.*` API for Postman compatibility. Use the legacy bindings only for IDE-specific operations (PSI inspection, file I/O, etc.).

--- a/skills/easy-api-assistant/docs/rule-guide.md
+++ b/skills/easy-api-assistant/docs/rule-guide.md
@@ -277,7 +277,7 @@ method.doc[@org.springframework.lang.Deprecated]=deprecated
 method.doc[#internal]=internal
 
 # Package-prefix match via groovy (wildcards are NOT supported by $class:)
-method.doc[groovy: it.containingClass().name().startsWith("com.example.web.")]=web
+method.doc[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]=web
 ```
 
 ---
@@ -342,11 +342,14 @@ When a rule value is prefixed with `groovy:`, it runs as a Groovy script via the
 `it` is the central object in every script. It wraps the current PSI element and exposes a script-friendly API:
 
 ```groovy
-// Name of the current element
+// Name of the current element; for a class context this is the simple name
 it.name()
 
-// Fully-qualified name of the containing class
-it.containingClass().name()
+// Fully-qualified name of the containing/current export class
+it.containingClass()?.qualifiedName()
+
+// Fully-qualified name of the class that originally declared an inherited member
+it.defineClass()?.qualifiedName()
 
 // Annotation access — returns the annotation wrapper or null
 it.ann("org.springframework.web.bind.annotation.RequestMapping")?.path()
@@ -358,6 +361,12 @@ it.doc()
 // Has annotation?
 it.hasAnn("java.lang.Deprecated")
 ```
+
+On class contexts, `name()` returns a simple name such as `TraceBean`;
+`qualifiedName()` returns an FQN such as `com.example.dto.TraceBean`. Always
+use `qualifiedName()` for package or FQN comparisons. For inherited members,
+`containingClass()` identifies the current export class and `defineClass()`
+identifies the original declaring class.
 
 ---
 
@@ -395,17 +404,17 @@ the same catalog when scanning your project.
 
 | Pattern | Detection signal (FQN / shape to search for) | Rule recipe |
 |---------|----------------------------------------------|-------------|
-| **Filter / Interceptor requiring a header** | `jakarta.servlet.Filter`, `jakarta.servlet.http.HttpFilter`, `javax.servlet.Filter`, `org.springframework.web.servlet.HandlerInterceptor` — implementations often call `request.getHeader("X-…")` in `doFilter` / `preHandle`. Search for `extends`/`implements` these types and confirm the FQN by resolving the import. | Add the header to every endpoint (no filter — applies globally): `method.additional.header={"name":"X-My-Header","value":"required-value","desc":"","required":true}`. Or scope it to a package via groovy: `method.additional.header[groovy: it.containingClass().name().startsWith("com.example.web.")]={"name":"X-My-Header","value":"\${value}","desc":"","required":true}`. |
+| **Filter / Interceptor requiring a header** | `jakarta.servlet.Filter`, `jakarta.servlet.http.HttpFilter`, `javax.servlet.Filter`, `org.springframework.web.servlet.HandlerInterceptor` — implementations often call `request.getHeader("X-…")` in `doFilter` / `preHandle`. Search for `extends`/`implements` these types and confirm the FQN by resolving the import. | Add the header to every endpoint (no filter — applies globally): `method.additional.header={"name":"X-My-Header","value":"required-value","desc":"","required":true}`. Or scope it to a package via groovy: `method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]={"name":"X-My-Header","value":"\${value}","desc":"","required":true}`. |
 | **WebFilter (Spring WebFlux)** | `org.springframework.web.server.WebFilter` — `filter()` that inspects `ServerHttpRequest`. | Same as above — `method.additional.header=…`. |
 | **Response wrapper (`@ControllerAdvice` + `ResponseBodyAdvice`)** | `org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice` — implementations wrap the body in `{ code, data, msg }`. Search for implementors; check the `beforeBodyWrite` return type. | Unwrap the response for documentation: `json.rule.convert[#regex:com\.example\.common\.ApiResult<(.*?)>]=${1}` (repeat for each wrapper type). |
-| **Custom argument resolver (injects hidden param)** | `org.springframework.web.method.support.HandlerMethodArgumentResolver` — `supportsParameter` checks for a custom annotation or type; `resolveArgument` returns the value. The parameter is **not** declared in the source signature. | Inject the param into the docs: `api.param.parse.before[groovy: it.containingClass().name().startsWith("com.example.web.")]=com.example.CurrentUser:current_user:the current user`. Or use `api.param.parse.before[@com.example.CurrentUser]=…` if annotated. |
+| **Custom argument resolver (injects hidden param)** | `org.springframework.web.method.support.HandlerMethodArgumentResolver` — `supportsParameter` checks for a custom annotation or type; `resolveArgument` returns the value. The parameter is **not** declared in the source signature. | Inject the param into the docs: `api.param.parse.before[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]=com.example.CurrentUser:current_user:the current user`. Or use `api.param.parse.before[@com.example.CurrentUser]=…` if annotated. |
 | **Meta-annotations (composed `@RequestMapping`)** | A custom annotation like `@GetRestApi` that is itself annotated `@GetMapping`. Search for annotations meta-annotated with `@org.springframework.web.bind.annotation.RequestMapping`. | Tell EasyApi to treat the custom annotation as a controller method marker: `class.is.spring.ctrl=groovy: it.hasAnn("com.example.GetRestApi")`. |
-| **Field naming convention (snake_case / camelCase mismatch)** | The DTO uses `camelCase`, but the API contract is `snake_case` (or vice-versa). Often visible in Jackson `@JsonNaming` or a `PropertyNamingStrategy`. | `field.name[groovy: it.containingClass().name().startsWith("com.example.dto.")]=groovy: it.name().replaceAll("([A-Z])") { "_" + it[1].toLowerCase() }` |
+| **Field naming convention (snake_case / camelCase mismatch)** | The DTO uses `camelCase`, but the API contract is `snake_case` (or vice-versa). Often visible in Jackson `@JsonNaming` or a `PropertyNamingStrategy`. | `field.name[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=groovy: it.name().replaceAll("([A-Z])") { "_" + it[1].toLowerCase() }` |
 | **Field ignores (sensitive fields)** | Fields named `password`, `secret`, `token`, `apiKey` that should never appear in exports. | `field.ignore[#regex:.*password.*]=true` · `field.ignore[#regex:.*(secret\|token\|apikey).*]=true` |
-| **Required / demo / default for a field** | A field is always required by the API but has no `@NotNull` in source, or needs a demo value for the exported example. | `field.required[groovy: it.containingClass().name().startsWith("com.example.dto.")]=name,email` · `field.demo[$class:com.example.dto.User]=18` |
-| **Path prefix per module / package** | Every controller in `com.example.admin` should be prefixed `/admin` in the docs, even if `@RequestMapping` doesn't declare it. | `class.prefix.path[groovy: it.name().startsWith("com.example.admin.")]=/admin` |
+| **Required / demo / default for a field** | A field is always required by the API but has no `@NotNull` in source, or needs a demo value for the exported example. | `field.required[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=name,email` · `field.demo[$class:com.example.dto.User]=18` |
+| **Path prefix per module / package** | Every controller in `com.example.admin` should be prefixed `/admin` in the docs, even if `@RequestMapping` doesn't declare it. | `class.prefix.path[groovy: it.qualifiedName()?.startsWith("com.example.admin.")]=/admin` |
 | **Enum representation** | The API exposes an enum as `{ "name": "ACTIVE", "value": 1 }` but EasyApi exports just the name. | `json.rule.convert[$class:com.example.Status]=groovy: '{"name":"' + it.name() + '","value":' + it.ann("com.example.Code")?.value() + '}'` |
-| **Status / version tag** | Every endpoint in `v2` package should carry a version label. | `method.doc[groovy: it.containingClass().name().startsWith("com.example.v2.")]=v2` |
+| **Status / version tag** | Every endpoint in `v2` package should carry a version label. | `method.doc[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.v2.")]=v2` |
 | **`@RequirePermission("admin")` → tag / header** | A custom security annotation that should become an `method.doc` or a Postman header. Search the codebase for `@com.example.RequirePermission` (resolve imports to confirm the FQN). | `method.doc[@com.example.RequirePermission]=admin` · `method.additional.header[@com.example.RequirePermission]={"name":"X-Permission","value":"\${it.ann('com.example.RequirePermission')?.value()}","desc":"","required":true}` |
 
 > **Detection tip for the AI assistant:** before proposing a rule, search the
@@ -478,10 +487,10 @@ the same catalog when scanning your project.
 
 | Pattern | Detection signal (PSI tools) | Rule recipe (full bundle) |
 |---------|------------------------------|---------------------------|
-| **Auth Token Chaining** (flagship) | **Producer:** endpoint path contains `/login`, `/signin`, `/auth`, `/token`, or `/oauth/token` (case-insensitive) OR method name contains `login`/`signin`/`authenticate`/`token`; return type carries a field named `token`/`accessToken`/`access_token`/`jwt`/`idToken`/`authToken`. **Consumer:** controllers in packages *other than* the auth controller. | **Producer** (post-response — extracts token, stores in env var):<br>`postman.test[groovy: it.containingClass().name() == "com.example.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("Authorization", token) }`<br>**Consumer** (attaches Bearer header to secured endpoints):<br>`method.additional.header[groovy: it.containingClass().name().startsWith("com.example.api.")]={"name":"Authorization","value":"Bearer ${Authorization}","desc":"bearer token from login","required":true}`<br>**Env var:** `Authorization` (reuse existing if present — resolve the name from any existing `method.additional.header=…${…}` rule via `get_existing_rules_for_key`, not from the Environments panel).<br>⚠ Uses `postman.test` (NOT `postman.prerequest`) — the token only exists after the login response.<br>⚠ If the token field is ambiguous (multiple candidates), call `ask_clarification` (single_choice) before writing the script. |
+| **Auth Token Chaining** (flagship) | **Producer:** endpoint path contains `/login`, `/signin`, `/auth`, `/token`, or `/oauth/token` (case-insensitive) OR method name contains `login`/`signin`/`authenticate`/`token`; return type carries a field named `token`/`accessToken`/`access_token`/`jwt`/`idToken`/`authToken`. **Consumer:** controllers in packages *other than* the auth controller. | **Producer** (post-response — extracts token, stores in env var):<br>`postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("Authorization", token) }`<br>**Consumer** (attaches Bearer header to secured endpoints):<br>`method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.api.")]={"name":"Authorization","value":"Bearer ${Authorization}","desc":"bearer token from login","required":true}`<br>**Env var:** `Authorization` (reuse existing if present — resolve the name from any existing `method.additional.header=…${…}` rule via `get_existing_rules_for_key`, not from the Environments panel).<br>⚠ Uses `postman.test` (NOT `postman.prerequest`) — the token only exists after the login response.<br>⚠ If the token field is ambiguous (multiple candidates), call `ask_clarification` (single_choice) before writing the script. |
 | **Static Auth (API Key / Basic)** | Security filter/interceptor calling `request.getHeader("X-API-Key")` / `"Authorization"` starting `Basic `; or custom `@ApiKeyAuth` annotation. Discover via `find_classes_by_annotation` + `get_psi_class_info` (read filter body for `getHeader(...)`). | **API-key-in-header:**<br>`method.additional.header={"name":"X-API-Key","value":"${apiKey}","desc":"api key","required":true}`<br>**API-key-in-query:**<br>`method.additional.param={"name":"key","type":"String","value":"${apiKey}","required":true,"desc":"api key"}`<br>**Basic auth:**<br>`method.additional.header={"name":"Authorization","value":"Basic ${basicAuth}","desc":"http basic credentials","required":true}`<br>**No script** — the user supplies the credential once in the Environments panel (base64-encode `user:pass` for Basic). |
 | **Per-Request Injection (Correlation / Idempotency)** | Filter/interceptor reading `request.getHeader("X-Request-Id")` / `"X-Correlation-Id"` / `"X-Trace-Id"`; or `Idempotency-Key` header on POST/PUT methods. | **Correlation ID** (global, pre-request):<br>`postman.prerequest=pm.request.headers.upsert("X-Request-Id", java.util.UUID.randomUUID().toString())`<br>**Idempotency key** (scoped to mutating methods — never unscoped):<br>`postman.prerequest[groovy: it.methodType().name() == "POST" || it.methodType().name() == "PUT"]=pm.request.headers.upsert("Idempotency-Key", java.util.UUID.randomUUID().toString())`<br>Uses `pm.request.headers.upsert(...)` (add-or-replace, case-insensitive), not `.add(...)` (which would duplicate). |
-| **Request Signing (HMAC)** | Filter/interceptor using `javax.crypto.Mac` / `HmacSHA256` / `Sha256.hmac`; reads `appSecret`/`appKey`/`accessKeyId`; or custom `@SignedRequest` annotation. | **Pre-request signing script** (computes HMAC, attaches signature header):<br>`postman.prerequest[groovy: it.containingClass().name().startsWith("com.example.api.")]=def mac = javax.crypto.Mac.getInstance("HmacSHA256"); mac.init(new javax.crypto.spec.SecretKeySpec("${appSecret}".getBytes("UTF-8"), "HmacSHA256")); def stringToSign = pm.request.url + "\n" + pm.request.body; def raw = mac.doFinal(stringToSign.getBytes("UTF-8")); def sig = raw.collect { String.format("%02x", it) }.join(); pm.request.headers.upsert("X-Signature", sig)`<br>**No hardcoded secret** — `${appSecret}` is always an env-var reference.<br>⚠ For non-trivial signing (AWS SigV4, etc.) treat as a scaffold + call `ask_clarification` for the canonical-string / algorithm variant. |
+| **Request Signing (HMAC)** | Filter/interceptor using `javax.crypto.Mac` / `HmacSHA256` / `Sha256.hmac`; reads `appSecret`/`appKey`/`accessKeyId`; or custom `@SignedRequest` annotation. | **Pre-request signing script** (computes HMAC, attaches signature header):<br>`postman.prerequest[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.api.")]=def mac = javax.crypto.Mac.getInstance("HmacSHA256"); mac.init(new javax.crypto.spec.SecretKeySpec("${appSecret}".getBytes("UTF-8"), "HmacSHA256")); def stringToSign = pm.request.url + "\n" + pm.request.body; def raw = mac.doFinal(stringToSign.getBytes("UTF-8")); def sig = raw.collect { String.format("%02x", it) }.join(); pm.request.headers.upsert("X-Signature", sig)`<br>**No hardcoded secret** — `${appSecret}` is always an env-var reference.<br>⚠ For non-trivial signing (AWS SigV4, etc.) treat as a scaffold + call `ask_clarification` for the canonical-string / algorithm variant. |
 | **401-Refresh** | Refresh endpoint at `/refresh`, `/token/refresh`; OR user explicitly asks for auto-refresh; OR documented "if 401, call /refresh" convention. | **Post-call rule** (detects 401, calls refresh, sets new header, forces retry):<br>`http.call.after=groovy: if (response.code() == 401) { def refreshReq = new com.itangcent.easyapi.core.http.HttpRequest("https://api.example.com/refresh", "POST", java.util.Collections.emptyList(), java.util.Collections.emptyList(), "grant_type=refresh_token", java.util.Collections.emptyList(), java.util.Collections.emptyList(), null); def resp = httpClient.executeSync(refreshReq); def newToken = new groovy.json.JsonSlurper().parseText(resp.body).access_token; if (newToken) { request.setHeader("Authorization", "Bearer " + newToken); response.discard() } }`<br>**Retry limit:** up to 3 (enforced by `HttpClientScriptInterceptor`). The retry re-sends the mutated request wrapper, so `request.setHeader(...)` + `response.discard()` is sufficient — `pm` is NOT available in `http.call.after` (use `session.set(...)` for cross-request persistence if needed).<br>⚠ Keep the refresh endpoint itself script-free (recursion guard limits sub-request hooks to depth < 2). Wrap in `try/catch`. |
 
 > **Detection tip for the AI assistant:** before proposing a workflow bundle,
@@ -652,10 +661,10 @@ clarification needed.
 postman.host={{order-service}}
 
 # Producer (post-response — extracts token, stores in namespaced env var)
-postman.test[groovy: it.containingClass().name() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
+postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
 
 # Consumer (attaches namespaced Bearer header to order-service secured endpoints)
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
 ```
 
 **Bundle 2 — `payment-service`** (a second `propose_rule_content`):
@@ -665,10 +674,10 @@ method.additional.header[groovy: it.containingClass().name().startsWith("com.exa
 postman.host={{payment-service}}
 
 # Producer (post-response — extracts token, stores in namespaced env var)
-postman.test[groovy: it.containingClass().name() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
+postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
 
 # Consumer (attaches namespaced Bearer header to payment-service secured endpoints)
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
 ```
 
 **Env vars** (user creates in the Environments panel): `order-service` (host),
@@ -701,7 +710,7 @@ consumer + host + env var, all carrying the same key).
 filter:
 
 ```
-api.name[groovy: it.containingClass().name() == "com.example.UserCtrl" && it.name() == "getUserName"]=Fetch User
+api.name[groovy: it.containingClass()?.qualifiedName() == "com.example.UserCtrl" && it.name() == "getUserName"]=Fetch User
 ```
 
 ### 2. Tag all endpoints in a controller
@@ -726,7 +735,7 @@ field.ignore[#regex:.*password.*]=true
 ### 5. Add a prefix to all fields in a DTO
 
 ```
-field.name.prefix[groovy: it.containingClass().name().startsWith("com.example.dto.")]=prop_
+field.name.prefix[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=prop_
 ```
 
 ### 6. Custom type conversion for Reactor types
@@ -778,7 +787,7 @@ Before EasyApi 3.0, rule editing happened in a dedicated "Built-in" tab inside t
   Note: `class:` (without `$`) is NOT a valid filter prefix in 3.0 — use `$class:`.
 - **`$class:` is exact-match only:** wildcards like `$class:com.example.*Controller`
   do NOT work. For package/pattern matching, use a `groovy:` filter
-  (e.g. `groovy: it.containingClass().name().startsWith("com.example.")`) or
+  (e.g. `groovy: it.containingClass()?.qualifiedName().startsWith("com.example.")`) or
   `#regex:`.
 - **No `~` regex prefix:** use `#regex:` instead.
 - **Header / param values are JSON:** `method.additional.header` takes a JSON

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetRuleContextTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetRuleContextTool.kt
@@ -1,0 +1,46 @@
+package com.itangcent.easyapi.core.ai.tools
+
+import com.itangcent.easyapi.core.rule.RuleKeyRegistry
+import com.itangcent.easyapi.core.rule.context.RuleScriptContextCatalog
+import com.itangcent.easyapi.core.util.json.GsonUtils
+
+/**
+ * Returns the executable script-context contract for one registered rule key.
+ *
+ * Unlike a prose recipe, this tool describes the actual runtime bindings,
+ * available stages, object properties, and callable method signatures. It
+ * resolves the key through [RuleKeyRegistry], so aliases are accepted and only
+ * keys known to the current project/channel/framework mix are returned.
+ */
+class GetRuleContextTool : AiTool {
+
+    override val name: String = "get_rule_context"
+
+    override val description: String =
+        "Return structured script context for one EasyAPI rule key: execution " +
+            "stage(s), it/request/response/api/common bindings, and callable " +
+            "object properties and methods. Use before authoring Groovy or Postman scripts."
+
+    override val kind: ToolKind = ToolKind.PERCEPTION
+
+    override val parametersSchema: Map<String, Any?> = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "key" to mapOf(
+                "type" to "string",
+                "description" to "Known rule key or alias (for example, \"field.ignore\" or \"postman.test\")."
+            )
+        ),
+        "required" to listOf("key")
+    )
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val keyName = (args["key"] as? String)?.trim()
+            ?: return ToolResult.Error("missing required parameter: key")
+        if (keyName.isEmpty()) return ToolResult.Error("missing required parameter: key")
+
+        val keyInfo = RuleKeyRegistry.getInstance(ctx.project).findKey(keyName)
+            ?: return ToolResult.Error("unknown rule key: $keyName")
+        return ToolResult.Text(GsonUtils.toJson(RuleScriptContextCatalog.describe(keyInfo.key, keyInfo.source)))
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ListRuleKeysTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ListRuleKeysTool.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.core.ai.tools
 
 import com.itangcent.easyapi.core.ai.agent.PromptCatalog
 import com.itangcent.easyapi.core.rule.RuleKeyRegistry
+import com.itangcent.easyapi.core.rule.context.RuleScriptContextCatalog
 import com.itangcent.easyapi.core.util.json.GsonUtils
 
 /**
@@ -11,9 +12,14 @@ import com.itangcent.easyapi.core.util.json.GsonUtils
  * [com.itangcent.easyapi.core.rule.RuleKeys] plus every registered channel's
  * channel-specific keys plus the implicit keys read by name via
  * `configReader.getFirst(…)`. Returns a JSON array of `{name, type, source}`
- * objects:
- * - `source` is `"general"`, `"implicit"`, or the channel id (e.g.
- *   `"hoppscotch"`, `"yapi"`).
+ * objects. Every result also includes a compact `scriptContext` summary with
+ * the execution mode, possible `it` types, key-specific bindings, and the
+ * `get_rule_context` detail-tool name. Call `get_rule_context(key=…)` before
+ * writing a Groovy or Postman script; it returns the complete object method
+ * and property directory.
+ *
+ * `source` is `"general"`, `"implicit"`, or a channel/framework id (e.g.
+ * `"hoppscotch"`, `"yapi"`).
  *
  * Keys are de-duplicated by name by [RuleKeyRegistry] — general keys take
  * precedence over channel/implicit keys with the same name.
@@ -41,8 +47,9 @@ class ListRuleKeysTool : AiTool {
 
     override val description: String =
         "List all known EasyAPI rule keys. Returns a JSON array of " +
-            "{name, type, source, description?, detailPromptId?}. " +
-            "Use this to discover what can be configured."
+            "{name, type, source, scriptContext, description?, detailPromptId?}. " +
+            "scriptContext is a compact summary; call get_rule_context(key=…) " +
+            "for bindings and callable object APIs."
 
     override val kind: ToolKind = ToolKind.PERCEPTION
 
@@ -50,11 +57,12 @@ class ListRuleKeysTool : AiTool {
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
         val keys = RuleKeyRegistry.getInstance(ctx.project).enabledKeys().map { info ->
-            val base = mutableMapOf(
+            val base = mutableMapOf<String, Any?>(
                 "name" to info.key.name,
                 "type" to info.key::class.simpleName,
                 "source" to info.source
             )
+            base["scriptContext"] = RuleScriptContextCatalog.describe(info.key, info.source).summary
             // Best-effort catalog join: attach description + detailPromptId
             // when a per-key recipe file exists. A missing/empty catalog
             // leaves the base shape unchanged (no throw).

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/RuleTools.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/RuleTools.kt
@@ -6,7 +6,7 @@ import com.itangcent.easyapi.core.ai.AIService
  * The standard set of tools handed to the [ToolRegistry] for a real
  * conversation.
  *
- * 14 perception tools + 1 staging action (`propose_rule_content`).
+ * 15 perception tools + 1 staging action (`propose_rule_content`).
  * `write_rule_file` is intentionally NOT registered in v1 — the disk write
  * happens only through the user-confirmed "Save…" UI flow.
  *
@@ -28,6 +28,7 @@ import com.itangcent.easyapi.core.ai.AIService
  */
 fun standardRuleTools(): List<AiTool> = listOf(
     ListRuleKeysTool(),
+    GetRuleContextTool(),
     GetPluginDocTool(),
     GetDetectionPromptTool(),
     GetRuleDetailTool(),
@@ -95,12 +96,14 @@ fun orchestratorToolRegistry(
  * The sub-agent's tool set for a Magic detection turn (Phase 3 —
  * design §3.5 / FR-3.2, FR-3.3).
  *
- * Five perception tools + one terminal action:
+ * Six perception tools + one terminal action:
  * - [FindClassesByAnnotationTool] / [FindClassesBySupertypeTool] — locate
  *   candidate classes by annotation or supertype.
  * - [GetPsiClassInfoTool] — drill into a class's methods/fields/signature.
  * - [GetRuleDetailTool] — fetch the per-key rule recipe so the sub-agent
  *   can draft concrete rule proposals.
+ * - [GetRuleContextTool] — fetch key-specific bindings and callable script
+ *   APIs before drafting a Groovy or Postman rule.
  * - [ListRuleKeysTool] — enumerate known rule keys (for proposal shape).
  * - [ReportFindingsTool] — terminal; stages the sub-agent's
  *   [com.itangcent.easyapi.core.ai.agent.TaskResult] and ends the
@@ -123,6 +126,7 @@ fun subAgentToolRegistry(): List<AiTool> = listOf(
     FindClassesBySupertypeTool(),
     GetPsiClassInfoTool(),
     GetRuleDetailTool(),
+    GetRuleContextTool(),
     ListRuleKeysTool(),
     ReportFindingsTool()
 )

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/DefaultPsiClassHelper.kt
@@ -357,7 +357,13 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             // Build the field path for fieldContext injection into rule scripts
             val fieldPath = if (parentPath != null) "$parentPath.$fieldName" else fieldName
 
-            if (engine.evaluate(RuleKeys.FIELD_IGNORE, accessibleField.psi, fieldContext = fieldPath)) {
+            if (engine.evaluate(
+                    RuleKeys.FIELD_IGNORE,
+                    accessibleField.psi,
+                    containingClass = psiClass,
+                    fieldContext = fieldPath
+                )
+            ) {
                 continue
             }
 
@@ -365,19 +371,42 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             if (accessibleField.psi is PsiField) {
                 val psiField = accessibleField.psi as PsiField
                 if (psiField.hasModifierProperty(PsiModifier.STATIC) && psiField.hasModifierProperty(PsiModifier.FINAL)) {
-                    if (engine.evaluate(RuleKeys.CONSTANT_FIELD_IGNORE, psiField)) {
+                    if (engine.evaluate(
+                            RuleKeys.CONSTANT_FIELD_IGNORE,
+                            psiField,
+                            containingClass = psiClass
+                        )
+                    ) {
                         continue
                     }
                 }
             }
 
-            engine.evaluate(RuleKeys.JSON_FIELD_PARSE_BEFORE, accessibleField.psi, fieldContext = fieldPath)
+            engine.evaluate(
+                RuleKeys.JSON_FIELD_PARSE_BEFORE,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
 
-            val customName = engine.evaluate(RuleKeys.FIELD_NAME, accessibleField.psi, fieldContext = fieldPath)
-            val prefix =
-                engine.evaluate(RuleKeys.FIELD_NAME_PREFIX, accessibleField.psi, fieldContext = fieldPath) ?: ""
-            val suffix =
-                engine.evaluate(RuleKeys.FIELD_NAME_SUFFIX, accessibleField.psi, fieldContext = fieldPath) ?: ""
+            val customName = engine.evaluate(
+                RuleKeys.FIELD_NAME,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
+            val prefix = engine.evaluate(
+                RuleKeys.FIELD_NAME_PREFIX,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            ) ?: ""
+            val suffix = engine.evaluate(
+                RuleKeys.FIELD_NAME_SUFFIX,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            ) ?: ""
             val baseName = customName?.takeIf { it.isNotBlank() } ?: fieldName
             val jsonFieldName = prefix + baseName + suffix
 
@@ -390,12 +419,30 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
                 break
             }
 
-            val fieldDefaultValue =
-                engine.evaluate(RuleKeys.FIELD_DEFAULT_VALUE, accessibleField.psi, fieldContext = fieldPath)
-            val fieldRequired = engine.evaluate(RuleKeys.FIELD_REQUIRED, accessibleField.psi, fieldContext = fieldPath)
-            val fieldDemo = engine.evaluate(RuleKeys.FIELD_DEMO, accessibleField.psi, fieldContext = fieldPath)
-            val fieldAdvancedStr =
-                engine.evaluate(RuleKeys.FIELD_ADVANCED, accessibleField.psi, fieldContext = fieldPath)
+            val fieldDefaultValue = engine.evaluate(
+                RuleKeys.FIELD_DEFAULT_VALUE,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
+            val fieldRequired = engine.evaluate(
+                RuleKeys.FIELD_REQUIRED,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
+            val fieldDemo = engine.evaluate(
+                RuleKeys.FIELD_DEMO,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
+            val fieldAdvancedStr = engine.evaluate(
+                RuleKeys.FIELD_ADVANCED,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
             val fieldAdvanced = if (!fieldAdvancedStr.isNullOrBlank()) {
                 runCatching { GsonUtils.fromJson<Map<String, Any?>>(fieldAdvancedStr) }
                     .onFailure { LOG.warn("DefaultPsiClassHelper: failed to parse field_advanced JSON: '$fieldAdvancedStr'", it) }
@@ -440,7 +487,12 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             )
 
             // Check json.unwrapped — if true, merge the field's object fields into the parent
-            val unwrapped = engine.evaluate(RuleKeys.JSON_UNWRAPPED, accessibleField.psi, fieldContext = fieldPath)
+            val unwrapped = engine.evaluate(
+                RuleKeys.JSON_UNWRAPPED,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
             if (unwrapped && fieldModel.model is ObjectModel.Object) {
                 for ((nestedName, nestedField) in (fieldModel.model as ObjectModel.Object).fields) {
                     val unwrappedName = prefix + nestedName + suffix
@@ -452,7 +504,12 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
                 fields[jsonFieldName] = fieldModel
             }
 
-            engine.evaluate(RuleKeys.JSON_FIELD_PARSE_AFTER, accessibleField.psi, fieldContext = fieldPath)
+            engine.evaluate(
+                RuleKeys.JSON_FIELD_PARSE_AFTER,
+                accessibleField.psi,
+                containingClass = psiClass,
+                fieldContext = fieldPath
+            )
         }
 
         val additional = engine.evaluate(RuleKeys.JSON_ADDITIONAL_FIELD, psiClass)
@@ -484,7 +541,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
         visited.remove(qualifiedName)
 
         // Apply field ordering if field.order rules are configured
-        val orderedFields = applyFieldOrdering(fields, accessibleFields, engine)
+        val orderedFields = applyFieldOrdering(fields, accessibleFields, psiClass, engine)
         if (orderedFields != null) {
             fields.clear()
             fields.putAll(orderedFields)
@@ -1022,13 +1079,14 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
     private suspend fun applyFieldOrdering(
         fields: LinkedHashMap<String, FieldModel>,
         accessibleFields: List<AccessibleField>,
+        containingClass: PsiClass,
         engine: RuleEngine
     ): LinkedHashMap<String, FieldModel>? {
         // First try field.order.with (comparator-style)
         val fieldByName = accessibleFields.associateBy { it.name }
         val hasOrderWith = accessibleFields.any { af ->
             // Probe: check if any rule is configured for field.order.with
-            engine.evaluate(RuleKeys.FIELD_ORDER_WITH, af.psi) { ctx ->
+            engine.evaluate(RuleKeys.FIELD_ORDER_WITH, af.psi, containingClass) { ctx ->
                 ctx.setExt("a", af.psi)
                 ctx.setExt("b", af.psi)
             } != null
@@ -1041,7 +1099,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
                 val af2 = fieldByName[entry2.key]
                 if (af1 != null && af2 != null) {
                     val result = kotlinx.coroutines.runBlocking {
-                        engine.evaluate(RuleKeys.FIELD_ORDER_WITH, af1.psi) { ctx ->
+                        engine.evaluate(RuleKeys.FIELD_ORDER_WITH, af1.psi, containingClass) { ctx ->
                             ctx.setExt("a", af1.psi)
                             ctx.setExt("b", af2.psi)
                         }
@@ -1062,7 +1120,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
         val fieldOrderMap = LinkedHashMap<String, String?>()
         var hasOrder = false
         for (af in accessibleFields) {
-            val order = engine.evaluate(RuleKeys.FIELD_ORDER, af.psi)
+            val order = engine.evaluate(RuleKeys.FIELD_ORDER, af.psi, containingClass)
             if (order != null) hasOrder = true
             fieldOrderMap[af.name] = order
         }

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidator.kt
@@ -23,9 +23,10 @@ import com.itangcent.easyapi.framework.spi.FrameworkRegistry
  * - **Hard errors** (block the proposal): unknown key, invalid filter prefix,
  *   malformed JSON value for the header/param keys.
  * - **Soft warnings** (never block): deprecated-but-valid filter forms such
- *   as the bare `class:` prefix; keys whose owning channel/framework is
- *   currently disabled in Settings (design C4a / task A5c). Reported back to
- *   the drafter / surfaced on the proposal card, but the proposal still
+ *   as the bare `class:` prefix; class-context `name()` calls that may be
+ *   mistaken for fully-qualified names; keys whose owning channel/framework
+ *   is currently disabled in Settings (design C4a / task A5c). Reported back
+ *   to the drafter / surfaced on the proposal card, but the proposal still
  *   proceeds.
  *
  * ## Key catalog
@@ -62,6 +63,9 @@ object RuleProposalValidator {
         "\$class:", "@", "#regex:", "#", "!", "groovy:"
     )
 
+    private val CLASS_CONTEXT_SIMPLE_NAME =
+        Regex("""(?:containingClass|defineClass)\(\)\s*\??\.\s*name\(\)""")
+
     /** Source kind for keys declared in [RuleKeys] (mirrors [RuleKeyRegistry]). */
     private const val SOURCE_GENERAL = "general"
     /** Source kind for keys read by name only (mirrors [RuleKeyRegistry]). */
@@ -93,19 +97,26 @@ object RuleProposalValidator {
             project?.let { buildDisabledSourceMap(it) } ?: emptyMap()
         val errors = mutableListOf<String>()
         val warnings = mutableListOf<String>()
+        val classContextSimpleNameWarningLines = classContextSimpleNameWarningLines(content)
         var inBlock = false
         content.lines().forEachIndexed { idx, raw ->
             val line = raw.trim()
             if (line.isEmpty()) return@forEachIndexed
-            // Multi-line groovy value-block: skip the body (it is a free-form
-            // script whose lines are not key=value).
+            // Plain comment (### is a directive, handled elsewhere; treat as
+            // non-rule for this check).
+            if (line.startsWith("#")) return@forEachIndexed
+            val lineNo = idx + 1
+            if (lineNo in classContextSimpleNameWarningLines) {
+                warnings += "line $lineNo: class-context name() returns a simple class name; " +
+                    "use qualifiedName() for FQN/package comparisons."
+            }
+            // Multi-line groovy value-block: scan each body line for semantic
+            // warnings above, but skip structural key=value validation because
+            // the body is a free-form script.
             if (inBlock) {
                 if (line == "```") inBlock = false
                 return@forEachIndexed
             }
-            // Plain comment (### is a directive, handled elsewhere; treat as
-            // non-rule for this check).
-            if (line.startsWith("#")) return@forEachIndexed
             val parsed = KeyValueLineParser.splitKeyFilterValue(line) ?: run {
                 // Not a key=value line — skip (directives, stray text). We do
                 // not error on every non-kv line to avoid false positives on
@@ -113,7 +124,6 @@ object RuleProposalValidator {
                 return@forEachIndexed
             }
             val (key, filter, value) = parsed
-            val lineNo = idx + 1
 
             if (key !in knownKeyNames) {
                 errors += "line $lineNo: unknown rule key '$key' (not in list_rule_keys)."
@@ -152,6 +162,25 @@ object RuleProposalValidator {
         }
         return RuleValidation(errors = errors, warnings = warnings)
     }
+
+    private fun classContextSimpleNameWarningLines(content: String): Set<Int> =
+        CLASS_CONTEXT_SIMPLE_NAME.findAll(content).mapNotNullTo(linkedSetOf()) { match ->
+            val matchStart = match.range.first
+            val lineStart = if (matchStart == 0) {
+                0
+            } else {
+                content.lastIndexOf('\n', matchStart - 1) + 1
+            }
+            val lineEnd = content.indexOf('\n', matchStart).let { index ->
+                if (index < 0) content.length else index
+            }
+            val sourceLine = content.substring(lineStart, lineEnd)
+            if (sourceLine.trimStart().startsWith("#")) {
+                null
+            } else {
+                content.substring(0, matchStart).count { it == '\n' } + 1
+            }
+        }
 
     private fun checkFilterPrefix(filter: String): FilterIssue? {
         if (filter.startsWith("class:")) return FilterIssue.Deprecated

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/context/RuleContext.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/context/RuleContext.kt
@@ -168,6 +168,39 @@ class RuleContext private constructor(
             return RuleContext(project, element, element, fieldContext, ss)
         }
 
+        /**
+         * Creates a context for a member as viewed from [containingClass].
+         *
+         * For inherited fields and methods, script `containingClass()` resolves
+         * to the class currently being processed while `defineClass()` resolves
+         * to the PSI member's declaring class.
+         */
+        fun fromMember(
+            project: Project,
+            element: PsiElement,
+            containingClass: com.intellij.psi.PsiClass,
+            fieldContext: String? = null
+        ): RuleContext {
+            val core = readSync {
+                when (element) {
+                    is com.intellij.psi.PsiField -> ResolvedField(
+                        name = element.name,
+                        psiField = element,
+                        annotations = element.annotations.toList(),
+                        containClass = containingClass
+                    )
+                    is com.intellij.psi.PsiMethod -> ResolvedMethod(
+                        name = element.name,
+                        psiMethod = element,
+                        containClass = containingClass
+                    )
+                    else -> element
+                }
+            }
+            val ss = SessionStorage.getInstance(project)
+            return RuleContext(project, element, core, fieldContext, ss)
+        }
+
         fun from(project: Project, method: ResolvedMethod, fieldContext: String? = null): RuleContext {
             val ss = SessionStorage.getInstance(project)
             return RuleContext(project, method.psiMethod, method, fieldContext, ss)

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalog.kt
@@ -1,0 +1,573 @@
+package com.itangcent.easyapi.core.rule.context
+
+import com.itangcent.easyapi.core.http.HttpRequestWrapper
+import com.itangcent.easyapi.core.http.HttpResponseWrapper
+import com.itangcent.easyapi.core.http.ScriptHttpClient
+import com.itangcent.easyapi.core.logging.IdeaConsole
+import com.itangcent.easyapi.core.rule.RuleKey
+import com.itangcent.easyapi.core.rule.parser.ScriptConfigWrapper
+import com.itangcent.easyapi.core.rule.parser.ScriptFilesWrapper
+import com.itangcent.easyapi.core.rule.parser.ScriptHelper
+import com.itangcent.easyapi.core.rule.parser.ScriptRuntime
+import com.itangcent.easyapi.core.rule.parser.ScriptStorageWrapper
+import com.itangcent.easyapi.core.script.pm.PmAuthConfig
+import com.itangcent.easyapi.core.script.pm.PmCookies
+import com.itangcent.easyapi.core.script.pm.PmExpectation
+import com.itangcent.easyapi.core.script.pm.PmHeaderList
+import com.itangcent.easyapi.core.script.pm.PmInfo
+import com.itangcent.easyapi.core.script.pm.PmObject
+import com.itangcent.easyapi.core.script.pm.PmPropertyList
+import com.itangcent.easyapi.core.script.pm.PmRequest
+import com.itangcent.easyapi.core.script.pm.PmRequestBody
+import com.itangcent.easyapi.core.script.pm.PmResponse
+import com.itangcent.easyapi.core.script.pm.PmResponseBDD
+import com.itangcent.easyapi.core.script.pm.PmResponseBDDNegated
+import com.itangcent.easyapi.core.script.pm.PmResponseHave
+import com.itangcent.easyapi.core.script.pm.PmResponseHaveNot
+import com.itangcent.easyapi.core.script.pm.PmSendRequest
+import com.itangcent.easyapi.core.script.pm.PmTest
+import com.itangcent.easyapi.core.script.pm.PmVariableScope
+import com.itangcent.easyapi.core.util.RuleToolUtils
+import com.itangcent.easyapi.core.util.text.RegexUtils
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.lang.reflect.Type
+import kotlin.reflect.KClass
+
+/**
+ * Key-aware catalog of rule-script contexts exposed to the AI authoring tools.
+ *
+ * The catalog is deliberately adjacent to the runtime context wrappers instead
+ * of adding metadata to [RuleKey]: keys are also contributed by channels and
+ * frameworks, while their execution context is determined by the caller. This
+ * keeps the normal RuleKey SPI compact and lets the catalog report an explicit
+ * `runtime-specific` fallback for third-party keys it does not yet recognize.
+ *
+ * Public method/property lists are reflected from the wrapper classes so the
+ * AI sees the APIs actually callable by Groovy rather than a duplicated,
+ * stale hand-maintained list. Semantic constraints (stage, mutability, and
+ * availability) remain explicit metadata because reflection cannot infer them.
+ */
+object RuleScriptContextCatalog {
+
+    private val excludedMethodNames = setOf("equals", "hashCode", "toString", "wait", "notify", "notifyAll", "finalize")
+
+    /** Builds a complete script-context profile for one registered rule key. */
+    fun describe(key: RuleKey<*>, source: String): RuleScriptProfile =
+        profile(key.name, key.aliases, source)
+
+    /**
+     * Returns a conservative profile for a key name when only the name is
+     * known. AI tools should prefer [describe] after resolving the key through
+     * RuleKeyRegistry so aliases and the contributing source are included.
+     */
+    fun describe(keyName: String): RuleScriptProfile = profile(keyName, emptyList(), "unknown")
+
+    private fun profile(key: String, aliases: List<String>, source: String): RuleScriptProfile {
+        val definition = when {
+            key in staticConfigurationKeys -> ProfileDefinition(
+                executionMode = "static-configuration",
+                summary = "Read as static configuration; EasyAPI does not evaluate a Groovy script for this key.",
+                stages = emptyList()
+            )
+
+            key in postmanPreRequestKeys -> postmanScriptDefinition(key, preRequest = true)
+            key in postmanTestKeys -> postmanScriptDefinition(key, preRequest = false)
+            key in postmanCollectionKeys -> collectionEventDefinition(
+                key = key,
+                collectionElementType = "PostmanEndpointContext",
+                description = "Collection export event. It evaluates as a Groovy rule; it does not run as a dashboard pm script."
+            )
+
+            key == "postman.format.after" -> formatAfterDefinition(
+                key = key,
+                itemType = "PostmanItem",
+                itemDescription = "Mutable Postman export item. This channel model is intentionally opaque to core; inspect its properties in the channel documentation before relying on it."
+            )
+
+            key in hoppscotchScriptKeys -> groovyDefinition(
+                itKinds = if (key.contains("class.")) listOf(ItKind.CLASS) else listOf(ItKind.METHOD, ItKind.CLASS),
+                summary = "Generates a Hoppscotch script string. EasyAPI evaluates this rule with Groovy context; the generated script is executed by Hoppscotch, not by EasyAPI."
+            )
+
+            key in hoppscotchCollectionKeys -> collectionEventDefinition(
+                key = key,
+                collectionElementType = "ApiEndpoint",
+                description = "Collection export event. It evaluates as a Groovy rule and exposes exported endpoints; it is not a Hoppscotch runtime script context."
+            )
+
+            key == "hopp.format.after" -> groovyDefinition(
+                itKinds = listOf(ItKind.METHOD),
+                additionalBindings = listOf(apiBinding("endpoint", "Endpoint being formatted; mutations write through to the export model.")),
+                additionalObjects = listOf(apiObject("endpoint")),
+                summary = "Runs after one Hoppscotch endpoint is formatted."
+            )
+
+            key == "openapi.format.after" -> groovyDefinition(
+                itKinds = listOf(ItKind.METHOD),
+                additionalBindings = listOf(
+                    ScriptBinding(
+                        name = "document",
+                        objectTypes = listOf("document"),
+                        availability = "always for this event",
+                        description = "Mutable OpenAPI document before serialization. It is a channel-owned model, so this core catalog does not claim a stable method surface."
+                    )
+                ),
+                additionalObjects = listOf(opaqueObject("document", "OpenApiDocument", "Mutable channel-owned OpenAPI model.")),
+                summary = "Runs after the OpenAPI document is built and before it is serialized."
+            )
+
+            key in openApiDocumentKeys -> groovyDefinition(
+                itKinds = listOf(ItKind.EMPTY),
+                summary = "Document-level OpenAPI metadata rule, evaluated once per export without a PSI element. Use helper/H for project-wide PSI lookups."
+            )
+
+            key == "http.call.before" -> groovyDefinition(
+                itKinds = listOf(ItKind.EMPTY),
+                additionalBindings = listOf(httpRequestBinding()),
+                additionalObjects = listOf(httpRequestObject()),
+                summary = "Runs immediately before an HTTP request is sent; request headers can be mutated."
+            )
+
+            key == "http.call.after" -> groovyDefinition(
+                itKinds = listOf(ItKind.EMPTY),
+                additionalBindings = listOf(httpRequestBinding(), httpResponseBinding()),
+                additionalObjects = listOf(httpRequestObject(), httpResponseObject()),
+                summary = "Runs after an HTTP response; call response.discard() to request a bounded retry."
+            )
+
+            key in exportAfterKeys -> groovyDefinition(
+                itKinds = listOf(ItKind.METHOD, ItKind.CLASS, ItKind.EMPTY),
+                additionalBindings = listOf(apiBinding("api", "Mutable API endpoint being exported; mutations write through to the export model.")),
+                additionalObjects = listOf(apiObject("api")),
+                summary = "Runs after an API endpoint is built; api exposes export-model mutations and cURL rendering."
+            )
+
+            key == "field.order.with" -> groovyDefinition(
+                itKinds = listOf(ItKind.FIELD, ItKind.METHOD),
+                additionalBindings = listOf(
+                    itBinding("a", listOf(ItKind.FIELD, ItKind.METHOD), "First member being compared for ordering."),
+                    itBinding("b", listOf(ItKind.FIELD, ItKind.METHOD), "Second member being compared for ordering.")
+                ),
+                additionalObjects = listOf(
+                    objectApi("a-field", ScriptPsiFieldContext::class, "Field member for ordering comparison."),
+                    objectApi("a-method", ScriptPsiMethodContext::class, "Getter/setter member for ordering comparison.")
+                ),
+                summary = "Compares two object-model members; a and b can be field or method contexts."
+            )
+
+            key.startsWith("custom.class.parse.") -> groovyDefinition(listOf(ItKind.CLASS))
+            key.startsWith("custom.method.parse.") -> groovyDefinition(listOf(ItKind.METHOD))
+            key.startsWith("custom.export.") -> groovyDefinition(
+                itKinds = listOf(ItKind.METHOD, ItKind.CLASS, ItKind.EMPTY),
+                additionalBindings = listOf(apiBinding("api", "Mutable API endpoint being exported.")),
+                additionalObjects = listOf(apiObject("api"))
+            )
+
+            else -> groovyDefinition(itKindsFor(key))
+        }
+
+        return RuleScriptProfile(
+            key = key,
+            aliases = aliases,
+            source = source,
+            executionMode = definition.executionMode,
+            summary = RuleScriptContextSummary(
+                executionMode = definition.executionMode,
+                itContexts = definition.stages.flatMap { stage ->
+                    stage.bindings.firstOrNull { it.name == "it" }?.objectTypes.orEmpty()
+                }.distinct(),
+                bindings = definition.stages.flatMap { it -> it.bindings.map(ScriptBinding::name) }.distinct(),
+                detailTool = "get_rule_context"
+            ),
+            description = definition.summary,
+            stages = definition.stages,
+            notes = definition.notes
+        )
+    }
+
+    private fun postmanScriptDefinition(key: String, preRequest: Boolean): ProfileDefinition {
+        val itKinds = if (key.contains("class.")) listOf(ItKind.CLASS) else listOf(ItKind.METHOD, ItKind.CLASS)
+        val phase = if (preRequest) "pre-request" else "post-response"
+        return ProfileDefinition(
+            executionMode = "postman-$phase",
+            summary = "This key has two stages: EasyAPI first evaluates the rule value with Groovy/it, then the resulting text runs as a Postman-compatible $phase script.",
+            stages = listOf(
+                groovyStage(
+                    name = "rule-evaluation",
+                    itKinds = itKinds,
+                    description = "Evaluates the rule value while exporting. This stage has EasyAPI Groovy bindings, including it."
+                ),
+                postmanStage(preRequest)
+            ),
+            notes = listOf(
+                "Do not use EasyAPI it/helper/session bindings in the generated pm script.",
+                if (preRequest) "response is null before the request is sent." else "response is available only after the request completes."
+            )
+        )
+    }
+
+    private fun collectionEventDefinition(
+        key: String,
+        collectionElementType: String,
+        description: String
+    ): ProfileDefinition = ProfileDefinition(
+        executionMode = "groovy-rule",
+        summary = description,
+        stages = listOf(
+            groovyStage(
+                name = "rule-evaluation",
+                itKinds = listOf(ItKind.EMPTY),
+                description = description,
+                additionalBindings = listOf(
+                    ScriptBinding(
+                        name = "collection",
+                        objectTypes = listOf("collection"),
+                        availability = "always for this event",
+                        description = "Collection passed by $key; element type: $collectionElementType."
+                    )
+                ),
+                additionalObjects = listOf(collectionObject(collectionElementType))
+            )
+        )
+    )
+
+    private fun formatAfterDefinition(key: String, itemType: String, itemDescription: String): ProfileDefinition = ProfileDefinition(
+        executionMode = "groovy-rule",
+        summary = "Runs after a $itemType is created; item and endpoint are key-specific export extensions.",
+        stages = listOf(
+            groovyStage(
+                name = "rule-evaluation",
+                itKinds = listOf(ItKind.METHOD),
+                description = "Runs after formatting one exported item for $key.",
+                additionalBindings = listOf(
+                    ScriptBinding("item", objectTypes = listOf("item"), availability = "always for this event", description = itemDescription),
+                    apiBinding("endpoint", "Mutable API endpoint that produced the export item.")
+                ),
+                additionalObjects = listOf(opaqueObject("item", itemType, itemDescription), apiObject("endpoint"))
+            )
+        )
+    )
+
+    private fun groovyDefinition(
+        itKinds: List<ItKind>,
+        additionalBindings: List<ScriptBinding> = emptyList(),
+        additionalObjects: List<ScriptObjectApi> = emptyList(),
+        summary: String? = null
+    ): ProfileDefinition = ProfileDefinition(
+        executionMode = "groovy-rule",
+        summary = summary ?: "EasyAPI evaluates this key as a Groovy rule with the shown PSI context and common helpers.",
+        stages = listOf(groovyStage("rule-evaluation", itKinds, additionalBindings = additionalBindings, additionalObjects = additionalObjects))
+    )
+
+    private fun groovyStage(
+        name: String,
+        itKinds: List<ItKind>,
+        description: String = "EasyAPI Groovy rule evaluation.",
+        additionalBindings: List<ScriptBinding> = emptyList(),
+        additionalObjects: List<ScriptObjectApi> = emptyList()
+    ): RuleScriptStage {
+        val itBinding = itBinding("it", itKinds, "Current rule context. Its concrete type depends on this rule key.")
+        val itObjects = itKinds.map { kind -> objectApi(kind.id, kind.type, kind.description) }
+        return RuleScriptStage(
+            name = name,
+            executionMode = "groovy-rule",
+            description = description,
+            bindings = listOf(itBinding) + commonGroovyBindings + additionalBindings,
+            objects = (itObjects + commonGroovyObjects + additionalObjects).distinctBy(ScriptObjectApi::id)
+        )
+    }
+
+    private fun postmanStage(preRequest: Boolean): RuleScriptStage {
+        val phase = if (preRequest) "postman-prerequest" else "postman-test"
+        val bindings = mutableListOf(
+            ScriptBinding("pm", objectTypes = listOf("pm"), availability = "always", description = "Postman-compatible root object."),
+            ScriptBinding("environment", objectTypes = listOf("environment"), availability = "always", description = "Active environment variables."),
+            ScriptBinding("globals", objectTypes = listOf("globals"), availability = "always", description = "Global variables."),
+            ScriptBinding("collectionVariables", objectTypes = listOf("collectionVariables"), availability = "always", description = "Project/collection variables."),
+            ScriptBinding("request", objectTypes = listOf("request"), availability = if (preRequest) "mutable before send" else "completed request; treat as read-only", description = "Current HTTP request."),
+            ScriptBinding("test", objectTypes = listOf("test"), availability = "always", description = "Registers named test assertions."),
+            ScriptBinding("cookies", objectTypes = listOf("cookies"), availability = if (preRequest) "empty before response" else "response cookies", description = "Cookies for this request/response cycle."),
+            ScriptBinding("info", objectTypes = listOf("info"), availability = "always", description = "Script execution metadata."),
+            ScriptBinding("logger", objectTypes = listOf("logger"), availability = "always", description = "EasyAPI console logger.")
+        )
+        if (!preRequest) {
+            bindings.add(ScriptBinding("response", objectTypes = listOf("response"), availability = "always", description = "Received HTTP response."))
+        }
+        return RuleScriptStage(
+            name = "generated-script",
+            executionMode = phase,
+            description = "The string returned by rule evaluation runs here. It has pm-style bindings and no EasyAPI it/helper/session bindings.",
+            bindings = bindings,
+            objects = postmanObjects
+        )
+    }
+
+    private fun itBinding(name: String, kinds: List<ItKind>, description: String): ScriptBinding =
+        ScriptBinding(name, objectTypes = kinds.map(ItKind::id), availability = "always", description = description)
+
+    private fun apiBinding(name: String, description: String): ScriptBinding =
+        ScriptBinding(name, objectTypes = listOf(name), availability = "key-specific", description = description)
+
+    private fun httpRequestBinding(): ScriptBinding =
+        ScriptBinding("request", objectTypes = listOf("request"), availability = "always for this event", description = "HTTP request wrapper; header mutations are carried to the send/retry attempt.")
+
+    private fun httpResponseBinding(): ScriptBinding =
+        ScriptBinding("response", objectTypes = listOf("response"), availability = "always for this event", description = "HTTP response wrapper; discard() requests a bounded retry.")
+
+    private fun apiObject(id: String): ScriptObjectApi =
+        objectApi(id, ScriptApiEndpoint::class, "Script-facing mutable API endpoint.")
+
+    private fun httpRequestObject(): ScriptObjectApi =
+        objectApi("request", HttpRequestWrapper::class, "Script-facing HTTP request wrapper.")
+
+    private fun httpResponseObject(): ScriptObjectApi =
+        objectApi("response", HttpResponseWrapper::class, "Script-facing HTTP response wrapper.")
+
+    private fun collectionObject(elementType: String): ScriptObjectApi =
+        objectApi("collection", List::class, "Read-only list-like collection; element type: $elementType.")
+            .copy(type = "kotlin.collections.List<$elementType>")
+
+    private fun opaqueObject(id: String, type: String, description: String): ScriptObjectApi =
+        ScriptObjectApi(id = id, type = type, description = description, properties = emptyList(), methods = emptyList())
+
+    private fun objectApi(id: String, type: KClass<*>, description: String): ScriptObjectApi {
+        val methods = type.java.methods
+            .asSequence()
+            .filter { Modifier.isPublic(it.modifiers) && it.name !in excludedMethodNames }
+            .filterNot { it.declaringClass == Any::class.java || it.declaringClass == Object::class.java }
+            .toList()
+        return ScriptObjectApi(
+            id = id,
+            type = type.qualifiedName ?: type.simpleName ?: "unknown",
+            description = description,
+            properties = propertiesOf(methods),
+            methods = methods
+                .asSequence()
+                .filterNot(::isBeanAccessor)
+                .map(::methodApi)
+                .distinctBy { "${it.name}(${it.parameters.joinToString { parameter -> parameter.type }})" }
+                .sortedWith(compareBy(ScriptMethodApi::name).thenBy { it.parameters.size })
+                .toList()
+        )
+    }
+
+    private fun propertiesOf(methods: List<Method>): List<ScriptPropertyApi> {
+        val setters = methods.filter { it.name.startsWith("set") && it.parameterCount == 1 }
+            .associateBy { it.name.removePrefix("set").replaceFirstChar(Char::lowercase) }
+        return methods.asSequence()
+            .filter { method ->
+                method.parameterCount == 0 &&
+                    ((method.name.startsWith("get") && method.name.length > 3) ||
+                        (method.name.startsWith("is") && method.name.length > 2))
+            }
+            .map { getter ->
+                val name = if (getter.name.startsWith("is")) {
+                    getter.name.removePrefix("is").replaceFirstChar(Char::lowercase)
+                } else {
+                    getter.name.removePrefix("get").replaceFirstChar(Char::lowercase)
+                }
+                ScriptPropertyApi(name, renderType(getter.genericReturnType), name in setters)
+            }
+            .distinctBy(ScriptPropertyApi::name)
+            .sortedBy(ScriptPropertyApi::name)
+            .toList()
+    }
+
+    private fun isBeanAccessor(method: Method): Boolean =
+        (method.parameterCount == 0 &&
+            ((method.name.startsWith("get") && method.name.length > 3) ||
+                (method.name.startsWith("is") && method.name.length > 2))) ||
+            (method.name.startsWith("set") && method.name.length > 3 && method.parameterCount == 1)
+
+    private fun methodApi(method: Method): ScriptMethodApi = ScriptMethodApi(
+        name = method.name,
+        returns = renderType(method.genericReturnType),
+        parameters = method.genericParameterTypes.mapIndexed { index, type ->
+            ScriptParameterApi(
+                name = method.parameters[index].name ?: "arg$index",
+                type = renderType(type),
+                optional = false,
+                vararg = method.isVarArgs && index == method.parameterCount - 1
+            )
+        }
+    )
+
+    private fun renderType(type: Type): String = type.typeName
+        .replace("java.lang.", "")
+        .replace("java.util.", "")
+        .replace("kotlin.collections.", "")
+        .replace("kotlin.", "")
+
+    private fun itKindsFor(key: String): List<ItKind> = when {
+        key == "ignore" -> listOf(ItKind.CLASS, ItKind.METHOD, ItKind.FIELD, ItKind.PARAMETER)
+        key == "api.name" || key == "folder.name" -> listOf(ItKind.METHOD, ItKind.CLASS)
+        key.startsWith("method.") || key == "endpoint.prefix.path" || key == "path.multi" -> listOf(ItKind.METHOD)
+        key.startsWith("class.") -> listOf(ItKind.CLASS)
+        key.startsWith("param.") || key.startsWith("custom.param.") -> listOf(ItKind.PARAMETER)
+        key.startsWith("field.") -> listOf(ItKind.FIELD, ItKind.METHOD)
+        key == "json.rule.convert" -> listOf(ItKind.TYPE)
+        key.startsWith("json.field.") -> listOf(ItKind.FIELD, ItKind.METHOD)
+        key.startsWith("json.class.") -> listOf(ItKind.CLASS)
+        key == "json.additional.field" || key == "json.unwrapped" -> listOf(ItKind.FIELD, ItKind.METHOD)
+        key.startsWith("api.class.") -> listOf(ItKind.CLASS)
+        key.startsWith("api.method.") -> listOf(ItKind.METHOD)
+        key.startsWith("api.param.") -> listOf(ItKind.PARAMETER)
+        key.startsWith("custom.class.") -> listOf(ItKind.CLASS)
+        key.startsWith("custom.method.") || key == "custom.http.method" || key == "custom.path" -> listOf(ItKind.METHOD, ItKind.CLASS)
+        key.startsWith("enum.") -> listOf(ItKind.CLASS)
+        key == "constant.field.ignore" -> listOf(ItKind.FIELD)
+        key == "properties.prefix" -> listOf(ItKind.CLASS)
+        key.endsWith(".host") -> listOf(ItKind.CLASS, ItKind.EMPTY)
+        else -> listOf(ItKind.EMPTY)
+    }
+
+    private data class ProfileDefinition(
+        val executionMode: String,
+        val summary: String,
+        val stages: List<RuleScriptStage>,
+        val notes: List<String> = emptyList()
+    )
+
+    private enum class ItKind(val id: String, val type: KClass<*>, val description: String) {
+        EMPTY("empty", ScriptItContext::class, "No PSI element is supplied; common helper bindings remain available."),
+        CLASS("class", ScriptPsiClassContext::class, "PSI class context."),
+        METHOD("method", ScriptPsiMethodContext::class, "PSI method context."),
+        FIELD("field", ScriptPsiFieldContext::class, "PSI field context; object-model fields may also be represented by a method context."),
+        PARAMETER("parameter", ScriptPsiParameterContext::class, "PSI parameter context."),
+        TYPE("type", ScriptPsiTypeContext::class, "PSI type context without a source element.")
+    }
+
+    private val commonGroovyBindings = listOf(
+        ScriptBinding("logger", aliases = listOf("LOG"), objectTypes = listOf("logger"), availability = "always", description = "EasyAPI console logger."),
+        ScriptBinding("session", aliases = listOf("S", "sessionStorage"), objectTypes = listOf("session"), availability = "always", description = "Operation session storage."),
+        ScriptBinding("tool", aliases = listOf("T"), objectTypes = listOf("tool"), availability = "always", description = "RuleToolUtils conversion, collection, JSON, string, and date helpers."),
+        ScriptBinding("regex", aliases = listOf("RE"), objectTypes = listOf("regex"), availability = "always", description = "Regular-expression helpers."),
+        ScriptBinding("files", aliases = listOf("F"), objectTypes = listOf("files"), availability = "always", description = "File save helper."),
+        ScriptBinding("config", aliases = listOf("C"), objectTypes = listOf("config"), availability = "always", description = "Resolved EasyAPI configuration values."),
+        ScriptBinding("localStorage", objectTypes = listOf("localStorage"), availability = "always", description = "Persistent local storage."),
+        ScriptBinding("fieldContext", objectTypes = listOf("fieldContext"), availability = "always", description = "Current object-model field path."),
+        ScriptBinding("httpClient", objectTypes = listOf("httpClient"), availability = "when an HTTP client is configured", description = "Blocking HTTP adapter for Groovy rules."),
+        ScriptBinding("helper", aliases = listOf("H"), objectTypes = listOf("helper"), availability = "always", description = "PSI class and documentation-link lookup helper."),
+        ScriptBinding("runtime", aliases = listOf("R"), objectTypes = listOf("runtime"), availability = "always", description = "Project, module, and source-file metadata."),
+    )
+
+    private val commonGroovyObjects = listOf(
+        objectApi("logger", IdeaConsole::class, "EasyAPI console logger."),
+        objectApi("session", ScriptStorageWrapper::class, "Operation session storage."),
+        objectApi("tool", RuleToolUtils::class, "Rule utility methods."),
+        objectApi("regex", RegexUtils::class, "Regular-expression utility methods."),
+        objectApi("files", ScriptFilesWrapper::class, "File save utility."),
+        objectApi("config", ScriptConfigWrapper::class, "Resolved configuration reader."),
+        objectApi("localStorage", ScriptStorageWrapper::class, "Persistent local storage."),
+        objectApi("fieldContext", ScriptFieldPathContext::class, "Current field path helper."),
+        objectApi("httpClient", ScriptHttpClient::class, "Synchronous adapter to the EasyAPI HTTP client."),
+        objectApi("helper", ScriptHelper::class, "PSI lookup helper."),
+        objectApi("runtime", ScriptRuntime::class, "Project and module metadata helper."),
+    )
+
+    private val postmanObjects = listOf(
+        objectApi("pm", PmObject::class, "Postman-compatible root object."),
+        objectApi("environment", PmVariableScope::class, "Active environment variables."),
+        objectApi("globals", PmVariableScope::class, "Global variables."),
+        objectApi("collectionVariables", PmVariableScope::class, "Project/collection variables."),
+        objectApi("request", PmRequest::class, "Current HTTP request."),
+        objectApi("response", PmResponse::class, "Received HTTP response."),
+        objectApi("test", PmTest::class, "Named test registration helper."),
+        objectApi("cookies", PmCookies::class, "Response cookie helper."),
+        objectApi("info", PmInfo::class, "Script execution metadata."),
+        objectApi("logger", IdeaConsole::class, "EasyAPI console logger."),
+        objectApi("headers", PmHeaderList::class, "Mutable HTTP header list."),
+        objectApi("body", PmRequestBody::class, "HTTP request body."),
+        objectApi("propertyList", PmPropertyList::class, "Form or URL-encoded property list."),
+        objectApi("auth", PmAuthConfig::class, "Request authentication settings."),
+        objectApi("sendRequest", PmSendRequest::class, "Additional HTTP request sender."),
+        objectApi("expectation", PmExpectation::class, "Fluent assertion builder."),
+        objectApi("responseBdd", PmResponseBDD::class, "Positive response BDD assertions."),
+        objectApi("responseBddNot", PmResponseBDDNegated::class, "Negated response BDD assertions."),
+        objectApi("responseHave", PmResponseHave::class, "Response body/header assertion methods."),
+        objectApi("responseHaveNot", PmResponseHaveNot::class, "Negated response body/header assertion methods."),
+    )
+
+    private val staticConfigurationKeys = setOf(
+        "markdown.template", "markdown.template.language", "markdown.template.url.ttl.seconds",
+        "markdown.template.url.max.bytes", "max.deep", "max.elements"
+    )
+
+    private val postmanPreRequestKeys = setOf("postman.prerequest", "postman.class.prerequest")
+    private val postmanTestKeys = setOf("postman.test", "postman.class.test")
+    private val postmanCollectionKeys = setOf("postman.collection.prerequest", "postman.collection.test")
+    private val hoppscotchScriptKeys = setOf("hopp.prerequest", "hopp.class.prerequest", "hopp.test", "hopp.class.test")
+    private val hoppscotchCollectionKeys = setOf("hopp.collection.prerequest", "hopp.collection.test")
+    private val openApiDocumentKeys = setOf("openapi.host", "openapi.server.url", "openapi.info.title", "openapi.info.version", "openapi.info.description")
+    private val exportAfterKeys = setOf("export.after", "custom.export.after")
+}
+
+/** A key-specific context contract returned to the AI as structured JSON. */
+data class RuleScriptProfile(
+    val key: String,
+    val aliases: List<String>,
+    val source: String,
+    val executionMode: String,
+    val summary: RuleScriptContextSummary,
+    val description: String,
+    val stages: List<RuleScriptStage>,
+    val notes: List<String>
+)
+
+/** Compact metadata embedded in `list_rule_keys` results. */
+data class RuleScriptContextSummary(
+    val executionMode: String,
+    val itContexts: List<String>,
+    val bindings: List<String>,
+    val detailTool: String
+)
+
+/** One runtime stage for a rule value or the emitted script it produces. */
+data class RuleScriptStage(
+    val name: String,
+    val executionMode: String,
+    val description: String,
+    val bindings: List<ScriptBinding>,
+    val objects: List<ScriptObjectApi>
+)
+
+/** A script variable and the object API identifiers it can reference. */
+data class ScriptBinding(
+    val name: String,
+    val aliases: List<String> = emptyList(),
+    val objectTypes: List<String>,
+    val availability: String,
+    val description: String
+)
+
+/** Public, Groovy-callable API for a script object. */
+data class ScriptObjectApi(
+    val id: String,
+    val type: String,
+    val description: String,
+    val properties: List<ScriptPropertyApi>,
+    val methods: List<ScriptMethodApi>
+)
+
+/** A readable script property; [writable] describes whether Groovy can assign it. */
+data class ScriptPropertyApi(
+    val name: String,
+    val type: String,
+    val writable: Boolean
+)
+
+/** A callable script method and its runtime-visible signature. */
+data class ScriptMethodApi(
+    val name: String,
+    val returns: String,
+    val parameters: List<ScriptParameterApi>
+)
+
+/** One method parameter in [ScriptMethodApi]. */
+data class ScriptParameterApi(
+    val name: String,
+    val type: String,
+    val optional: Boolean,
+    val vararg: Boolean
+)

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContexts.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContexts.kt
@@ -341,7 +341,7 @@ open class ScriptPsiClassContext(context: RuleContext) : ScriptItContext(context
  * it.args().each { p -> logger.info(p.name()) }
  *
  * // Get containing class
- * it.containingClass().name()
+ * it.containingClass()?.qualifiedName()
  * ```
  */
 open class ScriptPsiMethodContext(context: RuleContext) : ScriptItContext(context), MethodContext {
@@ -434,8 +434,8 @@ class ScriptPsiMethodInClassContext(
         return ScriptPsiClassContext(context.withElement(containingClass))
     }
 
-    override fun defineClass(): ScriptPsiClassContext? {
-        return psiMethod().containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
+    override fun defineClass(): ScriptPsiClassContext? = readSync {
+        psiMethod().containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 }
 
@@ -456,7 +456,7 @@ class ScriptPsiMethodInClassContext(
  * it.type().name()
  *
  * // Get containing class
- * it.containingClass().name()
+ * it.containingClass()?.qualifiedName()
  *
  * // Check if enum field
  * if (it.isEnumField()) { ... }
@@ -523,8 +523,8 @@ class ScriptPsiFieldInClassContext(
         return ScriptPsiClassContext(context.withElement(containingClass))
     }
 
-    override fun defineClass(): ScriptPsiClassContext? {
-        return psiField().containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
+    override fun defineClass(): ScriptPsiClassContext? = readSync {
+        psiField().containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 }
 
@@ -896,18 +896,18 @@ class ScriptResolvedClassContext(
 class ScriptResolvedMethodContext(context: RuleContext, private val resolvedMethod: ResolvedMethod) :
     ScriptPsiMethodContext(context.withElement(resolvedMethod.psiMethod)) {
 
-    override fun returnType(): ScriptTypeContext {
-        return ScriptTypeContext(context, resolvedMethod.returnType)
+    override fun returnType(): ScriptTypeContext = readSync {
+        ScriptTypeContext(context, resolvedMethod.returnType)
     }
 
-    override fun args(): Array<ScriptPsiParameterContext> {
+    override fun args(): Array<ScriptPsiParameterContext> = readSync {
         val params = resolvedMethod.params
-        return Array(params.size) { i -> ScriptResolvedParameterContext(context, params[i]) }
+        Array(params.size) { i -> ScriptResolvedParameterContext(context, params[i]) }
     }
 
-    override fun argTypes(): Array<ScriptTypeContext> {
+    override fun argTypes(): Array<ScriptTypeContext> = readSync {
         val params = resolvedMethod.params
-        return Array(params.size) { i -> ScriptTypeContext(context, params[i].type) }
+        Array(params.size) { i -> ScriptTypeContext(context, params[i].type) }
     }
 
     override fun containingClass(): ScriptPsiClassContext? {
@@ -916,32 +916,32 @@ class ScriptResolvedMethodContext(context: RuleContext, private val resolvedMeth
         return resolvedMethod.containClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 
-    override fun defineClass(): ScriptPsiClassContext? {
-        return resolvedMethod.psiMethod.containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
+    override fun defineClass(): ScriptPsiClassContext? = readSync {
+        resolvedMethod.psiMethod.containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 }
 
 class ScriptResolvedFieldContext(context: RuleContext, private val resolvedField: ResolvedField) :
     ScriptPsiFieldContext(context.withElement(resolvedField.psiField)) {
 
-    override fun type(): ScriptTypeContext {
-        return ScriptTypeContext(context, resolvedField.type)
+    override fun type(): ScriptTypeContext = readSync {
+        ScriptTypeContext(context, resolvedField.type)
     }
 
     override fun containingClass(): ScriptPsiClassContext? {
         return resolvedField.containClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 
-    override fun defineClass(): ScriptPsiClassContext? {
-        return resolvedField.psiField.containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
+    override fun defineClass(): ScriptPsiClassContext? = readSync {
+        resolvedField.psiField.containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 }
 
 class ScriptResolvedParameterContext(context: RuleContext, private val resolvedParam: ResolvedParam) :
     ScriptPsiParameterContext(context.withElement(resolvedParam.psiParameter)) {
 
-    override fun type(): ScriptTypeContext {
-        return ScriptTypeContext(context, resolvedParam.type)
+    override fun type(): ScriptTypeContext = readSync {
+        ScriptTypeContext(context, resolvedParam.type)
     }
 }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngine.kt
@@ -46,9 +46,31 @@ class RuleEngine internal constructor(
         return forEachApplicable(key) { RuleContext.from(project, element, fieldContext) }
     }
 
+    suspend fun evaluate(
+        key: RuleKey.StringKey,
+        element: PsiElement,
+        containingClass: com.intellij.psi.PsiClass,
+        fieldContext: String? = null
+    ): String? {
+        return forEachApplicable(key) {
+            RuleContext.fromMember(project, element, containingClass, fieldContext)
+        }
+    }
+
     suspend fun evaluate(key: RuleKey.StringKey, element: PsiElement, contextHandle: (RuleContext) -> Unit): String? {
         return forEachApplicable(key) {
             RuleContext.from(project, element).also(contextHandle)
+        }
+    }
+
+    suspend fun evaluate(
+        key: RuleKey.StringKey,
+        element: PsiElement,
+        containingClass: com.intellij.psi.PsiClass,
+        contextHandle: (RuleContext) -> Unit
+    ): String? {
+        return forEachApplicable(key) {
+            RuleContext.fromMember(project, element, containingClass).also(contextHandle)
         }
     }
 
@@ -87,6 +109,22 @@ class RuleEngine internal constructor(
         return forEachApplicable(key) { RuleContext.from(project, element, fieldContext) } ?: false
     }
 
+    /**
+     * Evaluates a member rule from the perspective of [containingClass].
+     * This preserves the distinction between a member's current containing
+     * class and its original declaring class for inherited members.
+     */
+    suspend fun evaluate(
+        key: RuleKey.BooleanKey,
+        element: PsiElement,
+        containingClass: com.intellij.psi.PsiClass,
+        fieldContext: String? = null
+    ): Boolean {
+        return forEachApplicable(key) {
+            RuleContext.fromMember(project, element, containingClass, fieldContext)
+        } ?: false
+    }
+
     suspend fun evaluate(key: RuleKey.BooleanKey, element: PsiElement, contextHandle: (RuleContext) -> Unit): Boolean {
         return forEachApplicable(key) {
             RuleContext.from(project, element).also(contextHandle)
@@ -97,13 +135,43 @@ class RuleEngine internal constructor(
         return forEachApplicable(key) { RuleContext.from(project, element) }
     }
 
+    suspend fun evaluate(
+        key: RuleKey.IntKey,
+        element: PsiElement,
+        containingClass: com.intellij.psi.PsiClass
+    ): Int? {
+        return forEachApplicable(key) { RuleContext.fromMember(project, element, containingClass) }
+    }
+
     suspend fun evaluate(key: RuleKey.EventKey, element: PsiElement, fieldContext: String? = null) {
         forEachApplicable(key) { RuleContext.from(project, element, fieldContext) }
+    }
+
+    suspend fun evaluate(
+        key: RuleKey.EventKey,
+        element: PsiElement,
+        containingClass: com.intellij.psi.PsiClass,
+        fieldContext: String? = null
+    ) {
+        forEachApplicable(key) {
+            RuleContext.fromMember(project, element, containingClass, fieldContext)
+        }
     }
 
     suspend fun evaluate(key: RuleKey.EventKey, element: PsiElement, contextHandle: (RuleContext) -> Unit) {
         forEachApplicable(key) {
             RuleContext.from(project, element).also(contextHandle)
+        }
+    }
+
+    suspend fun evaluate(
+        key: RuleKey.EventKey,
+        element: PsiElement,
+        containingClass: com.intellij.psi.PsiClass,
+        contextHandle: (RuleContext) -> Unit
+    ) {
+        forEachApplicable(key) {
+            RuleContext.fromMember(project, element, containingClass).also(contextHandle)
         }
     }
 

--- a/src/main/resources/ai/agent-base.md
+++ b/src/main/resources/ai/agent-base.md
@@ -3,8 +3,9 @@ modify EasyApi rule files through a conversation.
 
 Work in a perceive → reason → act loop:
 - Perceive before you propose. Use the read-only tools to gather
-  context: the rule-key catalog (`list_rule_keys`), the authoritative
-  guide (`get_plugin_doc` with name="rule-guide"; also "overview",
+  context: the rule-key catalog (`list_rule_keys`), the key-specific script
+  contract (`get_rule_context` before drafting any Groovy or Postman script),
+  the authoritative guide (`get_plugin_doc` with name="rule-guide"; also "overview",
   "index", "settings-guide", "usage-guide"), the user's
   endpoints (`list_project_endpoints`), relevant classes/methods
   (`get_psi_class_info`, `get_psi_method_info`,
@@ -29,10 +30,19 @@ Work in a perceive → reason → act loop:
 
 Perception tools (read-only, run automatically):
 - `list_rule_keys` — every known rule key (general + channel + framework + implicit),
-  filtered to the channels/frameworks enabled in Settings. Each entry may carry
+  filtered to the channels/frameworks enabled in Settings. Each entry carries a
+  compact `scriptContext` (execution mode, possible `it` types and bindings)
+  plus `detailTool: "get_rule_context"`; use it for discovery, then fetch the
+  full object API only for keys you intend to author. Entries may also carry
   `description` (one-line "when to use") and `detailPromptId` (the id to pass to
-  `get_rule_detail` for the full recipe). Keys without a per-key recipe file omit
-  both fields.
+  `get_rule_detail` for the full recipe). Keys without a per-key recipe file
+  omit the latter two fields.
+- `get_rule_context` — fetch the authoritative, structured runtime contract for
+  one known key: all execution stages, `it` kinds, `request` / `response` /
+  `api` and common bindings, plus each object's writable properties and
+  callable method signatures. **Call this before writing a Groovy or Postman
+  script.** In particular, Postman keys have a rule-evaluation `it` stage and
+  a separate generated `pm` script stage; `response` is absent before a request.
 - `get_detection_prompt` — fetch the full detection recipe for one detection
   family by `id` (e.g. `static-auth`, `auth-token-chaining`, `spring-filters-interceptors`).
   The reactive path lists the available ids at conversation start; pull a recipe
@@ -123,13 +133,20 @@ method.additional.header={"name":"Authorization","value":"Bearer ${token}","desc
 Valid filter prefixes (and ONLY these):
 - `$class:<FQN>` — exact class-name match. Wildcards are NOT supported.
   For package/pattern matching use `groovy:` (e.g.
-  `groovy: it.containingClass().name().startsWith("com.example.web.")`).
+  `groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")`).
 - `@<AnnotationFqn>` — annotation presence.
 - `#regex:<pattern>` — regex match; captured groups available as
   `${1}`, `${2}` in the value.
 - `#<tag>` — JavaDoc/KDoc tag.
 - `!<expr>` — negation.
 - `groovy:<script>` — truthy script result = match.
+
+Class identity in Groovy is context-sensitive:
+- `name()` on a class context returns only the simple name.
+- `qualifiedName()` returns the fully-qualified class name and is required for
+  FQN equality and package-prefix comparisons.
+- For inherited members, `containingClass()` is the class currently being
+  exported, while `defineClass()` is the original declaring class.
 
 There is NO `~` prefix and NO `class:` prefix (the bare `class:` form
 from older docs is invalid — use `$class:`).
@@ -241,13 +258,13 @@ it doesn't.
 
 **Bad (unreadable single-line filter):**
 ```
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.merchant.") && !it.containingClass().name().equals("com.example.merchant.AuthController") && !it.containingClass().name().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.merchant.") && !it.containingClass()?.qualifiedName().equals("com.example.merchant.AuthController") && !it.containingClass()?.qualifiedName().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
 ```
 
 **Good (multi-line groovy value-block):**
 ```
 method.additional.header=groovy:```
-def cls = it.containingClass()?.name()
+def cls = it.containingClass()?.qualifiedName()
 if (cls?.startsWith("com.example.merchant.")
     && cls != "com.example.merchant.AuthController"
     && cls != "com.example.merchant.PublicController") {

--- a/src/main/resources/ai/rules/field.ignore.md
+++ b/src/main/resources/ai/rules/field.ignore.md
@@ -32,6 +32,18 @@ Multiple fields on the same class means multiple lines (the key uses
 default merge semantics — boolean rules do not merge, so each line is
 its own rule).
 
+When the user asks to ignore every field originally declared by a base
+class, compare the declaring class's **fully-qualified name**:
+
+```
+field.ignore=groovy:it.defineClass()?.qualifiedName() == "com.example.dto.TraceBean"
+```
+
+For inherited members, `containingClass()` is the class currently being
+exported, while `defineClass()` is the class that originally declared the
+field. Class-context `name()` returns only the simple name; always use
+`qualifiedName()` for FQN or package comparisons.
+
 ## Check existing rules first
 
 Before proposing, call `get_existing_rules_for_key` for `field.ignore`.

--- a/src/main/resources/ai/rules/method.additional.header.md
+++ b/src/main/resources/ai/rules/method.additional.header.md
@@ -39,13 +39,13 @@ value when the condition holds, or `null` when it doesn't.
 
 **Bad (unreadable single-line filter):**
 ```
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.merchant.") && !it.containingClass().name().equals("com.example.merchant.AuthController") && !it.containingClass().name().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.merchant.") && !it.containingClass()?.qualifiedName().equals("com.example.merchant.AuthController") && !it.containingClass()?.qualifiedName().equals("com.example.merchant.PublicController")]={"name":"Authorization","value":"Bearer ${token}","desc":"JWT","required":true}
 ```
 
 **Good (multi-line groovy value-block):**
 ```
 method.additional.header=groovy:```
-def cls = it.containingClass()?.name()
+def cls = it.containingClass()?.qualifiedName()
 if (cls?.startsWith("com.example.merchant.")
     && cls != "com.example.merchant.AuthController"
     && cls != "com.example.merchant.PublicController") {

--- a/src/main/resources/ai/sub-agent-base.md
+++ b/src/main/resources/ai/sub-agent-base.md
@@ -26,6 +26,10 @@ Perception tools (read-only, run automatically):
     recipes of every rule file scoped to that channel (and enabled in
     Settings). Use this when you want a tour of what a channel supports.
   - At least one of `key` / `channel` / `format` / `framework` is required.
+- `get_rule_context` — return structured, key-specific script bindings and
+  callable object APIs. Before drafting any Groovy or Postman script, use
+  `get_rule_context(key="…")` to distinguish rule-evaluation `it` from any
+  generated script's `pm` / `request` / `response` bindings.
 - `get_psi_class_info` — inspect a class's methods/fields/signature/annotations
   by fully-qualified name (e.g. `com.example.filter.MyJwtFilter`).
 - `find_classes_by_annotation` — discover classes by annotation FQN or simple

--- a/src/main/resources/docs/knowledge-base/easyapi-script-reference.md
+++ b/src/main/resources/docs/knowledge-base/easyapi-script-reference.md
@@ -872,4 +872,27 @@ The existing EasyAPI rule script bindings remain available for advanced use case
 | `helper` / `H` | Class lookup |
 | `runtime` / `R` | Project/module metadata |
 
+### PSI class identity in rule scripts
+
+Rule scripts expose two different kinds of name APIs. Their semantics are
+intentionally different:
+
+| Context API | Result |
+|-------------|--------|
+| `name()` on a class context | simple class name, for example `TraceBean` |
+| `qualifiedName()` on a class context | Fully-qualified class name, for example `com.example.dto.TraceBean` |
+| `type().name()` | Fully-qualified type name, including type arguments when present |
+
+For inherited fields and methods:
+
+- `containingClass()` returns the class currently being exported.
+- `defineClass()` returns the class that originally declared the member.
+
+Always use `qualifiedName()` when comparing a class to an FQN or package
+prefix. For example, to ignore all fields declared by a shared base class:
+
+```groovy
+field.ignore=groovy:it.defineClass()?.qualifiedName() == "com.example.dto.TraceBean"
+```
+
 > **Recommendation:** For Pre-request and Post-response scripts in the API Dashboard, prefer the `pm.*` API for Postman compatibility. Use the legacy bindings only for IDE-specific operations (PSI inspection, file I/O, etc.).

--- a/src/main/resources/docs/knowledge-base/rule-guide.md
+++ b/src/main/resources/docs/knowledge-base/rule-guide.md
@@ -277,7 +277,7 @@ method.doc[@org.springframework.lang.Deprecated]=deprecated
 method.doc[#internal]=internal
 
 # Package-prefix match via groovy (wildcards are NOT supported by $class:)
-method.doc[groovy: it.containingClass().name().startsWith("com.example.web.")]=web
+method.doc[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]=web
 ```
 
 ---
@@ -342,11 +342,14 @@ When a rule value is prefixed with `groovy:`, it runs as a Groovy script via the
 `it` is the central object in every script. It wraps the current PSI element and exposes a script-friendly API:
 
 ```groovy
-// Name of the current element
+// Name of the current element; for a class context this is the simple name
 it.name()
 
-// Fully-qualified name of the containing class
-it.containingClass().name()
+// Fully-qualified name of the containing/current export class
+it.containingClass()?.qualifiedName()
+
+// Fully-qualified name of the class that originally declared an inherited member
+it.defineClass()?.qualifiedName()
 
 // Annotation access — returns the annotation wrapper or null
 it.ann("org.springframework.web.bind.annotation.RequestMapping")?.path()
@@ -358,6 +361,12 @@ it.doc()
 // Has annotation?
 it.hasAnn("java.lang.Deprecated")
 ```
+
+On class contexts, `name()` returns a simple name such as `TraceBean`;
+`qualifiedName()` returns an FQN such as `com.example.dto.TraceBean`. Always
+use `qualifiedName()` for package or FQN comparisons. For inherited members,
+`containingClass()` identifies the current export class and `defineClass()`
+identifies the original declaring class.
 
 ---
 
@@ -395,17 +404,17 @@ the same catalog when scanning your project.
 
 | Pattern | Detection signal (FQN / shape to search for) | Rule recipe |
 |---------|----------------------------------------------|-------------|
-| **Filter / Interceptor requiring a header** | `jakarta.servlet.Filter`, `jakarta.servlet.http.HttpFilter`, `javax.servlet.Filter`, `org.springframework.web.servlet.HandlerInterceptor` — implementations often call `request.getHeader("X-…")` in `doFilter` / `preHandle`. Search for `extends`/`implements` these types and confirm the FQN by resolving the import. | Add the header to every endpoint (no filter — applies globally): `method.additional.header={"name":"X-My-Header","value":"required-value","desc":"","required":true}`. Or scope it to a package via groovy: `method.additional.header[groovy: it.containingClass().name().startsWith("com.example.web.")]={"name":"X-My-Header","value":"\${value}","desc":"","required":true}`. |
+| **Filter / Interceptor requiring a header** | `jakarta.servlet.Filter`, `jakarta.servlet.http.HttpFilter`, `javax.servlet.Filter`, `org.springframework.web.servlet.HandlerInterceptor` — implementations often call `request.getHeader("X-…")` in `doFilter` / `preHandle`. Search for `extends`/`implements` these types and confirm the FQN by resolving the import. | Add the header to every endpoint (no filter — applies globally): `method.additional.header={"name":"X-My-Header","value":"required-value","desc":"","required":true}`. Or scope it to a package via groovy: `method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]={"name":"X-My-Header","value":"\${value}","desc":"","required":true}`. |
 | **WebFilter (Spring WebFlux)** | `org.springframework.web.server.WebFilter` — `filter()` that inspects `ServerHttpRequest`. | Same as above — `method.additional.header=…`. |
 | **Response wrapper (`@ControllerAdvice` + `ResponseBodyAdvice`)** | `org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice` — implementations wrap the body in `{ code, data, msg }`. Search for implementors; check the `beforeBodyWrite` return type. | Unwrap the response for documentation: `json.rule.convert[#regex:com\.example\.common\.ApiResult<(.*?)>]=${1}` (repeat for each wrapper type). |
-| **Custom argument resolver (injects hidden param)** | `org.springframework.web.method.support.HandlerMethodArgumentResolver` — `supportsParameter` checks for a custom annotation or type; `resolveArgument` returns the value. The parameter is **not** declared in the source signature. | Inject the param into the docs: `api.param.parse.before[groovy: it.containingClass().name().startsWith("com.example.web.")]=com.example.CurrentUser:current_user:the current user`. Or use `api.param.parse.before[@com.example.CurrentUser]=…` if annotated. |
+| **Custom argument resolver (injects hidden param)** | `org.springframework.web.method.support.HandlerMethodArgumentResolver` — `supportsParameter` checks for a custom annotation or type; `resolveArgument` returns the value. The parameter is **not** declared in the source signature. | Inject the param into the docs: `api.param.parse.before[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.web.")]=com.example.CurrentUser:current_user:the current user`. Or use `api.param.parse.before[@com.example.CurrentUser]=…` if annotated. |
 | **Meta-annotations (composed `@RequestMapping`)** | A custom annotation like `@GetRestApi` that is itself annotated `@GetMapping`. Search for annotations meta-annotated with `@org.springframework.web.bind.annotation.RequestMapping`. | Tell EasyApi to treat the custom annotation as a controller method marker: `class.is.spring.ctrl=groovy: it.hasAnn("com.example.GetRestApi")`. |
-| **Field naming convention (snake_case / camelCase mismatch)** | The DTO uses `camelCase`, but the API contract is `snake_case` (or vice-versa). Often visible in Jackson `@JsonNaming` or a `PropertyNamingStrategy`. | `field.name[groovy: it.containingClass().name().startsWith("com.example.dto.")]=groovy: it.name().replaceAll("([A-Z])") { "_" + it[1].toLowerCase() }` |
+| **Field naming convention (snake_case / camelCase mismatch)** | The DTO uses `camelCase`, but the API contract is `snake_case` (or vice-versa). Often visible in Jackson `@JsonNaming` or a `PropertyNamingStrategy`. | `field.name[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=groovy: it.name().replaceAll("([A-Z])") { "_" + it[1].toLowerCase() }` |
 | **Field ignores (sensitive fields)** | Fields named `password`, `secret`, `token`, `apiKey` that should never appear in exports. | `field.ignore[#regex:.*password.*]=true` · `field.ignore[#regex:.*(secret\|token\|apikey).*]=true` |
-| **Required / demo / default for a field** | A field is always required by the API but has no `@NotNull` in source, or needs a demo value for the exported example. | `field.required[groovy: it.containingClass().name().startsWith("com.example.dto.")]=name,email` · `field.demo[$class:com.example.dto.User]=18` |
-| **Path prefix per module / package** | Every controller in `com.example.admin` should be prefixed `/admin` in the docs, even if `@RequestMapping` doesn't declare it. | `class.prefix.path[groovy: it.name().startsWith("com.example.admin.")]=/admin` |
+| **Required / demo / default for a field** | A field is always required by the API but has no `@NotNull` in source, or needs a demo value for the exported example. | `field.required[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=name,email` · `field.demo[$class:com.example.dto.User]=18` |
+| **Path prefix per module / package** | Every controller in `com.example.admin` should be prefixed `/admin` in the docs, even if `@RequestMapping` doesn't declare it. | `class.prefix.path[groovy: it.qualifiedName()?.startsWith("com.example.admin.")]=/admin` |
 | **Enum representation** | The API exposes an enum as `{ "name": "ACTIVE", "value": 1 }` but EasyApi exports just the name. | `json.rule.convert[$class:com.example.Status]=groovy: '{"name":"' + it.name() + '","value":' + it.ann("com.example.Code")?.value() + '}'` |
-| **Status / version tag** | Every endpoint in `v2` package should carry a version label. | `method.doc[groovy: it.containingClass().name().startsWith("com.example.v2.")]=v2` |
+| **Status / version tag** | Every endpoint in `v2` package should carry a version label. | `method.doc[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.v2.")]=v2` |
 | **`@RequirePermission("admin")` → tag / header** | A custom security annotation that should become an `method.doc` or a Postman header. Search the codebase for `@com.example.RequirePermission` (resolve imports to confirm the FQN). | `method.doc[@com.example.RequirePermission]=admin` · `method.additional.header[@com.example.RequirePermission]={"name":"X-Permission","value":"\${it.ann('com.example.RequirePermission')?.value()}","desc":"","required":true}` |
 
 > **Detection tip for the AI assistant:** before proposing a rule, search the
@@ -478,10 +487,10 @@ the same catalog when scanning your project.
 
 | Pattern | Detection signal (PSI tools) | Rule recipe (full bundle) |
 |---------|------------------------------|---------------------------|
-| **Auth Token Chaining** (flagship) | **Producer:** endpoint path contains `/login`, `/signin`, `/auth`, `/token`, or `/oauth/token` (case-insensitive) OR method name contains `login`/`signin`/`authenticate`/`token`; return type carries a field named `token`/`accessToken`/`access_token`/`jwt`/`idToken`/`authToken`. **Consumer:** controllers in packages *other than* the auth controller. | **Producer** (post-response — extracts token, stores in env var):<br>`postman.test[groovy: it.containingClass().name() == "com.example.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("Authorization", token) }`<br>**Consumer** (attaches Bearer header to secured endpoints):<br>`method.additional.header[groovy: it.containingClass().name().startsWith("com.example.api.")]={"name":"Authorization","value":"Bearer ${Authorization}","desc":"bearer token from login","required":true}`<br>**Env var:** `Authorization` (reuse existing if present — resolve the name from any existing `method.additional.header=…${…}` rule via `get_existing_rules_for_key`, not from the Environments panel).<br>⚠ Uses `postman.test` (NOT `postman.prerequest`) — the token only exists after the login response.<br>⚠ If the token field is ambiguous (multiple candidates), call `ask_clarification` (single_choice) before writing the script. |
+| **Auth Token Chaining** (flagship) | **Producer:** endpoint path contains `/login`, `/signin`, `/auth`, `/token`, or `/oauth/token` (case-insensitive) OR method name contains `login`/`signin`/`authenticate`/`token`; return type carries a field named `token`/`accessToken`/`access_token`/`jwt`/`idToken`/`authToken`. **Consumer:** controllers in packages *other than* the auth controller. | **Producer** (post-response — extracts token, stores in env var):<br>`postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("Authorization", token) }`<br>**Consumer** (attaches Bearer header to secured endpoints):<br>`method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.api.")]={"name":"Authorization","value":"Bearer ${Authorization}","desc":"bearer token from login","required":true}`<br>**Env var:** `Authorization` (reuse existing if present — resolve the name from any existing `method.additional.header=…${…}` rule via `get_existing_rules_for_key`, not from the Environments panel).<br>⚠ Uses `postman.test` (NOT `postman.prerequest`) — the token only exists after the login response.<br>⚠ If the token field is ambiguous (multiple candidates), call `ask_clarification` (single_choice) before writing the script. |
 | **Static Auth (API Key / Basic)** | Security filter/interceptor calling `request.getHeader("X-API-Key")` / `"Authorization"` starting `Basic `; or custom `@ApiKeyAuth` annotation. Discover via `find_classes_by_annotation` + `get_psi_class_info` (read filter body for `getHeader(...)`). | **API-key-in-header:**<br>`method.additional.header={"name":"X-API-Key","value":"${apiKey}","desc":"api key","required":true}`<br>**API-key-in-query:**<br>`method.additional.param={"name":"key","type":"String","value":"${apiKey}","required":true,"desc":"api key"}`<br>**Basic auth:**<br>`method.additional.header={"name":"Authorization","value":"Basic ${basicAuth}","desc":"http basic credentials","required":true}`<br>**No script** — the user supplies the credential once in the Environments panel (base64-encode `user:pass` for Basic). |
 | **Per-Request Injection (Correlation / Idempotency)** | Filter/interceptor reading `request.getHeader("X-Request-Id")` / `"X-Correlation-Id"` / `"X-Trace-Id"`; or `Idempotency-Key` header on POST/PUT methods. | **Correlation ID** (global, pre-request):<br>`postman.prerequest=pm.request.headers.upsert("X-Request-Id", java.util.UUID.randomUUID().toString())`<br>**Idempotency key** (scoped to mutating methods — never unscoped):<br>`postman.prerequest[groovy: it.methodType().name() == "POST" || it.methodType().name() == "PUT"]=pm.request.headers.upsert("Idempotency-Key", java.util.UUID.randomUUID().toString())`<br>Uses `pm.request.headers.upsert(...)` (add-or-replace, case-insensitive), not `.add(...)` (which would duplicate). |
-| **Request Signing (HMAC)** | Filter/interceptor using `javax.crypto.Mac` / `HmacSHA256` / `Sha256.hmac`; reads `appSecret`/`appKey`/`accessKeyId`; or custom `@SignedRequest` annotation. | **Pre-request signing script** (computes HMAC, attaches signature header):<br>`postman.prerequest[groovy: it.containingClass().name().startsWith("com.example.api.")]=def mac = javax.crypto.Mac.getInstance("HmacSHA256"); mac.init(new javax.crypto.spec.SecretKeySpec("${appSecret}".getBytes("UTF-8"), "HmacSHA256")); def stringToSign = pm.request.url + "\n" + pm.request.body; def raw = mac.doFinal(stringToSign.getBytes("UTF-8")); def sig = raw.collect { String.format("%02x", it) }.join(); pm.request.headers.upsert("X-Signature", sig)`<br>**No hardcoded secret** — `${appSecret}` is always an env-var reference.<br>⚠ For non-trivial signing (AWS SigV4, etc.) treat as a scaffold + call `ask_clarification` for the canonical-string / algorithm variant. |
+| **Request Signing (HMAC)** | Filter/interceptor using `javax.crypto.Mac` / `HmacSHA256` / `Sha256.hmac`; reads `appSecret`/`appKey`/`accessKeyId`; or custom `@SignedRequest` annotation. | **Pre-request signing script** (computes HMAC, attaches signature header):<br>`postman.prerequest[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.api.")]=def mac = javax.crypto.Mac.getInstance("HmacSHA256"); mac.init(new javax.crypto.spec.SecretKeySpec("${appSecret}".getBytes("UTF-8"), "HmacSHA256")); def stringToSign = pm.request.url + "\n" + pm.request.body; def raw = mac.doFinal(stringToSign.getBytes("UTF-8")); def sig = raw.collect { String.format("%02x", it) }.join(); pm.request.headers.upsert("X-Signature", sig)`<br>**No hardcoded secret** — `${appSecret}` is always an env-var reference.<br>⚠ For non-trivial signing (AWS SigV4, etc.) treat as a scaffold + call `ask_clarification` for the canonical-string / algorithm variant. |
 | **401-Refresh** | Refresh endpoint at `/refresh`, `/token/refresh`; OR user explicitly asks for auto-refresh; OR documented "if 401, call /refresh" convention. | **Post-call rule** (detects 401, calls refresh, sets new header, forces retry):<br>`http.call.after=groovy: if (response.code() == 401) { def refreshReq = new com.itangcent.easyapi.core.http.HttpRequest("https://api.example.com/refresh", "POST", java.util.Collections.emptyList(), java.util.Collections.emptyList(), "grant_type=refresh_token", java.util.Collections.emptyList(), java.util.Collections.emptyList(), null); def resp = httpClient.executeSync(refreshReq); def newToken = new groovy.json.JsonSlurper().parseText(resp.body).access_token; if (newToken) { request.setHeader("Authorization", "Bearer " + newToken); response.discard() } }`<br>**Retry limit:** up to 3 (enforced by `HttpClientScriptInterceptor`). The retry re-sends the mutated request wrapper, so `request.setHeader(...)` + `response.discard()` is sufficient — `pm` is NOT available in `http.call.after` (use `session.set(...)` for cross-request persistence if needed).<br>⚠ Keep the refresh endpoint itself script-free (recursion guard limits sub-request hooks to depth < 2). Wrap in `try/catch`. |
 
 > **Detection tip for the AI assistant:** before proposing a workflow bundle,
@@ -652,10 +661,10 @@ clarification needed.
 postman.host={{order-service}}
 
 # Producer (post-response — extracts token, stores in namespaced env var)
-postman.test[groovy: it.containingClass().name() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
+postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
 
 # Consumer (attaches namespaced Bearer header to order-service secured endpoints)
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
 ```
 
 **Bundle 2 — `payment-service`** (a second `propose_rule_content`):
@@ -665,10 +674,10 @@ method.additional.header[groovy: it.containingClass().name().startsWith("com.exa
 postman.host={{payment-service}}
 
 # Producer (post-response — extracts token, stores in namespaced env var)
-postman.test[groovy: it.containingClass().name() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
+postman.test[groovy: it.containingClass()?.qualifiedName() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
 
 # Consumer (attaches namespaced Bearer header to payment-service secured endpoints)
-method.additional.header[groovy: it.containingClass().name().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
+method.additional.header[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
 ```
 
 **Env vars** (user creates in the Environments panel): `order-service` (host),
@@ -701,7 +710,7 @@ consumer + host + env var, all carrying the same key).
 filter:
 
 ```
-api.name[groovy: it.containingClass().name() == "com.example.UserCtrl" && it.name() == "getUserName"]=Fetch User
+api.name[groovy: it.containingClass()?.qualifiedName() == "com.example.UserCtrl" && it.name() == "getUserName"]=Fetch User
 ```
 
 ### 2. Tag all endpoints in a controller
@@ -726,7 +735,7 @@ field.ignore[#regex:.*password.*]=true
 ### 5. Add a prefix to all fields in a DTO
 
 ```
-field.name.prefix[groovy: it.containingClass().name().startsWith("com.example.dto.")]=prop_
+field.name.prefix[groovy: it.containingClass()?.qualifiedName().startsWith("com.example.dto.")]=prop_
 ```
 
 ### 6. Custom type conversion for Reactor types
@@ -778,7 +787,7 @@ Before EasyApi 3.0, rule editing happened in a dedicated "Built-in" tab inside t
   Note: `class:` (without `$`) is NOT a valid filter prefix in 3.0 — use `$class:`.
 - **`$class:` is exact-match only:** wildcards like `$class:com.example.*Controller`
   do NOT work. For package/pattern matching, use a `groovy:` filter
-  (e.g. `groovy: it.containingClass().name().startsWith("com.example.")`) or
+  (e.g. `groovy: it.containingClass()?.qualifiedName().startsWith("com.example.")`) or
   `#regex:`.
 - **No `~` regex prefix:** use `#regex:` instead.
 - **Header / param values are JSON:** `method.additional.header` takes a JSON

--- a/src/main/resources/extensions/field-utils.config
+++ b/src/main/resources/extensions/field-utils.config
@@ -4,8 +4,8 @@ description: Field handling utilities (ignore system fields, transient, serialVe
 default-enabled: true
 ---
 
-# Ignore fields from java.lang system classes
-field.ignore=groovy:!it.containingClass().name().startsWith("java.lang")&&it.defineClass().name().startsWith("java.lang")
+# Ignore fields inherited from java.lang system classes
+field.ignore=groovy:!it.containingClass()?.qualifiedName()?.startsWith("java.lang.")&&it.defineClass()?.qualifiedName()?.startsWith("java.lang.")
 
 # Ignore transient field
 field.ignore=groovy:it.hasModifier("transient")

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/RuleAuthoringKnowledgeSemanticsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/RuleAuthoringKnowledgeSemanticsTest.kt
@@ -1,0 +1,58 @@
+package com.itangcent.easyapi.core.ai
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/** Guards the rule-authoring knowledge supplied to built-in and external AI agents. */
+class RuleAuthoringKnowledgeSemanticsTest {
+
+    @Test
+    fun testClassIdentityExamplesUseQualifiedName() {
+        val sources = buildList {
+            add(File("src/main/resources/ai/agent-base.md"))
+            addAll(markdownFiles(File("src/main/resources/ai/rules")))
+            addAll(markdownFiles(File("docs/knowledge-base")))
+            add(File("skills/easy-api-assistant/SKILL.md"))
+        }
+        val missing = sources.filterNot(File::isFile)
+        assertTrue("Rule-authoring knowledge files must exist: $missing", missing.isEmpty())
+
+        val violations = sources.flatMap { source ->
+            source.readLines().mapIndexedNotNull { index, line ->
+                if (CLASS_CONTEXT_SIMPLE_NAME.containsMatchIn(line)) {
+                    "${source.path}:${index + 1}: ${line.trim()}"
+                } else {
+                    null
+                }
+            }
+        }
+        assertTrue(
+            "AI rule-authoring sources must not use class-context name(); " +
+                "use qualifiedName() so FQN/package rules are unambiguous:\n" +
+                violations.joinToString("\n"),
+            violations.isEmpty()
+        )
+    }
+
+    @Test
+    fun testScriptReferenceDocumentsClassIdentitySemantics() {
+        val reference = File("docs/knowledge-base/easyapi-script-reference.md").readText()
+        assertTrue(
+            "Script reference must document name() as a simple class name",
+            reference.contains("simple class name")
+        )
+        assertTrue("Script reference must document qualifiedName()", reference.contains("qualifiedName()"))
+        assertTrue("Script reference must document containingClass()", reference.contains("containingClass()"))
+        assertTrue("Script reference must document defineClass()", reference.contains("defineClass()"))
+    }
+
+    private fun markdownFiles(directory: File): List<File> =
+        directory.walkTopDown().filter { it.isFile && it.extension == "md" }.toList()
+
+    private companion object {
+        val CLASS_CONTEXT_SIMPLE_NAME = Regex(
+            """(?:containingClass|defineClass)\(\)\??\.name\(\)"""
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/agent/SystemPromptBuilderTest.kt
@@ -129,6 +129,14 @@ class SystemPromptBuilderTest {
             text.contains("get_detection_prompt")
         )
         Assert.assertTrue(
+            "base prompt should document get_rule_context",
+            text.contains("get_rule_context")
+        )
+        Assert.assertTrue(
+            "base prompt should require context lookup before scripts",
+            text.contains("before writing a Groovy or Postman")
+        )
+        Assert.assertTrue(
             "base prompt should document get_rule_detail",
             text.contains("get_rule_detail")
         )
@@ -241,7 +249,7 @@ class SystemPromptBuilderTest {
         // the only menu the sub-agent LLM should trust.
         val text = SystemPromptBuilder.buildSubAgent().content
         for (tool in listOf(
-            "list_rule_keys", "get_rule_detail", "get_psi_class_info",
+            "list_rule_keys", "get_rule_detail", "get_rule_context", "get_psi_class_info",
             "find_classes_by_annotation", "find_classes_by_supertype",
             "report_findings"
         )) {
@@ -289,7 +297,7 @@ class SystemPromptBuilderTest {
         }
         // And the 6 registered tools MUST be advertised.
         for (registered in listOf(
-            "list_rule_keys", "get_rule_detail", "get_psi_class_info",
+            "list_rule_keys", "get_rule_detail", "get_rule_context", "get_psi_class_info",
             "find_classes_by_annotation", "find_classes_by_supertype",
             "report_findings"
         )) {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/OrchestratorToolRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/OrchestratorToolRegistryTest.kt
@@ -16,9 +16,9 @@ import org.junit.Assert
  *   `get_detection_prompt`); the orchestrator never touches PSI directly.
  *   No `report_findings` (sub-agent-only terminal action).
  * - **Sub-agent** — `{ find_classes_by_annotation, find_classes_by_supertype,
- *   get_psi_class_info, get_rule_detail, list_rule_keys, report_findings }`.
- *   No `propose_rule_content`, no `run_sub_agent` — the sub-agent cannot
- *   recurse and cannot stage final rule content.
+ *   get_psi_class_info, get_rule_detail, get_rule_context, list_rule_keys,
+ *   report_findings }`. No `propose_rule_content`, no `run_sub_agent` — the
+ *   sub-agent cannot recurse and cannot stage final rule content.
  *
  * `create_task_list` is intentionally absent from both sets: the task list
  * is seeded by the caller (FR-2.4), and sub-agents don't manage the
@@ -103,8 +103,8 @@ class OrchestratorToolRegistryTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     /**
-     * Full set assertion — the sub-agent advertises EXACTLY the five
-     * perception tools + `report_findings`.
+     * Full set assertion — the sub-agent advertises EXACTLY six perception
+     * tools + `report_findings`.
      *
      * Catches a regression where an orchestrator tool is accidentally
      * added to the sub-agent's set.
@@ -114,14 +114,15 @@ class OrchestratorToolRegistryTest : EasyApiLightCodeInsightFixtureTestCase() {
         val names = subAgentTools.schemas().map { it.name }
 
         Assert.assertEquals(
-            "sub-agent should advertise exactly 6 tools: $names",
-            6, names.size
+            "sub-agent should advertise exactly 7 tools: $names",
+            7, names.size
         )
         // Perception tools.
         Assert.assertTrue(names.contains("find_classes_by_annotation"))
         Assert.assertTrue(names.contains("find_classes_by_supertype"))
         Assert.assertTrue(names.contains("get_psi_class_info"))
         Assert.assertTrue(names.contains("get_rule_detail"))
+        Assert.assertTrue(names.contains("get_rule_context"))
         Assert.assertTrue(names.contains("list_rule_keys"))
         // Sub-agent terminal action.
         Assert.assertTrue(names.contains("report_findings"))

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
@@ -53,6 +53,17 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertTrue("should contain postman.test", text.contains("postman.test"))
     }
 
+    fun testListRuleKeysIncludesCompactScriptContext() {
+        val result = runBlocking { ListRuleKeysTool().execute(emptyMap(), ctx()) }
+        val keys: List<Map<String, Any?>> =
+            com.itangcent.easyapi.core.util.json.GsonUtils.fromJson((result as ToolResult.Text).value)
+        val fieldIgnore = keys.first { it["name"] == "field.ignore" }
+        val context = fieldIgnore["scriptContext"] as? Map<*, *>
+        Assert.assertNotNull("field.ignore should expose a context summary", context)
+        Assert.assertEquals("groovy-rule", context!!["executionMode"])
+        Assert.assertEquals("get_rule_context", context["detailTool"])
+    }
+
     fun testListRuleKeysAttachesCatalogMetadataForKeysWithRecipeFile() {
         // A5 catalog join: keys that have a per-key recipe file in
         // ai/rules/<key>.md get `description` + `detailPromptId` attached.
@@ -107,6 +118,38 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         // Every key should at least have name + type + source.
         Assert.assertTrue("should contain api.name", text.contains("api.name"))
         Assert.assertTrue("should contain \"source\"", text.contains("source"))
+    }
+
+    // --- GetRuleContextTool ---
+
+    fun testGetRuleContextReturnsKeySpecificObjectApi() {
+        val result = runBlocking {
+            GetRuleContextTool().execute(mapOf("key" to "http.call.after"), ctx())
+        }
+        Assert.assertTrue("result: $result", result is ToolResult.Text)
+        val text = (result as ToolResult.Text).value
+        Assert.assertTrue(text.contains("HttpRequestWrapper"))
+        Assert.assertTrue(text.contains("HttpResponseWrapper"))
+        Assert.assertTrue(text.contains("discard"))
+    }
+
+    fun testGetRuleContextAcceptsAliasesAndRejectsUnknownKeys() {
+        val aliasResult = runBlocking {
+            GetRuleContextTool().execute(mapOf("key" to "doc.field"), ctx())
+        }
+        Assert.assertTrue("result: $aliasResult", aliasResult is ToolResult.Text)
+        Assert.assertTrue((aliasResult as ToolResult.Text).value.contains("field.doc"))
+
+        val unknownResult = runBlocking {
+            GetRuleContextTool().execute(mapOf("key" to "not.a.real.key"), ctx())
+        }
+        Assert.assertTrue(unknownResult is ToolResult.Error)
+    }
+
+    fun testGetRuleContextRejectsMissingKey() {
+        val result = runBlocking { GetRuleContextTool().execute(emptyMap(), ctx()) }
+        Assert.assertTrue(result is ToolResult.Error)
+        Assert.assertTrue((result as ToolResult.Error).message.contains("missing required parameter"))
     }
 
     // --- GetPluginDocTool ---
@@ -429,6 +472,7 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         val tools = standardRuleTools()
         val names = tools.map { it.name }.toSet()
         Assert.assertTrue("list_rule_keys", names.contains("list_rule_keys"))
+        Assert.assertTrue("get_rule_context", names.contains("get_rule_context"))
         Assert.assertTrue("get_plugin_doc", names.contains("get_plugin_doc"))
         Assert.assertTrue("get_detection_prompt", names.contains("get_detection_prompt"))
         Assert.assertTrue("get_rule_detail", names.contains("get_rule_detail"))
@@ -450,7 +494,7 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
             "write_rule_file must NOT be registered in v1",
             names.contains("write_rule_file")
         )
-        Assert.assertEquals("exactly 17 tools (15 + 2 task-list tools)", 17, tools.size)
+        Assert.assertEquals("exactly 18 tools (16 + 2 task-list tools)", 18, tools.size)
     }
 
     // --- GetDetectionPromptTool ---

--- a/src/test/kotlin/com/itangcent/easyapi/core/config/config/LayeredConfigReaderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/config/config/LayeredConfigReaderTest.kt
@@ -59,7 +59,7 @@ class LayeredConfigReaderTest {
     @Test
     fun testConfigTextParserInlineValue() {
         val text = """
-            field.ignore=groovy:!it.containingClass().name().startsWith("java.lang")
+            field.ignore=groovy:!it.containingClass()?.qualifiedName()?.startsWith("java.lang.")
             api.name=test
         """.trimIndent()
         val entries = runBlocking { parser.parse(text, "test").toList() }

--- a/src/test/kotlin/com/itangcent/easyapi/core/config/config/source/FieldUtilsConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/config/config/source/FieldUtilsConfigIntegrationTest.kt
@@ -205,4 +205,41 @@ class FieldUtilsConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase()
         // field-utils config ignores fields that are not private or protected
         assertFalse("Public field 'publicField' should be ignored", fields!!.containsKey("publicField"))
     }
+
+    /**
+     * Fields inherited from a `java.lang.*` class must be ignored while fields
+     * declared by the exported class remain visible. This exercises the
+     * difference between `containingClass()` and `defineClass()` with real PSI.
+     */
+    fun testFieldDeclaredByJavaLangSuperclassIsIgnored() = runTest {
+        myFixture.addClass(
+            """
+            package java.lang.fixture;
+            public class TraceBean {
+                protected String traceId;
+            }
+            """.trimIndent()
+        )
+        myFixture.addClass(
+            """
+            package com.itangcent.fieldutils;
+            import java.lang.fixture.TraceBean;
+            public class InheritedFieldDTO extends TraceBean {
+                private String ownField;
+            }
+            """.trimIndent()
+        )
+
+        val psiClass = findClass("com.itangcent.fieldutils.InheritedFieldDTO")
+        assertNotNull("Should find InheritedFieldDTO", psiClass)
+
+        val model = PsiClassHelper.getInstance(project).buildObjectModel(psiClass!!)
+        val fields = model?.asObject()?.fields
+        assertNotNull("Should build inherited object fields", fields)
+        assertTrue("Child field 'ownField' should be kept", fields!!.containsKey("ownField"))
+        assertFalse(
+            "Inherited field 'traceId' declared by java.lang.fixture.TraceBean should be ignored",
+            fields.containsKey("traceId")
+        )
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/extension/BuiltInExtensionRuleSemanticsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/extension/BuiltInExtensionRuleSemanticsTest.kt
@@ -1,0 +1,40 @@
+package com.itangcent.easyapi.core.extension
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Semantic safety checks applied to every bundled extension rule.
+ *
+ * The registry test separately guarantees that every bundled extension is
+ * discovered. This test audits every discovered rule body for expressions
+ * that are syntactically valid but use a simple class name where a qualified
+ * name or package is required.
+ */
+class BuiltInExtensionRuleSemanticsTest {
+
+    @Test
+    fun testClassContextFqnComparisonsUseQualifiedName() {
+        val violations = ExtensionConfigRegistry.allExtensions().flatMap { extension ->
+            extension.content.lineSequence().mapIndexedNotNull { index, line ->
+                if (CLASS_CONTEXT_NAME_USED_AS_FQN.containsMatchIn(line)) {
+                    "${extension.code}:${index + 1}: ${line.trim()}"
+                } else {
+                    null
+                }
+            }.toList()
+        }
+
+        assertTrue(
+            "Class contexts return a simple name from name(); use qualifiedName() " +
+                "for FQN/package comparisons:\n${violations.joinToString("\n")}",
+            violations.isEmpty()
+        )
+    }
+
+    private companion object {
+        val CLASS_CONTEXT_NAME_USED_AS_FQN = Regex(
+            """(?:containingClass|defineClass)\(\)\??\.name\(\)\s*(?:\.\s*(?:startsWith|endsWith|equals|matches)\s*\(\s*["'][^"']*\.[^"']*|(?:==|!=)\s*["'][^"']*\.[^"']*)"""
+        )
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/MemberRuleContextIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/MemberRuleContextIntegrationTest.kt
@@ -1,0 +1,49 @@
+package com.itangcent.easyapi.core.psi
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Verifies that field rules see inherited members from the exported class's
+ * perspective while retaining access to the member's declaring class.
+ */
+class MemberRuleContextIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    override fun createConfigReader(): TestConfigReader = TestConfigReader.fromConfigText(
+        project,
+        """
+        field.name=groovy:it.containingClass()?.qualifiedName() == "com.example.Child" && it.defineClass()?.qualifiedName() == "com.example.Parent" ? "renamedInheritedField" : null
+        """.trimIndent()
+    )
+
+    fun testInheritedFieldNameRuleUsesCurrentAndDeclaringClasses() = runTest {
+        myFixture.addClass(
+            """
+            package com.example;
+            public class Parent {
+                protected String inheritedField;
+            }
+            """.trimIndent()
+        )
+        myFixture.addClass(
+            """
+            package com.example;
+            public class Child extends Parent {
+                private String ownField;
+            }
+            """.trimIndent()
+        )
+
+        val childClass = findClass("com.example.Child")
+        assertNotNull("Should find Child", childClass)
+
+        val fields = PsiClassHelper.getInstance(project)
+            .buildObjectModel(childClass!!)
+            ?.asObject()
+            ?.fields
+        assertNotNull("Should build Child fields", fields)
+        assertTrue("Own field should be preserved", fields!!.containsKey("ownField"))
+        assertTrue("Inherited field should be renamed by member-aware rule", fields.containsKey("renamedInheritedField"))
+        assertFalse("Original inherited field name should be replaced", fields.containsKey("inheritedField"))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidatorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidatorTest.kt
@@ -9,11 +9,12 @@ import org.junit.Test
  * Tests for [RuleProposalValidator].
  *
  * Covers the v1 review-agent policy: hard errors on unknown keys, invalid
- * filter prefixes, and malformed JSON values; soft warnings only on the
- * deprecated bare `class:` filter form.
+ * filter prefixes, and malformed JSON values; soft warnings for deprecated
+ * filters and class-context `name()` calls that may be mistaken for FQNs.
  */
 class RuleProposalValidatorTest {
 
+    @Test
     fun testCleanRulePasses() {
         val content = """
             # A clean rule file
@@ -26,6 +27,7 @@ class RuleProposalValidatorTest {
         assertTrue("unexpected warnings: ${result.warnings}", result.warnings.isEmpty())
     }
 
+    @Test
     fun testUnknownKeyIsBlocked() {
         // The preamble is explicit that `api.header` does NOT exist.
         val content = "api.header=X-Foo:bar"
@@ -34,6 +36,7 @@ class RuleProposalValidatorTest {
         assertTrue(result.errors.any { it.contains("unknown rule key") && it.contains("api.header") })
     }
 
+    @Test
     fun testBareClassFilterIsOnlyAWarning() {
         val content = "method.doc[class:com.example.web.UserController]=user"
         val result = RuleProposalValidator.validate(content)
@@ -42,6 +45,7 @@ class RuleProposalValidatorTest {
         assertTrue(result.warnings.any { it.contains("deprecated") && it.contains("class:") })
     }
 
+    @Test
     fun testInvalidFilterPrefixIsBlocked() {
         val content = "method.doc[~com.example.UserController]=user"
         val result = RuleProposalValidator.validate(content)
@@ -49,6 +53,7 @@ class RuleProposalValidatorTest {
         assertTrue(result.errors.any { it.contains("invalid filter") })
     }
 
+    @Test
     fun testMalformedJsonHeaderValueIsBlocked() {
         val content = "method.additional.header=Authorization:Bearer token"
         val result = RuleProposalValidator.validate(content)
@@ -56,15 +61,17 @@ class RuleProposalValidatorTest {
         assertTrue(result.errors.any { it.contains("not valid JSON") })
     }
 
+    @Test
     fun testValidDollarClassFilterPasses() {
-        val content = "method.doc[\${'$'}class:com.example.web.UserController]=user"
+        val content = "method.doc[\$class:com.example.web.UserController]=user"
         val result = RuleProposalValidator.validate(content)
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testGroovyFilterAndValueBlockPass() {
         val content = """
-            method.additional.header[groovy: it.containingClass().name().startsWith("com.example.web.")]={"name":"Authorization","value":"Bearer ${'$'}{token}","required":true}
+            method.additional.header[groovy: it.containingClass()?.qualifiedName()?.startsWith("com.example.web.")]={"name":"Authorization","value":"Bearer ${'$'}{token}","required":true}
             method.additional.header=groovy:```
             return '{"name":"Authorization","value":"Bearer ${'$'}{token}","required":true}'
             ```
@@ -73,6 +80,76 @@ class RuleProposalValidatorTest {
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
+    fun testDefineClassSimpleNameProducesSoftWarning() {
+        val content = """field.ignore=groovy: it.defineClass()?.name() == "com.example.dto.TraceBean""""
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue(
+            "warnings: ${result.warnings}",
+            result.warnings.any {
+                it.contains("line 1") && it.contains("class-context name()") && it.contains("qualifiedName()")
+            }
+        )
+    }
+
+    @Test
+    fun testContainingClassSimpleNameProducesSoftWarning() {
+        val content =
+            """field.ignore=groovy: it.containingClass().name().startsWith("com.example.")"""
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue("warnings: ${result.warnings}", result.warnings.any { it.contains("class-context name()") })
+    }
+
+    @Test
+    fun testClassSimpleNameInMultiLineGroovyBlockProducesSoftWarning() {
+        val content = """
+            field.ignore=groovy:```
+            def declaringType = it.defineClass()?.name()
+            return declaringType == "com.example.dto.TraceBean"
+            ```
+        """.trimIndent()
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue(
+            "warnings: ${result.warnings}",
+            result.warnings.any { it.contains("line 2") && it.contains("class-context name()") }
+        )
+    }
+
+    @Test
+    fun testClassSimpleNameSplitAcrossGroovyBlockLinesProducesSoftWarning() {
+        val content = """
+            field.ignore=groovy:```
+            def declaringType = it.defineClass()
+                ?.name()
+            return declaringType == "com.example.dto.TraceBean"
+            ```
+        """.trimIndent()
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue(
+            "warnings: ${result.warnings}",
+            result.warnings.any { it.contains("line 2") && it.contains("class-context name()") }
+        )
+    }
+
+    @Test
+    fun testClassQualifiedNameDoesNotProduceSimpleNameWarning() {
+        val content =
+            """field.ignore=groovy: it.defineClass()?.qualifiedName() == "com.example.dto.TraceBean"""
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue("unexpected warnings: ${result.warnings}", result.warnings.isEmpty())
+    }
+
+    @Test
     fun testAliasesAreAcceptedAsKnownKeys() {
         // `doc.param` is an alias of `param.doc` per RuleKeys.kt.
         val content = "doc.param=the current user"
@@ -80,6 +157,7 @@ class RuleProposalValidatorTest {
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testCommentAndDirectiveLinesAreIgnored() {
         val content = """
             # a comment
@@ -95,6 +173,7 @@ class RuleProposalValidatorTest {
     // JSON-value keys: each of the four keys must validate JSON when inline.
     // -------------------------------------------------------------------------
 
+    @Test
     fun testMalformedParamValueIsBlocked() {
         val content = "method.additional.param=not json"
         val result = RuleProposalValidator.validate(content)
@@ -102,6 +181,7 @@ class RuleProposalValidatorTest {
         assertTrue(result.errors.any { it.contains("not valid JSON") && it.contains("method.additional.param") })
     }
 
+    @Test
     fun testMalformedResponseHeaderValueIsBlocked() {
         val content = "method.additional.response.header=X-Foo:bar"
         val result = RuleProposalValidator.validate(content)
@@ -111,6 +191,7 @@ class RuleProposalValidatorTest {
         )
     }
 
+    @Test
     fun testMalformedJsonAdditionalFieldValueIsBlocked() {
         val content = "json.additional.field=plain string"
         val result = RuleProposalValidator.validate(content)
@@ -118,12 +199,14 @@ class RuleProposalValidatorTest {
         assertTrue(result.errors.any { it.contains("not valid JSON") && it.contains("json.additional.field") })
     }
 
+    @Test
     fun testValidJsonParamValuePasses() {
         val content = """method.additional.param={"name":"page","value":"1"}"""
         val result = RuleProposalValidator.validate(content)
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testBlankJsonValueSkipsJsonCheck() {
         // An empty value for a JSON-value key should not trigger the JSON
         // parser — `value.isNotBlank()` short-circuits the check.
@@ -132,6 +215,7 @@ class RuleProposalValidatorTest {
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testGroovyPrefixedValueSkipsJsonCheck() {
         // `groovy:`-prefixed values are scripts, not JSON; the validator
         // must skip JSON validation for them.
@@ -144,18 +228,21 @@ class RuleProposalValidatorTest {
     // Filter prefixes: every valid prefix must be accepted.
     // -------------------------------------------------------------------------
 
+    @Test
     fun testAtPrefixFilterPasses() {
         val content = "method.doc[@com.example.WebController]=user"
         val result = RuleProposalValidator.validate(content)
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testRegexPrefixFilterPasses() {
         val content = "method.doc[#regex:.*Controller]=user"
         val result = RuleProposalValidator.validate(content)
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testTagPrefixFilterPasses() {
         // `#<tag>` — a hash-prefixed tag, distinct from `#regex:`.
         val content = "method.doc[#spring]=user"
@@ -163,12 +250,14 @@ class RuleProposalValidatorTest {
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testNotPrefixFilterPasses() {
         val content = "method.doc[!com.example.InternalController]=user"
         val result = RuleProposalValidator.validate(content)
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testGroovyPrefixFilterPasses() {
         val content = "method.doc[groovy: it.name().contains(\"Controller\")]=user"
         val result = RuleProposalValidator.validate(content)
@@ -179,15 +268,17 @@ class RuleProposalValidatorTest {
     // splitKeyFilterValue edge cases
     // -------------------------------------------------------------------------
 
-    fun testEmptyFilterBracketIsTreatedAsNoFilter() {
-        // `method.doc[]=value` — empty filter → treated as no filter (no prefix
-        // check), so no error. This exercises the `filter.isEmpty()` branch
-        // in splitKeyFilterValue.
+    @Test
+    fun testEmptyFilterBracketIsRejectedAsUnknownKey() {
+        // An empty filter is not valid `key[filter]` syntax. The shared parser
+        // deliberately preserves the whole left-hand side as the key.
         val content = "method.doc[]=user"
         val result = RuleProposalValidator.validate(content)
-        assertTrue("errors: ${result.errors}", result.ok)
+        assertFalse(result.ok)
+        assertTrue(result.errors.any { it.contains("unknown rule key") && it.contains("method.doc[]") })
     }
 
+    @Test
     fun testNonKeyValueLinesAreIgnored() {
         // Stray text that is not `key=value` and not a comment should not
         // produce errors (the parser skips lines it can't parse).
@@ -200,6 +291,7 @@ class RuleProposalValidatorTest {
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testBracketEqualsInsideFilterDoesNotSplitEarly() {
         // `=` inside `[...]` must not be treated as the key=value separator.
         // Here the filter contains `=` and the real `=` is after the `]`.
@@ -212,6 +304,7 @@ class RuleProposalValidatorTest {
     // Multi-line groovy value-block handling
     // -------------------------------------------------------------------------
 
+    @Test
     fun testMultiLineGroovyBlockBodyIsSkipped() {
         // The body of a ```-delimited block is free-form script — lines inside
         // must not be parsed as key=value, even if they look like one.
@@ -226,6 +319,7 @@ class RuleProposalValidatorTest {
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testBlockClosingLineEndingWithBackticks() {
         // A value ending with ``` (block opener on the same line as `key=`)
         // must enter block mode and skip subsequent lines until the closing ``` .
@@ -239,6 +333,7 @@ class RuleProposalValidatorTest {
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testMultipleErrorsAreAllReported() {
         // Two distinct hard errors should both appear in the result.
         val content = """
@@ -251,18 +346,21 @@ class RuleProposalValidatorTest {
         assertTrue(result.errors.any { it.contains("invalid filter") })
     }
 
+    @Test
     fun testEmptyContentIsValid() {
         val result = RuleProposalValidator.validate("")
         assertTrue("errors: ${result.errors}", result.ok)
         assertEquals(0, result.warnings.size)
     }
 
+    @Test
     fun testBlankLinesAreIgnored() {
         val content = "\n\n   \napi.name=My API\n\n"
         val result = RuleProposalValidator.validate(content)
         assertTrue("errors: ${result.errors}", result.ok)
     }
 
+    @Test
     fun testRuleValidationOkProperty() {
         // Direct coverage of the `ok` convenience property on the data class.
         val ok = RuleValidation(errors = emptyList(), warnings = listOf("w"))

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalogTest.kt
@@ -1,0 +1,102 @@
+package com.itangcent.easyapi.core.rule.context
+
+import com.itangcent.easyapi.core.rule.RuleKeys
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RuleScriptContextCatalogTest {
+
+    @Test
+    fun `field ignore describes field and method it contexts`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.FIELD_IGNORE, "general")
+        val stage = profile.stages.single()
+
+        assertEquals("groovy-rule", profile.executionMode)
+        assertTrue(stage.binding("it").objectTypes.containsAll(listOf("field", "method")))
+
+        val field = stage.objectApi("field")
+        assertTrue(field.methods.any { it.name == "type" })
+        assertTrue(field.methods.any { it.name == "containingClass" })
+        assertTrue(field.methods.any { it.name == "defineClass" })
+    }
+
+    @Test
+    fun `http call after exposes request response and retry control`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.HTTP_CALL_AFTER, "general")
+        val stage = profile.stages.single()
+
+        assertTrue(stage.bindings.any { it.name == "request" })
+        assertTrue(stage.bindings.any { it.name == "response" })
+        assertTrue(stage.objectApi("request").methods.any { it.name == "setHeader" })
+        assertTrue(stage.objectApi("response").methods.any { it.name == "discard" })
+    }
+
+    @Test
+    fun `export after exposes mutable api endpoint`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.EXPORT_AFTER, "general")
+        val stage = profile.stages.single()
+
+        assertTrue(stage.bindings.any { it.name == "api" })
+        val api = stage.objectApi("api")
+        assertTrue(api.methods.any { it.name == "appendDesc" })
+        assertTrue(api.methods.any { it.name == "toCurl" })
+    }
+
+    @Test
+    fun `postman pre request separates rule it from generated script bindings`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.POSTMAN_PREREQUEST, "general")
+        val ruleStage = profile.stage("rule-evaluation")
+        val scriptStage = profile.stage("generated-script")
+
+        assertTrue(ruleStage.binding("it").objectTypes.contains("method"))
+        assertTrue(scriptStage.bindings.any { it.name == "pm" })
+        assertTrue(scriptStage.bindings.any { it.name == "request" })
+        assertFalse(scriptStage.bindings.any { it.name == "response" })
+        assertTrue(scriptStage.objectApi("request").properties.any { it.name == "headers" })
+    }
+
+    @Test
+    fun `postman test exposes response`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.POSTMAN_TEST, "general")
+        val scriptStage = profile.stage("generated-script")
+
+        assertTrue(scriptStage.bindings.any { it.name == "response" })
+        assertTrue(scriptStage.objectApi("response").methods.any { it.name == "json" })
+    }
+
+    @Test
+    fun `common tool bindings expose their callable APIs`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.FIELD_IGNORE, "general")
+        val stage = profile.stages.single()
+
+        assertTrue(stage.objectApi("session").methods.any { it.name == "get" })
+        assertTrue(stage.objectApi("session").methods.any { it.name == "set" })
+        assertTrue(stage.objectApi("config").methods.any { it.name == "get" })
+        assertTrue(stage.objectApi("helper").methods.any { it.name == "findClass" })
+        assertTrue(stage.objectApi("tool").methods.any { it.name == "toJson" })
+    }
+
+    @Test
+    fun `static configuration has no script bindings`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.MARKDOWN_TEMPLATE, "general")
+
+        assertEquals("static-configuration", profile.executionMode)
+        assertTrue(profile.stages.isEmpty())
+        assertNotNull(profile.summary)
+    }
+
+    private fun RuleScriptStage.binding(name: String): ScriptBinding =
+        bindings.firstOrNull { it.name == name }
+            ?: throw AssertionError("missing binding '$name': $bindings")
+
+    private fun RuleScriptStage.objectApi(id: String): ScriptObjectApi =
+        objects.firstOrNull { it.id == id }
+            ?: throw AssertionError("missing object '$id': $objects")
+
+    private fun RuleScriptProfile.stage(name: String): RuleScriptStage =
+        stages.firstOrNull { it.name == name }
+            ?: throw AssertionError("missing stage '$name': $stages")
+}

--- a/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideWorkflowCatalogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideWorkflowCatalogTest.kt
@@ -76,7 +76,7 @@ class RuleGuideWorkflowCatalogTest {
         assertTrue(
             "auth-chaining recipe value must be a literal script (no groovy: prefix): " +
                 "postman.test[...]=def token = pm.response.json()...",
-            content.contains("postman.test[groovy: it.containingClass().name() == \"com.example.AuthController\"]=def token = pm.response.json().token")
+            content.contains("postman.test[groovy: it.containingClass()?.qualifiedName() == \"com.example.AuthController\"]=def token = pm.response.json().token")
         )
         assertFalse(
             "auth-chaining recipe value must NOT be groovy-prefixed " +
@@ -96,7 +96,7 @@ class RuleGuideWorkflowCatalogTest {
         )
         assertTrue(
             "auth-chaining recipe must use a groovy filter with containingClass()",
-            content.contains("postman.test[groovy: it.containingClass().name() == \"com.example.AuthController\"]")
+            content.contains("postman.test[groovy: it.containingClass()?.qualifiedName() == \"com.example.AuthController\"]")
         )
     }
 
@@ -128,7 +128,7 @@ class RuleGuideWorkflowCatalogTest {
         assertTrue(
             "HMAC recipe value must be a literal script (no groovy: prefix): " +
                 "postman.prerequest[...]=def mac = javax.crypto.Mac...",
-            content.contains("postman.prerequest[groovy: it.containingClass().name().startsWith(\"com.example.api.\")]=def mac = javax.crypto.Mac")
+            content.contains("postman.prerequest[groovy: it.containingClass()?.qualifiedName().startsWith(\"com.example.api.\")]=def mac = javax.crypto.Mac")
         )
         assertFalse(
             "HMAC recipe value must NOT be groovy-prefixed " +


### PR DESCRIPTION
## Summary
- expose rule-key-specific script bindings, execution stages, and reflected object APIs through AI tools
- improve rule validation and PSI context handling, with aligned built-in rule guidance
- update authoring documentation and extend regression coverage for rule semantics and tool registration

## Testing
- ./gradlew test (6904 tests completed, 10 skipped)
- ./gradlew build
- git diff --check

## Risks / rollback
- Low risk: changes are scoped to rule authoring, scripting context metadata, and AI guidance. Revert commit 9cda170f to roll back.