### PR TITLE
fix(rules): write rule files as UTF-8 with BOM to avoid mojibake

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ReadRuleFileTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/ReadRuleFileTool.kt
@@ -1,8 +1,8 @@
 package com.itangcent.easyapi.core.ai.tools
 
 import com.itangcent.easyapi.core.ai.agent.FileReadConsentGate
+import com.itangcent.easyapi.core.config.RuleFileTextIo
 import com.itangcent.easyapi.core.logging.IdeaLog
-import java.nio.file.Files
 
 /**
  * Perception tool that reads a **rule file** by name or path.
@@ -90,7 +90,7 @@ class ReadRuleFileTool : AiTool, IdeaLog {
 
     private fun readPath(target: java.nio.file.Path, displayPath: String): ToolResult {
         return runCatching {
-            ToolResult.Text(Files.readString(target))
+            ToolResult.Text(RuleFileTextIo.readUtf8StrippingBom(target))
         }.getOrElse {
             ToolResult.Error("failed to read $displayPath: ${it.message}")
         }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/WriteRuleFileTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/WriteRuleFileTool.kt
@@ -1,6 +1,6 @@
 package com.itangcent.easyapi.core.ai.tools
 
-import java.nio.file.Files
+import com.itangcent.easyapi.core.config.RuleFileTextIo
 import java.nio.file.Path
 
 /**
@@ -52,7 +52,7 @@ class WriteRuleFileTool : AiTool {
         val resolved: Path = ctx.ruleFileResolver.resolve(pathStr)
             ?: return ToolResult.Error("path outside allowed rule directories: $pathStr")
         return runCatching {
-            Files.writeString(resolved, content)
+            RuleFileTextIo.writeUtf8WithBom(resolved, content)
             // Clear any staged proposal now that the write has landed.
             ctx.workingMemory.proposal = null
             ToolResult.Text("Wrote ${content.length} chars to $resolved")

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/ui/AiChatPanel.kt
@@ -22,6 +22,7 @@ import com.itangcent.easyapi.core.ai.agent.TaskList
 import com.itangcent.easyapi.core.ai.agent.TaskStatus
 import com.itangcent.easyapi.core.ai.agent.TurnOutcome
 import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.config.RuleFileTextIo
 import com.itangcent.easyapi.core.ide.support.NotificationUtils
 import com.itangcent.easyapi.core.logging.IdeaLog
 import kotlinx.coroutines.CoroutineScope
@@ -1384,7 +1385,7 @@ class AiChatPanel(
         val targetFile = dialog.targetFile()
         try {
             Files.createDirectories(targetFile.parentFile.toPath())
-            Files.writeString(targetFile.toPath(), content)
+            RuleFileTextIo.writeUtf8WithBom(targetFile.toPath(), content)
 
             // Folder is the source of truth — no settings-list registration needed.
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/config/RuleFileTextIo.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/config/RuleFileTextIo.kt
@@ -1,0 +1,46 @@
+package com.itangcent.easyapi.core.config
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * UTF-8 text I/O for rule files (`.properties` / `.rules` under `.easyapi/`).
+ *
+ * IntelliJ IDEA opens `.properties` files without a BOM as ISO-8859-1 (the
+ * `java.util.Properties` default), so non-ASCII rule content — e.g. the
+ * Chinese comments in AI-generated rules — renders garbled, and recent IDEA
+ * builds disable the per-file encoding selector for `.properties` entirely.
+ * Per the IDEA encoding rules, a UTF-8 BOM takes precedence over every other
+ * setting, so files written by the plugin carry one.
+ *
+ * The plugin's own readers ([readUtf8StrippingBom] / [stripBom]) remove the
+ * BOM before the text is parsed or displayed, so a BOM never leaks into rule
+ * keys, editor content, or AI tool results.
+ */
+object RuleFileTextIo {
+
+    private const val UTF8_BOM = "\uFEFF"
+
+    /**
+     * Writes [content] to [path] as UTF-8 with a leading BOM.
+     *
+     * A BOM already present in [content] is replaced (not duplicated), so
+     * read-modify-write round trips are stable.
+     */
+    fun writeUtf8WithBom(path: Path, content: String) {
+        val body = if (content.startsWith(UTF8_BOM)) content.substring(UTF8_BOM.length) else content
+        Files.write(path, (UTF8_BOM + body).toByteArray(StandardCharsets.UTF_8))
+    }
+
+    /**
+     * Reads [path] as UTF-8, stripping a leading BOM if present.
+     */
+    fun readUtf8StrippingBom(path: Path): String = stripBom(Files.readString(path, StandardCharsets.UTF_8))
+
+    /**
+     * Strips a single leading UTF-8 BOM character from [content].
+     */
+    fun stripBom(content: String): String =
+        if (content.startsWith(UTF8_BOM)) content.substring(UTF8_BOM.length) else content
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/config/parser/ConfigTextParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/config/parser/ConfigTextParser.kt
@@ -3,6 +3,7 @@ package com.itangcent.easyapi.core.config.parser
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.core.config.RuleFileTextIo
 import com.itangcent.easyapi.core.config.model.ConfigEntry
 import com.itangcent.easyapi.core.config.resource.ConfigResourceLoader
 import com.itangcent.easyapi.core.logging.IdeaLog
@@ -65,7 +66,10 @@ class ConfigTextParser(
     private val resourceLoader: ConfigResourceLoader get() = ConfigResourceLoader.getInstance(project)
 
     suspend fun parse(text: String, sourceId: String, baseDir: String? = null): Sequence<ConfigEntry> {
-        return parseLines(text.lines(), sourceId, baseDir, DirectiveState(), buildSettingResolver()).asSequence()
+        // Strip a leading UTF-8 BOM so rule files written by the plugin (see
+        // RuleFileTextIo) parse identically to BOM-less files.
+        val content = RuleFileTextIo.stripBom(text)
+        return parseLines(content.lines(), sourceId, baseDir, DirectiveState(), buildSettingResolver()).asSequence()
     }
 
     /**
@@ -199,7 +203,7 @@ class ConfigTextParser(
         if (loaded != null) {
             result.addAll(
                 parseLines(
-                    loaded.content.lines(),
+                    RuleFileTextIo.stripBom(loaded.content).lines(),
                     sourceId,
                     loaded.baseDir,
                     state,

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/RuleFileEditDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/RuleFileEditDialog.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
 import com.itangcent.easyapi.core.ai.ui.AiChatPanel
 import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.config.RuleFileTextIo
 import com.itangcent.easyapi.core.ide.support.NotificationUtils
 import com.itangcent.easyapi.core.logging.IdeaLog
 import kotlinx.coroutines.CoroutineScope
@@ -34,7 +35,8 @@ import javax.swing.JScrollPane
  *
  * On OK:
  * - If the name changed, renames the file on disk (same directory).
- * - Writes the (possibly edited) content via `Files.writeString`.
+ * - Writes the (possibly edited) content as UTF-8 with a BOM
+ *   (see [RuleFileTextIo]).
  * - Triggers `ConfigReader.getInstance(project).reload()` so new rules take
  * effect immediately.
  *
@@ -227,7 +229,7 @@ class RuleFileEditDialog(
     private fun loadContentAsync() {
         scope.launch {
             val content = withContext(Dispatchers.IO) {
-                runCatching { Files.readString(Paths.get(filePath)) }
+                runCatching { RuleFileTextIo.readUtf8StrippingBom(Paths.get(filePath)) }
                     .onFailure { LOG.warn("Failed to read rule file $filePath", it) }
                     .getOrElse { "" }
             }
@@ -312,7 +314,7 @@ class RuleFileEditDialog(
                     }
                 }
                 // Write content.
-                runCatching { Files.writeString(newPath, content) }
+                runCatching { RuleFileTextIo.writeUtf8WithBom(newPath, content) }
                     .onFailure {
                         LOG.warn("Failed to write rule file $newPath", it)
                         withContext(Dispatchers.Main) {

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/RulesTabPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/RulesTabPanel.kt
@@ -6,6 +6,7 @@ import com.intellij.ui.table.TableView
 import com.intellij.util.ui.ColumnInfo
 import com.intellij.util.ui.ListTableModel
 import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.config.RuleFileTextIo
 import com.itangcent.easyapi.core.config.source.GlobalFileConfigSource
 import com.itangcent.easyapi.core.config.source.ProjectFileConfigSource
 import com.itangcent.easyapi.core.ide.support.NotificationUtils
@@ -225,7 +226,7 @@ class GlobalRulesSubTab(
         Files.createDirectories(dir)
         val baseName = RuleFileSupport.nextAvailableName(dir, ".easy.api.properties")
         val newPath = dir.resolve(baseName)
-        Files.writeString(newPath, "")
+        RuleFileTextIo.writeUtf8WithBom(newPath, "")
         val abs = newPath.toAbsolutePath().toString()
         rows.add(RuleFileRow(abs, enabled = true, size = 0L))
         rows.sortBy { it.path }
@@ -373,7 +374,7 @@ class ProjectRulesSubTab(
         Files.createDirectories(dir)
         val baseName = RuleFileSupport.nextAvailableName(dir, ".easy.api.properties")
         val newPath = dir.resolve(baseName)
-        Files.writeString(newPath, "")
+        RuleFileTextIo.writeUtf8WithBom(newPath, "")
         val abs = newPath.toAbsolutePath().toString()
         easyapiRows.add(RuleFileRow(abs, enabled = true, size = 0L))
         easyapiRows.sortBy { it.path }

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/PerceptionToolsTest.kt
@@ -317,6 +317,26 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         }
     }
 
+    fun testReadRuleFileStripsBom() {
+        // Issue #755: rule files written by the plugin carry a UTF-8 BOM so
+        // IDEA detects the encoding; read_rule_file must strip it so the
+        // agent sees clean content.
+        val basePath = project.basePath ?: throw IllegalStateException("project base path required")
+        val easyapiDir = java.io.File(basePath, ".easyapi").apply { mkdirs() }
+        try {
+            val bom = String(byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()), Charsets.UTF_8)
+            java.io.File(easyapiDir, "bombed.properties").writeText(bom + "api.name=BomFree")
+
+            val result = runBlocking {
+                ReadRuleFileTool().execute(mapOf("path" to "bombed.properties"), ctx())
+            }
+            Assert.assertTrue("result: $result", result is ToolResult.Text)
+            Assert.assertEquals("api.name=BomFree", (result as ToolResult.Text).value)
+        } finally {
+            easyapiDir.deleteRecursively()
+        }
+    }
+
     // --- GetExistingRulesForKeyTool ---
 
     fun testGetExistingRulesFallsBackToGetAll() {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/WriteRuleFileToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/WriteRuleFileToolTest.kt
@@ -67,8 +67,18 @@ class WriteRuleFileToolTest : EasyApiLightCodeInsightFixtureTestCase() {
                 text.contains("written.rules")
             )
 
-            val onDisk = Files.readString(java.nio.file.Paths.get(targetPath))
-            Assert.assertEquals(content, onDisk)
+            val onDisk = java.nio.file.Paths.get(targetPath)
+            val bytes = Files.readAllBytes(onDisk)
+            Assert.assertArrayEquals(
+                "written file should start with a UTF-8 BOM (issue #755)",
+                byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()),
+                bytes.copyOfRange(0, 3)
+            )
+            Assert.assertEquals(
+                "content after the BOM should be exactly what was written",
+                content,
+                com.itangcent.easyapi.core.config.RuleFileTextIo.readUtf8StrippingBom(onDisk)
+            )
         } finally {
             easyapiDir.deleteRecursively()
         }

--- a/src/test/kotlin/com/itangcent/easyapi/core/config/RuleFileTextIoTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/config/RuleFileTextIoTest.kt
@@ -1,0 +1,107 @@
+package com.itangcent.easyapi.core.config
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.nio.file.Files
+
+/**
+ * Tests for [RuleFileTextIo] — the UTF-8-with-BOM convention for rule files
+ * (issue #755).
+ *
+ * Plain unit test: the helper is pure `java.nio` with no IDE dependency.
+ * The BOM string is built from its three bytes so the test source itself
+ * contains only visible ASCII.
+ */
+class RuleFileTextIoTest {
+
+    private val bom = String(byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()), Charsets.UTF_8)
+    private val bomBytes = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+
+    @Test
+    fun testWriteUtf8WithBomPrependsBomBytes() {
+        val path = Files.createTempFile("easyapi-bom-", ".properties")
+        try {
+            RuleFileTextIo.writeUtf8WithBom(path, "api.name=测试")
+            val bytes = Files.readAllBytes(path)
+            assertArrayEquals(
+                "file should start with the UTF-8 BOM bytes",
+                bomBytes,
+                bytes.copyOfRange(0, 3)
+            )
+            assertEquals(
+                "content after the BOM should be the UTF-8 payload",
+                "api.name=测试",
+                String(bytes.copyOfRange(3, bytes.size), Charsets.UTF_8)
+            )
+        } finally {
+            Files.deleteIfExists(path)
+        }
+    }
+
+    @Test
+    fun testWriteUtf8WithBomWritesEmptyContentAsBomOnly() {
+        val path = Files.createTempFile("easyapi-bom-empty-", ".properties")
+        try {
+            RuleFileTextIo.writeUtf8WithBom(path, "")
+            assertArrayEquals(
+                "an empty rule file should still carry the BOM so IDEA detects UTF-8",
+                bomBytes,
+                Files.readAllBytes(path)
+            )
+        } finally {
+            Files.deleteIfExists(path)
+        }
+    }
+
+    @Test
+    fun testWriteUtf8WithBomDoesNotDuplicateBom() {
+        val path = Files.createTempFile("easyapi-bom-dup-", ".properties")
+        try {
+            RuleFileTextIo.writeUtf8WithBom(path, bom + "api.name=x")
+            val bytes = Files.readAllBytes(path)
+            assertArrayEquals(
+                "an existing BOM in the content must be replaced, not duplicated",
+                bomBytes,
+                bytes.copyOfRange(0, 3)
+            )
+            assertFalse(
+                "no second BOM may appear after the first",
+                bytes.copyOfRange(3, bytes.size).take(3).toByteArray().contentEquals(bomBytes)
+            )
+        } finally {
+            Files.deleteIfExists(path)
+        }
+    }
+
+    @Test
+    fun testReadUtf8StrippingBomRemovesBom() {
+        val path = Files.createTempFile("easyapi-bom-read-", ".properties")
+        try {
+            Files.write(path, (bom + "api.name=值").toByteArray(Charsets.UTF_8))
+            assertEquals("api.name=值", RuleFileTextIo.readUtf8StrippingBom(path))
+        } finally {
+            Files.deleteIfExists(path)
+        }
+    }
+
+    @Test
+    fun testReadUtf8StrippingBomKeepsBomlessContent() {
+        val path = Files.createTempFile("easyapi-nobom-", ".properties")
+        try {
+            Files.write(path, "api.name=plain".toByteArray(Charsets.UTF_8))
+            assertEquals("api.name=plain", RuleFileTextIo.readUtf8StrippingBom(path))
+        } finally {
+            Files.deleteIfExists(path)
+        }
+    }
+
+    @Test
+    fun testStripBom() {
+        assertEquals("api.name=x", RuleFileTextIo.stripBom(bom + "api.name=x"))
+        assertEquals("api.name=x", RuleFileTextIo.stripBom("api.name=x"))
+        // Only a leading BOM is stripped; an embedded one is preserved.
+        assertEquals("a$bom", RuleFileTextIo.stripBom("a$bom"))
+    }
+}


### PR DESCRIPTION
## Summary

- Non-ASCII text in rule files — most often the Chinese comments in AI-generated rules — rendered garbled in IDEA: `.properties` files without a BOM are opened as ISO-8859-1 (the `java.util.Properties` default), and recent IDEA builds disable the per-file encoding selector for `.properties` entirely.
- New `RuleFileTextIo` helper centralizes the convention: every plugin write site (settings "new file", rule edit dialog, AI chat save, `write_rule_file` tool) emits UTF-8 with a BOM; every plugin read path strips the BOM before parsing or display, and `ConfigTextParser` strips a leading BOM so BOM'd files parse identically to BOM-less ones.
- A BOM never leaks into rule keys, editor content, or AI tool results.
- Fixes #755

## Testing

- `RuleFileTextIoTest` — BOM write / read-strip / no-duplication round trips (plain unit test).
- `WriteRuleFileToolTest` — the written file starts with the BOM bytes and the content round-trips.
- `PerceptionToolsTest.testReadRuleFileStripsBom` — `read_rule_file` returns BOM-free content.
- Also ran `ConfigTextParserTest`, `FileConfigHelperTest`, and the settings UI test package — green.

## Risks / rollback

- Existing BOM-less files keep working (stripping is a no-op); only files rewritten by the plugin gain a BOM. External tooling that reads rule files as strict ASCII would see 3 extra leading bytes.
- Single-commit revert if needed.
