### PR TITLE
release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the EasyAPI plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-09-05
+
+### Added
+-  add best-effort compatibility builds for older IDEA versions
+- feat(ai): accept simple class names in PSI tools (#763)
+- feat(ai): self-describing rule keys with exported context catalogs (#762)
+
+### Fixed
+-  stop dropping public fields from exported models
+-  propagate required flag to @RequestHeader-derived headers
+-  prevent read-access error in rule scripts
+- fix(rules): surface rule failures during export (#761)
+- fix(ai): read rule files relative to project dir (#758)
+- fix(rules): garbled Chinese text in rule files (#759)
+
+### Improved
+- test: cover read-access fix for rule scripts
+- perf(rule): speed up field-model building
+- test: add MyBatis-Plus IPage response coverage
+- enhance(ai): teach the rule agent contextType() (#760)
+- docs(git-commit): require user-facing commit subjects (#752)
+- docs: document isExtend FQN contract (#753)
+
+---
+
 ## [3.1.9] - 2026-08-11
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.workers.max=2
 kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
 # Plugin base version (semver, e.g. 3.1.9) — bumped by script/release.sh.
 # Full version is <base>.<since>.<until|0>, e.g. 3.1.9.252.0.
-pluginBaseVersion=3.1.9
+pluginBaseVersion=3.2.0
 # Default IDEA compatibility lower bound (build number, e.g. 252 = 2025.2).
 # Override per invocation: ./gradlew buildPlugin -PpluginSinceBuild=243 [-PpluginUntilBuild=252]
 pluginSinceBuild=252


### PR DESCRIPTION
## Release Changes

* fix: stop dropping public fields from exported models
* fix: propagate required flag to @RequestHeader-derived headers
* feat: add best-effort compatibility builds for older IDEA versions
* test: cover read-access fix for rule scripts
* perf(rule): speed up field-model building
* test: add MyBatis-Plus IPage response coverage
* fix: prevent read-access error in rule scripts
* feat(ai): accept simple class names in PSI tools (#763)
* feat(ai): self-describing rule keys with exported context catalogs (#762)
* fix(rules): surface rule failures during export (#761)
* fix(ai): read rule files relative to project dir (#758)
* fix(rules): garbled Chinese text in rule files (#759)
* enhance(ai): teach the rule agent contextType() (#760)
* docs(git-commit): require user-facing commit subjects (#752)
* docs: document isExtend FQN contract (#753)