### PR TITLE
feat(ai): accept simple class names in PSI tools

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationTool.kt
@@ -8,82 +8,90 @@ import com.itangcent.easyapi.core.logging.IdeaLog
 import com.itangcent.easyapi.core.util.json.GsonUtils
 
 /**
- * Perception tool that finds classes annotated with one or more annotation FQNs
- * or simple names.
+ * Perception tool that finds classes annotated with one or more annotation
+ * names — fully qualified or simple.
  *
  * Uses [AnnotatedElementsSearch.searchPsiClasses] — the same API the dashboard
- * scanner uses. Resolves the annotation class (or simple name with optional
+ * scanner uses. Resolves the annotation name (or simple name with optional
  * `context`) via [PsiNameResolver.resolveAllClasses], then searches for classes
- * annotated with it in the project scope.
+ * annotated with it in the project scope. A simple annotation name is probed
+ * against every matching annotation class, so e.g. `"RestController"` covers
+ * both Spring and Spring-Boot variants without needing the FQN.
  *
  * Only sees annotation-declared components; pair with
  * [FindClassesBySupertypeTool] to cover inheritance-declared components
  * (filters extending `OncePerRequestFilter`,...).
  *
- * Supports batch: pass `annotationFqns` (array) to probe multiple annotations
- * in one call. Returns a JSON object mapping each annotation FQN to its results.
+ * Supports batch: pass `annotations` (array) to probe multiple annotations
+ * in one call. Returns a JSON object mapping each annotation to its results.
  */
 class FindClassesByAnnotationTool : AiTool, IdeaLog {
 
     override val name: String = "find_classes_by_annotation"
 
     override val description: String =
-        "Find project classes annotated with the given annotation(s). Pass " +
-            "`annotationFqn` (string) for one, or `annotationFqns` (array) to " +
-            "batch-probe multiple annotations. Returns a JSON array of FQNs for " +
-            "a single annotation, or a JSON object mapping each annotation to " +
-            "its array for batch mode."
+        "Find project classes annotated with the given annotation(s) — each by " +
+            "simple or fully qualified name (e.g. \"RestController\"). Pass " +
+            "`annotation` for one or `annotations` (array) for batch. Returns " +
+            "FQNs of matching classes (JSON array for one; name-to-array map " +
+            "for batch). A simple name probes every matching annotation class."
 
     override val kind: ToolKind = ToolKind.PERCEPTION
 
     override val parametersSchema: Map<String, Any?> = mapOf(
         "type" to "object",
         "properties" to mapOf(
-            "annotationFqn" to mapOf(
+            "annotation" to mapOf(
                 "type" to "string",
-                "description" to "Fully qualified annotation name (or simple name when `context` is supplied)."
+                "description" to "Annotation name — simple or fully qualified."
             ),
-            "annotationFqns" to mapOf(
+            "annotations" to mapOf(
                 "type" to "array",
                 "items" to mapOf("type" to "string"),
-                "description" to "Multiple annotation FQNs to probe in one call (batch mode)."
+                "description" to "Multiple annotation names to probe (batch mode)."
             ),
             "context" to mapOf(
                 "type" to "string",
-                "description" to "Optional: file path or class FQN whose import scope " +
-                    "is used to resolve simple-name annotation entries."
+                "description" to "Optional: file path or class FQN whose import " +
+                    "scope narrows simple annotation names."
             )
         )
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val fqns = PsiNameResolver.extractStringList(args, "annotationFqn", "annotationFqns")
-        if (fqns.isEmpty()) return ToolResult.Error("missing parameter: provide `annotationFqn` (string) or `annotationFqns` (array)")
+        val names = PsiNameResolver.extractStringList(
+            args, "annotation", "annotations", "annotationFqn", "annotationFqns"
+        )
+        if (names.isEmpty()) {
+            return ToolResult.Error(
+                "missing parameter: provide `annotation` (string) or `annotations` (array)"
+            )
+        }
 
         val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
 
-        if (fqns.size == 1) {
-            return ToolResult.Text(GsonUtils.toJson(searchOne(fqns[0], ctx, contextElement)))
+        if (names.size == 1) {
+            return ToolResult.Text(GsonUtils.toJson(searchOne(names[0], ctx, contextElement)))
         }
-        val result = fqns.associateWith { searchOne(it, ctx, contextElement) }
+        val result = names.associateWith { searchOne(it, ctx, contextElement) }
         return ToolResult.Text(GsonUtils.toJson(result))
     }
 
     private suspend fun searchOne(
-        annotationFqn: String,
+        annotationName: String,
         ctx: ToolContext,
         contextElement: PsiElement?
     ): List<String> = read {
         val annotationClasses = PsiNameResolver.resolveAllClasses(
-            annotationFqn, ctx.project, contextElement
+            annotationName, ctx.project, contextElement
         )
         if (annotationClasses.isEmpty()) {
-            LOG.info("annotation not resolvable in scope: $annotationFqn")
+            LOG.info("annotation not resolvable in scope: $annotationName")
             return@read emptyList<String>()
         }
         val validAnnotations = annotationClasses.filter { it.isAnnotationType }
         if (validAnnotations.isEmpty()) {
-            LOG.info("resolved FQN is not an annotation type: $annotationFqn")
+            LOG.info("resolved FQN is not an annotation type: $annotationName")
             return@read emptyList<String>()
         }
         val scope = GlobalSearchScope.projectScope(ctx.project)
@@ -94,7 +102,7 @@ class FindClassesByAnnotationTool : AiTool, IdeaLog {
         }
             .distinct()
             .sorted()
-        LOG.info("found ${hits.size} class(es) annotated with $annotationFqn")
+        LOG.info("found ${hits.size} class(es) annotated with $annotationName")
         hits
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeTool.kt
@@ -18,14 +18,15 @@ import com.itangcent.easyapi.core.util.json.GsonUtils
  * `OncePerRequestFilter` and interceptors implement `HandlerInterceptor`,
  * with no annotation marking them as such. This tool closes that gap.
  *
- * Resolves the supertype by FQN (or simple name with optional `context`) via
- * [PsiNameResolver.resolveAllClasses], then searches its inheritors in the
- * project scope via [ClassInheritorsSearch]. The supertype itself is excluded
- * from the result so the agent gets only the concrete implementations it
- * cares about.
+ * Resolves the supertype by name — fully qualified or simple, with an optional
+ * `context` — via [PsiNameResolver.resolveAllClasses], then searches its
+ * inheritors in the project scope via [ClassInheritorsSearch]. A simple
+ * supertype name is probed against every matching type. The supertype itself
+ * is excluded from the result so the agent gets only the concrete
+ * implementations it cares about.
  *
- * Supports batch: pass `supertypeFqns` (array) to probe multiple supertypes
- * in one call. Returns a JSON object mapping each supertype FQN to its results.
+ * Supports batch: pass `supertypes` (array) to probe multiple supertypes
+ * in one call. Returns a JSON object mapping each supertype to its results.
  */
 class FindClassesBySupertypeTool : AiTool, IdeaLog {
 
@@ -33,13 +34,13 @@ class FindClassesBySupertypeTool : AiTool, IdeaLog {
 
     override val description: String =
         "Find project classes that extend or implement the given supertype(s) " +
-            "(class or interface). Pass `supertypeFqn` (string) for one, or " +
-            "`supertypeFqns` (array) to batch-probe multiple. Returns a JSON " +
-            "array of FQNs (excluding the supertype itself) for a single " +
-            "supertype, or a JSON object mapping each to its array for batch. " +
-            "Use for inheritance-declared components — e.g. servlet filters " +
-            "extending OncePerRequestFilter, interceptors implementing " +
-            "HandlerInterceptor, or argument resolvers implementing " +
+            "(class or interface) — each by simple or fully qualified name " +
+            "(e.g. \"OncePerRequestFilter\"). Pass `supertype` for one or " +
+            "`supertypes` (array) for batch. Returns FQNs of inheritors, " +
+            "excluding the supertype itself (JSON array for one; name-to-array " +
+            "map for batch). Use for inheritance-declared components: servlet " +
+            "filters extending OncePerRequestFilter, interceptors implementing " +
+            "HandlerInterceptor, argument resolvers implementing " +
             "HandlerMethodArgumentResolver."
 
     override val kind: ToolKind = ToolKind.PERCEPTION
@@ -47,50 +48,53 @@ class FindClassesBySupertypeTool : AiTool, IdeaLog {
     override val parametersSchema: Map<String, Any?> = mapOf(
         "type" to "object",
         "properties" to mapOf(
-            "supertypeFqn" to mapOf(
+            "supertype" to mapOf(
                 "type" to "string",
-                "description" to "Fully qualified name of the class or interface " +
-                    "(or simple name when `context` is supplied) whose " +
-                    "subclasses/implementations to find " +
-                    "(e.g. \"org.springframework.web.filter.OncePerRequestFilter\" " +
-                    "or \"org.springframework.web.servlet.HandlerInterceptor\")."
+                "description" to "Supertype class/interface name — simple or fully " +
+                    "qualified — whose subclasses/implementations to find."
             ),
-            "supertypeFqns" to mapOf(
+            "supertypes" to mapOf(
                 "type" to "array",
                 "items" to mapOf("type" to "string"),
-                "description" to "Multiple supertype FQNs to probe in one call (batch mode)."
+                "description" to "Multiple supertype names to probe (batch mode)."
             ),
             "context" to mapOf(
                 "type" to "string",
-                "description" to "Optional: file path or class FQN whose import scope " +
-                    "is used to resolve simple-name supertype entries."
+                "description" to "Optional: file path or class FQN whose import " +
+                    "scope narrows simple supertype names."
             )
         )
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val fqns = PsiNameResolver.extractStringList(args, "supertypeFqn", "supertypeFqns")
-        if (fqns.isEmpty()) return ToolResult.Error("missing parameter: provide `supertypeFqn` (string) or `supertypeFqns` (array)")
+        val names = PsiNameResolver.extractStringList(
+            args, "supertype", "supertypes", "supertypeFqn", "supertypeFqns"
+        )
+        if (names.isEmpty()) {
+            return ToolResult.Error(
+                "missing parameter: provide `supertype` (string) or `supertypes` (array)"
+            )
+        }
 
         val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
 
-        if (fqns.size == 1) {
-            return ToolResult.Text(GsonUtils.toJson(searchOne(fqns[0], ctx, contextElement)))
+        if (names.size == 1) {
+            return ToolResult.Text(GsonUtils.toJson(searchOne(names[0], ctx, contextElement)))
         }
-        val result = fqns.associateWith { searchOne(it, ctx, contextElement) }
+        val result = names.associateWith { searchOne(it, ctx, contextElement) }
         return ToolResult.Text(GsonUtils.toJson(result))
     }
 
     private suspend fun searchOne(
-        supertypeFqn: String,
+        supertypeName: String,
         ctx: ToolContext,
         contextElement: PsiElement?
     ): List<String> = read {
         val supertypes = PsiNameResolver.resolveAllClasses(
-            supertypeFqn, ctx.project, contextElement
+            supertypeName, ctx.project, contextElement
         )
         if (supertypes.isEmpty()) {
-            LOG.info("supertype not resolvable in scope: $supertypeFqn")
+            LOG.info("supertype not resolvable in scope: $supertypeName")
             return@read emptyList<String>()
         }
         val scope = GlobalSearchScope.projectScope(ctx.project)
@@ -99,11 +103,11 @@ class FindClassesBySupertypeTool : AiTool, IdeaLog {
                 .findAll()
                 .filterIsInstance<PsiClass>()
                 .mapNotNull { it.qualifiedName }
-                .filter { it != supertypeFqn }
+                .filter { it != supertypeName }
         }
             .distinct()
             .sorted()
-        LOG.info("found ${inheritors.size} inheritor(s) of $supertypeFqn")
+        LOG.info("found ${inheritors.size} inheritor(s) of $supertypeName")
         inheritors
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoTool.kt
@@ -6,78 +6,87 @@ import com.itangcent.easyapi.core.logging.IdeaLog
 import com.itangcent.easyapi.core.util.json.GsonUtils
 
 /**
- * Perception tool that returns PSI class info for one or more classes
- *.
+ * Perception tool that returns PSI class info for one or more classes.
  *
- * Resolves each class by FQN (or simple name with optional `context`) inside a
- * read action and returns name, modifiers, annotations, fields (with additive
- * `typeFqn` — the [com.itangcent.easyapi.core.psi.type.ResolvedType.qualifiedName]
- * with type args encoded inline), and method signatures (with additive
- * `returnTypeFqn` and per-parameter `typeFqn`).
+ * Resolves each class by name — fully qualified or simple, with an optional
+ * `context` for import-scope disambiguation — inside a read action and returns
+ * name, modifiers, annotations, fields (with additive `typeFqn` — the
+ * [com.itangcent.easyapi.core.psi.type.ResolvedType.qualifiedName] with type
+ * args encoded inline), and method signatures (with additive `returnTypeFqn`
+ * and per-parameter `typeFqn`).
  *
  * All signature building is delegated to [PsiSignatureBuilder] — this tool
  * only resolves the PSI class and builds error messages.
  *
- * Supports batch: pass `fqns` (array) to inspect multiple classes in one call.
- * Returns a JSON object for a single class, or a JSON object mapping each FQN
- * to its info (or an error string) for batch mode.
+ * Supports batch: pass `classNames` (array) to inspect multiple classes in one
+ * call. Returns a JSON object for a single class, or a JSON object mapping
+ * each requested name to its info (or an error string) for batch mode.
  */
 class GetPsiClassInfoTool : AiTool, IdeaLog {
 
     override val name: String = "get_psi_class_info"
 
     override val description: String =
-        "Get info about Java/Kotlin class(es) by fully qualified name. Pass " +
-            "`fqn` (string) for one, or `fqns` (array) to batch-inspect multiple. " +
-            "Returns JSON {name, fqn, modifiers, annotations, fields:[{name, type}], " +
-            "methods:[{name, signature}]} for a single class, or a JSON object " +
-            "mapping each FQN to its info for batch mode."
+        "Get info about Java/Kotlin class(es) by simple or fully qualified name " +
+            "(e.g. \"AuthResponse\"). Pass `className` for one, or `classNames` " +
+            "(array) for batch. Returns JSON {name, fqn, modifiers, annotations, " +
+            "fields, methods}. An ambiguous simple name errors with the " +
+            "candidate FQNs — pass `context` (file path / class FQN) or retry " +
+            "with a listed FQN."
 
     override val kind: ToolKind = ToolKind.PERCEPTION
 
     override val parametersSchema: Map<String, Any?> = mapOf(
         "type" to "object",
         "properties" to mapOf(
-            "fqn" to mapOf(
+            "className" to mapOf(
                 "type" to "string",
-                "description" to "Fully qualified class name (or simple name when `context` is supplied)."
+                "description" to "Simple or fully qualified class name."
             ),
-            "fqns" to mapOf(
+            "classNames" to mapOf(
                 "type" to "array",
                 "items" to mapOf("type" to "string"),
-                "description" to "Multiple fully qualified class names to inspect in one call (batch mode)."
+                "description" to "Multiple class names to inspect (batch mode)."
             ),
             "context" to mapOf(
                 "type" to "string",
-                "description" to "Optional: file path or class FQN whose import scope " +
-                    "is used to resolve simple-name `fqn`/`fqns` entries and field " +
-                    "type FQNs."
+                "description" to "Optional: file path or class FQN whose import " +
+                    "scope disambiguates simple class names."
             )
         )
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val fqns = PsiNameResolver.extractStringList(args, "fqn", "fqns")
-        if (fqns.isEmpty()) return ToolResult.Error("missing parameter: provide `fqn` (string) or `fqns` (array)")
+        val names = PsiNameResolver.extractStringList(
+            args, "className", "classNames", "fqn", "fqns"
+        )
+        if (names.isEmpty()) {
+            return ToolResult.Error(
+                "missing parameter: provide `className` (string) or `classNames` (array)"
+            )
+        }
 
         val contextElement = PsiNameResolver.resolveContextArg(args, ctx.project)
 
-        if (fqns.size == 1) {
-            val info = lookupOne(fqns[0], ctx, contextElement)
+        if (names.size == 1) {
+            val info = lookupOne(names[0], ctx, contextElement)
             if (info == null) {
-                return ToolResult.Error(buildNotFoundMessage(fqns[0], ctx, contextElement))
+                return ToolResult.Error(buildNotFoundMessage(names[0], ctx, contextElement))
             }
             return ToolResult.Text(GsonUtils.toJson(info))
         }
-        val result = fqns.associateWith { lookupOne(it, ctx, contextElement) ?: "not found" }
+        val result = names.associateWith {
+            lookupOne(it, ctx, contextElement) ?: buildNotFoundMessage(it, ctx, contextElement)
+        }
         return ToolResult.Text(GsonUtils.toJson(result))
     }
 
     /**
      * Builds the error message for a missing class. When the lookup was a
-     * simple name without context and `PsiNameResolver` found multiple
-     * matches, the message guides the agent to `find_classes_by_name`.
-     * Otherwise a plain "class not found" is returned.
+     * simple name without context and [PsiNameResolver] found multiple
+     * matches, the message lists the candidate FQNs so the agent can retry
+     * with the fully qualified name or a `context`. Otherwise a plain "class
+     * not found" is returned.
      */
     private suspend fun buildNotFoundMessage(
         fqn: String,
@@ -89,8 +98,7 @@ class GetPsiClassInfoTool : AiTool, IdeaLog {
         if (!fqn.contains('.') && contextElement == null) {
             val matches = PsiNameResolver.resolveAllClasses(fqn, ctx.project, null)
             if (matches.size > 1) {
-                return "ambiguous simple name '$fqn': ${matches.size} classes match, " +
-                    "use find_classes_by_name to disambiguate"
+                return PsiNameResolver.ambiguityMessage(fqn, matches)
             }
         }
         return "class not found: $fqn"

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoTool.kt
@@ -8,9 +8,10 @@ import com.itangcent.easyapi.core.util.json.GsonUtils
 /**
  * Perception tool that returns info about a single PSI method.
  *
- * Resolves the class by FQN (or simple name with optional `context`), then
- * walks its methods matching by name + (optional) parameter count. Returns
- * the signature, annotations, parameters (with additive `typeFqn` — the
+ * Resolves the class by name — fully qualified or simple, with an optional
+ * `context` for import-scope disambiguation — then walks its methods matching
+ * by name + (optional) parameter count. Returns the signature, annotations,
+ * parameters (with additive `typeFqn` — the
  * [com.itangcent.easyapi.core.psi.type.ResolvedType.qualifiedName] with type args
  * encoded inline), return type info (`returnType` / `returnTypeFqn`), the
  * doc-comment text, and — when `detail="full"` — the method body (truncated
@@ -31,20 +32,21 @@ class GetPsiMethodInfoTool : AiTool, IdeaLog {
     override val name: String = "get_psi_method_info"
 
     override val description: String =
-        "Get info about a method in a class. Returns JSON {className, name, " +
+        "Get info about a method in a class. Class name — simple or fully " +
+            "qualified — in `className`; method name in `methodName` (optional " +
+            "`paramCount` narrows overloads). Returns JSON {className, name, " +
             "signature, annotations, parameters, docComment, returnType, " +
-            "returnTypeFqn}. `paramCount` is optional and narrows the match " +
-            "when a class overloads the method name. Pass `detail=\"full\"` " +
-            "to include the method `body` (truncated to `maxBodyChars`)."
+            "returnTypeFqn}. detail=\"full\" includes the method `body` " +
+            "(truncated to `maxBodyChars`)."
 
     override val kind: ToolKind = ToolKind.PERCEPTION
 
     override val parametersSchema: Map<String, Any?> = mapOf(
         "type" to "object",
         "properties" to mapOf(
-            "fqn" to mapOf(
+            "className" to mapOf(
                 "type" to "string",
-                "description" to "Fully qualified class name (or simple name when `context` is supplied)."
+                "description" to "Simple or fully qualified class name."
             ),
             "methodName" to mapOf(
                 "type" to "string",
@@ -57,28 +59,32 @@ class GetPsiMethodInfoTool : AiTool, IdeaLog {
             "detail" to mapOf(
                 "type" to "string",
                 "enum" to listOf("signature", "full"),
-                "description" to "Optional: level of detail. \"signature\" (default) " +
-                    "omits the body; \"full\" includes a truncated `body` field."
+                "description" to "Optional: \"signature\" (default) or \"full\" " +
+                    "(includes a truncated `body`)."
             ),
             "maxBodyChars" to mapOf(
                 "type" to "integer",
-                "description" to "Optional: max characters for the `body` field " +
-                    "(only when detail=\"full\"). Defaults to $DEFAULT_MAX_BODY_CHARS."
+                "description" to "Optional: max chars for `body` when detail=\"full\" " +
+                    "(default $DEFAULT_MAX_BODY_CHARS)."
             ),
             "context" to mapOf(
                 "type" to "string",
-                "description" to "Optional: file path or class FQN whose import scope " +
-                    "is used to resolve simple-name `fqn` and parameter/return type FQNs."
+                "description" to "Optional: file path or class FQN whose import " +
+                    "scope disambiguates a simple `className`."
             )
         ),
-        "required" to listOf("fqn", "methodName")
+        "required" to listOf("className", "methodName")
     )
 
     override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
-        val fqn = args["fqn"] as? String
+        // `className` is the current parameter name; `fqn` is accepted as a
+        // legacy alias so older persisted conversations keep working.
+        val className = (args["className"] as? String) ?: (args["fqn"] as? String)
         val methodName = args["methodName"] as? String
-        if (fqn.isNullOrBlank() || methodName.isNullOrBlank()) {
-            return ToolResult.Error("missing required parameter(s): fqn, methodName")
+        if (className.isNullOrBlank() || methodName.isNullOrBlank()) {
+            return ToolResult.Error(
+                "missing required parameter(s): className, methodName"
+            )
         }
         val paramCount = (args["paramCount"] as? Number)?.toInt()
         val detail = (args["detail"] as? String)?.takeIf { it == "full" } ?: "signature"
@@ -91,7 +97,7 @@ class GetPsiMethodInfoTool : AiTool, IdeaLog {
         // require one. The detail="signature" fast path does NOT touch
         // psiMethod.body?.text.
         val info = read {
-            val psiClass = PsiNameResolver.resolveClass(fqn, ctx.project, contextElement)
+            val psiClass = PsiNameResolver.resolveClass(className, ctx.project, contextElement)
                 ?: return@read null
             val psiMethod = psiClass.methods.firstOrNull { m ->
                 m.name == methodName &&
@@ -102,35 +108,37 @@ class GetPsiMethodInfoTool : AiTool, IdeaLog {
             val enrichmentContext = contextElement ?: psiClass.containingFile
             PsiSignatureBuilder.methodToInfoMap(
                 psiMethod = psiMethod,
-                className = psiClass.qualifiedName ?: fqn,
+                className = psiClass.qualifiedName ?: className,
                 project = ctx.project,
                 contextElement = enrichmentContext,
                 detail = detail,
                 maxBodyChars = maxBodyChars
             )
-        } ?: return ToolResult.Error(buildNotFoundMessage(fqn, ctx, contextElement, methodName))
+        } ?: return ToolResult.Error(
+            buildNotFoundMessage(className, ctx, contextElement, methodName)
+        )
 
         return ToolResult.Text(GsonUtils.toJson(info))
     }
 
     /**
      * Builds the error message for a missing class or method. When the
-     * lookup was a simple name without context and `PsiNameResolver` found
-     * multiple matches, the message guides the agent to `find_classes_by_name`.
+     * lookup was a simple name without context and [PsiNameResolver] found
+     * multiple matches, the message lists the candidate FQNs so the agent can
+     * retry with the fully qualified name or a `context`.
      */
     private suspend fun buildNotFoundMessage(
-        fqn: String,
+        className: String,
         ctx: ToolContext,
         contextElement: PsiElement?,
         methodName: String
     ): String {
-        if (!fqn.contains('.') && contextElement == null) {
-            val matches = PsiNameResolver.resolveAllClasses(fqn, ctx.project, null)
+        if (!className.contains('.') && contextElement == null) {
+            val matches = PsiNameResolver.resolveAllClasses(className, ctx.project, null)
             if (matches.size > 1) {
-                return "ambiguous simple name '$fqn': ${matches.size} classes match, " +
-                    "use find_classes_by_name to disambiguate"
+                return PsiNameResolver.ambiguityMessage(className, matches)
             }
         }
-        return "method not found: $fqn#$methodName"
+        return "method not found: $className#$methodName"
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/PsiNameResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ai/tools/PsiNameResolver.kt
@@ -33,6 +33,9 @@ import com.itangcent.easyapi.core.psi.type.TypeResolver
  */
 internal object PsiNameResolver : IdeaLog {
 
+    /** Maximum number of candidate FQNs listed in an ambiguity message. */
+    private const val MAX_AMBIGUITY_CANDIDATES = 8
+
     /**
      * Resolves [name] to a single [PsiClass], or `null` when the name is
      * blank, ambiguous (more than one match in the no-context simple-name
@@ -199,9 +202,31 @@ internal object PsiNameResolver : IdeaLog {
     }
 
     /**
+     * Builds the ambiguity message for a simple name that matches more than
+     * one class, listing the first [MAX_AMBIGUITY_CANDIDATES] candidate FQNs
+     * so the agent can retry with the fully qualified name or a `context`.
+     *
+     * @param name the ambiguous simple name.
+     * @param matches every class that matched the name.
+     * @return a ready-to-return error message.
+     */
+    fun ambiguityMessage(name: String, matches: List<PsiClass>): String {
+        val fqns = matches.mapNotNull { it.qualifiedName }.distinct().sorted()
+        val shown = fqns.take(MAX_AMBIGUITY_CANDIDATES).joinToString(", ")
+        val truncation = if (fqns.size > MAX_AMBIGUITY_CANDIDATES) ", ..." else ""
+        return "ambiguous simple name '$name': ${fqns.size} classes match ($shown$truncation). " +
+            "Retry with the fully qualified name or with a context (file path / class FQN)."
+    }
+
+    /**
      * Extracts a string list from a tool's argument map, supporting both
      * single-value (`[singleKey]` → string) and batch (`[batchKey]` → array)
      * modes. Blank entries are filtered out.
+     *
+     * Optional legacy keys let a renamed parameter keep accepting its
+     * historical name (e.g. `fqn` after a rename to `className`): the legacy
+     * keys are consulted only when the primary single and batch keys are both
+     * absent, so a caller that supplies the current name always wins.
      *
      * Shared by tools that accept single-or-batch name/FQN parameters
      * ([GetPsiClassInfoTool], [FindClassesByAnnotationTool],
@@ -212,18 +237,24 @@ internal object PsiNameResolver : IdeaLog {
      * @param singleKey the key for the single-value form (e.g. `"fqn"`, `"name"`).
      * @param batchKey the key for the batch form (e.g. `"fqns"`, `"names"`).
      *   When present, takes precedence over [singleKey].
+     * @param legacySingleKey optional deprecated single-value key to fall back to.
+     * @param legacyBatchKey optional deprecated batch key to fall back to.
      * @return the non-blank string list (possibly empty).
      */
     fun extractStringList(
         args: Map<String, Any?>,
         singleKey: String,
-        batchKey: String
+        batchKey: String,
+        legacySingleKey: String? = null,
+        legacyBatchKey: String? = null
     ): List<String> {
         val batch = args[batchKey] as? List<*>
+            ?: legacyBatchKey?.let { args[it] as? List<*> }
         if (batch != null) {
             return batch.mapNotNull { it?.toString()?.takeIf { s -> s.isNotBlank() } }
         }
         val single = args[singleKey] as? String
+            ?: legacySingleKey?.let { args[it] as? String }
         return if (single.isNullOrBlank()) emptyList() else listOf(single)
     }
 }

--- a/src/main/resources/ai/agent-base.md
+++ b/src/main/resources/ai/agent-base.md
@@ -75,7 +75,8 @@ Perception tools (read-only, run automatically):
 - `read_rule_file` — read an existing `.properties`/`.rules` file from `.easyapi/`
   or `~/.easyapi/` by name (see "Tool selection" below).
 - `list_project_endpoints` — the user's API endpoints.
-- `get_psi_class_info` / `get_psi_method_info` — inspect source code (classes/methods).
+- `get_psi_class_info` / `get_psi_method_info` — inspect source code
+  (classes/methods) by simple or fully qualified class name.
 - `find_classes_by_annotation` / `find_classes_by_supertype` / `find_classes_by_name` —
   discover classes by annotation, supertype, or simple name.
 - `get_existing_rules_for_key` — current values for a key across all sources.
@@ -139,25 +140,27 @@ guess one.
 Legacy `.easy.api.config*` files in the project root are auto-loaded and
 read-only; do not target them with `read_rule_file`.
 
-To inspect source code, use the PSI tools instead:
-- **Class info** → `get_psi_class_info` with the fully qualified name
-  (e.g. `"com.example.filter.MyJwtFilter"`). Returns fields, methods,
-  annotations, and signatures.
-- **Method info** → `get_psi_method_info` with the class FQN + method
-  name (optional `paramCount` for overloads). Returns signature,
-  annotations, parameters, and doc comment.
-- **Find classes** → `find_classes_by_annotation` or
-  `find_classes_by_supertype` to discover classes, then
+To inspect source code, use the PSI tools instead. Every PSI tool accepts a
+class **simple name** (`MyJwtFilter`) or a **fully qualified name**
+(`com.example.filter.MyJwtFilter`) — use whichever you have:
+- **Class info** → `get_psi_class_info` with the class in `className`.
+  Returns fields, methods, annotations, and signatures.
+- **Method info** → `get_psi_method_info` with the class in `className`
+  + the method name (optional `paramCount` for overloads). Returns
+  signature, annotations, parameters, and doc comment.
+- **Find classes** → `find_classes_by_annotation` /
+  `find_classes_by_supertype` / `find_classes_by_name` to discover
+  classes by annotation, supertype, or simple name (e.g. probe
+  `find_classes_by_supertype` with `OncePerRequestFilter` to catch
+  servlet filters declared by inheritance); then
   `get_psi_class_info` to inspect each hit.
 
-If you only know the class's simple name (e.g. `MyJwtFilter`), use
-`find_classes_by_name` as the **primary** tool — it resolves simple
-names to FQNs via the stub index and accepts an optional `context`
-(class FQN or file path) to prefer an import-reachable match. Keep
-`find_classes_by_supertype` (e.g. probe `OncePerRequestFilter`) and
-`find_classes_by_annotation` for when you know the supertype or
-annotation but not the class name; then use the returned FQN with
-`get_psi_class_info`.
+A simple name that matches several classes (common across modules) is
+ambiguous: pass `context` (class FQN or file path) to prefer the
+import-reachable match, or read the candidate FQNs the error lists and
+retry with one of them. `find_classes_by_name` returns just the FQN
+list, which is handy when you must pick between matches before
+inspecting.
 
 ## Rule file format (CRITICAL — follow exactly)
 

--- a/src/main/resources/ai/sub-agent-base.md
+++ b/src/main/resources/ai/sub-agent-base.md
@@ -37,11 +37,13 @@ Perception tools (read-only, run automatically):
   stage and the `it` kinds the script can call; then fetch the referenced
   objects' method signatures via `get_script_object_api(ids=[...])`.
 - `get_psi_class_info` — inspect a class's methods/fields/signature/annotations
-  by fully-qualified name (e.g. `com.example.filter.MyJwtFilter`).
-- `find_classes_by_annotation` — discover classes by annotation FQN or simple
-  name (e.g. `jakarta.servlet.annotation.WebFilter`, `@RestController`).
-- `find_classes_by_supertype` — discover classes by supertype FQN (e.g.
-  `org.springframework.web.filter.OncePerRequestFilter`,
+  by name — fully qualified (e.g. `com.example.filter.MyJwtFilter`) or simple
+  (e.g. `MyJwtFilter` when unambiguous).
+- `find_classes_by_annotation` — discover classes by annotation name — fully
+  qualified or simple (e.g. `jakarta.servlet.annotation.WebFilter`,
+  `@RestController`).
+- `find_classes_by_supertype` — discover classes by supertype name — fully
+  qualified or simple (e.g. `org.springframework.web.filter.OncePerRequestFilter`,
   `org.springframework.web.servlet.HandlerInterceptor`).
 
 Action tool (terminal — ends your turn):

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesByAnnotationToolTest.kt
@@ -103,7 +103,7 @@ class FindClassesByAnnotationToolTest : EasyApiLightCodeInsightFixtureTestCase()
         addClasses()
         val result = runBlocking {
             FindClassesByAnnotationTool().execute(
-                mapOf("annotationFqn" to "com.example.Marker"),
+                mapOf("annotation" to "com.example.Marker"),
                 ctx()
             )
         }
@@ -167,7 +167,7 @@ class FindClassesByAnnotationToolTest : EasyApiLightCodeInsightFixtureTestCase()
         }
         Assert.assertTrue(result is ToolResult.Error)
         Assert.assertTrue(
-            (result as ToolResult.Error).message.contains("annotationFqn")
+            (result as ToolResult.Error).message.contains("provide `annotation`")
         )
     }
 
@@ -259,12 +259,12 @@ class FindClassesByAnnotationToolTest : EasyApiLightCodeInsightFixtureTestCase()
     // tolerance + context parameter
     // ------------------------------------------------------------------
 
-    fun testAcceptsSimpleNameForAnnotationFqn() {
+    fun testAcceptsSimpleNameForAnnotation() {
         addClasses()
         // "Marker" is a simple name — resolveAllClasses finds com.example.Marker.
         val result = runBlocking {
             FindClassesByAnnotationTool().execute(
-                mapOf("annotationFqn" to "Marker"),
+                mapOf("annotation" to "Marker"),
                 ctx()
             )
         }

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/FindClassesBySupertypeToolTest.kt
@@ -98,7 +98,7 @@ class FindClassesBySupertypeToolTest : EasyApiLightCodeInsightFixtureTestCase() 
         addClasses()
         val result = runBlocking {
             FindClassesBySupertypeTool().execute(
-                mapOf("supertypeFqn" to "org.springframework.web.filter.OncePerRequestFilter"),
+                mapOf("supertype" to "org.springframework.web.filter.OncePerRequestFilter"),
                 ctx()
             )
         }
@@ -166,7 +166,7 @@ class FindClassesBySupertypeToolTest : EasyApiLightCodeInsightFixtureTestCase() 
         }
         Assert.assertTrue(result is ToolResult.Error)
         Assert.assertTrue(
-            (result as ToolResult.Error).message.contains("supertypeFqn")
+            (result as ToolResult.Error).message.contains("provide `supertype`")
         )
     }
 
@@ -206,12 +206,12 @@ class FindClassesBySupertypeToolTest : EasyApiLightCodeInsightFixtureTestCase() 
     // tolerance + context parameter
     // ------------------------------------------------------------------
 
-    fun testAcceptsSimpleNameForSupertypeFqn() {
+    fun testAcceptsSimpleNameForSupertype() {
         addClasses()
         // "OncePerRequestFilter" is a simple name — resolveAllClasses finds it.
         val result = runBlocking {
             FindClassesBySupertypeTool().execute(
-                mapOf("supertypeFqn" to "OncePerRequestFilter"),
+                mapOf("supertype" to "OncePerRequestFilter"),
                 ctx()
             )
         }

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiClassInfoToolTest.kt
@@ -304,7 +304,7 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         }
         val result = runBlocking {
             GetPsiClassInfoTool().execute(
-                mapOf("fqn" to "User"),
+                mapOf("className" to "User"),
                 ctx()
             )
         }
@@ -313,25 +313,29 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertEquals("com.example.User", map["fqn"])
     }
 
-    fun testAmbiguousSimpleNameReturnsErrorGuidingToFindClassesByName() {
+    fun testAmbiguousSimpleNameErrorListsCandidateFqns() {
         addClassesForTolerance()
         // Two User classes (com.example.User + com.example.dto.User), no
-        // context → ambiguous → error guiding to find_classes_by_name.
+        // context → ambiguous → error lists both candidate FQNs.
         val result = runBlocking {
             GetPsiClassInfoTool().execute(
-                mapOf("fqn" to "User"),
+                mapOf("className" to "User"),
                 ctx()
             )
         }
         Assert.assertTrue("expected Error result, got $result", result is ToolResult.Error)
         val msg = (result as ToolResult.Error).message
         Assert.assertTrue(
-            "error should mention find_classes_by_name: $msg",
-            msg.contains("find_classes_by_name")
-        )
-        Assert.assertTrue(
             "error should mention ambiguous: $msg",
             msg.contains("ambiguous")
+        )
+        Assert.assertTrue(
+            "error should list the first candidate FQN: $msg",
+            msg.contains("com.example.User")
+        )
+        Assert.assertTrue(
+            "error should list the second candidate FQN: $msg",
+            msg.contains("com.example.dto.User")
         )
     }
 
@@ -384,7 +388,7 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         addClasses()
         val result = runBlocking {
             GetPsiClassInfoTool().execute(
-                mapOf("fqn" to "com.example.User"),
+                mapOf("className" to "com.example.User"),
                 ctx()
             )
         }
@@ -510,11 +514,11 @@ class GetPsiClassInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertEquals(ToolKind.PERCEPTION, GetPsiClassInfoTool().kind)
     }
 
-    fun testSchemaDeclaresFqnAndFqnsProperties() {
+    fun testSchemaDeclaresClassNameAndClassNamesProperties() {
         val schema = GetPsiClassInfoTool().parametersSchema
         val props = schema["properties"] as Map<*, *>
-        Assert.assertTrue("should declare fqn", props.containsKey("fqn"))
-        Assert.assertTrue("should declare fqns", props.containsKey("fqns"))
+        Assert.assertTrue("should declare className", props.containsKey("className"))
+        Assert.assertTrue("should declare classNames", props.containsKey("classNames"))
     }
 
     private class NoOpApprovalGate : ApprovalGate {

--- a/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ai/tools/GetPsiMethodInfoToolTest.kt
@@ -201,7 +201,7 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         val result = runBlocking {
             GetPsiMethodInfoTool().execute(
                 mapOf(
-                    "fqn" to "com.example.Calculator",
+                    "className" to "com.example.Calculator",
                     "methodName" to "multiply"
                 ),
                 ctx()
@@ -264,7 +264,7 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testSchemaDeclaresRequiredParameters() {
         val schema = GetPsiMethodInfoTool().parametersSchema
         val required = schema["required"] as List<*>
-        Assert.assertTrue("fqn must be required", required.contains("fqn"))
+        Assert.assertTrue("className must be required", required.contains("className"))
         Assert.assertTrue("methodName must be required", required.contains("methodName"))
     }
 
@@ -668,7 +668,7 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         val result = runBlocking {
             GetPsiMethodInfoTool().execute(
                 mapOf(
-                    "fqn" to "Calculator",
+                    "className" to "Calculator",
                     "methodName" to "multiply"
                 ),
                 ctx()
@@ -702,12 +702,12 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         )
     }
 
-    fun testAmbiguousSimpleNameReturnsError() {
+    fun testAmbiguousSimpleNameErrorListsCandidateFqns() {
         addClassesForTolerance()
         val result = runBlocking {
             GetPsiMethodInfoTool().execute(
                 mapOf(
-                    "fqn" to "Calculator",
+                    "className" to "Calculator",
                     "methodName" to "multiply"
                 ),
                 ctx()
@@ -716,8 +716,12 @@ class GetPsiMethodInfoToolTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertTrue("expected Error result, got $result", result is ToolResult.Error)
         val msg = (result as ToolResult.Error).message
         Assert.assertTrue(
-            "error should mention find_classes_by_name: $msg",
-            msg.contains("find_classes_by_name")
+            "error should mention ambiguous: $msg",
+            msg.contains("ambiguous")
+        )
+        Assert.assertTrue(
+            "error should list the candidate FQNs: $msg",
+            msg.contains("com.example.Calculator") && msg.contains("com.example.dto.Calculator")
         )
     }
 


### PR DESCRIPTION
## Summary

The AI rule-authoring assistant's class-inspection tools now treat class
names uniformly: `get_psi_class_info`, `get_psi_method_info`,
`find_classes_by_annotation`, and `find_classes_by_supertype` all accept a
**simple** or **fully qualified** name through `className` / `annotation` /
`supertype` parameters.

- Parameter schemas and tool descriptions were rewritten to advertise
  simple-name support (previously FQN-first wording and `fqn`-style params).
  Legacy keys (`fqn`, `annotationFqn`, `supertypeFqn`, …) still work as
  undocumented aliases so in-flight conversations are not broken.
- Ambiguity errors for simple names now list the candidate FQNs so the agent
  can retry with the fully qualified name or a `context` argument instead of
  an extra `find_classes_by_name` round trip.
- `agent-base.md` / `sub-agent-base.md` prompts were updated to match.
- Tool tests now cover both a simple-name and a fully-qualified-name success
  path under the current parameter keys.

## Testing

- `./gradlew test` targeted at all five PSI tool test classes, the shared
  resolver tests, and prompt-content guards
  (`SystemPromptBuilderTest`, `AgentBaseCatalogIdGuardTest`) — all green.

## Risks / rollback

- No behavior change for existing fully-qualified callers; legacy parameter
  keys remain accepted.
- Rollback is a revert of this commit; no data migration involved.
