### PR TITLE
fix(ai): resolve rule file relative paths against the project dir

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ReadRuleFileTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ReadRuleFileTool.kt
@@ -14,8 +14,10 @@ import com.itangcent.easyapi.core.logging.IdeaLog
  * directories. This is the preferred form: the agent does not know the
  * user's home directory, so addressing files by name avoids guessing
  * absolute paths.
- * 2. An absolute path inside a tracked rule directory — validated by
- * [ToolContext.ruleFileResolver.resolve]. Accepted as a fallback.
+ * 2. A path inside a tracked rule directory — validated by
+ * [ToolContext.ruleFileResolver.resolve]. Relative paths resolve against
+ * the project base directory, never the process working directory.
+ * Accepted as a fallback.
  *
  * Paths that fall outside the tracked directories are **not** silently read.
  * For clearly-foreign paths (the `/etc` directory, `.java`/`.kt` files,
@@ -35,7 +37,8 @@ class ReadRuleFileTool : AiTool, IdeaLog {
             "(e.g. \"security.properties\") or a scope-prefixed name " +
             "(\"global:jwt.rules\" / \"project:custom.rules\"); the tool " +
             "resolves it against the tracked.easyapi/ rule folders. An " +
-            "absolute path inside a tracked folder is also accepted. You do " +
+            "absolute path inside a tracked folder is also accepted; a " +
+            "relative path resolves against the project root. You do " +
             "NOT know the user's home directory — never hard-code " +
             "\"/Users/<name>\" or a literal \"~\"; address files by name. " +
             "An out-of-scope path asks the user for one-time consent. NOT " +
@@ -83,7 +86,7 @@ class ReadRuleFileTool : AiTool, IdeaLog {
         // One-time consent granted — read the requested path directly.
         LOG.info("read_rule_file: user granted consent for $path")
         val target = runCatching {
-            java.nio.file.Paths.get(path).toAbsolutePath().normalize()
+            ctx.ruleFileResolver.absolutize(java.nio.file.Paths.get(path))
         }.getOrNull() ?: return buildOutsideAllowedError(path)
         return readPath(target, path)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/core/config/source/RuleFileResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/config/source/RuleFileResolver.kt
@@ -37,12 +37,26 @@ class RuleFileResolver(private val project: Project) {
     /**
      * Resolve [requestedPath] against the allowed directories.
      *
+     * Relative paths resolve against the project base directory (see
+     * [absolutize]) before the allow-list check.
+     *
      * @return The resolved, normalised [Path] if it is inside an allowed dir,
      * or `null` if access is refused.
      */
     fun resolve(requestedPath: String): Path? {
-        val candidate = Paths.get(requestedPath).toAbsolutePath().normalize()
+        val candidate = absolutize(Paths.get(requestedPath))
         return allowedDirs().firstOrNull { candidate.startsWith(it) }?.let { candidate }
+    }
+
+    /**
+     * Absolutises [path]. Relative paths resolve against the project base
+     * directory — never the process working directory — so an agent-supplied
+     * path like `.easy.api.properties` addresses a file inside the project.
+     */
+    fun absolutize(path: Path): Path {
+        val base = project.basePath
+        val resolved = if (!path.isAbsolute && base != null) Paths.get(base).resolve(path) else path
+        return resolved.toAbsolutePath().normalize()
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
@@ -337,6 +337,27 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         }
     }
 
+    fun testReadRuleFileRelativePathResolvesAgainstProjectDir() {
+        // Issue #754: a consented relative path must resolve against the
+        // project base directory, not the process working directory. The
+        // project root is not a tracked rule dir here, so the read goes
+        // through the consent gate; once granted, the project-root file
+        // is read.
+        val basePath = project.basePath ?: throw IllegalStateException("project base path required")
+        val rootRuleFile = java.io.File(basePath, "root-rule-754.properties")
+        try {
+            rootRuleFile.writeText("api.name=ProjectRoot")
+            val gate = com.itangcent.easyapi.core.ai.agent.FakeFileReadConsentGate(grant = true)
+            val result = runBlocking {
+                ReadRuleFileTool().execute(mapOf("path" to "root-rule-754.properties"), ctx(readConsents = gate))
+            }
+            Assert.assertTrue("result: $result", result is ToolResult.Text)
+            Assert.assertEquals("api.name=ProjectRoot", (result as ToolResult.Text).value)
+        } finally {
+            rootRuleFile.delete()
+        }
+    }
+
     // --- GetExistingRulesForKeyTool ---
 
     fun testGetExistingRulesFallsBackToGetAll() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/config/config/source/RuleFileResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/config/config/source/RuleFileResolverTest.kt
@@ -76,6 +76,27 @@ class RuleFileResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertEquals(expected, resolver.resolve(target.toString()))
     }
 
+    fun testResolveRelativePathAgainstProjectBase() {
+        // Issue #754: a relative path must resolve against the project base
+        // directory, never the process working directory.
+        val base = project.basePath ?: return
+        val expected = Paths.get(base, ".easyapi", "rule.config")
+            .toAbsolutePath().normalize()
+        assertEquals(expected, resolver().resolve(".easyapi/rule.config"))
+    }
+
+    fun testAbsolutizeRelativePathUsesProjectBase() {
+        val base = project.basePath ?: return
+        val expected = Paths.get(base, ".easy.api.properties")
+            .toAbsolutePath().normalize()
+        assertEquals(expected, resolver().absolutize(Paths.get(".easy.api.properties")))
+    }
+
+    fun testResolveRefusesRelativePathOutsideAllowedDirs() {
+        // Even project-relative, a path outside the tracked rule dirs is refused.
+        assertNull(resolver().resolve("src/main/resources/rule.config"))
+    }
+
     // --- resolveByName ---
 
     fun testResolvesByNameInGlobalDir() {


### PR DESCRIPTION
## Summary

- `read_rule_file` failed when the agent passed a relative path (e.g. `.easy.api.properties`): path resolution anchored at the JVM working directory instead of the project, so the agent could not read the existing rules and generated new ones blind.
- `RuleFileResolver.absolutize()` now anchors relative paths at the project base path; both the allow-list check in `resolve()` and the consent-granted read path in `ReadRuleFileTool` go through it. The tool description documents the behavior for the model.
- Fixes #754

## Testing

- `RuleFileResolverTest` — a relative path resolves against the project dir and passes the allow-list check.
- `PerceptionToolsTest` — `read_rule_file` with a relative path returns the file content.
- Ran: `./gradlew test --tests "com.itangcent.easyapi.core.config.config.source.RuleFileResolverTest" --tests "com.itangcent.easyapi.core.ai.tools.PerceptionToolsTest"` — green.

## Risks / rollback

- Absolute paths, allow-list security checks, and the out-of-scope consent flow are unchanged. `write_rule_file` relative paths now land in the project instead of the IDE working directory, which is the intended behavior.
- Single-commit revert if needed.
