### PR TITLE
enhance(ai): make it.contextType() discoverable to the rule agent

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidator.kt
@@ -24,10 +24,11 @@ import com.itangcent.easyapi.framework.spi.FrameworkRegistry
  *   malformed JSON value for the header/param keys.
  * - **Soft warnings** (never block): deprecated-but-valid filter forms such
  *   as the bare `class:` prefix; class-context `name()` calls that may be
- *   mistaken for fully-qualified names; keys whose owning channel/framework
- *   is currently disabled in Settings (design C4a / task A5c). Reported back
- *   to the drafter / surfaced on the proposal card, but the proposal still
- *   proceeds.
+ *   mistaken for fully-qualified names; `respondsTo(` probes that guess the
+ *   context kind instead of calling `it.contextType()`; keys whose owning
+ *   channel/framework is currently disabled in Settings (design C4a / task
+ *   A5c). Reported back to the drafter / surfaced on the proposal card, but
+ *   the proposal still proceeds.
  *
  * ## Key catalog
  *
@@ -66,6 +67,14 @@ object RuleProposalValidator {
     private val CLASS_CONTEXT_SIMPLE_NAME =
         Regex("""(?:containingClass|defineClass)\(\)\s*\??\.\s*name\(\)""")
 
+    /**
+     * Groovy MOP probing of the context kind, e.g.
+     * `it.respondsTo('containingClass')`. Functionally valid but fragile —
+     * the built-in discriminator `it.contextType()` states the kind directly
+     * (issue #756).
+     */
+    private val RESPONDS_TO_USAGE = Regex("""\brespondsTo\s*\(""")
+
     /** Source kind for keys declared in [RuleKeys] (mirrors [RuleKeyRegistry]). */
     private const val SOURCE_GENERAL = "general"
     /** Source kind for keys read by name only (mirrors [RuleKeyRegistry]). */
@@ -97,7 +106,8 @@ object RuleProposalValidator {
             project?.let { buildDisabledSourceMap(it) } ?: emptyMap()
         val errors = mutableListOf<String>()
         val warnings = mutableListOf<String>()
-        val classContextSimpleNameWarningLines = classContextSimpleNameWarningLines(content)
+        val classContextSimpleNameWarningLines = matchWarningLines(content, CLASS_CONTEXT_SIMPLE_NAME)
+        val respondsToWarningLines = matchWarningLines(content, RESPONDS_TO_USAGE)
         var inBlock = false
         content.lines().forEachIndexed { idx, raw ->
             val line = raw.trim()
@@ -109,6 +119,11 @@ object RuleProposalValidator {
             if (lineNo in classContextSimpleNameWarningLines) {
                 warnings += "line $lineNo: class-context name() returns a simple class name; " +
                     "use qualifiedName() for FQN/package comparisons."
+            }
+            if (lineNo in respondsToWarningLines) {
+                warnings += "line $lineNo: respondsTo() guesses the context kind from the " +
+                    "method surface; use it.contextType() (returns 'class'/'method'/" +
+                    "'field'/'param') instead."
             }
             // Multi-line groovy value-block: scan each body line for semantic
             // warnings above, but skip structural key=value validation because
@@ -163,8 +178,12 @@ object RuleProposalValidator {
         return RuleValidation(errors = errors, warnings = warnings)
     }
 
-    private fun classContextSimpleNameWarningLines(content: String): Set<Int> =
-        CLASS_CONTEXT_SIMPLE_NAME.findAll(content).mapNotNullTo(linkedSetOf()) { match ->
+    /**
+     * Maps [pattern] matches in [content] to 1-based line numbers, skipping
+     * matches on comment lines. Shared by the semantic soft warnings.
+     */
+    private fun matchWarningLines(content: String, pattern: Regex): Set<Int> =
+        pattern.findAll(content).mapNotNullTo(linkedSetOf()) { match ->
             val matchStart = match.range.first
             val lineStart = if (matchStart == 0) {
                 0

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalog.kt
@@ -304,7 +304,25 @@ object RuleScriptContextCatalog {
     }
 
     private fun itBinding(name: String, kinds: List<ItKind>, description: String): ScriptBinding =
-        ScriptBinding(name, objectTypes = kinds.map(ItKind::id), availability = "always", description = description)
+        ScriptBinding(
+            name,
+            objectTypes = kinds.map(ItKind::id),
+            availability = "always",
+            description = description + discriminatorSuffix(name, kinds)
+        )
+
+    /**
+     * Hint appended to a binding description when the binding can hold more
+     * than one context kind. The contract requires the script to tell the
+     * kinds apart, and the built-in discriminator is `contextType()`. Without
+     * the hint the model invents Groovy MOP idioms such as
+     * `it.respondsTo('containingClass')` to guess the kind (issue #756).
+     */
+    private fun discriminatorSuffix(name: String, kinds: List<ItKind>): String {
+        if (kinds.size <= 1) return ""
+        val values = kinds.map(ItKind::contextType).distinct().joinToString("/") { "'$it'" }
+        return " Discriminate with $name.contextType(), which returns $values."
+    }
 
     private fun apiBinding(name: String, description: String): ScriptBinding =
         ScriptBinding(name, objectTypes = listOf(name), availability = "key-specific", description = description)
@@ -429,13 +447,17 @@ object RuleScriptContextCatalog {
         val notes: List<String> = emptyList()
     )
 
-    private enum class ItKind(val id: String, val type: KClass<*>, val description: String) {
-        EMPTY("empty", ScriptItContext::class, "No PSI element is supplied; common helper bindings remain available."),
-        CLASS("class", ScriptPsiClassContext::class, "PSI class context."),
-        METHOD("method", ScriptPsiMethodContext::class, "PSI method context."),
-        FIELD("field", ScriptPsiFieldContext::class, "PSI field context; object-model fields may also be represented by a method context."),
-        PARAMETER("parameter", ScriptPsiParameterContext::class, "PSI parameter context."),
-        TYPE("type", ScriptPsiTypeContext::class, "PSI type context without a source element.")
+    /**
+     * The runtime `contextType()` return value for the kind, as defined by
+     * the [ScriptItContext] hierarchy — used to teach the discriminator.
+     */
+    private enum class ItKind(val id: String, val contextType: String, val type: KClass<*>, val description: String) {
+        EMPTY("empty", "unknown", ScriptItContext::class, "No PSI element is supplied; common helper bindings remain available."),
+        CLASS("class", "class", ScriptPsiClassContext::class, "PSI class context."),
+        METHOD("method", "method", ScriptPsiMethodContext::class, "PSI method context."),
+        FIELD("field", "field", ScriptPsiFieldContext::class, "PSI field context; object-model fields may also be represented by a method context."),
+        PARAMETER("parameter", "param", ScriptPsiParameterContext::class, "PSI parameter context."),
+        TYPE("type", "class", ScriptPsiTypeContext::class, "PSI type context without a source element.")
     }
 
     private val commonGroovyBindings = listOf(

--- a/src/main/resources/ai/agent-base.md
+++ b/src/main/resources/ai/agent-base.md
@@ -147,6 +147,12 @@ Class identity in Groovy is context-sensitive:
   FQN equality and package-prefix comparisons.
 - For inherited members, `containingClass()` is the class currently being
   exported, while `defineClass()` is the original declaring class.
+- When a rule key accepts several context kinds (e.g. `custom.method.is.api`
+  evaluates `it` as a class OR a method), discriminate with
+  `it.contextType()` — it returns `"class"` / `"method"` / `"field"` /
+  `"param"` (and `"unknown"` when no PSI element is bound). Never probe the
+  method surface with Groovy MOP idioms such as
+  `it.respondsTo('containingClass')` to guess the context kind.
 
 There is NO `~` prefix and NO `class:` prefix (the bare `class:` form
 from older docs is invalid — use `$class:`).

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidatorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/RuleProposalValidatorTest.kt
@@ -10,7 +10,9 @@ import org.junit.Test
  *
  * Covers the v1 review-agent policy: hard errors on unknown keys, invalid
  * filter prefixes, and malformed JSON values; soft warnings for deprecated
- * filters and class-context `name()` calls that may be mistaken for FQNs.
+ * filters, class-context `name()` calls that may be mistaken for FQNs, and
+ * `respondsTo(` probes that guess the context kind instead of calling
+ * `it.contextType()` (issue #756).
  */
 class RuleProposalValidatorTest {
 
@@ -143,6 +145,62 @@ class RuleProposalValidatorTest {
     fun testClassQualifiedNameDoesNotProduceSimpleNameWarning() {
         val content =
             """field.ignore=groovy: it.defineClass()?.qualifiedName() == "com.example.dto.TraceBean"""
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue("unexpected warnings: ${result.warnings}", result.warnings.isEmpty())
+    }
+
+    @Test
+    fun testRespondsToProbeProducesSoftWarning() {
+        // Issue #756: the model guesses the context kind from the method
+        // surface instead of calling the built-in discriminator.
+        val content =
+            """field.ignore=groovy: !it.respondsTo('containingClass').isEmpty()"""
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue(
+            "warnings: ${result.warnings}",
+            result.warnings.any {
+                it.contains("line 1") && it.contains("respondsTo()") && it.contains("contextType()")
+            }
+        )
+    }
+
+    @Test
+    fun testRespondsToInsideGroovyBlockProducesSoftWarning() {
+        val content = """
+            field.ignore=groovy:```
+            def isMethod = !it.respondsTo('containingClass').isEmpty()
+            return isMethod
+            ```
+        """.trimIndent()
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue(
+            "warnings: ${result.warnings}",
+            result.warnings.any { it.contains("line 2") && it.contains("respondsTo()") }
+        )
+    }
+
+    @Test
+    fun testRespondsToInCommentProducesNoWarning() {
+        val content = """
+            # it.respondsTo('containingClass') is the old workaround
+            api.name=My API
+        """.trimIndent()
+        val result = RuleProposalValidator.validate(content)
+
+        assertTrue("errors: ${result.errors}", result.ok)
+        assertTrue("unexpected warnings: ${result.warnings}", result.warnings.isEmpty())
+    }
+
+    @Test
+    fun testContextTypeDiscriminatorProducesNoWarning() {
+        val content =
+            """field.ignore=groovy: it.contextType() == "method" && it.name() == "toString""""
         val result = RuleProposalValidator.validate(content)
 
         assertTrue("errors: ${result.errors}", result.ok)

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/context/RuleScriptContextCatalogTest.kt
@@ -88,6 +88,45 @@ class RuleScriptContextCatalogTest {
         assertNotNull(profile.summary)
     }
 
+    @Test
+    fun `multi kind it binding states the contextType discriminator`() {
+        // Issue #756: without the hint the model probes the method surface
+        // with it.respondsTo('containingClass') to guess the context kind.
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.FIELD_IGNORE, "general")
+        val itBinding = profile.stages.single().binding("it")
+
+        assertTrue(
+            "it description should teach the discriminator: '${itBinding.description}'",
+            itBinding.description.contains("it.contextType()")
+        )
+        assertTrue(
+            "it description should list the runtime values: '${itBinding.description}'",
+            itBinding.description.contains("'field'/'method'")
+        )
+    }
+
+    @Test
+    fun `single kind it binding has no discriminator hint`() {
+        val profile = RuleScriptContextCatalog.describe(RuleKeys.METHOD_DOC, "general")
+        val itBinding = profile.stages.single().binding("it")
+
+        assertFalse(
+            "single-kind keys have nothing to discriminate: '${itBinding.description}'",
+            itBinding.description.contains("contextType")
+        )
+    }
+
+    @Test
+    fun `multi kind custom method keys state class and method values`() {
+        val profile = RuleScriptContextCatalog.describe("custom.method.is.api")
+        val itBinding = profile.stages.single().binding("it")
+
+        assertTrue(
+            "custom.method.* keys run with class OR method contexts: '${itBinding.description}'",
+            itBinding.description.contains("'method'/'class'")
+        )
+    }
+
     private fun RuleScriptStage.binding(name: String): ScriptBinding =
         bindings.firstOrNull { it.name == name }
             ?: throw AssertionError("missing binding '$name': $bindings")


### PR DESCRIPTION
## Summary

Implements the three concrete changes requested in #756 so the AI rule-authoring agent uses the built-in `it.contextType()` discriminator instead of Groovy MOP probing:

- **`RuleScriptContextCatalog`** — when a binding can hold more than one context kind (e.g. `custom.method.is.api` runs with `it` as a class *or* a method), its description now states the discriminator explicitly: *"Discriminate with it.contextType(), which returns 'method'/'class'."* The values are derived from a new `ItKind.contextType` property that mirrors the `ScriptItContext` hierarchy (`"unknown"` for empty contexts, `"param"` for parameters).
- **`agent-base.md`** — the "Class identity in Groovy is context-sensitive" section now documents `contextType()` and its return values, and tells the model not to probe the method surface with `respondsTo('containingClass')`.
- **`RuleProposalValidator`** — new soft warning (never blocks) when a proposal uses `respondsTo(`, suggesting `it.contextType()` instead. Shares the line-mapping helper with the existing `name()` warning.

The issue's longer-term item (a `description` field on `ScriptMethodApi` / few-shot examples of built-in extension scripts) is deliberately out of scope.

Fixes #756

## Testing

- `RuleScriptContextCatalogTest` — 3 new cases: multi-kind `it` binding carries the hint with correct runtime values; single-kind binding carries none; `custom.method.*` keys state `'method'/'class'`.
- `RuleProposalValidatorTest` — 4 new cases: inline `respondsTo(` warns; `respondsTo(` inside a groovy value-block warns with the right line number; `respondsTo(` in a comment does not warn; a clean `contextType()` rule does not warn.
- Verified no golden-file or prompt-guard regression: `AgentBaseCatalogIdGuardTest`, `RuleAuthoringKnowledgeSemanticsTest`, `PerceptionToolsTest`, `RuleProposalValidatorDisabledSourceTest`, `CustomRuleKeysTest` all green.

## Risks / rollback

- Pure prompt/contract surface: no runtime rule evaluation changes. Existing proposals gain at most a soft warning, never a block.
- Single-commit revert if needed.
