### PR TITLE
docs: document isExtend FQN contract

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/export/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/export/EndpointBuilder.kt
@@ -4,8 +4,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
-import com.itangcent.easyapi.core.export.ApiHeader
-import com.itangcent.easyapi.core.export.ApiParameter
 import com.itangcent.easyapi.core.psi.PsiClassHelper
 import com.itangcent.easyapi.core.psi.helper.DocHelper
 import com.itangcent.easyapi.core.psi.helper.DocMetadataResolver
@@ -110,7 +108,7 @@ class EndpointBuilder(private val project: Project) {
      *
      * The `method.return.main` rule specifies a field name within the response type where
      * the `@return` doc comment should be placed. For example, with `Result<T>`:
-     * - Rule: `method.return.main[groovy:it.returnType().isExtend("Result")]=data`
+     * - Rule: `method.return.main[groovy:it.returnType().isExtend("com.example.Result")]=data`
      * - `@return "processed result"` is attached to the `data` field instead of the root
      *
      * If no explicit rule is set and `settings.inferReturnMain` is true, auto-detects

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContexts.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContexts.kt
@@ -37,6 +37,14 @@ interface ClassContext {
     fun fields(): Array<ScriptPsiFieldContext>
     fun fieldCnt(): Int
     fun type(): ScriptTypeContext
+
+    /**
+     * Checks whether this class is, or inherits from, [superClass].
+     *
+     * @param superClass the **fully qualified name** of the base class or
+     * interface, e.g. `"java.lang.Exception"`. A simple name like
+     * `"Exception"` never matches.
+     */
     fun isExtend(superClass: String): Boolean
     fun isMap(): Boolean
     fun isCollection(): Boolean
@@ -651,6 +659,13 @@ class ScriptTypeContext(private val context: RuleContext, private val resolvedTy
 
     override fun toString(): String = resolvedType.qualifiedName()
 
+    /**
+     * Checks whether this type is, or inherits from, [superClass].
+     *
+     * @param superClass the **fully qualified name** of the base class or
+     * interface, e.g. `"java.lang.Exception"`. A simple name like
+     * `"Exception"` never matches.
+     */
     fun isExtend(superClass: String): Boolean = when (resolvedType) {
         is ResolvedType.ClassType -> InheritanceHelper.isInheritor(resolvedType.psiClass, superClass)
         else -> false


### PR DESCRIPTION
## Summary

- Documents the FQN contract on both script-facing `isExtend` declarations (`ClassContext`, `ScriptTypeContext`): the `superClass` argument must be the **fully qualified name**; a simple name silently never matches
- Fixes the `method.return.main` rule example in `EndpointBuilder` that used a bare `"Result"` — the exact mistake the contract docs now prevent
- Drops redundant `ApiHeader` / `ApiParameter` imports in `EndpointBuilder` (both types live in the same package `core.export`)

## Testing

- No runtime behavior change (imports + KDoc only)
- Verified via full-repo search that the fixed example was the only `isExtend`/`isInheritor` call site passing a simple class name; all other usages (including built-in `.config` rule files such as `jackson.config` and `*-validation-strict.config`) already pass fully qualified names, traced through `annValue`/`annMaps` normalization (`type.canonicalText`) and `qualifiedName()` sources

## Risks / Rollback

None — zero behavioral impact. Revert the commit to roll back.
